### PR TITLE
fix: improve notch closing animation

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -35,6 +35,18 @@ struct ContentView: View {
     @Default(.useMusicVisualizer) var useMusicVisualizer
 
     @Default(.showNotHumanFace) var showNotHumanFace
+    @Default(.useModernCloseAnimation) var useModernCloseAnimation
+
+    var notchTransition: AnyTransition {
+        if useModernCloseAnimation {
+            return .move(edge: .top).combined(with: .opacity)
+        } else {
+            return .asymmetric(
+                insertion: .opacity,
+                removal: .opacity
+            )
+        }
+    }
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -48,9 +60,9 @@ struct ContentView: View {
                 }
                 .padding(.bottom, vm.notchState == .open ? 30 : 0) // Safe area to ensure the notch does not close if the cursor is within 30px of the notch from the bottom.
                 .animation(.bouncy.speed(1.2), value: hoverAnimation)
-                .animation(.easeInOut(duration: 0.3), value: vm.notchState)
+                .animation(useModernCloseAnimation ? .easeInOut(duration: 0.3) : .bouncy.speed(1.2), value: vm.notchState)
                 .animation(.smooth, value: gestureProgress)
-                .transition(.move(edge: .top).combined(with: .opacity))
+                .transition(notchTransition)
                 .allowsHitTesting(true)
                 .conditionalModifier(Defaults[.openNotchOnHover]) { view in
                     view.onHover { hovering in

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -48,9 +48,9 @@ struct ContentView: View {
                 }
                 .padding(.bottom, vm.notchState == .open ? 30 : 0) // Safe area to ensure the notch does not close if the cursor is within 30px of the notch from the bottom.
                 .animation(.bouncy.speed(1.2), value: hoverAnimation)
-                .animation(.bouncy.speed(1.2), value: vm.notchState)
+                .animation(.easeInOut(duration: 0.3), value: vm.notchState)
                 .animation(.smooth, value: gestureProgress)
-                .transition(.blurReplace.animation(.interactiveSpring(dampingFraction: 1)))
+                .transition(.move(edge: .top).combined(with: .opacity))
                 .allowsHitTesting(true)
                 .conditionalModifier(Defaults[.openNotchOnHover]) { view in
                     view.onHover { hovering in

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -768,6 +768,7 @@ struct Appearance: View {
                 Defaults.Toggle("Settings icon in notch", key: .settingsIconInNotch)
                 Defaults.Toggle("Enable window shadow", key: .enableShadow)
                 Defaults.Toggle("Corner radius scaling", key: .cornerRadiusScaling)
+                Defaults.Toggle("Use simpler close animation", key: .useModernCloseAnimation)
             } header: {
                 Text("General")
             }

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -68,6 +68,7 @@ extension Defaults.Keys {
     static let accentColor = Key<Color>("accentColor", default: Color.blue)
     static let enableShadow = Key<Bool>("enableShadow", default: true)
     static let cornerRadiusScaling = Key<Bool>("cornerRadiusScaling", default: true)
+    static let useModernCloseAnimation = Key<Bool>("useModernCloseAnimation", default: true)
     static let showNotHumanFace = Key<Bool>("showNotHumanFace", default: true)
     static let tileShowLabels = Key<Bool>("tileShowLabels", default: false)
     static let showCalendar = Key<Bool>("showCalendar", default: true)


### PR DESCRIPTION
Replace sliding circle animation with a clean vertical transition. The notch now moves straight up when closing, maintaining better visual coverage of the hardware notch throughout the animation.