### PR TITLE
Add Layout Customization for Home View

### DIFF
--- a/boringNotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/boringNotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/Defaults",
       "state" : {
-        "revision" : "cc938ecf0bed848dc80a9726ac5455104e3f9dae",
-        "version" : "9.0.2"
+        "revision" : "00c82eff4550c87cf9c547d7e5493a6a97837061",
+        "version" : "9.0.3"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {

--- a/boringNotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/boringNotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,13 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/Defaults",
       "state" : {
+<<<<<<< Updated upstream
         "revision" : "00c82eff4550c87cf9c547d7e5493a6a97837061",
         "version" : "9.0.3"
+=======
+        "branch" : "main",
+        "revision" : "00c82eff4550c87cf9c547d7e5493a6a97837061"
+>>>>>>> Stashed changes
       }
     },
     {
@@ -15,8 +20,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
       "state" : {
-        "revision" : "7ecc38bb6edf7d087d30e737057b8d8a9b7f51eb",
-        "version" : "2.2.4"
+        "revision" : "045cf174010beb335fa1d2567d18c057b8787165",
+        "version" : "2.3.0"
       }
     },
     {
@@ -34,7 +39,7 @@
       "location" : "https://github.com/airbnb/lottie-spm.git",
       "state" : {
         "branch" : "main",
-        "revision" : "8c6edf4f0fa84fe9c058600a4295eb0c01661c69"
+        "revision" : "90fa25ba0feb39c22915d41b55226cc95955dfcc"
       }
     },
     {
@@ -69,8 +74,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "0ef1ee0220239b3776f433314515fd849025673f",
-        "version" : "2.6.4"
+        "revision" : "0ca3004e98712ea2b39dd881d28448630cce1c99",
+        "version" : "2.7.0"
       }
     },
     {

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -5,7 +5,6 @@
 //  Created by Harsh Vardhan Goswami  on 02/08/24
 //  Modified by Richard Kunkli on 24/08/2024.
 //
-
 import AVFoundation
 import Combine
 import Defaults
@@ -67,8 +66,57 @@ struct ContentView: View {
                         .animation(notchStateAnimation, value: vm.notchState)
                 }
                 .conditionalModifier(Defaults[.openNotchOnHover]) { view in
+<<<<<<< Updated upstream
                     view.onHover { hovering in
                         handleHover(hovering)
+=======
+                    view.onHover { systemHovering in
+                        let hovering = systemHovering || vm.isMouseHovering()
+
+                        if hovering {
+                            withAnimation(.bouncy.speed(1.2)) {
+                                hoverAnimation = true
+                                isHovering = true
+                            }
+
+                            if (vm.notchState == .closed) && Defaults[.enableHaptics] {
+                                haptics.toggle()
+                            }
+
+                            if coordinator.sneakPeek.show {
+                                return
+                            }
+
+                            hoverTask?.cancel()
+
+                            let task = DispatchWorkItem { [weak vm] in
+                                guard let vm = vm, vm.notchState == .closed else { return }
+                                DispatchQueue.main.async {
+                                    withAnimation(.bouncy.speed(1.2)) {
+                                        doOpen()
+                                    }
+                                }
+                            }
+
+                            hoverTask = task
+                            DispatchQueue.main.asyncAfter(deadline: .now() + Defaults[.minimumHoverDuration], execute: task)
+
+                        } else {
+                            hoverTask?.cancel()
+                            hoverTask = nil
+
+                            withAnimation(.bouncy.speed(1.2)) {
+                                hoverAnimation = false
+                                isHovering = false
+                            }
+
+                            if vm.notchState == .open {
+                                withAnimation(.bouncy.speed(1.2)) {
+                                    vm.close()
+                                }
+                            }
+                        }
+>>>>>>> Stashed changes
                     }
                 }
                 .conditionalModifier(!Defaults[.openNotchOnHover]) { view in
@@ -126,11 +174,13 @@ struct ContentView: View {
                     }
                 }
                 .sensoryFeedback(.alignment, trigger: haptics)
+                // --- Context Menu Modification START ---
                 .contextMenu {
                     SettingsLink(label: {
                         Text("Settings")
                     })
                     .keyboardShortcut(KeyEquivalent(","), modifiers: .command)
+<<<<<<< Updated upstream
 //                    Button("Edit") { // Doesnt work....
 //                        let dn = DynamicNotch(content: EditPanelView())
 //                        dn.toggle()
@@ -141,7 +191,10 @@ struct ContentView: View {
 //                    .disabled(true)
 //                    #endif
 //                    .keyboardShortcut("E", modifiers: .command)
+=======
+>>>>>>> Stashed changes
                 }
+                // --- Context Menu Modification END ---
         }
         .frame(maxWidth: openNotchSize.width, maxHeight: openNotchSize.height, alignment: .top)
         .shadow(color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow]) ? .black.opacity(0.6) : .clear, radius: Defaults[.cornerRadiusScaling] ? 10 : 5)
