### PR TITLE
Easier default shortcut for sneak peek

### DIFF
--- a/boringNotch/Shortcuts/ShortcutConstants.swift
+++ b/boringNotch/Shortcuts/ShortcutConstants.swift
@@ -13,5 +13,5 @@ extension KeyboardShortcuts.Name {
     static let toggleMicrophone = Self("toggleMicrophone", default: .init(.f5, modifiers: [.function]))
     static let decreaseBacklight = Self("decreaseBacklight", default: .init(.f1, modifiers: [.command]))
     static let increaseBacklight = Self("increaseBacklight", default: .init(.f2, modifiers: [.command]))
-    static let toggleSneakPeek = Self("toggleSneakPeek", default: .init(.f6, modifiers: [.command]))
+    static let toggleSneakPeek = Self("toggleSneakPeek", default: .init(.h, modifiers: [.command, .shift]))
 }


### PR DESCRIPTION
The current default keyboard shortcut for the sneak peek is `⌘ + F6`. For most people on a MacBook, their function keys are set to use the special features instead of standard functions, meaning they would need to press `⌘ + fn + F6`. This isn't very intuitive or clear. Technically it works (I tested it), but some users might not understand that. This was part of the issue with #176 and perhaps some others who want to use the shortcut. I'm suggesting that the default be `⌘ + Shift + H` which this simple PR would do.