### PR TITLE
Open Entire Notch with Shortcut

### DIFF
--- a/boringNotch/Shortcuts/ShortcutConstants.swift
+++ b/boringNotch/Shortcuts/ShortcutConstants.swift
@@ -14,4 +14,5 @@ extension KeyboardShortcuts.Name {
     static let decreaseBacklight = Self("decreaseBacklight", default: .init(.f1, modifiers: [.command]))
     static let increaseBacklight = Self("increaseBacklight", default: .init(.f2, modifiers: [.command]))
     static let toggleSneakPeek = Self("toggleSneakPeek", default: .init(.h, modifiers: [.command, .shift]))
+    static let toggleNotchOpen = Self("toggleNotchOpen", default: .init(.i, modifiers: [.command, .shift]))
 }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -957,6 +957,9 @@ struct Shortcuts: View {
                     .foregroundStyle(.secondary)
                     .font(.caption)
             }
+            Section {
+                KeyboardShortcuts.Recorder("Toggle Notch Open:", name: .toggleNotchOpen)
+            }
         }
         .tint(Defaults[.accentColor])
         .navigationTitle("Shortcuts")


### PR DESCRIPTION
## What it does
Record or use the standard shortcut of `Command + Shift + I` to open the entire notch. The notch will remain open for 3 seconds and then close. The notch will close if you press the shortcut again.

## Why?
Someone requested this feature in #135. I think it is a good idea. Honestly, I'll probably use it a lot more than the sneak peek shortcut because I like to see the album art bigger if I'm trying to figure out what song is playing. 

## Changes
1. I added a new shortcut variable to the `KeyboardShortcuts`
2. Registered this with the `onKeyDown` function in the `AppDelegate`. Inside the `AppeDelegate` I added the logic for dispatching a work item because this will allow me to cancel the notch close dispatch if the user closes the notch before the timeout.
3. A setting in the keyboard shortcuts to change the default shortcut.

I chose to name it "Toggle Notch Open" because it also closes the notch.