### PR TITLE
Better webcam management

### DIFF
--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -120,12 +120,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             )
         }
         
-        if let cam = AVCaptureDevice.default(for: .video) {
-            //
-        } else {
-            Defaults[.showMirror] = false
-        }
-        
         window = BoringNotchWindow(
             contentRect: NSRect(x: 0, y: 0, width: sizing.size.opened.width! + 20, height: sizing.size.opened.height! + 30),
             styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -133,14 +133,14 @@ struct NotchHomeView: View {
                         }
                 }
                 
-                if Defaults[.showMirror] {
-                    CircularPreviewView(webcamManager: webcamManager)
+                if Defaults[.showMirror] && webcamManager.cameraAvailable && webcamManager.authorizationStatus != .denied {
+                    CameraPreviewView(webcamManager: webcamManager)
                         .scaledToFit()
                         .opacity(vm.notchState == .closed ? 0 : 1)
                         .blur(radius: vm.notchState == .closed ? 20 : 0)
                 }
                 
-                if !Defaults[.showMirror] && !Defaults[.showCalendar] {
+                if (!Defaults[.showMirror] || !webcamManager.cameraAvailable || webcamManager.authorizationStatus == .denied) && !Defaults[.showCalendar] {
                     Rectangle()
                         .fill(Defaults[.coloredSpectrogram] ? Color(nsColor: musicManager.avgColor).gradient : Color.gray.gradient)
                         .mask {

--- a/boringNotch/components/Webcam/WebcamView.swift
+++ b/boringNotch/components/Webcam/WebcamView.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import SwiftUI
 import Defaults
 
-struct CircularPreviewView: View {
+struct CameraPreviewView: View {
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var webcamManager: WebcamManager
 
@@ -51,16 +51,8 @@ struct CircularPreviewView: View {
             .onDisappear {
                 webcamManager.stopSession()
             }
-            .disabled(!checkVideoInput())
         }
         .aspectRatio(1, contentMode: .fit)
-    }
-    func checkVideoInput() -> Bool {
-        if let cam = AVCaptureDevice.default(for: .video) {
-            return true
-        }
-        
-        return false
     }
 }
 
@@ -81,5 +73,5 @@ struct CameraPreviewLayerView: NSViewRepresentable {
 }
 
 #Preview {
-    CircularPreviewView(webcamManager: WebcamManager())
+    CameraPreviewView(webcamManager: WebcamManager())
 }


### PR DESCRIPTION
This pull request introduces several significant changes to improve the webcam functionality and user experience . The changes include enhancements to camera authorization handling, camera availability checks, and the overall webcam management logic.

### Webcam Functionality Enhancements:

* **Authorization and Availability Checks**:
  - Added properties `authorizationStatus` and `cameraAvailable` to `WebcamManager` to track camera authorization status and availability. (`boringNotch/managers/WebcamManager.swift`)
  - Implemented methods to check and request video authorization, and to check camera availability. (`boringNotch/managers/WebcamManager.swift`)

* **Session Management**:
  - Added observers for device connection and disconnection notifications to dynamically handle camera availability. (`boringNotch/managers/WebcamManager.swift`)
  - Refactored session setup to handle cases where the camera is not available or access is denied. (`boringNotch/managers/WebcamManager.swift`)

### Codebase Simplification:

* **Refactored Views**:
  - Replaced `CircularPreviewView` with `CameraPreviewView` to better reflect its purpose and added checks for camera availability and authorization status. (`boringNotch/components/Webcam/WebcamView.swift`) [[1]](diffhunk://#diff-f0e3fef829539834b9c781af429c02f7e29209d9b5e2edbd2aebbbc3274da542L12-R12) [[2]](diffhunk://#diff-f0e3fef829539834b9c781af429c02f7e29209d9b5e2edbd2aebbbc3274da542L54-L64) [[3]](diffhunk://#diff-f0e3fef829539834b9c781af429c02f7e29209d9b5e2edbd2aebbbc3274da542L84-R76)
  - Updated `NotchHomeView` to conditionally show the camera preview based on the new properties in `WebcamManager`. (`boringNotch/components/Notch/NotchHomeView.swift`)

* **Removed Redundant Code**:
  - Removed the `checkVideoInput` method and redundant code related to camera input checks. (`boringNotchApp.swift`, `boringNotch/components/Webcam/WebcamView.swift`) [[1]](diffhunk://#diff-a518eededa367d0584feb08ea05f72cd7f9ae9a3c11d83866adcb76e4367d3d0L123-L128) [[2]](diffhunk://#diff-f0e3fef829539834b9c781af429c02f7e29209d9b5e2edbd2aebbbc3274da542L54-L64)