### PR TITLE
Album Art Blur for Live Activity

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -344,9 +344,22 @@ struct ContentView: View {
                 Color.clear
                     .aspectRatio(1, contentMode: .fit)
                     .background(
-                        Image(nsImage: musicManager.albumArt)
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
+                        ZStack {
+                            Image(nsImage: musicManager.albumArt)
+                                .resizable()
+                                .interpolation(.high)
+                                .aspectRatio(contentMode: .fill)
+                                .blur(radius: 1.5)
+
+                            Image(systemName: "play")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 12, height: 12)
+                                .foregroundColor(musicManager.avgColor.usingColorSpace(.sRGB)!.brightnessComponent < 0.7 ? .white.opacity(0.7) : .black.opacity(0.7)
+)
+                        }
+                        .frame(width: 48, height: 48)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
                     )
                     .clipped()
                     .clipShape(RoundedRectangle(cornerRadius: MusicPlayerImageSizes.cornerRadiusInset.closed))


### PR DESCRIPTION
I’ve modified the Album Art blurs for the Live Activity Album Art to overlay the Play icon and apply a blur effect. 

It also handles brightness of the album art for darker or brigher album arts. 

For example, 

<img width="340" alt="Screenshot 2025-04-07 at 17 20 28" src="https://github.com/user-attachments/assets/4f3c47a7-beb8-4e05-94de-8a8db0c3dcc6" />

Becomes this: 
<img width="378" alt="Screenshot 2025-04-07 at 17 16 04" src="https://github.com/user-attachments/assets/5d3aefa2-2140-4773-a6f9-3a1170c3f615" />

I can't seem to find precedent among Apple apps or OS of album art or images at such a low resolution, but at least on my  Macbook Air M2, the album arts are quite bad and pixelated, and that causes issues of aliasing (I think that's the right word, I'm not a computer graphics person). 

Maybe this could become a setting, as this is more user preference than anything. But I think it looks better. 

