### PR TITLE
fix bug[#372]:calender continues with haptic feedback after disabling it

### DIFF
--- a/boringNotch/components/Calender/BoringCalendar.swift
+++ b/boringNotch/components/Calender/BoringCalendar.swift
@@ -45,7 +45,9 @@ struct WheelPicker: View {
                             withAnimation{
                                 scrollPosition = indexForDate(date, offset: offset) - config.offset
                             }
-                            haptics.toggle()
+                            if (Defaults[.enableHaptics]) {
+                                haptics.toggle()
+                            }
                         }
                     }
                 }
@@ -107,7 +109,9 @@ struct WheelPicker: View {
         switch targetDateIndex{
         case todayIndex-config.past..<todayIndex+config.future:
             selectedDate = dateForIndex(targetDateIndex, offset: offset)
-            haptics.toggle()
+            if (Defaults[.enableHaptics]) {
+                haptics.toggle()
+            }
         default:
             return
         }


### PR DESCRIPTION
## fixed bug[#372] 
**Change**: check ``Defaults[.enableHaptics]`` before toggling ``haptics``