### PR TITLE
Add support for multi-line wrapping of long event titles

### DIFF
--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -2402,6 +2402,9 @@
         }
       }
     },
+    "Allow event titles to wrap across multiple lines so long titles are readable; this may increase the calendar list height." : {
+
+    },
     "Always hide in fullscreen" : {
       "localizations" : {
         "ar" : {
@@ -2501,6 +2504,9 @@
           }
         }
       }
+    },
+    "Always show full event titles" : {
+
     },
     "Always show tabs" : {
       "localizations" : {

--- a/boringNotch/components/Calendar/BoringCalendar.swift
+++ b/boringNotch/components/Calendar/BoringCalendar.swift
@@ -268,6 +268,7 @@ struct EventListView: View {
     @ObservedObject private var calendarManager = CalendarManager.shared
     let events: [EventModel]
     @Default(.autoScrollToNextEvent) private var autoScrollToNextEvent
+    @Default(.showFullEventTitles) private var showFullEventTitles
 
 
     static func filteredEvents(events: [EventModel]) -> [EventModel] {
@@ -379,7 +380,7 @@ struct EventListView: View {
                         Text(event.title)
                             .font(.callout)
                             .foregroundColor(.white)
-                            .lineLimit(1)
+                            .lineLimit(showFullEventTitles ? nil : 1)
                         Spacer(minLength: 0)
                         VStack(alignment: .trailing, spacing: 4) {
                             if event.isAllDay {
@@ -417,7 +418,7 @@ struct EventListView: View {
                             .font(.callout)
                             .fontWeight(.medium)
                             .foregroundColor(.white)
-                            .lineLimit(2)
+                            .lineLimit(showFullEventTitles ? nil : 2)
 
                         if let location = event.location, !location.isEmpty {
                             Text(location)

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -687,6 +687,9 @@ struct CalendarSettings: View {
             Defaults.Toggle(key: .autoScrollToNextEvent) {
                 Text("Auto-scroll to next event")
             }
+            Defaults.Toggle(key: .showFullEventTitles) {
+                Text("Always show full event titles")
+            }
             Section(header: Text("Calendars")) {
                 if calendarManager.calendarAuthorizationStatus != .fullAccess {
                     Text("Calendar access is denied. Please enable it in System Settings.")

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -171,6 +171,7 @@ extension Defaults.Keys {
         // MARK: Calendar
     static let calendarSelectionState = Key<CalendarSelectionState>("calendarSelectionState", default: .all)
     static let hideAllDayEvents = Key<Bool>("hideAllDayEvents", default: false)
+    static let showFullEventTitles = Key<Bool>("showFullEventTitles", default: false)
     static let autoScrollToNextEvent = Key<Bool>("autoScrollToNextEvent", default: false)
     
         // MARK: Fullscreen Media Detection


### PR DESCRIPTION
This pull request adds a new user preference that allows event titles in the calendar to wrap across multiple lines, preventing truncation of long titles at the expense of using more vertical space.