### PR TITLE
Clipboard Tab with history enable/disable feature

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		14E9FEAA2C70BF610062E83F /* DownloadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E9FEA92C70BF610062E83F /* DownloadView.swift */; };
 		14E9FEAE2C7325770062E83F /* Button+Bouncing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E9FEAD2C7325770062E83F /* Button+Bouncing.swift */; };
 		14FC6E502C7DED5600C7BEA5 /* DataTypes+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FC6E4F2C7DED5600C7BEA5 /* DataTypes+Extensions.swift */; };
+		46EDBE5E2E0F80C90045E914 /* NotchClipboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EDBE5D2E0F80C60045E914 /* NotchClipboardView.swift */; };
+		46EDBE602E0F81620045E914 /* ClipboardMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EDBE5F2E0F815F0045E914 /* ClipboardMonitor.swift */; };
 		507266DB2C908E2E00A2D00D /* HoverButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507266DA2C908E2E00A2D00D /* HoverButton.swift */; };
 		9A0887322C7A693000C160EA /* TabButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0887312C7A693000C160EA /* TabButton.swift */; };
 		9A0887352C7AFF8E00C160EA /* TabSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0887342C7AFF8E00C160EA /* TabSelectionView.swift */; };
@@ -189,6 +191,8 @@
 		14E9FEA92C70BF610062E83F /* DownloadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadView.swift; sourceTree = "<group>"; };
 		14E9FEAD2C7325770062E83F /* Button+Bouncing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Button+Bouncing.swift"; sourceTree = "<group>"; };
 		14FC6E4F2C7DED5600C7BEA5 /* DataTypes+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataTypes+Extensions.swift"; sourceTree = "<group>"; };
+		46EDBE5D2E0F80C60045E914 /* NotchClipboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchClipboardView.swift; sourceTree = "<group>"; };
+		46EDBE5F2E0F815F0045E914 /* ClipboardMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardMonitor.swift; sourceTree = "<group>"; };
 		507266DA2C908E2E00A2D00D /* HoverButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverButton.swift; sourceTree = "<group>"; };
 		9A0887312C7A693000C160EA /* TabButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabButton.swift; sourceTree = "<group>"; };
 		9A0887342C7AFF8E00C160EA /* TabSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSelectionView.swift; sourceTree = "<group>"; };
@@ -236,6 +240,7 @@
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		112FB72F2CCF12CC0015238C /* private */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = private; sourceTree = "<group>"; };
+		46EDBE592E0F805B0045E914 /* Clipboard */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Clipboard; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -292,6 +297,7 @@
 		14288DE22C6E016F00B9F80C /* observers */ = {
 			isa = PBXGroup;
 			children = (
+				46EDBE5F2E0F815F0045E914 /* ClipboardMonitor.swift */,
 				B1A78C812C8BA08100BD51B0 /* FullscreenMediaDetection.swift */,
 			);
 			path = observers;
@@ -308,6 +314,7 @@
 		1471639B2C5D362F0068B555 /* components */ = {
 			isa = PBXGroup;
 			children = (
+				46EDBE592E0F805B0045E914 /* Clipboard */,
 				B141C23B2CA5F50900AC8CC8 /* Onboarding */,
 				B1C448992C97375A001F0858 /* Tips */,
 				14C08BB72C8DE49E000F8AA0 /* Calendar */,
@@ -538,6 +545,7 @@
 		B186542F2C6F455E000B926A /* Notch */ = {
 			isa = PBXGroup;
 			children = (
+				46EDBE5D2E0F80C60045E914 /* NotchClipboardView.swift */,
 				1160F8D72DD98230006FBB94 /* NotchShape.swift */,
 				9A987A032C73CA66005CA465 /* NotchShelfView.swift */,
 				9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */,
@@ -607,6 +615,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				112FB72F2CCF12CC0015238C /* private */,
+				46EDBE592E0F805B0045E914 /* Clipboard */,
 			);
 			name = boringNotch;
 			packageProductDependencies = (
@@ -694,6 +703,7 @@
 				11CC44A22CEE614100C7244B /* BoringViewCoordinator.swift in Sources */,
 				B186543C2C6F49AE000B926A /* ShortcutConstants.swift in Sources */,
 				B1D365CE2C6A979C0047BDBC /* LiveActivityModifier.swift in Sources */,
+				46EDBE602E0F81620045E914 /* ClipboardMonitor.swift in Sources */,
 				11CFC65B2E097E9D00748C80 /* WelcomeView.swift in Sources */,
 				14D570C02C5EA5870011E668 /* AnimatedFace.swift in Sources */,
 				B1D6FD432C6603730015F173 /* SoftwareUpdater.swift in Sources */,
@@ -701,6 +711,7 @@
 				14D570CB2C5F4B2C0011E668 /* BatteryStatusViewModel.swift in Sources */,
 				9A0887322C7A693000C160EA /* TabButton.swift in Sources */,
 				B10A848C2C7BCD150088BFFC /* AirDrop.swift in Sources */,
+				46EDBE5E2E0F80C90045E914 /* NotchClipboardView.swift in Sources */,
 				1153BD9C2D98853B00979FB0 /* NowPlayingController.swift in Sources */,
 				B141C2412CA5F53F00AC8CC8 /* SparkleView.swift in Sources */,
 				116398962DF5D6C00052E6AF /* CalendarServiceProviding.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -31,12 +31,14 @@ struct ContentView: View {
 
     @State private var haptics: Bool = false
 
+    @StateObject private var clipboardMonitor = ClipboardMonitor()
     @Namespace var albumArtNamespace
 
     @Default(.useMusicVisualizer) var useMusicVisualizer
 
     @Default(.showNotHumanFace) var showNotHumanFace
     @Default(.useModernCloseAnimation) var useModernCloseAnimation
+    @Default(.showClipboard) var showClipboard
 
     private let extendedHoverPadding: CGFloat = 30
     private let zeroHeightHoverPadding: CGFloat = 10
@@ -126,6 +128,9 @@ struct ContentView: View {
                         }
                     }
                 })
+                .onChange(of: showClipboard) { _, newValue in
+                                clipboardMonitor.toggleMonitoring(newValue)
+                            }
                 .onChange(of: vm.notchState) { _, newState in
                     // Reset hover state when notch state changes
                     if newState == .closed && isHovering {
@@ -262,6 +267,8 @@ struct ContentView: View {
                               NotchHomeView(albumArtNamespace: albumArtNamespace)
                           case .shelf:
                               NotchShelfView()
+                          case .clipboard:
+                              NotchClipboardView(clipboardMonitor: clipboardMonitor)
                       }
                   }
               }

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -15,7 +15,7 @@ import SwiftUIIntrospect
 
 struct ContentView: View {
     @EnvironmentObject var vm: BoringViewModel
-    @StateObject var webcamManager: WebcamManager = .init()
+    @ObservedObject var webcamManager = WebcamManager.shared
 
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     @ObservedObject var musicManager = MusicManager.shared
@@ -30,6 +30,8 @@ struct ContentView: View {
     @State private var gestureProgress: CGFloat = .zero
 
     @State private var haptics: Bool = false
+    
+    @StateObject private var clipboardMonitor = ClipboardMonitor()
 
     @StateObject private var clipboardMonitor = ClipboardMonitor()
     @Namespace var albumArtNamespace
@@ -170,11 +172,11 @@ struct ContentView: View {
 //                    .keyboardShortcut("E", modifiers: .command)
                 }
         }
+        .padding(.bottom, 8)
         .frame(maxWidth: openNotchSize.width, maxHeight: openNotchSize.height, alignment: .top)
-        .shadow(color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow]) ? .black.opacity(0.6) : .clear, radius: Defaults[.cornerRadiusScaling] ? 10 : 5)
+        .shadow(color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow]) ? .black.opacity(0.2) : .clear, radius: Defaults[.cornerRadiusScaling] ? 6 : 4)
         .background(dragDetector)
         .environmentObject(vm)
-        .environmentObject(webcamManager)
     }
 
     @ViewBuilder
@@ -264,7 +266,7 @@ struct ContentView: View {
                   if vm.notchState == .open {
                       switch coordinator.currentView {
                           case .home:
-                              NotchHomeView(albumArtNamespace: albumArtNamespace)
+                          NotchHomeView(albumArtNamespace: albumArtNamespace)
                           case .shelf:
                               NotchShelfView()
                           case .clipboard:

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -238,6 +238,12 @@
     "Circle" : {
 
     },
+    "Clipboard" : {
+
+    },
+    "Clipboard is empty" : {
+      "extractionState" : "manual"
+    },
     "Close" : {
 
     },

--- a/boringNotch/components/Calendar/BoringCalendar.swift
+++ b/boringNotch/components/Calendar/BoringCalendar.swift
@@ -151,7 +151,7 @@ struct CalendarView: View {
     @EnvironmentObject var vm: BoringViewModel
     @StateObject private var calendarManager = CalendarManager()
     @State private var selectedDate = Date()
-
+    
     var body: some View {
         VStack(spacing: 8) {
             HStack {

--- a/boringNotch/components/Clipboard/ClipboardTile.swift
+++ b/boringNotch/components/Clipboard/ClipboardTile.swift
@@ -1,0 +1,108 @@
+//
+//  ClipboardTile.swift
+//  boringNotch
+//
+//  Updated by Mustafa Ramadan on 28/6/2025 & Created by Alessandro Gravagno on 24/04/25.
+//
+
+import SwiftUI
+import AppKit
+
+
+struct ClipboardTile: View {
+    var text: String
+    var bundleID: String
+    @State private var isCopied: Bool = false
+    @State private var isHovering: Bool = false
+    
+    init(text: String, bundleID: String) {
+        self.text = text
+        self.bundleID = bundleID
+    }
+    
+    var body: some View {
+        Rectangle()
+            .fill(.white.opacity(isHovering ? 0.5 : 0.4))
+            .opacity(isHovering ? 0.3 : 0.2)
+            .overlay(
+                clipboardLabel
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            )
+            .frame(width: 170, height: 55)
+            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+            .onHover { hovering in
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isHovering = hovering
+                    }
+                }
+            .onTapGesture {
+                ClipboardMonitor.CopyFromApp(text)
+                isCopied = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                    isCopied = false
+                }
+            }
+    }
+    
+    private var clipboardLabel: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(text)
+                .foregroundStyle(.white.opacity(0.9))
+                .lineLimit(2)
+                .truncationMode(.tail)
+                .font(.system(size: 10, weight: .regular, design: .rounded))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(height: 30, alignment: .top)
+                .padding(.horizontal, 5)
+                .padding(.top,3)
+
+            Spacer(minLength: 2)
+
+            HStack(alignment: .center) {
+                ZStack {
+                    clipboardIconBackground
+                    AppIcon(for: bundleID)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 16, height: 16)
+                        .opacity(0.85)
+                }
+                .padding(.leading, 4)
+
+                Spacer()
+
+                Image(systemName: isCopied ? "checkmark" : "clipboard")
+                    .contentTransition(.symbolEffect(.replace))
+                    .foregroundStyle(.white.opacity(0.7))
+                    .padding(.trailing, 6)
+                    .font(.system(size: 10, weight: .medium, design: .rounded))
+            }
+            .padding(.bottom, 2)
+        }
+        .contentShape(Rectangle())
+        .frame(maxHeight: .infinity, alignment: .top)
+    }
+    
+    private var clipboardIconBackground: some View {
+        Color.clear
+            .aspectRatio(1, contentMode: .fit)
+            .background(
+                AppIcon(for: bundleID)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            )
+            .scaleEffect(x: 1.3, y: 3.4)
+            .rotationEffect(.degrees(90))
+            .blur(radius:40)
+    }
+}
+
+#Preview {
+    HStack{
+        ClipboardTile(text: "Copia 1 Copia 1 Copia 1 Copia 1 .frame(height: 18)", bundleID: "com.apple.Notes")
+        ClipboardTile(text: "Copia 2", bundleID: "com.spotify.client")
+        ClipboardTile(text: "Copia 3", bundleID: "com.apple.music")
+    }
+    
+}

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -40,6 +40,22 @@ struct BoringHeader: View {
 
             HStack(spacing: 4) {
                 if vm.notchState == .open {
+                    if Defaults[.showMirror] {
+                        Button(action: {
+                            vm.toggleCameraPreview()
+                        }) {
+                            Capsule()
+                                .fill(.black)
+                                .frame(width: 30, height: 30)
+                                .overlay {
+                                    Image(systemName: "web.camera")
+                                        .foregroundColor(.white)
+                                        .padding()
+                                        .imageScale(.medium)
+                                }
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                    }
                     if Defaults[.settingsIconInNotch] {
                         Button(action: {
                             SettingsWindowController.shared.showWindow()

--- a/boringNotch/components/Notch/NotchClipboardView.swift
+++ b/boringNotch/components/Notch/NotchClipboardView.swift
@@ -1,0 +1,43 @@
+//
+//  NotchClipboardView.swift
+//  boringNotch
+//
+//  Updated by Mustafa Ramadan on 28/6/2025 & Created by Alessandro Gravagno on 23/04/25.
+//
+
+import SwiftUI
+
+struct NotchClipboardView : View {
+    
+    @ObservedObject var clipboardMonitor: ClipboardMonitor
+    
+    init(clipboardMonitor: ClipboardMonitor) {
+        self.clipboardMonitor = clipboardMonitor
+    }
+
+    private let gridRows = [
+        GridItem(.adaptive(minimum: 200)),
+    ]
+    
+    var body: some View {
+        if clipboardMonitor.data.isEmpty {
+            Text("Clipboard is empty")
+                .foregroundStyle(.white.opacity(0.4))
+                .frame(maxWidth: .infinity, maxHeight: 148)
+                .font(.system(.title3, design: .rounded))
+                
+        } else {
+            ScrollView{
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 3), spacing: 11) {
+                    ForEach(clipboardMonitor.data.reversed(), id: \.self) { item in
+                        ClipboardTile(text: item.text, bundleID: item.bundleID)
+                    }
+                }.padding(.horizontal, 12)
+            }.scrollIndicators(.never)
+        }
+    }
+}
+
+#Preview {
+    NotchClipboardView(clipboardMonitor: ClipboardMonitor())
+}

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -3,7 +3,7 @@
 //  boringNotch
 //
 //  Created by Hugo Persson on 2024-08-18.
-//  Modified by Harsh Vardhan Goswami & Richard Kunkli
+//  Modified by Harsh Vardhan Goswami & Richard Kunkli & Mustafa Ramadan
 //
 
 import Combine
@@ -179,11 +179,11 @@ struct MusicControlsView: View {
 
 struct NotchHomeView: View {
     @EnvironmentObject var vm: BoringViewModel
-    @EnvironmentObject var webcamManager: WebcamManager
+    @ObservedObject var webcamManager = WebcamManager.shared
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     let albumArtNamespace: Namespace.ID
-
+    
     var body: some View {
         Group {
             if !coordinator.firstLaunch {
@@ -196,16 +196,18 @@ struct NotchHomeView: View {
     private var mainContent: some View {
         HStack(alignment: .top, spacing: 20) {
             MusicPlayerView(albumArtNamespace: albumArtNamespace)
-
+            
             if Defaults[.showCalendar] {
                 CalendarView()
-                .onHover { isHovering in
-                    vm.isHoveringCalendar = isHovering
-                }
-                .environmentObject(vm)
+                    .onHover { isHovering in
+                        vm.isHoveringCalendar = isHovering
+                    }
+                    .environmentObject(vm)
             }
-
-            if Defaults[.showMirror] && webcamManager.cameraAvailable {
+            
+            if Defaults[.showMirror],
+               webcamManager.cameraAvailable,
+               vm.isCameraExpanded {
                 CameraPreviewView(webcamManager: webcamManager)
                     .scaledToFit()
                     .opacity(vm.notchState == .closed ? 0 : 1)
@@ -336,7 +338,8 @@ struct CustomSlider: View {
 }
 
 #Preview {
-    NotchHomeView(albumArtNamespace: Namespace().wrappedValue)
-        .environmentObject(BoringViewModel())
-        .environmentObject(WebcamManager())
+    NotchHomeView(
+        albumArtNamespace: Namespace().wrappedValue,
+    )
+    .environmentObject(BoringViewModel())
 }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -143,6 +143,7 @@ struct GeneralSettings: View {
     @Default(.enableGestures) var enableGestures
     @Default(.openNotchOnHover) var openNotchOnHover
     @Default(.alwaysHideInFullscreen) var alwaysHideInFullscreen
+    @Default(.showClipboard) var showClipboard
     
     var body: some View {
         Form {
@@ -1031,6 +1032,11 @@ struct Appearance: View {
                 HStack {
                     Text("Additional features")
                 }
+            }
+            Section {
+                Defaults.Toggle("Enable clipboard feature", key: .showClipboard)
+            } header: {
+                Text("Clipboard")
             }
             
             Section {

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Defaults
 
 struct TabModel: Identifiable {
     let id = UUID()
@@ -14,10 +15,12 @@ struct TabModel: Identifiable {
     let view: NotchViews
 }
 
-let tabs = [
-    TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
-]
+var tabs: [TabModel] {
+    [
+        TabModel(label: "Home", icon: "house.fill", view: .home),
+        TabModel(label: "Shelf", icon: "tray.fill", view: .shelf),
+    ] + (Defaults[.showClipboard] ? [TabModel(label: "Clipboard", icon: "clipboard.fill", view: .clipboard)] : [])
+}
 
 struct TabSelectionView: View {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
@@ -30,7 +33,7 @@ struct TabSelectionView: View {
                             coordinator.currentView = tab.view
                         }
                     }
-                    .frame(height: 26)
+                    .frame(height: 26, alignment: .center)
                     .foregroundStyle(tab.view == coordinator.currentView ? .white : .gray)
                     .background {
                         if tab.view == coordinator.currentView {

--- a/boringNotch/components/Webcam/WebcamView.swift
+++ b/boringNotch/components/Webcam/WebcamView.swift
@@ -118,5 +118,5 @@ struct CameraPreviewLayerView: NSViewRepresentable {
 }
 
 #Preview {
-    CameraPreviewView(webcamManager: WebcamManager())
+    CameraPreviewView(webcamManager: .shared)
 }

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -27,6 +27,7 @@ public enum NotchState {
 public enum NotchViews {
     case home
     case shelf
+    case clipboard
 }
 
 enum SettingsEnum {

--- a/boringNotch/managers/WebcamManager.swift
+++ b/boringNotch/managers/WebcamManager.swift
@@ -8,6 +8,8 @@ import AVFoundation
 import SwiftUI
 
 class WebcamManager: NSObject, ObservableObject {
+    static let shared = WebcamManager()
+    
     @Published var previewLayer: AVCaptureVideoPreviewLayer? {
         didSet {
             objectWillChange.send()
@@ -58,7 +60,7 @@ class WebcamManager: NSObject, ObservableObject {
     
     // MARK: - Properties
     
-    override init() {
+    private override init() {
         super.init()
         NotificationCenter.default.addObserver(self, selector: #selector(deviceWasDisconnected), name: .AVCaptureDeviceWasDisconnected, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(deviceWasConnected), name: .AVCaptureDeviceWasConnected, object: nil)

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -35,6 +35,10 @@ class BoringViewModel: NSObject, ObservableObject {
     @Published var notchSize: CGSize = getClosedNotchSize()
     @Published var closedNotchSize: CGSize = getClosedNotchSize()
     
+    let webcamManager = WebcamManager.shared
+    @Published var isCameraExpanded: Bool = false
+    @Published var isRequestingAuthorization: Bool = false
+    
     deinit {
         destroy()
     }
@@ -100,6 +104,54 @@ class BoringViewModel: NSObject, ObservableObject {
         return noNotchAndFullscreen ? 0 : closedNotchSize.height
     }
 
+    func toggleCameraPreview() {
+        if isRequestingAuthorization {
+            return
+        }
+
+        switch webcamManager.authorizationStatus {
+        case .authorized:
+            if webcamManager.isSessionRunning {
+                webcamManager.stopSession()
+                isCameraExpanded = false
+            } else if webcamManager.cameraAvailable {
+                webcamManager.startSession()
+                isCameraExpanded = true
+            }
+
+        case .denied, .restricted:
+            DispatchQueue.main.async {
+                NSApp.setActivationPolicy(.regular)
+                NSApp.activate(ignoringOtherApps: true)
+
+                let alert = NSAlert()
+                alert.messageText = "Camera Access Required"
+                alert.informativeText = "Please allow camera access in System Settings."
+                alert.addButton(withTitle: "Open Settings")
+                alert.addButton(withTitle: "Cancel")
+
+                if alert.runModal() == .alertFirstButtonReturn {
+                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera") {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+
+                NSApp.setActivationPolicy(.accessory)
+                NSApp.deactivate()
+            }
+
+        case .notDetermined:
+            isRequestingAuthorization = true
+            webcamManager.checkAndRequestVideoAuthorization()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                self.isRequestingAuthorization = false
+            }
+
+        default:
+            break
+        }
+    }
+    
     func isMouseHovering(position: NSPoint = NSEvent.mouseLocation) -> Bool {
         let screenFrame = getScreenFrame(screen)
         if let frame = screenFrame {

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -153,6 +153,9 @@ extension Defaults.Keys {
     // MARK: Media Controller
     static let mediaController = Key<MediaControllerType>("mediaController", default: defaultMediaController)
     
+    // MARK: Clipboard
+    static let showClipboard = Key<Bool>("showClipboard", default: true)
+    
     // Helper to determine the default media controller based on macOS version
     static var defaultMediaController: MediaControllerType {
         if #available(macOS 15.4, *) {

--- a/boringNotch/observers/ClipboardMonitor.swift
+++ b/boringNotch/observers/ClipboardMonitor.swift
@@ -1,0 +1,90 @@
+//
+//  ClipboardMonitor.swift
+//  boringNotch
+//
+//  Updated by Mustafa Ramadan on 28/6/2025 & Created by Alessandro Gravagno on 28/04/25.
+//
+
+import SwiftUI
+import AppKit
+import Defaults
+
+class ClipboardMonitor: ObservableObject{
+    @Published var data: Array<ClipboardData> = []
+
+    private var timer: Timer?
+    private var lastChangeCount: Int = NSPasteboard.general.changeCount
+    private static var isInternalCopy = false
+
+    init() {
+        if Defaults[.showClipboard] {
+            startMonitoring()
+        }
+    }
+
+    private func startMonitoring() {
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.checkClipboard()
+        }
+    }
+    
+    private func checkClipboard() {
+        let pasteboard = NSPasteboard.general
+        if pasteboard.changeCount != lastChangeCount {
+            lastChangeCount = pasteboard.changeCount
+            
+            if ClipboardMonitor.isInternalCopy {
+                ClipboardMonitor.isInternalCopy = false
+                return
+            }
+
+            if let copiedText = pasteboard.string(forType: .string),
+               let activeApp = NSWorkspace.shared.frontmostApplication {
+                
+                let bundleID = activeApp.bundleIdentifier ?? "sconosciuto"
+                
+                DispatchQueue.main.async {
+                    self.addToClipboard(element: ClipboardData(text: copiedText, bundleID: bundleID))
+                }
+            }
+        }
+    }
+    
+    private func addToClipboard(element: ClipboardData){
+        if self.data.contains(element) {
+            self.data.removeAll(where: { $0 == element })
+        }
+        self.data.append(element)
+        
+        // Keep only the latest 48 clipboard items to avoid memory bloat
+        if self.data.count > 48 {
+            self.data.removeFirst()
+        }
+    }
+    
+    static func CopyFromApp(_ text: String){
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        isInternalCopy = true
+        pasteboard.setString(text, forType: .string)
+    }
+    
+    func toggleMonitoring(_ enabled: Bool) {
+        if enabled {
+            startMonitoring()
+        } else {
+            timer?.invalidate()
+            timer = nil
+            data.removeAll()
+        }
+    }
+    
+    deinit {
+        timer?.invalidate()
+    }
+}
+
+struct ClipboardData: Hashable {
+    var text: String
+    var bundleID: String
+}


### PR DESCRIPTION
This PR introduces a brand-new Clipboard Monitor that tracks your copied text, shows it inside the Notch, and displays the source app that copied it — all with sleek native visuals.

Features:
• Live clipboard monitoring (disabled by default)
• Automatically shows a new “Clipboard” tab when enabled
• Each entry shows copied text, app icon, and clipboard status
• Visual feedback: re-copying an item shows ✅ checkmark
• Keeps history of last 48 clipboard items for performance (CPU/RAM)
• Easy enable / disable the feature works live without restarting

Credits:
This feature is heavily based on https://github.com/TheBoredTeam/boring.notch/pull/560 — Clipboard Tab, originally contributed by @Al3Gr. Special thanks to @Al3Gr for the efforts, concept and for the foundation of this feature! 🙏

I reused the core logic, refactored the UI, added a toggle in settings, improved performance, and integrated the feature cleanly with the latest notch system tested will — making it ready for production.

🖤 Built with love and boring ambition ;)


https://github.com/user-attachments/assets/5212eeb0-d5bb-421f-b340-01336e09a8b8