### PR TITLE
Prevent sneak peek from triggering when app changes

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -36,12 +36,12 @@ struct ContentView: View {
             NotchLayout()
                 .padding(.horizontal, vm.notchState == .open ? Defaults[.cornerRadiusScaling] ? (vm.sizes.cornerRadius.opened.inset! - 5) : (vm.sizes.cornerRadius.closed.inset! - 5) : 12)
                 .padding([.horizontal, .bottom], vm.notchState == .open ? 12 : 0)
-                .frame(maxWidth: (((musicManager.isPlaying || !musicManager.isPlayerIdle) && vm.notchState == .closed && vm.showMusicLiveActivityOnClosed) || (vm.expandingView.show && (vm.expandingView.type == .battery)) || Defaults[.inlineHUD]) ? nil : vm.notchSize.width + ((hoverAnimation || (vm.notchState == .closed)) ? 20 : 0) + gestureProgress, maxHeight: ((vm.sneakPeak.show && vm.sneakPeak.type != .music) || (vm.sneakPeak.show && vm.sneakPeak.type == .music && vm.notchState == .closed)) ? nil : vm.notchSize.height + (hoverAnimation ? 8 : 0) + gestureProgress / 3, alignment: .top)
+                .frame(maxWidth: (((musicManager.isPlaying || !musicManager.isPlayerIdle) && vm.notchState == .closed && vm.showMusicLiveActivityOnClosed) || (vm.expandingView.show && (vm.expandingView.type == .battery)) || Defaults[.inlineHUD]) ? nil : vm.notchSize.width + ((hoverAnimation || (vm.notchState == .closed)) ? 20 : 0) + gestureProgress, maxHeight: ((vm.sneakPeek.show && vm.sneakPeek.type != .music) || (vm.sneakPeek.show && vm.sneakPeek.type == .music && vm.notchState == .closed)) ? nil : vm.notchSize.height + (hoverAnimation ? 8 : 0) + gestureProgress / 3, alignment: .top)
                 .background(.black)
                 .mask {
                     NotchShape(cornerRadius: ((vm.notchState == .open) && Defaults[.cornerRadiusScaling]) ? vm.sizes.cornerRadius.opened.inset : vm.sizes.cornerRadius.closed.inset)
                 }
-                .frame(width: vm.notchState == .closed ? (((musicManager.isPlaying || !musicManager.isPlayerIdle) && vm.showMusicLiveActivityOnClosed) || (vm.expandingView.show && (vm.expandingView.type == .battery)) || (Defaults[.inlineHUD] && vm.sneakPeak.show && vm.sneakPeak.type != .music)) ? nil : Sizes().size.closed.width! + (hoverAnimation ? 20 : 0) + gestureProgress : nil, height: vm.notchState == .closed ? Sizes().size.closed.height! + (hoverAnimation ? 8 : 0) + gestureProgress / 3 : nil, alignment: .top)
+                .frame(width: vm.notchState == .closed ? (((musicManager.isPlaying || !musicManager.isPlayerIdle) && vm.showMusicLiveActivityOnClosed) || (vm.expandingView.show && (vm.expandingView.type == .battery)) || (Defaults[.inlineHUD] && vm.sneakPeek.show && vm.sneakPeek.type != .music)) ? nil : Sizes().size.closed.width! + (hoverAnimation ? 20 : 0) + gestureProgress : nil, height: vm.notchState == .closed ? Sizes().size.closed.height! + (hoverAnimation ? 8 : 0) + gestureProgress / 3 : nil, alignment: .top)
                 .conditionalModifier(Defaults[.openNotchOnHover]) { view in
                     view
                         .onHover { hovering in
@@ -54,7 +54,7 @@ struct ContentView: View {
                                     haptics.toggle()
                                 }
                                 
-                                if vm.sneakPeak.show {
+                                if vm.sneakPeek.show {
                                     return
                                 }
                                 
@@ -212,8 +212,8 @@ struct ContentView: View {
                             .frame(width: 76, alignment: .trailing)
                         }
                         .frame(height: Sizes().size.closed.height! + (hoverAnimation ? 8 : 0), alignment: .center)
-                    } else if vm.sneakPeak.show && Defaults[.inlineHUD] && (vm.sneakPeak.type != .music) && (vm.sneakPeak.type != .battery) {
-                        InlineHUD(type: $vm.sneakPeak.type, value: $vm.sneakPeak.value, icon: $vm.sneakPeak.icon, hoverAnimation: $hoverAnimation, gestureProgress: $gestureProgress)
+                    } else if vm.sneakPeek.show && Defaults[.inlineHUD] && (vm.sneakPeek.type != .music) && (vm.sneakPeek.type != .battery) {
+                        InlineHUD(type: $vm.sneakPeek.type, value: $vm.sneakPeek.value, icon: $vm.sneakPeek.icon, hoverAnimation: $hoverAnimation, gestureProgress: $gestureProgress)
                             .transition(.opacity)
                     } else if !vm.expandingView.show && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle) && vm.showMusicLiveActivityOnClosed {
                         MusicLiveActivity()
@@ -223,15 +223,15 @@ struct ContentView: View {
                             .blur(radius: abs(gestureProgress) > 0.3 ? min(abs(gestureProgress), 8) : 0)
                     }
                     
-                    if vm.sneakPeak.show && !Defaults[.inlineHUD] {
-                        if (vm.sneakPeak.type != .music) && (vm.sneakPeak.type != .battery) {
-                            SystemEventIndicatorModifier(eventType: $vm.sneakPeak.type, value: $vm.sneakPeak.value, icon: $vm.sneakPeak.icon, sendEventBack: { _ in
+                    if vm.sneakPeek.show && !Defaults[.inlineHUD] {
+                        if (vm.sneakPeek.type != .music) && (vm.sneakPeek.type != .battery) {
+                            SystemEventIndicatorModifier(eventType: $vm.sneakPeek.type, value: $vm.sneakPeek.value, icon: $vm.sneakPeek.icon, sendEventBack: { _ in
                                 //
                             })
                             .padding(.bottom, 10)
                             .padding(.leading, 4)
                             .padding(.trailing, 8)
-                        } else if vm.sneakPeak.type != .battery {
+                        } else if vm.sneakPeek.type != .battery {
                             if vm.notchState == .closed {
                                 HStack(alignment: .center) {
                                     Image(systemName: "music.note")
@@ -246,7 +246,7 @@ struct ContentView: View {
                     }
                 }
             }
-            .conditionalModifier((vm.sneakPeak.show && (vm.sneakPeak.type == .music) && vm.notchState == .closed) || (vm.sneakPeak.show && (vm.sneakPeak.type != .music) && (musicManager.isPlaying || !musicManager.isPlayerIdle))) { view in
+            .conditionalModifier((vm.sneakPeek.show && (vm.sneakPeek.type == .music) && vm.notchState == .closed) || (vm.sneakPeek.show && (vm.sneakPeek.type != .music) && (musicManager.isPlaying || !musicManager.isPlayerIdle))) { view in
                 view
                     .fixedSize()
             }

--- a/boringNotch/components/BoringSystemTiles.swift
+++ b/boringNotch/components/BoringSystemTiles.swift
@@ -83,7 +83,7 @@ struct BoringSystemTiles: View {
                 }, label: "Clipboard History", showEmojis: Defaults[.showEmojis], emoji: "✨")
                 //                SystemItemButton(icon: "keyboard", onTap: {
                 //                    vm?.close()
-                //                    vm?.toggleSneakPeak(status: true, type: .backlight, value: 1)
+                //                    vm?.togglesneakPeek(status: true, type: .backlight, value: 1)
                 //                }, label: "💡 Keyboard Backlight")
             }
             GridRow {

--- a/boringNotch/components/Notch/NotchContentView.swift
+++ b/boringNotch/components/Notch/NotchContentView.swift
@@ -129,7 +129,7 @@ struct NotchContentView: View {
         
         let dynamicWidth: CGFloat = chargingInfoWidth + musicPlayingWidth + closedWidth
             // Return the appropriate width based on the notch state
-        return vm.notchState == .open ? vm.musicPlayerSizes.player.size.opened.width! + 30 : dynamicWidth + (vm.sneakPeak.show ? -12 : 0)
+        return vm.notchState == .open ? vm.musicPlayerSizes.player.size.opened.width! + 30 : dynamicWidth + (vm.sneakPeek.show ? -12 : 0)
     }
 
 

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -216,7 +216,7 @@ class MusicManager: ObservableObject {
     
     private func updateSneakPeek() {
         if self.isPlaying && Defaults[.enableSneakPeek] && !self.detector.currentAppInFullScreen {
-            self.vm.toggleSneakPeak(status: true, type: SneakContentType.music)
+            self.vm.togglesneakPeek(status: true, type: SneakContentType.music)
         }
     }
     

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -185,6 +185,8 @@ class MusicManager: ObservableObject {
     func musicIsPaused(state: Bool, bypass: Bool = false, setIdle: Bool = false) {
         if musicToggledManually && !bypass { return }
         
+        let previousState = self.isPlaying
+        
         withAnimation(.smooth) {
             self.isPlaying = state
             self.playbackManager.isPlaying = state
@@ -194,7 +196,12 @@ class MusicManager: ObservableObject {
             }
             
             updateFullscreenMediaDetection()
-            updateSneakPeek()
+            
+            // Only update sneak peek if the state has actually changed
+            if previousState != state {
+                updateSneakPeek()
+            }
+            
             updateIdleState(setIdle: setIdle, state: state)
         }
     }

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -29,7 +29,7 @@ enum SneakContentType {
     case download
 }
 
-struct SneakPeak {
+struct sneakPeek {
     var show: Bool = false
     var type: SneakContentType = .music
     var value: CGFloat = 0
@@ -72,7 +72,7 @@ class BoringViewModel: NSObject, ObservableObject {
     @AppStorage("showWhatsNew") var showWhatsNew: Bool = true
     @Published var whatsNewOnClose: (() -> Void)?
     @Published var notchMetastability: Bool = true // True if notch not open
-    private var sneakPeakDispatch: DispatchWorkItem?
+    private var sneakPeekDispatch: DispatchWorkItem?
     private var expandingViewDispatch: DispatchWorkItem?
     @Published var showCHPanel: Bool = false
     @Published var optionKeyPressed: Bool = true
@@ -103,18 +103,18 @@ class BoringViewModel: NSObject, ObservableObject {
         }
     }
     
-    @Published var sneakPeak: SneakPeak = .init() {
+    @Published var sneakPeek: sneakPeek = .init() {
         didSet {
-            if sneakPeak.show {
-                sneakPeakDispatch?.cancel()
+            if sneakPeek.show {
+                sneakPeekDispatch?.cancel()
 
-                sneakPeakDispatch = DispatchWorkItem { [weak self] in
+                sneakPeekDispatch = DispatchWorkItem { [weak self] in
                     guard let self = self else { return }
                     withAnimation {
-                        self.toggleSneakPeak(status: false, type: SneakContentType.music)
+                        self.togglesneakPeek(status: false, type: SneakContentType.music)
                     }
                 }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: sneakPeakDispatch!)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: sneakPeekDispatch!)
             }
         }
     }
@@ -181,7 +181,7 @@ class BoringViewModel: NSObject, ObservableObject {
     }
 
     func setupWorkersNotificationObservers() {
-        notifier.setupObserver(notification: notifier.sneakPeakNotification, handler: sneakPeakEvent)
+        notifier.setupObserver(notification: notifier.sneakPeekNotification, handler: sneakPeekEvent)
 
         notifier.setupObserver(notification: notifier.micStatusNotification, handler: initialMicStatus)
     }
@@ -190,7 +190,7 @@ class BoringViewModel: NSObject, ObservableObject {
         currentMicStatus = notification.userInfo?.first?.value as! Bool
     }
 
-    @objc func sneakPeakEvent(_ notification: Notification) {
+    @objc func sneakPeekEvent(_ notification: Notification) {
         let decoder = JSONDecoder()
         if let decodedData = try? decoder.decode(SharedSneakPeek.self, from: notification.userInfo?.first?.value as! Data) {
             let contentType = decodedData.type == "brightness" ? SneakContentType.brightness : decodedData.type == "volume" ? SneakContentType.volume : decodedData.type == "backlight" ? SneakContentType.backlight : decodedData.type == "mic" ? SneakContentType.mic : SneakContentType.brightness
@@ -200,7 +200,7 @@ class BoringViewModel: NSObject, ObservableObject {
             
             print(decodedData)
             
-            toggleSneakPeak(status: decodedData.show, type: contentType, value: value, icon: icon)
+            togglesneakPeek(status: decodedData.show, type: contentType, value: value, icon: icon)
             
         } else {
             print("Failed to decode JSON data")
@@ -219,7 +219,7 @@ class BoringViewModel: NSObject, ObservableObject {
         notifier.postNotification(name: notifier.toggleMicNotification.name, userInfo: nil)
     }
     
-    func toggleSneakPeak(status: Bool, type: SneakContentType, value: CGFloat = 0, icon: String = "") {
+    func togglesneakPeek(status: Bool, type: SneakContentType, value: CGFloat = 0, icon: String = "") {
         if type != .music {
             close()
             if !hudReplacement {
@@ -228,10 +228,10 @@ class BoringViewModel: NSObject, ObservableObject {
         }
         DispatchQueue.main.async {
             withAnimation(.smooth) {
-                self.sneakPeak.show = status
-                self.sneakPeak.type = type
-                self.sneakPeak.value = value
-                self.sneakPeak.icon = icon
+                self.sneakPeek.show = status
+                self.sneakPeek.type = type
+                self.sneakPeek.value = value
+                self.sneakPeek.icon = icon
             }
         }
 


### PR DESCRIPTION
Due to the new fullscreen detection code, sneak peek will trigger every time the active app changes even if playback status doesn't change. I also added in some spelling fixes.