### PR TITLE
fix: Typo/grammatical issue in settings toggle label

### DIFF
--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -1309,7 +1309,7 @@ struct Appearance: View {
                         .tag(MirrorShapeEnum.rectangle)
                 }
                 Defaults.Toggle(key: .showNotHumanFace) {
-                    Text("Show cool face animation while inactivity")
+                    Text("Show cool face animation while inactive")
                 }
             } header: {
                 HStack {


### PR DESCRIPTION
This is such a small change that I'm not sure if this is considered rude or something in open-source (I'm pretty new to open-source), but just when testing the 2.7-rc.3, I noticed this small thing and just decided to propose this.