### PR TITLE
Fix UI freezes by replacing blocking semaphores with async/await in music controllers

### DIFF
--- a/boringNotch/MediaControllers/AppleMusicController.swift
+++ b/boringNotch/MediaControllers/AppleMusicController.swift
@@ -5,7 +5,7 @@
 //  Created by Alexander on 2025-03-29.
 //
 
-import Foundation
+@preconcurrency import Foundation
 import Combine
 import SwiftUI
 

--- a/boringNotch/MediaControllers/MediaControllerProtocol.swift
+++ b/boringNotch/MediaControllers/MediaControllerProtocol.swift
@@ -10,14 +10,14 @@ import AppKit
 
 protocol MediaControllerProtocol: ObservableObject {
     var playbackStatePublisher: Published<PlaybackState>.Publisher { get }
-    func play()
-    func pause()
-    func seek(to time: Double)
-    func nextTrack()
-    func previousTrack()
-    func togglePlay()
-    func toggleShuffle()
-    func toggleRepeat()
+    func play() async
+    func pause() async
+    func seek(to time: Double) async
+    func nextTrack() async
+    func previousTrack() async
+    func togglePlay() async
+    func toggleShuffle() async
+    func toggleRepeat() async
     func isActive() -> Bool
     func updatePlaybackInfo()
 }

--- a/boringNotch/MediaControllers/MediaControllerProtocol.swift
+++ b/boringNotch/MediaControllers/MediaControllerProtocol.swift
@@ -5,7 +5,7 @@
 //  Created by Alexander on 2025-03-29.
 //
 
-import Foundation
+@preconcurrency import Foundation
 import AppKit
 
 protocol MediaControllerProtocol: ObservableObject {

--- a/boringNotch/MediaControllers/NowPlayingController.swift
+++ b/boringNotch/MediaControllers/NowPlayingController.swift
@@ -82,27 +82,27 @@ final class NowPlayingController: ObservableObject, MediaControllerProtocol {
     }
 
     // MARK: - Protocol Implementation
-    func play() {
+    func play() async {
         MRMediaRemoteSendCommandFunction(0, nil)
     }
 
-    func pause() {
+    func pause() async {
         MRMediaRemoteSendCommandFunction(1, nil)
     }
 
-    func togglePlay() {
+    func togglePlay() async {
         MRMediaRemoteSendCommandFunction(2, nil)
     }
 
-    func nextTrack() {
+    func nextTrack() async {
         MRMediaRemoteSendCommandFunction(4, nil)
     }
 
-    func previousTrack() {
+    func previousTrack() async {
         MRMediaRemoteSendCommandFunction(5, nil)
     }
 
-    func seek(to time: Double) {
+    func seek(to time: Double) async {
         MRMediaRemoteSetElapsedTimeFunction(time)
     }
 
@@ -110,17 +110,21 @@ final class NowPlayingController: ObservableObject, MediaControllerProtocol {
         return true
     }
     
-    func toggleShuffle() {
+    func toggleShuffle() async {
         // MRMediaRemoteSendCommandFunction(6, nil)
         MRMediaRemoteSetShuffleModeFunction( playbackState.isShuffled ? 1 : 3)
-        playbackState.isShuffled.toggle()
+        await MainActor.run {
+            playbackState.isShuffled.toggle()
+        }
     }
     
-    func toggleRepeat() {
+    func toggleRepeat() async {
         // MRMediaRemoteSendCommandFunction(7, nil)
-        let newRepeatMode = (playbackState.repeatMode == .off) ? 3 : (playbackState.repeatMode.rawValue - 1)
-        playbackState.repeatMode = RepeatMode(rawValue: newRepeatMode) ?? .off
-        MRMediaRemoteSetRepeatModeFunction(newRepeatMode)
+        await MainActor.run {
+            let newRepeatMode = (playbackState.repeatMode == .off) ? 3 : (playbackState.repeatMode.rawValue - 1)
+            playbackState.repeatMode = RepeatMode(rawValue: newRepeatMode) ?? .off
+            MRMediaRemoteSetRepeatModeFunction(newRepeatMode)
+        }
     }
     
     // MARK: - Setup Methods

--- a/boringNotch/MediaControllers/NowPlayingController.swift
+++ b/boringNotch/MediaControllers/NowPlayingController.swift
@@ -7,7 +7,7 @@
 
 import AppKit
 import Combine
-import Foundation
+@preconcurrency import Foundation
 
 final class NowPlayingController: ObservableObject, MediaControllerProtocol {
     // Stub for now to conform with ControllerProtocol

--- a/boringNotch/MediaControllers/SpotifyController.swift
+++ b/boringNotch/MediaControllers/SpotifyController.swift
@@ -5,7 +5,7 @@
 //  Created by Alexander on 2025-03-29.
 //
 
-import Foundation
+@preconcurrency import Foundation
 import Combine
 import SwiftUI
 

--- a/boringNotch/MediaControllers/YouTubeMusicController.swift
+++ b/boringNotch/MediaControllers/YouTubeMusicController.swift
@@ -23,7 +23,6 @@ class YouTubeMusicController: MediaControllerProtocol {
     private var refreshTimer: Timer?
     private var cancellables = Set<AnyCancellable>()
     private var isAuthenticating = false
-    // Removed authQueue - using async/await instead
     
     init() {
         setupAppStateObservers()

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -359,39 +359,57 @@ class MusicManager: ObservableObject {
 
     // MARK: - Public Methods for controlling playback
     func playPause() {
-        activeController?.togglePlay()
+        Task {
+            await activeController?.togglePlay()
+        }
     }
 
     func play() {
-        activeController?.play()
+        Task {
+            await activeController?.play()
+        }
     }
 
     func pause() {
-        activeController?.pause()
+        Task {
+            await activeController?.pause()
+        }
     }
 
     func toggleShuffle() {
-        activeController?.toggleShuffle()
+        Task {
+            await activeController?.toggleShuffle()
+        }
     }
 
     func toggleRepeat() {
-        activeController?.toggleRepeat()
+        Task {
+            await activeController?.toggleRepeat()
+        }
     }
     
     func togglePlay() {
-        activeController?.togglePlay()
+        Task {
+            await activeController?.togglePlay()
+        }
     }
 
     func nextTrack() {
-        activeController?.nextTrack()
+        Task {
+            await activeController?.nextTrack()
+        }
     }
 
     func previousTrack() {
-        activeController?.previousTrack()
+        Task {
+            await activeController?.previousTrack()
+        }
     }
 
     func seek(to position: TimeInterval) {
-        activeController?.seek(to: position)
+        Task {
+            await activeController?.seek(to: position)
+        }
     }
 
     func openMusicApp() {


### PR DESCRIPTION
Media controllers were using patterns that could freeze the UI. `SpotifyController` and `AppleMusicController` used semaphores for `AppleScript` calls, while `YouTubeMusicController` used `DispatchQueue` and completion handlers.

Changes:
- Replaced semaphore-based blocking with async/await in AppleMusic/Spotify controllers
- Converted YouTubeMusicController from DispatchQueue/callbacks to async/await
- Added @preconcurrency imports for Swift 6 readiness
- Updated to modern Task.sleep(for:) syntax
- Added async protocol methods where missing

This fix prevents UI freezes during:
- App initialization when music apps are running
- Playback state change notifications
- User interactions (seek, shuffle, repeat)                                                                                                                                                                

The async implementation allows the main thread to remain responsive while AppleScript execution happens in the background. All controllers now follow consistent async patterns and are ready for Swift 6 strict concurrency.

