### PR TITLE
fix: resolve inline sneak peek keyboard shortcut issue

### DIFF
--- a/boringNotch/BoringViewCoordinator.swift
+++ b/boringNotch/BoringViewCoordinator.swift
@@ -212,10 +212,11 @@ class BoringViewCoordinator: ObservableObject {
             if expandingView.show {
                 expandingViewTask?.cancel()
                 let duration: TimeInterval = (expandingView.type == .download ? 2 : 3)
+                let currentType = expandingView.type
                 expandingViewTask = Task { [weak self] in
                     try? await Task.sleep(for: .seconds(duration))
                     guard let self = self, !Task.isCancelled else { return }
-                    self.toggleExpandingView(status: false, type: .battery)
+                    self.toggleExpandingView(status: false, type: currentType)
                 }
             } else {
                 expandingViewTask?.cancel()

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -207,11 +207,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         KeyboardShortcuts.onKeyDown(for: .toggleSneakPeek) { [weak self] in
             guard let self = self else { return }
-            self.coordinator.toggleSneakPeek(
-                status: !self.coordinator.sneakPeek.show,
-                type: .music,
-                duration: 3.0
-            )
+            
+            // Check the current sneak peek style setting
+            if Defaults[.sneakPeekStyles] == .standard {
+                self.coordinator.toggleSneakPeek(
+                    status: !self.coordinator.sneakPeek.show,
+                    type: .music,
+                    duration: 3.0
+                )
+            } else {
+                // For inline style, use the expanding view
+                self.coordinator.toggleExpandingView(
+                    status: !self.coordinator.expandingView.show,
+                    type: .music
+                )
+            }
         }
 
         KeyboardShortcuts.onKeyDown(for: .toggleNotchOpen) { [weak self] in


### PR DESCRIPTION
- Fix keyboard shortcut (Cmd+Shift+H) not working for inline sneak peek style
- Keyboard shortcut now respects user's sneak peek style setting
- Standard style: shows sneak peek below notch (unchanged)
- Inline style: expands notch to show music info within (now working)
- Fix expanding view timer to preserve correct content type
- Ensures consistent behavior between manual shortcut and automatic music triggers

Fixes this issue: https://github.com/TheBoredTeam/boring.notch/issues/718
<img width="788" height="87" alt="Screenshot 2025-09-02 at 12 17 15 PM" src="https://github.com/user-attachments/assets/1dec0b9c-f9ff-4070-9f00-4d67be500de6" />
