### PR TITLE
Add camera toggle feature with dynamic calendar resizing, Smarter Space, More Future Potential

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -30,6 +30,8 @@ struct ContentView: View {
     @State private var gestureProgress: CGFloat = .zero
 
     @State private var haptics: Bool = false
+    
+    @State private var isCameraExpanded: Bool = false
 
     @Namespace var albumArtNamespace
 
@@ -169,7 +171,6 @@ struct ContentView: View {
         .shadow(color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow]) ? .black.opacity(0.6) : .clear, radius: Defaults[.cornerRadiusScaling] ? 10 : 5)
         .background(dragDetector)
         .environmentObject(vm)
-        .environmentObject(webcamManager)
     }
 
     @ViewBuilder
@@ -259,7 +260,10 @@ struct ContentView: View {
                   if vm.notchState == .open {
                       switch coordinator.currentView {
                           case .home:
-                              NotchHomeView(albumArtNamespace: albumArtNamespace)
+                          NotchHomeView(
+                            albumArtNamespace: albumArtNamespace,
+                            isCameraExpanded: $vm.isCameraExpanded
+                          )
                           case .shelf:
                               NotchShelfView()
                       }

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -31,7 +31,6 @@ struct ContentView: View {
 
     @State private var haptics: Bool = false
     
-    @State private var isCameraExpanded: Bool = false
 
     @Namespace var albumArtNamespace
 

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -15,7 +15,7 @@ import SwiftUIIntrospect
 
 struct ContentView: View {
     @EnvironmentObject var vm: BoringViewModel
-    @StateObject var webcamManager: WebcamManager = .init()
+    @ObservedObject var webcamManager = WebcamManager.shared
 
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     @ObservedObject var musicManager = MusicManager.shared
@@ -51,6 +51,10 @@ struct ContentView: View {
                          : cornerRadiusInsets.closed.bottom
                 )
                 .padding([.horizontal, .bottom], vm.notchState == .open ? 12 : 0)
+                .shadow(
+                    color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow]) ? .black.opacity(0.6) : .clear,
+                    radius: Defaults[.cornerRadiusScaling] ? 10 : 5
+                )
                 .background(.black)
                 .mask {
                     ((vm.notchState == .open) && Defaults[.cornerRadiusScaling])
@@ -259,10 +263,7 @@ struct ContentView: View {
                   if vm.notchState == .open {
                       switch coordinator.currentView {
                           case .home:
-                          NotchHomeView(
-                            albumArtNamespace: albumArtNamespace,
-                            isCameraExpanded: $vm.isCameraExpanded
-                          )
+                          NotchHomeView(albumArtNamespace: albumArtNamespace)
                           case .shelf:
                               NotchShelfView()
                       }

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -168,7 +168,7 @@ struct ContentView: View {
         }
         .padding(.bottom, 8)
         .frame(maxWidth: openNotchSize.width, maxHeight: openNotchSize.height, alignment: .top)
-        .shadow(color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow]) ? .red.opacity(0.2) : .clear, radius: Defaults[.cornerRadiusScaling] ? 6 : 4)
+        .shadow(color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow]) ? .black.opacity(0.2) : .clear, radius: Defaults[.cornerRadiusScaling] ? 6 : 4)
         .background(dragDetector)
         .environmentObject(vm)
     }

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -166,8 +166,9 @@ struct ContentView: View {
 //                    .keyboardShortcut("E", modifiers: .command)
                 }
         }
+        .padding(.bottom, 8)
         .frame(maxWidth: openNotchSize.width, maxHeight: openNotchSize.height, alignment: .top)
-        .shadow(color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow]) ? .black.opacity(0.6) : .clear, radius: Defaults[.cornerRadiusScaling] ? 10 : 5)
+        .shadow(color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow]) ? .red.opacity(0.2) : .clear, radius: Defaults[.cornerRadiusScaling] ? 6 : 4)
         .background(dragDetector)
         .environmentObject(vm)
     }

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -51,10 +51,6 @@ struct ContentView: View {
                          : cornerRadiusInsets.closed.bottom
                 )
                 .padding([.horizontal, .bottom], vm.notchState == .open ? 12 : 0)
