### PR TITLE
Support for low power mode battery visual

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -206,7 +206,8 @@ struct ContentView: View {
                             HStack {
                                 BoringBatteryView(
                                     batteryPercentage: batteryModel.batteryPercentage, isPluggedIn: batteryModel.isPluggedIn,
-                                    batteryWidth: 30
+                                    batteryWidth: 30,
+                                    isInLowPowerMode: batteryModel.isInLowPowerMode
                                 )
                             }
                             .frame(width: 76, alignment: .trailing)

--- a/boringNotch/components/Live activities/BoringBattery.swift
+++ b/boringNotch/components/Live activities/BoringBattery.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct BatteryView: View {
     @State var percentage: Float
     @State var isCharging: Bool
+    @State var isInLowPowerMode: Bool
     var batteryWidth: CGFloat = 26
     var animationStyle: BoringAnimations = BoringAnimations()
     
@@ -11,7 +12,9 @@ struct BatteryView: View {
     }
     
     var batteryColor: Color {
-        if percentage.isLessThanOrEqualTo(20) {
+        if isInLowPowerMode {
+            return .yellow
+        } else if percentage.isLessThanOrEqualTo(20) {
             return .red
         } else if isCharging {
             return .green
@@ -52,13 +55,14 @@ struct BoringBatteryView: View {
     @State var batteryPercentage: Float = 0
     @State var isPluggedIn:Bool = false
     @State var batteryWidth: CGFloat = 26
+    @State var isInLowPowerMode: Bool
     
     var body: some View {
         HStack {
             Text("\(Int32(batteryPercentage))%")
                 .font(.callout)
                 .foregroundStyle(.white)
-            BatteryView(percentage: batteryPercentage, isCharging: isPluggedIn, batteryWidth: batteryWidth)
+            BatteryView(percentage: batteryPercentage, isCharging: isPluggedIn, isInLowPowerMode: isInLowPowerMode, batteryWidth: batteryWidth)
         }
         
     }
@@ -68,6 +72,7 @@ struct BoringBatteryView: View {
     BoringBatteryView(
         batteryPercentage: 40,
         isPluggedIn: true,
-        batteryWidth: 30
+        batteryWidth: 30,
+        isInLowPowerMode: false
     ).frame(width: 200, height: 200)
 }

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -56,7 +56,9 @@ struct BoringHeader: View {
                     if Defaults[.showBattery] {
                         BoringBatteryView(
                             batteryPercentage: batteryModel.batteryPercentage,
-                            isPluggedIn: batteryModel.isPluggedIn, batteryWidth: 30)
+                            isPluggedIn: batteryModel.isPluggedIn, batteryWidth: 30,
+                            isInLowPowerMode: batteryModel.isInLowPowerMode
+                        )
                     }
                 }
             }

--- a/boringNotch/components/Notch/NotchContentView.swift
+++ b/boringNotch/components/Notch/NotchContentView.swift
@@ -100,7 +100,7 @@ struct NotchContentView: View {
                         
                         if vm.notchState == .closed && vm.expandingView.show  {
                             if vm.expandingView.type == .battery {
-                                BoringBatteryView(batteryPercentage: batteryModel.batteryPercentage, isPluggedIn: batteryModel.isPluggedIn, batteryWidth: 30)
+                                BoringBatteryView(batteryPercentage: batteryModel.batteryPercentage, isPluggedIn: batteryModel.isPluggedIn, batteryWidth: 30, isInLowPowerMode: batteryModel.isInLowPowerMode)
                             } else {
                                 ProgressIndicator(type: .text, progress: 0.01, color: Defaults[.accentColor]).padding(.trailing, 4)
                             }

--- a/boringNotch/models/BatteryStatusViewModel.swift
+++ b/boringNotch/models/BatteryStatusViewModel.swift
@@ -26,16 +26,12 @@ class BatteryStatusViewModel: ObservableObject {
         self.vm = vm
         updateBatteryStatus()
         startMonitoring()
+        // get the system power mode and setup an observer
+        self.isInLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
         NotificationCenter.default.addObserver(self, selector: #selector(powerStateChanged), name: Notification.Name.NSProcessInfoPowerStateDidChange, object: nil)
     }
 
     private func updateBatteryStatus() {
-        if ProcessInfo.processInfo.isLowPowerModeEnabled == true {
-            self.isInLowPowerMode = true
-        } else {
-            self.isInLowPowerMode = false
-        }
-        
         if let snapshot = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
            let sources = IOPSCopyPowerSourcesList(snapshot)?.takeRetainedValue() as? [CFTypeRef] {
             for source in sources {
@@ -84,6 +80,7 @@ class BatteryStatusViewModel: ObservableObject {
         }
     }
     
+    // function to update battery model if system low power mode changes
     @objc func powerStateChanged(_ notification: Notification) {
         DispatchQueue.main.async {
             self.isInLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled

--- a/boringNotch/models/BatteryStatusViewModel.swift
+++ b/boringNotch/models/BatteryStatusViewModel.swift
@@ -16,18 +16,26 @@ class BatteryStatusViewModel: ObservableObject {
     @Published var batteryPercentage: Float = 0.0
     @Published var isPluggedIn: Bool = false
     @Published var showChargingInfo: Bool = false
-    
+    @Published var isInLowPowerMode: Bool = false
+
     private var powerSourceChangedCallback: IOPowerSourceCallbackType?
     private var runLoopSource: Unmanaged<CFRunLoopSource>?
     var animations: BoringAnimations = BoringAnimations()
-    
+
     init(vm: BoringViewModel) {
         self.vm = vm
         updateBatteryStatus()
         startMonitoring()
+        NotificationCenter.default.addObserver(self, selector: #selector(powerStateChanged), name: Notification.Name.NSProcessInfoPowerStateDidChange, object: nil)
     }
-    
+
     private func updateBatteryStatus() {
+        if ProcessInfo.processInfo.isLowPowerModeEnabled == true {
+            self.isInLowPowerMode = true
+        } else {
+            self.isInLowPowerMode = false
+        }
+        
         if let snapshot = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
            let sources = IOPSCopyPowerSourcesList(snapshot)?.takeRetainedValue() as? [CFTypeRef] {
             for source in sources {
@@ -35,36 +43,32 @@ class BatteryStatusViewModel: ObservableObject {
                    let currentCapacity = info[kIOPSCurrentCapacityKey] as? Int,
                    let maxCapacity = info[kIOPSMaxCapacityKey] as? Int,
                    let isCharging = info["Is Charging"] as? Bool {
-                    
-                    
                     if(Defaults[.chargingInfoAllowed]) {
-                        
+
                         withAnimation {
                             self.batteryPercentage = Float((currentCapacity * 100) / maxCapacity)
                         }
-                        
+
                         if (isCharging && !self.isPluggedIn) {
                             DispatchQueue.main.asyncAfter(deadline: .now() + (vm.firstLaunch ? 6 : 0)) {
                                 self.vm.toggleExpandingView(status: true, type: .battery)
                                 self.showChargingInfo = true
                                 self.isPluggedIn = true
                             }
-                            
+
                         }
                         withAnimation {
                             self.isPluggedIn = isCharging
                         }
-                        
                     }
-                    
                 }
             }
         }
     }
-    
+
     private func startMonitoring() {
         let context = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
-        
+
         powerSourceChangedCallback = { context in
             if let context = context {
                 let mySelf = Unmanaged<BatteryStatusViewModel>.fromOpaque(context).takeUnretainedValue()
@@ -73,13 +77,19 @@ class BatteryStatusViewModel: ObservableObject {
                 }
             }
         }
-        
+
         if let runLoopSource = IOPSNotificationCreateRunLoopSource(powerSourceChangedCallback!, context)?.takeRetainedValue() {
             self.runLoopSource = Unmanaged<CFRunLoopSource>.passRetained(runLoopSource)
             CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .defaultMode)
         }
     }
     
+    @objc func powerStateChanged(_ notification: Notification) {
+        DispatchQueue.main.async {
+            self.isInLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
+        }
+    }
+
     deinit {
         if let runLoopSource = runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetCurrent(), runLoopSource.takeUnretainedValue(), .defaultMode)


### PR DESCRIPTION
Currently the battery in the notch header does not properly indicate when your Mac is in low power mode (#173). I added support for this by accessing `ProcessInfo.processInfo.isLowPowerModeEnabled` and setting up an Notification observer to update the `BatteryStatusViewModel` when this changes. If the battery is in low power mode, it will show yellow, *regardless of the percentage and charge mode*. I believe this is consistent with how Apple does it.