### PR TITLE
Fix selected calendar logic

### DIFF
--- a/boringNotch/Providers/CalendarServiceProviding.swift
+++ b/boringNotch/Providers/CalendarServiceProviding.swift
@@ -13,7 +13,7 @@ import EventKit
 protocol CalendarServiceProviding {
     func requestAccess() async -> Bool
     func calendars() async -> [CalendarModel]
-    func events(from start: Date, to end: Date, calendars: [String]) async -> [EventModel]
+    func events(from start: Date, to end: Date, settings: CalendarSettingsProviding) async -> [EventModel]
 }
 
 class CalendarService: CalendarServiceProviding {
@@ -65,9 +65,9 @@ class CalendarService: CalendarServiceProviding {
         return calendars.map { CalendarModel(from: $0) }
     }
     
-    func events(from start: Date, to end: Date, calendars ids: [String]) async -> [EventModel] {
+    func events(from start: Date, to end: Date, settings: CalendarSettingsProviding) async -> [EventModel] {
         let allCalendars = await self.calendars()
-        let filteredCalendars = allCalendars.filter { ids.isEmpty || ids.contains($0.id) }
+        let filteredCalendars = allCalendars.filter { settings.getCalendarSelected($0) }
         let ekCalendars = filteredCalendars.compactMap { calendarModel in
             store.calendars(for: .event).first { $0.calendarIdentifier == calendarModel.id } ??
             store.calendars(for: .reminder).first { $0.calendarIdentifier == calendarModel.id }

--- a/boringNotch/Providers/CalendarSettingsProviding.swift
+++ b/boringNotch/Providers/CalendarSettingsProviding.swift
@@ -1,0 +1,12 @@
+//
+//  CalendarSettingsProviding.swift
+//  boringNotch
+//
+//  Created by David Ashman on 6/17/25.
+//
+
+
+protocol CalendarSettingsProviding {
+    func getCalendarSelected(_ calendar: CalendarModel) -> Bool
+    func setCalendarSelected(_ calendar: CalendarModel, isSelected: Bool) async
+}


### PR DESCRIPTION
Refactor selected calendar logic to fix issue with unselected calendar events showing up.  The selected calendar set was unnecessarily being stored in the CalendarManager and the events were not updated at correct times.  This resulted in events from non-selected calendars sometimes showing up.