### PR TITLE
Fix calendar event fetching

### DIFF
--- a/boringNotch/managers/CalendarManager.swift
+++ b/boringNotch/managers/CalendarManager.swift
@@ -87,7 +87,7 @@ class CalendarManager: ObservableObject {
     }
     
     func updateCurrentDate(_ date: Date) {
-        currentWeekStartDate = date
+        currentWeekStartDate = Calendar.current.startOfDay(for: date)
         fetchEvents()
     }
 }


### PR DESCRIPTION
This change fixes #139 by ensuring that the `currentWeekStartDate` is set to the start of the day for the given date.