@@ -176,6 +229,11 @@ struct ContentView: View {
 
                             HStack {
                                 BoringBatteryView(
+<<<<<<< Updated upstream
+=======
+                                    batteryPercentage: batteryModel.batteryPercentage,
+                                    isPluggedIn: batteryModel.isPluggedIn,
+>>>>>>> Stashed changes
                                     batteryWidth: 30,
                                     isCharging: batteryModel.isCharging,
                                     isInLowPowerMode: batteryModel.isInLowPowerMode,

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -308,6 +308,9 @@
         }
       }
     },
+    "Drag items to reorder them in the notch. Toggle visibility (Music Player cannot be hidden)." : {
+
+    },
     "Drop files here" : {
 
     },
@@ -420,7 +423,11 @@
     "High" : {
 
     },
+<<<<<<< Updated upstream
     "https://github.com/th-ch/youtube-music" : {
+=======
+    "Home View Layout" : {
+>>>>>>> Stashed changes
 
     },
     "HUD style" : {

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -10,8 +10,8 @@ import Combine
 import Defaults
 import SwiftUI
 
-// MARK: - Music Player Components
-
+// --- MusicPlayerView, AlbumArtView, MusicControlsView ---
+// (Keep these structs exactly as they were defined before)
 struct MusicPlayerView: View {
     @EnvironmentObject var vm: BoringViewModel
     let albumArtNamespace: Namespace.ID
@@ -174,8 +174,8 @@ struct MusicControlsView: View {
         .frame(maxWidth: .infinity, alignment: .center)
     }
 }
+// --- End of MusicPlayerView components ---
 
-// MARK: - Main View
 
 struct NotchHomeView: View {
     @EnvironmentObject var vm: BoringViewModel
@@ -183,6 +183,10 @@ struct NotchHomeView: View {
     @EnvironmentObject var webcamManager: WebcamManager
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     let albumArtNamespace: Namespace.ID
+
+    // Use @Default directly again
+    @Default(.homeLayoutItems) var homeLayoutItems
+    @Default(.visibleHomeItems) var visibleHomeItems
 
     var body: some View {
         Group {
@@ -193,8 +197,10 @@ struct NotchHomeView: View {
         .transition(.opacity.combined(with: .blurReplace))
     }
 
+    // Modify mainContent to use the @Default variable and .id()
     private var mainContent: some View {
         HStack(alignment: .top, spacing: 20) {
+<<<<<<< Updated upstream
             MusicPlayerView(albumArtNamespace: albumArtNamespace)
 
             if Defaults[.showCalendar] {
@@ -210,15 +216,64 @@ struct NotchHomeView: View {
                     .scaledToFit()
                     .opacity(vm.notchState == .closed ? 0 : 1)
                     .blur(radius: vm.notchState == .closed ? 20 : 0)
+=======
+            // Iterate over the @Default variable
+            // Add .id(homeLayoutItems) to the ForEach to force redraw on change
+            ForEach(homeLayoutItems, id: \.self) { itemType in
+                // Conditionally render based on visibility
+                if visibleHomeItems.contains(itemType) {
+                    viewForItem(itemType)
+                }
+>>>>>>> Stashed changes
             }
+            .id(homeLayoutItems) // Add this ID modifier
         }
         .transition(.opacity.animation(.smooth.speed(0.9))
             .combined(with: .blurReplace.animation(.smooth.speed(0.9)))
             .combined(with: .move(edge: .top)))
         .blur(radius: vm.notchState == .closed ? 30 : 0)
     }
+
+    // Helper function - Ensure NotchItemType is now visible
+    @ViewBuilder
+    private func viewForItem(_ itemType: NotchItemType) -> some View {
+        switch itemType {
+        case .music:
+            MusicPlayerView(albumArtNamespace: albumArtNamespace)
+                .environmentObject(vm)
+                .environmentObject(musicManager)
+        case .calendar:
+             if Defaults[.showCalendar] {
+                CalendarView()
+                   .onContinuousHover { phase in
+                       if Defaults[.closeGestureEnabled] {
+                           switch phase {
+                           case .active: Defaults[.closeGestureEnabled] = false
+                           case .ended: Defaults[.closeGestureEnabled] = false
+                           }
+                       }
+                   }
+                   .environmentObject(vm)
+             } else {
+                 EmptyView()
+             }
+        case .mirror:
+            if Defaults[.showMirror] && webcamManager.cameraAvailable {
+                CameraPreviewView(webcamManager: webcamManager)
+                     .scaledToFit()
+                     .opacity(vm.notchState == .closed ? 0 : 1)
+                     .blur(radius: vm.notchState == .closed ? 20 : 0)
+                     .environmentObject(vm)
+             } else {
+                  EmptyView()
+             }
+        }
+    }
 }
 
+
+// --- MusicSliderView, CustomSlider, Preview Provider ---
+// (Keep these structs exactly as they were defined before)
 struct MusicSliderView: View {
     @Binding var sliderValue: Double
     @Binding var duration: Double
@@ -302,12 +357,10 @@ struct CustomSlider: View {
             let filledTrackWidth = min(rangeSpan == .zero ? 0 : ((value - range.lowerBound) / rangeSpan) * width, width)
 
             ZStack(alignment: .leading) {
-                // Background track
                 Rectangle()
                     .fill(.gray.opacity(0.3))
                     .frame(height: height)
 
-                // Filled track
                 Rectangle()
                     .fill(color)
                     .frame(width: filledTrackWidth, height: height)

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -36,6 +36,7 @@ enum HideNotchOption: String, Defaults.Serializable {
     case never
 }
 
+<<<<<<< Updated upstream
 // Define notification names at file scope
 extension Notification.Name {
     static let mediaControllerChanged = Notification.Name("mediaControllerChanged")
@@ -50,6 +51,26 @@ enum MediaControllerType: String, CaseIterable, Identifiable, Defaults.Serializa
     
     var id: String { self.rawValue }
 }
+=======
+// --- Ensure this is public and at the top level ---
+public enum NotchItemType: String, Codable, Hashable, Defaults.Serializable, CaseIterable, Identifiable {
+    case music = "Music Player"
+    case calendar = "Calendar"
+    case mirror = "Webcam Mirror"
+
+    public var id: String { self.rawValue }
+
+    public var systemImage: String {
+        switch self {
+        case .music: "music.note"
+        case .calendar: "calendar"
+        case .mirror: "web.camera"
+        }
+    }
+}
+// --- End NotchItemType Definition ---
+
+>>>>>>> Stashed changes
 
 extension Defaults.Keys {
         // MARK: General
@@ -57,7 +78,7 @@ extension Defaults.Keys {
     static let showOnAllDisplays = Key<Bool>("showOnAllDisplays", default: false)
     static let automaticallySwitchDisplay = Key<Bool>("automaticallySwitchDisplay", default: true)
     static let releaseName = Key<String>("releaseName", default: "Wolf Painting 🐺🎨")
-    
+
         // MARK: Behavior
     static let minimumHoverDuration = Key<TimeInterval>("minimumHoverDuration", default: 0.3)
     static let enableHaptics = Key<Bool>("enableHaptics", default: true)
@@ -74,7 +95,7 @@ extension Defaults.Keys {
     static let nonNotchHeight = Key<CGFloat>("nonNotchHeight", default: 32)
     static let notchHeight = Key<CGFloat>("notchHeight", default: 32)
         //static let openLastTabByDefault = Key<Bool>("openLastTabByDefault", default: false)
-    
+
         // MARK: Appearance
     static let showEmojis = Key<Bool>("showEmojis", default: false)
         //static let alwaysShowTabs = Key<Bool>("alwaysShowTabs", default: true)
@@ -97,50 +118,57 @@ extension Defaults.Keys {
     static let useMusicVisualizer = Key<Bool>("useMusicVisualizer", default: true)
     static let customVisualizers = Key<[CustomVisualizer]>("customVisualizers", default: [])
     static let selectedVisualizer = Key<CustomVisualizer?>("selectedVisualizer", default: nil)
-    
+
         // MARK: Gestures
     static let enableGestures = Key<Bool>("enableGestures", default: true)
     static let closeGestureEnabled = Key<Bool>("closeGestureEnabled", default: true)
     static let gestureSensitivity = Key<CGFloat>("gestureSensitivity", default: 200.0)
-    
+
         // MARK: Media playback
     static let coloredSpectrogram = Key<Bool>("coloredSpectrogram", default: true)
     static let enableSneakPeek = Key<Bool>("enableSneakPeek", default: false)
     static let enableFullscreenMediaDetection = Key<Bool>("enableFullscreenMediaDetection", default: true)
     static let waitInterval = Key<Double>("waitInterval", default: 3)
-    
+
         // MARK: Battery
+<<<<<<< Updated upstream
     static let showPowerStatusNotifications = Key<Bool>("showPowerStatusNotifications", default: true)
     static let showBatteryIndicator = Key<Bool>("showBatteryIndicator", default: true)
     static let showBatteryPercentage = Key<Bool>("showBatteryPercentage", default: true)
     static let showPowerStatusIcons = Key<Bool>("showPowerStatusIcons", default: true)
     
+=======
+    static let chargingInfoAllowed = Key<Bool>("chargingInfoAllowed", default: true)
+    static let showBattery = Key<Bool>("showBattery", default: true)
+
+>>>>>>> Stashed changes
         // MARK: Downloads
     static let enableDownloadListener = Key<Bool>("enableDownloadListener", default: true)
     static let enableSafariDownloads = Key<Bool>("enableSafariDownloads", default: true)
     static let selectedDownloadIndicatorStyle = Key<DownloadIndicatorStyle>("selectedDownloadIndicatorStyle", default: DownloadIndicatorStyle.progress)
     static let selectedDownloadIconStyle = Key<DownloadIconStyle>("selectedDownloadIconStyle", default: DownloadIconStyle.onlyAppIcon)
-    
+
         // MARK: HUD
     static let inlineHUD = Key<Bool>("inlineHUD", default: false)
     static let enableGradient = Key<Bool>("enableGradient", default: false)
     static let systemEventIndicatorShadow = Key<Bool>("systemEventIndicatorShadow", default: false)
     static let systemEventIndicatorUseAccent = Key<Bool>("systemEventIndicatorUseAccent", default: false)
-    
+
         // MARK: Shelf
     static let boringShelf = Key<Bool>("boringShelf", default: true)
     static let openShelfByDefault = Key<Bool>("openShelfByDefault", default: true)
-    
+
         // MARK: Calendar
     static let calendarSelectionState = Key<CalendarSelectionState>("calendarSelectionState", default: .all)
-    
+
         // MARK: Fullscreen Media Detection
     static let alwaysHideInFullscreen = Key<Bool>("alwaysHideInFullscreen", default: false)
-    
+
     static let hideNotchOption = Key<HideNotchOption>("hideNotchOption", default: .nowPlayingOnly)
-    
+
     // MARK: Wobble Animation
     static let enableWobbleAnimation = Key<Bool>("enableWobbleAnimation", default: false)
+<<<<<<< Updated upstream
     
     // MARK: Media Controller
     static let mediaController = Key<MediaControllerType>("mediaController", default: defaultMediaController)
@@ -153,4 +181,10 @@ extension Defaults.Keys {
             return .nowPlaying
         }
     }
+=======
+
+    // MARK: Layout Customization
+    static let homeLayoutItems = Key<[NotchItemType]>("homeLayoutItems", default: [.music, .calendar, .mirror])
+    static let visibleHomeItems = Key<Set<NotchItemType>>("visibleHomeItems", default: [.music, .calendar, .mirror])
+>>>>>>> Stashed changes
 }


### PR DESCRIPTION
Created an option in the settings menu to reorder the elements in the notch container as desired. The feature allows you to click the icon, drag and drop to change the order, and disable the UI element.