### PR TITLE
Preserve a file's name when dragging it from drop zone

### DIFF
--- a/boringNotch/components/Shelf/DropItemView.swift
+++ b/boringNotch/components/Shelf/DropItemView.swift
@@ -37,7 +37,9 @@ struct DropItemView: View {
                     .allowsTightening(true)
             }
             .contentShape(Rectangle())
-            .onDrag { NSItemProvider(contentsOf: item.storageURL) ?? .init() }
+            .onDrag {
+                handleOnDrag(for: item)
+            }
             .frame(width: 64, height: 64)
             
             if hover {
@@ -62,5 +64,16 @@ struct DropItemView: View {
                 }
             }
         }
+    }
+
+    private func handleOnDrag(for item: TrayDrop.DropItem) -> NSItemProvider {
+        guard let itemProvider = NSItemProvider(contentsOf: item.storageURL) else {
+            return NSItemProvider()
+        }
+        
+        let nameWithoutExtension = (item.fileName as NSString).deletingPathExtension
+        itemProvider.suggestedName = nameWithoutExtension
+        
+        return itemProvider
     }
 }


### PR DESCRIPTION
## Description
Fixes a bug mentioned in #264 where file names are reset when being dragged out of the drop zone.

## Changes
- Set `.suggestedName` in `NSItemProvider` to the file's name
- Don't include the file name extension as this is added automatically