### PR TITLE
[UI] [Notch-Shape] Change to the smooth curves notch shape

### DIFF
--- a/boringNotch/components/Notch/NotchShape.swift
+++ b/boringNotch/components/Notch/NotchShape.swift
@@ -32,17 +32,34 @@ struct NotchShape: Shape {
     
     func path(in rect: CGRect) -> Path {
         var path = Path()
-        
-        path.addArc(center: CGPoint(x: rect.minX, y: topCornerRadius), radius: topCornerRadius, startAngle: .degrees(-90), endAngle: .degrees(0), clockwise: false)
+        // Start from the top left corner
+        path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+        // Top left inner curve
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX + topCornerRadius, y: topCornerRadius),
+            control: CGPoint(x: rect.minX + topCornerRadius, y: rect.minY) // Control point for inner curve
+        )
+        // Left vertical line
         path.addLine(to: CGPoint(x: rect.minX + topCornerRadius, y: rect.maxY - bottomCornerRadius))
-        path.addArc(center: CGPoint(x: rect.minX + topCornerRadius + bottomCornerRadius, y: rect.maxY - bottomCornerRadius), radius: bottomCornerRadius, startAngle: .degrees(180), endAngle: .degrees(90), clockwise: true)
+        // Bottom left corner
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX + topCornerRadius + bottomCornerRadius, y: rect.maxY),
+            control: CGPoint(x: rect.minX + topCornerRadius, y: rect.maxY)
+        )
         path.addLine(to: CGPoint(x: rect.maxX - topCornerRadius - bottomCornerRadius, y: rect.maxY))
-        path.addArc(center: CGPoint(x: rect.maxX - topCornerRadius - bottomCornerRadius, y: rect.maxY - bottomCornerRadius), radius: bottomCornerRadius, startAngle: .degrees(90), endAngle: .degrees(0), clockwise: true)
+        // Bottom right corner
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX - topCornerRadius, y: rect.maxY - bottomCornerRadius),
+            control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.maxY)
+        )
         path.addLine(to: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY + bottomCornerRadius))
         
-        path.addArc(center: CGPoint(x: rect.maxX, y: topCornerRadius), radius: topCornerRadius, startAngle: .degrees(180), endAngle: .degrees(270), clockwise: false)
+        // Closing the path to top right inner curve
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX, y: rect.minY),
+            control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY) // Control point for inner curve
+        )
         path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
-        
         return path
     }
 }


### PR DESCRIPTION
Hi,

I'm interested in this development. I began to design a dynamic notch for my personal use. After a while, I landed here.
I have been creating production-level apps for Apple for the past 8 years. I would be pleased to work on it and turn it into a fledge product-type repository if all of you are comfortable with it.
I am going to start with a small, excellent design change.

# Related Issue
- Refactor notch shape to smooth curves notch shape


**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

# Description

Use `addQuadCurve` for smooth curves defined by a control point, while` addArc` is for drawing arcs or circles based on angles and radii. Each method serves different visual purposes in your SwiftUI designs.

# Screenshot

Before             	   |  Updated
:-------------------------:|:-------------------------:
<img width="239" alt="notch-shape-arc-preview-before" src="https://github.com/user-attachments/assets/8979c1b3-0093-4f59-bbf5-2b1855e7c22e"> | <img width="259" alt="notch-shape-quad-curve-preview-after" src="https://github.com/user-attachments/assets/a73ccdfb-21e4-45c1-a03a-d2be611dc1cb">
<img width="236" alt="notch-shape-arc-rendering-before" src="https://github.com/user-attachments/assets/542c051a-8ee2-4531-af2e-0304d6411239"> | <img width="244" alt="notch-shape-quad-curve-rendering-after" src="https://github.com/user-attachments/assets/ad7d2b87-3a78-4044-9464-00e87b9485de">
<img width="605" alt="notch-shape-arc-home-before" src="https://github.com/user-attachments/assets/9de4e4c2-7d0f-4ea0-a947-5d05c89696f7"> | <img width="613" alt="notch-shape-quad-curve-home-after" src="https://github.com/user-attachments/assets/8c883929-142b-43c2-956b-c8aec6f8d48f"> | ![notch-shape-quad-curve-after](https://github.com/user-attachments/assets/623aa431-01b8-4941-8be6-364c7fa7521b)
![notch-shape-arc-before](https://github.com/user-attachments/assets/2d385b82-3b33-4d35-bab9-55778f01e38e) | ![notch-shape-quad-curve-after](https://github.com/user-attachments/assets/e7140631-58a5-4e47-b287-4ce70ef091a0)
# How Verified
How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
