### PR TITLE
fix(calendar): enhance WheelPicker scrolling performance

### DIFF
--- a/boringNotch/components/Calender/BoringCalendar.swift
+++ b/boringNotch/components/Calender/BoringCalendar.swift
@@ -32,7 +32,7 @@ struct WheelPicker: View {
             HStack(spacing: config.spacing) {
                 let totalSteps = config.steps * (config.past + config.future)
                 let spacerNum = config.offset
-                ForEach(0..<totalSteps + 2 * spacerNum, id: \.self) { index in
+                ForEach(0..<totalSteps + 2 * spacerNum + 1, id: \.self) { index in
                     if(index < spacerNum || index > totalSteps + spacerNum - 1){
                         Spacer().frame(width: 24, height: 24).id(index)
                     } else {


### PR DESCRIPTION
While scrolling through the calendar's WheelPicker, I noticed that the selected date would jump directly to the left edge, preventing users from easily selecting dates located on the right side of the list through scrolling alone.

To address this, I made some adjustments by adding spacers to both ends of the list, allowing users to select any date through simple scroll gestures. Additionally, I optimized the dateButton selection logic: whether the user selects a date by scrolling or tapping, the selected date will now automatically center in the view (this part involves some hardcoding, and I welcome feedback for further improvement).

I also refactored the dateButton to minimize unnecessary recalculations, transforming it into a stateless component for better performance and maintainability.