-                .shadow(
-                    color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow]) ? .black.opacity(0.6) : .clear,
-                    radius: Defaults[.cornerRadiusScaling] ? 10 : 5
-                )
                 .background(.black)
                 .mask {
                     ((vm.notchState == .open) && Defaults[.cornerRadiusScaling])

--- a/boringNotch/components/Calendar/BoringCalendar.swift
+++ b/boringNotch/components/Calendar/BoringCalendar.swift
@@ -151,7 +151,8 @@ struct CalendarView: View {
     @EnvironmentObject var vm: BoringViewModel
     @StateObject private var calendarManager = CalendarManager()
     @State private var selectedDate = Date()
-
+    var isCameraExpanded: Bool
+    
     var body: some View {
         VStack(spacing: 8) {
             HStack {
@@ -275,7 +276,7 @@ struct EventListView: View {
 }
 
 #Preview {
-    CalendarView()
+    CalendarView(isCameraExpanded: false)
         .frame(width: 250)
         .padding(.horizontal)
         .background(.black)

--- a/boringNotch/components/Calendar/BoringCalendar.swift
+++ b/boringNotch/components/Calendar/BoringCalendar.swift
@@ -151,7 +151,6 @@ struct CalendarView: View {
     @EnvironmentObject var vm: BoringViewModel
     @StateObject private var calendarManager = CalendarManager()
     @State private var selectedDate = Date()
-    var isCameraExpanded: Bool
     
     var body: some View {
         VStack(spacing: 8) {
@@ -276,7 +275,7 @@ struct EventListView: View {
 }
 
 #Preview {
-    CalendarView(isCameraExpanded: false)
+    CalendarView()
         .frame(width: 250)
         .padding(.horizontal)
         .background(.black)

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -40,6 +40,20 @@ struct BoringHeader: View {
 
             HStack(spacing: 4) {
                 if vm.notchState == .open {
+                    Button(action: {
+                        vm.toggleCameraPreview()
+                    }) {
+                        Capsule()
+                            .fill(.black)
+                            .frame(width: 30, height: 30)
+                            .overlay {
+                                Image(systemName: "web.camera")
+                                    .foregroundColor(.white)
+                                    .padding()
+                                    .imageScale(.medium)
+                            }
+                    }
+                    .buttonStyle(PlainButtonStyle())
                     if Defaults[.settingsIconInNotch] {
                         Button(action: {
                             SettingsWindowController.shared.showWindow()

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -40,20 +40,22 @@ struct BoringHeader: View {
 
             HStack(spacing: 4) {
                 if vm.notchState == .open {
-                    Button(action: {
-                        vm.toggleCameraPreview()
-                    }) {
-                        Capsule()
-                            .fill(.black)
-                            .frame(width: 30, height: 30)
-                            .overlay {
-                                Image(systemName: "web.camera")
-                                    .foregroundColor(.white)
-                                    .padding()
-                                    .imageScale(.medium)
-                            }
+                    if Defaults[.showMirror] {
+                        Button(action: {
+                            vm.toggleCameraPreview()
+                        }) {
+                            Capsule()
+                                .fill(.black)
+                                .frame(width: 30, height: 30)
+                                .overlay {
+                                    Image(systemName: "web.camera")
+                                        .foregroundColor(.white)
+                                        .padding()
+                                        .imageScale(.medium)
+                                }
+                        }
+                        .buttonStyle(PlainButtonStyle())
                     }
-                    .buttonStyle(PlainButtonStyle())
                     if Defaults[.settingsIconInNotch] {
                         Button(action: {
                             SettingsWindowController.shared.showWindow()

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -179,12 +179,10 @@ struct MusicControlsView: View {
 
 struct NotchHomeView: View {
     @EnvironmentObject var vm: BoringViewModel
-    @EnvironmentObject var webcamManager: WebcamManager
+    @ObservedObject var webcamManager = WebcamManager.shared
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     let albumArtNamespace: Namespace.ID
-
-    @Binding var isCameraExpanded: Bool
     
     var body: some View {
         Group {
@@ -208,9 +206,9 @@ struct NotchHomeView: View {
             }
             
             if Defaults[.showMirror],
-               vm.webcamManager.cameraAvailable,
-               isCameraExpanded {
-                CameraPreviewView(webcamManager: vm.webcamManager)
+               webcamManager.cameraAvailable,
+               vm.isCameraExpanded {
+                CameraPreviewView(webcamManager: webcamManager)
                     .frame(width: 150, height: 150)
                     .scaledToFit()
                     .opacity(vm.notchState == .closed ? 0 : 1)
@@ -343,8 +341,7 @@ struct CustomSlider: View {
 #Preview {
     NotchHomeView(
         albumArtNamespace: Namespace().wrappedValue,
-        isCameraExpanded: .constant(false)
+//        isCameraExpanded: .constant(false)
     )
     .environmentObject(BoringViewModel())
-    .environmentObject(WebcamManager())
 }

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -184,6 +184,8 @@ struct NotchHomeView: View {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     let albumArtNamespace: Namespace.ID
 
+    @Binding var isCameraExpanded: Bool
+    
     var body: some View {
         Group {
             if !coordinator.firstLaunch {
@@ -198,15 +200,19 @@ struct NotchHomeView: View {
             MusicPlayerView(albumArtNamespace: albumArtNamespace)
 
             if Defaults[.showCalendar] {
-                CalendarView()
+                CalendarView(isCameraExpanded: isCameraExpanded)
                 .onHover { isHovering in
                     vm.isHoveringCalendar = isHovering
                 }
                 .environmentObject(vm)
             }
 
-            if Defaults[.showMirror] && webcamManager.cameraAvailable {
-                CameraPreviewView(webcamManager: webcamManager)
+            if Defaults[.showMirror] && vm.webcamManager.cameraAvailable {
+                CameraPreviewView(webcamManager: vm.webcamManager)
+                    .frame(
+                        width:  isCameraExpanded ? 150 : 0,
+                        height: isCameraExpanded ? 150 : 0
+                    )
                     .scaledToFit()
                     .opacity(vm.notchState == .closed ? 0 : 1)
                     .blur(radius: vm.notchState == .closed ? 20 : 0)
@@ -336,7 +342,12 @@ struct CustomSlider: View {
 }
 
 #Preview {
-    NotchHomeView(albumArtNamespace: Namespace().wrappedValue)
-        .environmentObject(BoringViewModel())
-        .environmentObject(WebcamManager())
+    let vm = BoringViewModel()
+    return NotchHomeView(
+        albumArtNamespace: Namespace().wrappedValue,
+        isCameraExpanded: .constant(false)
+    )
+    .environmentObject(vm)
+    .environmentObject(WebcamManager())
 }
+ 

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -209,7 +209,6 @@ struct NotchHomeView: View {
                webcamManager.cameraAvailable,
                vm.isCameraExpanded {
                 CameraPreviewView(webcamManager: webcamManager)
-                    .frame(width: 150, height: 150)
                     .scaledToFit()
                     .opacity(vm.notchState == .closed ? 0 : 1)
                     .blur(radius: vm.notchState == .closed ? 20 : 0)

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -341,7 +341,6 @@ struct CustomSlider: View {
 #Preview {
     NotchHomeView(
         albumArtNamespace: Namespace().wrappedValue,
-//        isCameraExpanded: .constant(false)
     )
     .environmentObject(BoringViewModel())
 }

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -3,7 +3,7 @@
 //  boringNotch
 //
 //  Created by Hugo Persson on 2024-08-18.
-//  Modified by Harsh Vardhan Goswami & Richard Kunkli
+//  Modified by Harsh Vardhan Goswami & Richard Kunkli & Mustafa Ramadan
 //
 
 import Combine
@@ -198,21 +198,20 @@ struct NotchHomeView: View {
     private var mainContent: some View {
         HStack(alignment: .top, spacing: 20) {
             MusicPlayerView(albumArtNamespace: albumArtNamespace)
-
+            
             if Defaults[.showCalendar] {
-                CalendarView(isCameraExpanded: isCameraExpanded)
-                .onHover { isHovering in
-                    vm.isHoveringCalendar = isHovering
-                }
-                .environmentObject(vm)
+                CalendarView()
+                    .onHover { isHovering in
+                        vm.isHoveringCalendar = isHovering
+                    }
+                    .environmentObject(vm)
             }
-
-            if Defaults[.showMirror] && vm.webcamManager.cameraAvailable {
+            
+            if Defaults[.showMirror],
+               vm.webcamManager.cameraAvailable,
+               isCameraExpanded {
                 CameraPreviewView(webcamManager: vm.webcamManager)
-                    .frame(
-                        width:  isCameraExpanded ? 150 : 0,
-                        height: isCameraExpanded ? 150 : 0
-                    )
+                    .frame(width: 150, height: 150)
                     .scaledToFit()
                     .opacity(vm.notchState == .closed ? 0 : 1)
                     .blur(radius: vm.notchState == .closed ? 20 : 0)
@@ -342,12 +341,10 @@ struct CustomSlider: View {
 }
 
 #Preview {
-    let vm = BoringViewModel()
-    return NotchHomeView(
+    NotchHomeView(
         albumArtNamespace: Namespace().wrappedValue,
         isCameraExpanded: .constant(false)
     )
-    .environmentObject(vm)
+    .environmentObject(BoringViewModel())
     .environmentObject(WebcamManager())
 }
- 

--- a/boringNotch/components/Webcam/WebcamView.swift
+++ b/boringNotch/components/Webcam/WebcamView.swift
@@ -118,5 +118,5 @@ struct CameraPreviewLayerView: NSViewRepresentable {
 }
 
 #Preview {
-    CameraPreviewView(webcamManager: WebcamManager())
+    CameraPreviewView(webcamManager: .shared)
 }

--- a/boringNotch/managers/WebcamManager.swift
+++ b/boringNotch/managers/WebcamManager.swift
@@ -8,6 +8,8 @@ import AVFoundation
 import SwiftUI
 
 class WebcamManager: NSObject, ObservableObject {
+    static let shared = WebcamManager()
+    
     @Published var previewLayer: AVCaptureVideoPreviewLayer? {
         didSet {
             objectWillChange.send()
@@ -58,7 +60,7 @@ class WebcamManager: NSObject, ObservableObject {
     
     // MARK: - Properties
     
-    override init() {
+    private override init() {
         super.init()
         NotificationCenter.default.addObserver(self, selector: #selector(deviceWasDisconnected), name: .AVCaptureDeviceWasDisconnected, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(deviceWasConnected), name: .AVCaptureDeviceWasConnected, object: nil)

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -35,7 +35,7 @@ class BoringViewModel: NSObject, ObservableObject {
     @Published var notchSize: CGSize = getClosedNotchSize()
     @Published var closedNotchSize: CGSize = getClosedNotchSize()
     
-    @Published var webcamManager = WebcamManager()
+    let webcamManager = WebcamManager.shared
     @Published var isCameraExpanded: Bool = false
     @Published var isRequestingAuthorization: Bool = false
     

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -35,6 +35,10 @@ class BoringViewModel: NSObject, ObservableObject {
     @Published var notchSize: CGSize = getClosedNotchSize()
     @Published var closedNotchSize: CGSize = getClosedNotchSize()
     
+    @Published var webcamManager = WebcamManager()
+    @Published var isCameraExpanded: Bool = false
+    @Published var isRequestingAuthorization: Bool = false
+    
     deinit {
         destroy()
     }
@@ -100,6 +104,54 @@ class BoringViewModel: NSObject, ObservableObject {
         return noNotchAndFullscreen ? 0 : closedNotchSize.height
     }
 
+    func toggleCameraPreview() {
+        if isRequestingAuthorization {
+            return
+        }
+
+        switch webcamManager.authorizationStatus {
+        case .authorized:
+            if webcamManager.isSessionRunning {
+                webcamManager.stopSession()
+                isCameraExpanded = false
+            } else if webcamManager.cameraAvailable {
+                webcamManager.startSession()
+                isCameraExpanded = true
+            }
+
+        case .denied, .restricted:
+            DispatchQueue.main.async {
+                NSApp.setActivationPolicy(.regular)
+                NSApp.activate(ignoringOtherApps: true)
+
+                let alert = NSAlert()
+                alert.messageText = "Camera Access Required"
+                alert.informativeText = "Please allow camera access in System Settings."
+                alert.addButton(withTitle: "Open Settings")
+                alert.addButton(withTitle: "Cancel")
+
+                if alert.runModal() == .alertFirstButtonReturn {
+                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera") {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+
+                NSApp.setActivationPolicy(.accessory)
+                NSApp.deactivate()
+            }
+
+        case .notDetermined:
+            isRequestingAuthorization = true
+            webcamManager.checkAndRequestVideoAuthorization()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                self.isRequestingAuthorization = false
+            }
+
+        default:
+            break
+        }
+    }
+    
     func isMouseHovering(position: NSPoint = NSEvent.mouseLocation) -> Bool {
         let screenFrame = getScreenFrame(screen)
         if let frame = screenFrame {


### PR DESCRIPTION
This PR introduces a simple but highly useful UX improvement:
dynamic toggling of the camera preview (mirror view).

What’s new:
 • Camera icon moved to header — easily accessible anytime.
 • Clicking the camera icon toggles mirror on/off.
 • When mirror is hidden, the calendar automatically expands wider.
 • When mirror is shown, calendar adjusts to narrower view.
 • Smooth transitions integrated with existing animations.
 • Code fully isolated, clean and backward-compatible.

Why this feature is useful:
 • Maximizes horizontal space when mirror is not needed.
 • Lays the foundation for toggleable side widgets in the future.
 • Keeps interface clean for users who rarely use mirror.
 • Can easily be extended to control other modules dynamically.

Hope you find this addition helpful! 😊

When camera is off:
<img width="826" alt="Screenshot 2025-06-21 at 5 31 22 pm" src="https://github.com/user-attachments/assets/ecb2bce9-1b71-47ea-852a-2f4c6e8f9b88" />

**I’m a full-stack web engineer and DevOps guy, but still pretty new to Swift/macOS development. Hopefully I got everything right 🙏 — always happy to improve if you spot anything!**

