### PR TITLE
feat: improve power status notifications and icons

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -224,7 +224,7 @@ struct ContentView: View {
                     if vm.expandingView.type == .battery && vm.expandingView.show && vm.notchState == .closed {
                         HStack(spacing: 0) {
                             HStack {
-                                Text("Charging")
+                                Text(batteryModel.isInitialPlugIn ? "Plugged In" : "Charging")
                                     .font(.subheadline)
                             }
 
@@ -234,9 +234,11 @@ struct ContentView: View {
 
                             HStack {
                                 BoringBatteryView(
-                                    batteryPercentage: batteryModel.batteryPercentage, isPluggedIn: batteryModel.isPluggedIn,
+                                    batteryPercentage: batteryModel.batteryPercentage, 
+                                    isPluggedIn: batteryModel.isPluggedIn,
                                     batteryWidth: 30,
-                                    isInLowPowerMode: batteryModel.isInLowPowerMode
+                                    isInLowPowerMode: batteryModel.isInLowPowerMode,
+                                    isInitialPlugIn: batteryModel.isInitialPlugIn
                                 )
                             }
                             .frame(width: 76, alignment: .trailing)

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -610,6 +610,9 @@
         }
       }
     },
+    "Plugged In" : {
+
+    },
     "Progress bar" : {
       "localizations" : {
         "en" : {

--- a/boringNotch/components/Live activities/BoringBattery.swift
+++ b/boringNotch/components/Live activities/BoringBattery.swift
@@ -4,6 +4,7 @@ struct BatteryView: View {
     @State var percentage: Float
     @State var isCharging: Bool
     @State var isInLowPowerMode: Bool
+    @State var isInitialPlugIn: Bool
     var batteryWidth: CGFloat = 26
     var animationStyle: BoringAnimations = BoringAnimations()
     
@@ -38,33 +39,42 @@ struct BatteryView: View {
                 .fill(batteryColor)
                 .frame(width: CGFloat(((CGFloat(CFloat(percentage)) / 100) * (batteryWidth - 6))), height: (batteryWidth - 2.75) - 18).padding(.leading, 2)
             if isCharging {
-                Image(.bolt)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .foregroundColor(.yellow)
-                    .frame(width: 16, height: 16)
-                    .padding(.leading, 7)
-                    .offset(y: -1)
+                if isInitialPlugIn {
+                    Image(systemName: "powerplug.fill")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .foregroundColor(.white)
+                        .frame(width: 16, height: 16)
+                        .padding(.leading, 7)
+                        .offset(y: -1)
+                } else {
+                    Image(systemName: "bolt.fill")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .foregroundColor(.white)
+                        .frame(width: 16, height: 16)
+                        .padding(.leading, 7)
+                        .offset(y: -1)
+                }
             }
-            
         }
     }
 }
 
 struct BoringBatteryView: View {
     @State var batteryPercentage: Float = 0
-    @State var isPluggedIn:Bool = false
+    @State var isPluggedIn: Bool = false
     @State var batteryWidth: CGFloat = 26
     @State var isInLowPowerMode: Bool
+    @State var isInitialPlugIn: Bool
     
     var body: some View {
         HStack {
             Text("\(Int32(batteryPercentage))%")
                 .font(.callout)
                 .foregroundStyle(.white)
-            BatteryView(percentage: batteryPercentage, isCharging: isPluggedIn, isInLowPowerMode: isInLowPowerMode, batteryWidth: batteryWidth)
+            BatteryView(percentage: batteryPercentage, isCharging: isPluggedIn, isInLowPowerMode: isInLowPowerMode, isInitialPlugIn: isInitialPlugIn, batteryWidth: batteryWidth)
         }
-        
     }
 }
 
@@ -73,6 +83,7 @@ struct BoringBatteryView: View {
         batteryPercentage: 40,
         isPluggedIn: true,
         batteryWidth: 30,
-        isInLowPowerMode: false
+        isInLowPowerMode: false,
+        isInitialPlugIn: true
     ).frame(width: 200, height: 200)
 }

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -57,8 +57,10 @@ struct BoringHeader: View {
                     if Defaults[.showBattery] {
                         BoringBatteryView(
                             batteryPercentage: batteryModel.batteryPercentage,
-                            isPluggedIn: batteryModel.isPluggedIn, batteryWidth: 30,
-                            isInLowPowerMode: batteryModel.isInLowPowerMode
+                            isPluggedIn: batteryModel.isPluggedIn, 
+                            batteryWidth: 30,
+                            isInLowPowerMode: batteryModel.isInLowPowerMode,
+                            isInitialPlugIn: batteryModel.isInitialPlugIn
                         )
                     }
                 }


### PR DESCRIPTION
- Add distinct states for "Plugged In" vs "Charging" notifications
- Show notifications based on actual power state transitions
- Replace lightning bolt with white plug icon when initially plugged in
- Use white bolt icon when actively charging
- Update battery indicators across notification popup and header view

This change better reflects macOS power states, showing "Plugged In" immediately when connected to power, followed by "Charging" when the system begins charging. Icons now match the state: plug for connected, bolt for charging.