### PR TITLE
Feature: sneak peak duration

### DIFF
--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -598,6 +598,7 @@ struct Media: View {
     @Default(.hideNotchOption) var hideNotchOption
     @Default(.enableSneakPeek) private var enableSneakPeek
     @Default(.sneakPeekStyles) var sneakPeekStyles
+    @Default(.sneakPeakDuration) var sneakPeakDuration
 
     @Default(.enableLyrics) var enableLyrics
 
@@ -648,6 +649,18 @@ struct Media: View {
                 Picker("Sneak Peek Style", selection: $sneakPeekStyles) {
                     ForEach(SneakPeekStyle.allCases) { style in
                         Text(style.rawValue).tag(style)
+                    }
+                }
+                if Defaults[.sneakPeekStyles] == .standard {
+                    HStack {
+                        Stepper(value: $sneakPeakDuration, in: 1...5, step: 0.5) {
+                            HStack {
+                                Text("Sneak Peek Duration")
+                                Spacer()
+                                Text("\(Defaults[.sneakPeakDuration], specifier: "%.1f") seconds")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
                     }
                 }
                 HStack {

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -585,7 +585,7 @@ class MusicManager: ObservableObject {
     private func updateSneakPeek() {
         if isPlaying && Defaults[.enableSneakPeek] {
             if Defaults[.sneakPeekStyles] == .standard {
-                coordinator.toggleSneakPeek(status: true, type: .music)
+                coordinator.toggleSneakPeek(status: true, type: .music, duration: Defaults[.sneakPeakDuration])
             } else {
                 coordinator.toggleExpandingView(status: true, type: .music)
             }

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -126,6 +126,7 @@ extension Defaults.Keys {
     static let coloredSpectrogram = Key<Bool>("coloredSpectrogram", default: true)
     static let enableSneakPeek = Key<Bool>("enableSneakPeek", default: false)
     static let sneakPeekStyles = Key<SneakPeekStyle>("sneakPeekStyles", default: .standard)
+    static let sneakPeakDuration = Key<Double>("sneakPeakDuration", default: 1.5)
     static let waitInterval = Key<Double>("waitInterval", default: 3)
     static let showShuffleAndRepeat = Key<Bool>("showShuffleAndRepeat", default: false)
     static let enableLyrics = Key<Bool>("enableLyrics", default: false)


### PR DESCRIPTION
Hi,

Users now can change sneak peak duration in the settings view.

I've added:

- `sneakPeakDuration` as project constant
- UI element in settings view, that shows only if style of SP is set to default
- used that constant when SP animation is called

If you've got any further suggestions about the code (styling/functionality), let me know.

_This PR addresses the first point of [issue #894](https://github.com/TheBoredTeam/boring.notch/issues/894)._