### PR TITLE
Minor Haptics Tweak

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -74,6 +74,10 @@ struct ContentView: View {
                 .conditionalModifier(!Defaults[.openNotchOnHover]) { view in
                     view
                         .onHover { hovering in
+                            if (vm.notchState == .closed) && Defaults[.enableHaptics] {
+                                haptics.toggle()
+                            }
+                                
                             withAnimation(vm.animation) {
                                 isHovering = hovering
                             }
@@ -84,9 +88,6 @@ struct ContentView: View {
                             }
                         }
                         .onTapGesture {
-                            if (vm.notchState == .closed) && Defaults[.enableHaptics] {
-                                haptics.toggle()
-                            }
                             doOpen()
                         }
                         .conditionalModifier(Defaults[.enableGestures]) { view in


### PR DESCRIPTION
Just a tiny tweak of the haptics for OpenOnClick behaviour.

When 'Open on hover' is off in the settings, the haptic happens on click action, which gets lost in the actual clicking haptics. To create a more tactile feel, I moved the haptics to happen on hover instead, essentially giving the same experience as the OpenOnHover behaviour, without the notch opening up.


This is my first ever pull request, so please let me know if I did everything correctly. :) Thanks!