### PR TITLE
added keyboard shortcut for sneak peek

### DIFF
--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -663,6 +663,9 @@
     "Shelf" : {
 
     },
+    "Shortcuts" : {
+
+    },
     "Show battery indicator" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -743,6 +746,9 @@
 
     },
     "TheBoringNotch" : {
+
+    },
+    "Toggle Sneak Peek:" : {
 
     },
     "Transform your notch truly yours" : {

--- a/boringNotch/Shortcuts/ShortcutConstants.swift
+++ b/boringNotch/Shortcuts/ShortcutConstants.swift
@@ -13,4 +13,5 @@ extension KeyboardShortcuts.Name {
     static let toggleMicrophone = Self("toggleMicrophone", default: .init(.f5, modifiers: [.function]))
     static let decreaseBacklight = Self("decreaseBacklight", default: .init(.f1, modifiers: [.command]))
     static let increaseBacklight = Self("increaseBacklight", default: .init(.f2, modifiers: [.command]))
+    static let toggleSneakPeek = Self("toggleSneakPeek", default: .init(.f6, modifiers: [.command]))
 }

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -101,7 +101,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.adjustWindowPosition()
         }
         
-        KeyboardShortcuts.onKeyUp(for: .toggleSneakPeek) { [weak self] in
+        KeyboardShortcuts.onKeyDown(for: .toggleSneakPeek) { [weak self] in
             guard let self = self else { return }
             
             self.vm.togglesneakPeek(

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -101,6 +101,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.adjustWindowPosition()
         }
         
+        KeyboardShortcuts.onKeyUp(for: .toggleSneakPeek) { [weak self] in
+            guard let self = self else { return }
+            
+            self.vm.togglesneakPeek(
+                status: !self.vm.sneakPeek.show,
+                type: .music
+            )
+        }
+        
         window = BoringNotchWindow(
             contentRect: NSRect(x: 0, y: 0, width: sizing.size.opened.width! + 20, height: sizing.size.opened.height! + 30),
             styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -54,6 +54,9 @@ struct SettingsView: View {
                 NavigationLink(destination: Shelf()) {
                     Label("Shelf", systemImage: "books.vertical")
                 }
+                NavigationLink(destination: Shortcuts()) {
+                    Label("Shortcuts", systemImage: "keyboard")
+                }
                 NavigationLink(destination: Extensions()) {
                     Label("Extensions", systemImage: "puzzlepiece.extension")
                 }
@@ -737,6 +740,16 @@ struct Appearance: View {
         }
         .tint(Defaults[.accentColor])
         .navigationTitle("Appearance")
+    }
+}
+
+struct Shortcuts: View {
+    var body: some View {
+        Form {
+            KeyboardShortcuts.Recorder("Toggle Sneak Peek:", name: .toggleSneakPeek)
+        }
+        .tint(Defaults[.accentColor])
+        .navigationTitle("Shelf")
     }
 }
 


### PR DESCRIPTION
This pr does the following:
1. Creates a new tab in settings called "Shortcuts"
2. Adds a shortcut for users to toggle the sneak peak (for music).

It addresses #163.