### PR TITLE
Music Gestures

### DIFF
--- a/boringNotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/boringNotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/sindresorhus/Defaults",
       "state" : {
         "branch" : "main",
-        "revision" : "3d98a76aab39eedf957274e98e15ebe6bb390b87"
+        "revision" : "d88a5c8cdb498e7536ef5ff88e7120e9b5874806"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
       "state" : {
-        "revision" : "7ecc38bb6edf7d087d30e737057b8d8a9b7f51eb",
-        "version" : "2.2.4"
+        "revision" : "045cf174010beb335fa1d2567d18c057b8787165",
+        "version" : "2.3.0"
       }
     },
     {
@@ -34,7 +34,7 @@
       "location" : "https://github.com/airbnb/lottie-spm.git",
       "state" : {
         "branch" : "main",
-        "revision" : "8c6edf4f0fa84fe9c058600a4295eb0c01661c69"
+        "revision" : "04f2fd18cc9404a0a0917265a449002674f24ec9"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TheBoredTeam/MacroVisionKit",
       "state" : {
-        "revision" : "b1b036d1b71438c2cf9dd5a32831d49b65a75202",
-        "version" : "0.0.0"
+        "revision" : "5e8b06c448298de182638bb28ca064eaf6b1fe99",
+        "version" : "0.1.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "0ef1ee0220239b3776f433314515fd849025673f",
-        "version" : "2.6.4"
+        "revision" : "0ca3004e98712ea2b39dd881d28448630cce1c99",
+        "version" : "2.7.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
-        "version" : "1.1.4"
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -66,6 +66,7 @@ struct ContentView: View {
                 .allowsHitTesting(true)
                 .animation(.smooth, value: gestureProgress)
                 .transition(.blurReplace.animation(.interactiveSpring(dampingFraction: 1.2)))
+                .animation(.smooth, value: musicGestureProgress)
                 .conditionalModifier(Defaults[.openNotchOnHover]) { view in
                     view.onHover { systemHovering in
                         let hovering = systemHovering || vm.isMouseHovering()
@@ -167,12 +168,12 @@ struct ContentView: View {
                                 .panGesture(direction: .right) { translation, phase in
                                     guard vm.notchState == .closed else { return nil }
                                     withAnimation(.smooth) {
-                                        gestureProgress = (translation / Defaults[.gestureSensitivity]) * 20
+                                        musicGestureProgress = (translation / Defaults[.gestureSensitivity]) * 10
                                     }
-
+                                    
                                     if phase == .ended {
                                         withAnimation(.smooth) {
-                                            gestureProgress = .zero
+                                            musicGestureProgress = .zero
                                         }
                                     }
                                     if translation > Defaults[.gestureSensitivity] {
@@ -180,7 +181,7 @@ struct ContentView: View {
                                             haptics.toggle()
                                         }
                                         withAnimation(.smooth) {
-                                            gestureProgress = .zero
+                                            musicGestureProgress = .zero
                                         }
                                         musicManager.nextTrack()
 
@@ -193,12 +194,12 @@ struct ContentView: View {
                                 .panGesture(direction: .left) { translation, phase in
                                     guard vm.notchState == .closed else { return nil }
                                     withAnimation(.smooth) {
-                                        gestureProgress = (translation / Defaults[.gestureSensitivity]) * 20
+                                        musicGestureProgress = -((translation / Defaults[.gestureSensitivity]) * 10)
                                     }
-
+                                    
                                     if phase == .ended {
                                         withAnimation(.smooth) {
-                                            gestureProgress = .zero
+                                            musicGestureProgress = .zero
                                         }
                                     }
                                     if translation > Defaults[.gestureSensitivity] {
@@ -206,7 +207,7 @@ struct ContentView: View {
                                             haptics.toggle()
                                         }
                                         withAnimation(.smooth) {
-                                            gestureProgress = .zero
+                                            musicGestureProgress = .zero
                                         }
                                         musicManager.previousTrack()
 
@@ -273,6 +274,7 @@ struct ContentView: View {
                 }
         }
         .frame(maxWidth: openNotchSize.width, maxHeight: openNotchSize.height, alignment: .top)
+        .offset(x: musicGestureProgress)
         .shadow(color: ((vm.notchState == .open || hoverAnimation) && Defaults[.enableShadow]) ? .black.opacity(0.6) : .clear, radius: Defaults[.cornerRadiusScaling] ? 10 : 5)
         .background(dragDetector)
         .environmentObject(vm)

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -144,6 +144,9 @@ struct ContentView: View {
                             view
                                 .panGesture(direction: .down) { translation, phase in
                                     guard vm.notchState == .closed else { return nil }
+                                    withAnimation(.smooth) {
+                                        gestureProgress = (translation / Defaults[.gestureSensitivity]) * 20
+                                    }
 
                                     if phase == .ended {
                                         withAnimation(.smooth) {

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -472,9 +472,6 @@
         }
       }
     },
-    "Media change with horizontal gestures" : {
-
-    },
     "Media inactivity timeout" : {
       "localizations" : {
         "en" : {

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -263,8 +263,7 @@ struct GeneralSettings: View {
             Defaults.Toggle("Enable gestures", key: .enableGestures)
                 .disabled(!openNotchOnHover)
             if enableGestures {
-                Toggle("Media change with horizontal gestures", isOn: .constant(false))
-                    .disabled(true)
+                Defaults.Toggle("Media change with horizontal gestures", key: .enableMusicGestures)
                 Defaults.Toggle("Close gesture", key: .closeGestureEnabled)
                 Slider(value: $gestureSensitivity, in: 100...300, step: 100) {
                     HStack {

--- a/boringNotch/extensions/PanGesture.swift
+++ b/boringNotch/extensions/PanGesture.swift
@@ -76,7 +76,7 @@ struct PanGestureView: NSViewRepresentable {
                         }
                 }
 
-                /// If the action returns with `true`, resset accumulatedScrolDeltas
+                /// If the action returns with `true`, reset accumulatedScrolDeltas
                 func handle() {
                     if direction == .left || direction == .right {
                         if action(abs(accumulatedScrollDeltaX), event.phase) ?? false == true {

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -80,13 +80,16 @@ extension Defaults.Keys {
     static let useMusicVisualizer = Key<Bool>("useMusicVisualizer", default: true)
     static let customVisualizers = Key<[CustomVisualizer]>("customVisualizers", default: [])
     static let selectedVisualizer = Key<CustomVisualizer?>("selectedVisualizer", default: nil)
-    
-        // MARK: Gestures
+
+    // MARK: Gestures
+
     static let enableGestures = Key<Bool>("enableGestures", default: true)
+    static let enableMusicGestures = Key<Bool>("enableMusicGestures", default: true)
     static let closeGestureEnabled = Key<Bool>("closeGestureEnabled", default: true)
     static let gestureSensitivity = Key<CGFloat>("gestureSensitivity", default: 200.0)
-    
-        // MARK: Media playback
+
+    // MARK: Media playback
+
     static let coloredSpectrogram = Key<Bool>("coloredSpectrogram", default: true)
     static let enableSneakPeek = Key<Bool>("enableSneakPeek", default: false)
     static let enableFullscreenMediaDetection = Key<Bool>("enableFullscreenMediaDetection", default: true)


### PR DESCRIPTION
This PR implements horizontal gestures to skip to the next/previous songs. 

I used the previous `.panGesture` view modifier, which required a minor modificiation.
The callback type had to be changed from `() -> Void` to `() -> Bool?`, where if the returned value is `true`, the `PanGesture` handler resets the accumulated scroll deltas. Returning `nil` or `false` will skip the reset.

This was used to avoid retriggering events, which in this case was skipping multiple songs.

https://github.com/user-attachments/assets/0344bb77-05f7-4edd-8abf-d4fbd301cbf1

