### PR TITLE
Add notifications tab and system delivery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 Thank you for taking the time to contribute! ❤️
 
-By following these guidelines, you show consideration for the time and effort of the developers who maintain this open-source project. In turn, this makes it easier for us to engage with your issue, review your changes, and support you in finalizing your pull requests.
+These guidelines help streamline the contribution process for everyone involved. By following them, you'll make it easier for maintainers to review your work and collaborate with you effectively.
 
-There are many ways to contribute: creating tutorials or blog posts, improving the documentation, submitting bug reports and feature requests, or writing code to be incorporated into Boring Notch itself.
+You can contribute in many ways: writing code, improving documentation, reporting bugs, requesting features, or creating tutorials and blog posts. Every contribution, large or small, helps make Boring Notch better.
 
 ## Table of Contents
 
@@ -123,7 +123,7 @@ If you need help or have questions:
 - Check the project documentation
 - Search existing issues for similar questions
 - Open a new issue with the "question" label
-- Join our community discussions (if applicable)
+- Join our [community Discord server](https://discord.com/servers/boring-notch-1269588937320566815)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
   <br>
 </h1>
 
-
 <p align="center">
   <a title="Crowdin" target="_blank" href="https://crowdin.com/project/boring-notch"><img src="https://badges.crowdin.net/boring-notch/localized.svg"></a>
   <img src="https://github.com/TheBoredTeam/boring.notch/actions/workflows/cicd.yml/badge.svg" alt="TheBoringNotch Build & Test" style="margin-right: 10px;" />
@@ -26,8 +25,8 @@ Say hello to **Boring Notch**, the coolest way to make your MacBook’s notch th
   <img src="https://github.com/user-attachments/assets/2d5f69c1-6e7b-4bc2-a6f1-bb9e27cf88a8" alt="Demo GIF" />
 </p>
 
-<!--https://github.com/user-attachments/assets/19b87973-4b3a-4853-b532-7e82d1d6b040-->
----
+## <!--https://github.com/user-attachments/assets/19b87973-4b3a-4853-b532-7e82d1d6b040-->
+
 <!--## Table of Contents
 - [Installation](#installation)
 - [Usage](#usage)
@@ -41,13 +40,16 @@ Say hello to **Boring Notch**, the coolest way to make your MacBook’s notch th
 
 ## Installation
 
-**System Requirements:**  
-- macOS **14 Sonoma** or later  
+**System Requirements:**
+
+- macOS **14 Sonoma** or later
 - Apple Silicon or Intel Mac
 
 ---
+
 > [!IMPORTANT]
 > We don't have an Apple Developer account yet. The application will show a popup on first launch that the app is from an unidentified developer.
+>
 > 1. Click **OK** to close the popup.
 > 2. Open **System Settings** > **Privacy & Security**.
 > 3. Scroll down and click **Open Anyway** next to the warning about the app.
@@ -55,8 +57,8 @@ Say hello to **Boring Notch**, the coolest way to make your MacBook’s notch th
 >
 > You only need to do this once.
 
-
 ### Option 1: Download and Install Manually
+
 <a href="https://github.com/TheBoredTeam/boring.notch/releases/latest/download/boringNotch.dmg" target="_self"><img width="200" src="https://github.com/user-attachments/assets/e3179be1-8416-4b8a-b417-743e1ecc67d6" alt="Download for macOS" /></a>
 
 ---
@@ -75,8 +77,11 @@ brew install --cask TheBoredTeam/boring-notch/boring-notch --no-quarantine
 - Hover over the notch to see it expand and reveal all its secrets.
 - Use the controls to manage your music like a rockstar.
 - Click the star in your menu bar to customize your notch to your heart's content.
+- In the Notifications tab, you can view battery and system alerts, and configure them to be delivered to the macOS Notification Center.
+- Notifications mirror an iOS-style center: filter by category (battery, calendar, shelf, system, info), mark as read or clear all, and choose banner/sound delivery from Settings.
 
 ## 📋 Roadmap
+
 - [x] Playback live activity 🎧
 - [x] Calendar integration 📆
 - [x] Reminders integration ☑️
@@ -86,16 +91,16 @@ brew install --cask TheBoredTeam/boring-notch/boring-notch --no-quarantine
 - [x] Shelf functionality with AirDrop 📚
 - [x] Notch sizing customization, finetuning on different display sizes 🖥️
 - [x] System HUD replacements (volume, brightness, backlight) 🎚️💡⌨️
-- [ ] Bluetooth Live Activity (connect/disconnect for bluetooth devices) 
+- [ ] Bluetooth Live Activity (connect/disconnect for bluetooth devices)
 - [ ] Weather integration ⛅️
 - [ ] Customizable Layout options 🛠️
 - [ ] Lock Screen Widgets 🔒
 - [ ] Extension system 🧩
-- [ ] Notifications (under consideration) 🔔
-<!-- - [ ] Clipboard history manager 📌 `Extension` -->
-<!-- - [ ] Download indicator of different browsers (Safari, Chromium browsers, Firefox) 🌍 `Extension`-->
-<!-- - [ ] Customizable function buttons 🎛️ -->
-<!-- - [ ] App switcher 🪄 -->
+- [x] Notifications 🔔
+  <!-- - [ ] Clipboard history manager 📌 `Extension` -->
+  <!-- - [ ] Download indicator of different browsers (Safari, Chromium browsers, Firefox) 🌍 `Extension`-->
+  <!-- - [ ] Customizable function buttons 🎛️ -->
+  <!-- - [ ] App switcher 🪄 -->
 
 <!-- ## 🧩 Extensions
 > [!NOTE]
@@ -111,48 +116,24 @@ brew install --cask TheBoredTeam/boring-notch/boring-notch --no-quarantine
 ### Installation
 
 1. **Clone the Repository**:
+
    ```bash
    git clone https://github.com/TheBoredTeam/boring.notch.git
    cd boring.notch
    ```
 
 2. **Open the Project in Xcode**:
+
    ```bash
    open boringNotch.xcodeproj
    ```
 
 3. **Build and Run**:
-    - Click the "Run" button or press `Cmd + R`. Watch the magic unfold!
+   - Click the "Run" button or press `Cmd + R`. Watch the magic unfold!
 
 ## 🤝 Contributing
 
-We’re all about good vibes and awesome contributions! Here’s how you can join the fun:
-
-1. **Fork the Repo**: Click that shiny "Fork" button and make your own version.
-2. **Clone Your Fork**:
-   ```bash
-   git clone https://github.com/{your-name}/boring.notch.git
-   # Replace {your-name} with your GitHub username
-   ```
-3. **Make sure to use the `dev` branch as base.**
-4. **Create a New Branch**:
-   ```bash
-   git checkout -b feature/{your-feature-name}
-   # Replace {your-feature-name} with a descriptive and concise name for your branch
-   # It is best practice to use only alphanumeric characters, write words in lowercase
-   # and seperate words with a single hyphen
-   ```
-5. **Make Your Changes**: Add that feature or fix that bug.
-6. **Commit Your Changes**:
-   ```bash
-   git commit -m "insert descriptive message here"
-   ```
-7. **Push to Your Fork**:
-   ```bash
-   git push origin feature/{your-feature-name}
-   # Remember to replace {your-feature-name} with the name you chose
-   ```
-8. **Create a Pull Request**: Head to the original repository and click on "New Pull Request." Fill in the required details, **make sure the base branch is set to `dev`**, and submit your PR. Let’s see what you’ve got!
+We’re all about good vibes and awesome contributions! Read [CONTRIBUTING.md](CONTRIBUTING.md) to learn how you can join the fun!
 
 ## Join our Discord Server
 
@@ -169,23 +150,25 @@ We’re all about good vibes and awesome contributions! Here’s how you can joi
 </a>
 
 ## Support us on Ko-fi!
+
 <!-- <a href="https://www.buymeacoffee.com/jfxh67wvfxq" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-red.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a> -->
+
 <a href="https://www.ko-fi.com/alexander5015" target="_blank"><img src="https://github.com/user-attachments/assets//a76175ef-7e93-475a-8b67-4922ba5964c2" alt="Support us on Ko-fi" style="height: 70px !important;width: 346px !important;" ></a>
 
 ## 🎉 Acknowledgments
 
-We would like to express our gratitude to the authors and maintainers of the open-source projects that made this possible. 
+We would like to express our gratitude to the authors and maintainers of the open-source projects that made this possible.
 
 ## Notable Projects
-- **[MediaRemoteAdapter](https://github.com/ungive/mediaremote-adapter)** –  An open-source project that allowed us to use the Now Playing source in macOS 15.4+
+
+- **[MediaRemoteAdapter](https://github.com/ungive/mediaremote-adapter)** – An open-source project that allowed us to use the Now Playing source in macOS 15.4+
 - **[NotchDrop](https://github.com/Lakr233/NotchDrop)** – An open-source project that has been instrumental in developing the first version of the "Shelf" feature in Boring Notch.
 
 For a full list of licenses and attributions, please see the [Third-Party Licenses](./THIRD_PARTY_LICENSES.md) file.
 
 ### Icon credits: [@maxtron95](https://github.com/maxtron95)
+
 ### Website credits: [@himanshhhhuv](https://github.com/himanshhhhuv)
 
 - **SwiftUI**: For making us look like coding wizards.
 - **You**: For being awesome and checking out **boring.notch**!
-
-

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -106,15 +106,18 @@
 		14E9FEAA2C70BF610062E83F /* DownloadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E9FEA92C70BF610062E83F /* DownloadView.swift */; };
 		14E9FEAE2C7325770062E83F /* Button+Bouncing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E9FEAD2C7325770062E83F /* Button+Bouncing.swift */; };
 		14FC6E502C7DED5600C7BEA5 /* DataTypes+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FC6E4F2C7DED5600C7BEA5 /* DataTypes+Extensions.swift */; };
+		30EAFFC29C71475389877537 /* NotchNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A7119A1D184FD9AF0917AD /* NotchNotification.swift */; };
 		507266DB2C908E2E00A2D00D /* HoverButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507266DA2C908E2E00A2D00D /* HoverButton.swift */; };
 		5917FD112E57891600E87F1C /* MediaKeyInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5917FD102E57891600E87F1C /* MediaKeyInterceptor.swift */; };
 		5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */; };
 		59D8C23C2E589FAA00147B33 /* VolumeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D8C23B2E589FAA00147B33 /* VolumeManager.swift */; };
+		705CCFF1D4BE4AC5873095BB /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD26844018D14759B62A7712 /* NotificationsView.swift */; };
 		9A0887322C7A693000C160EA /* TabButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0887312C7A693000C160EA /* TabButton.swift */; };
 		9A0887352C7AFF8E00C160EA /* TabSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0887342C7AFF8E00C160EA /* TabSelectionView.swift */; };
 		9A987A0D2C73CA66005CA465 /* ShelfView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A987A032C73CA66005CA465 /* ShelfView.swift */; };
 		9A987A102C73CA8D005CA465 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 9A987A0F2C73CA8D005CA465 /* Collections */; };
 		9AB0C6BD2C73C9CB00F7CD30 /* NotchHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */; };
+		A355ED9C43544DB3A924F720 /* NotificationCenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86B063905624DE6B2F691FD /* NotificationCenterManager.swift */; };
 		B10348D92C74E56000475897 /* ConditionalModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10348D82C74E56000475897 /* ConditionalModifier.swift */; };
 		B10F84A32C6C9596009F3026 /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10F84A22C6C9596009F3026 /* TestView.swift */; };
 		B141C2412CA5F53F00AC8CC8 /* SparkleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B141C2402CA5F53E00AC8CC8 /* SparkleView.swift */; };
@@ -280,10 +283,12 @@
 		5917FD102E57891600E87F1C /* MediaKeyInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaKeyInterceptor.swift; sourceTree = "<group>"; };
 		5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationRelauncher.swift; sourceTree = "<group>"; };
 		59D8C23B2E589FAA00147B33 /* VolumeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeManager.swift; sourceTree = "<group>"; };
+		65A7119A1D184FD9AF0917AD /* NotchNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchNotification.swift; sourceTree = "<group>"; };
 		9A0887312C7A693000C160EA /* TabButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabButton.swift; sourceTree = "<group>"; };
 		9A0887342C7AFF8E00C160EA /* TabSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSelectionView.swift; sourceTree = "<group>"; };
 		9A987A032C73CA66005CA465 /* ShelfView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShelfView.swift; sourceTree = "<group>"; };
 		9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotchHomeView.swift; sourceTree = "<group>"; };
+		AD26844018D14759B62A7712 /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
 		B10348D82C74E56000475897 /* ConditionalModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalModifier.swift; sourceTree = "<group>"; };
 		B10F84A22C6C9596009F3026 /* TestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView.swift; sourceTree = "<group>"; };
 		B141C2402CA5F53E00AC8CC8 /* SparkleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleView.swift; sourceTree = "<group>"; };
@@ -308,6 +313,7 @@
 		B1F0A0012E60000100000001 /* BrightnessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrightnessManager.swift; sourceTree = "<group>"; };
 		B1F747F82EC7E94000F841DB /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
 		B1FEB4982C7686630066EBBC /* PanGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanGesture.swift; sourceTree = "<group>"; };
+		E86B063905624DE6B2F691FD /* NotificationCenterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterManager.swift; sourceTree = "<group>"; };
 		F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryActivityManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -495,6 +501,7 @@
 				B18654302C6F4590000B926A /* Settings */,
 				B186542F2C6F455E000B926A /* Notch */,
 				9A0887332C7AFF7E00C160EA /* Tabs */,
+				825D0BEFDEC04F488769322B /* Notifications */,
 				B186542E2C6F453B000B926A /* Music */,
 				14D570BF2C5EA5870011E668 /* AnimatedFace.swift */,
 				14288DE72C6E01C800B9F80C /* ProgressIndicator.swift */,
@@ -516,6 +523,7 @@
 				147163992C5D35FF0068B555 /* MusicManager.swift */,
 				149E0B962C737D00006418B1 /* WebcamManager.swift */,
 				14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */,
+				E86B063905624DE6B2F691FD /* NotificationCenterManager.swift */,
 				B1F0A0012E60000100000001 /* BrightnessManager.swift */,
 				59D8C23B2E589FAA00147B33 /* VolumeManager.swift */,
 			);
@@ -633,9 +641,18 @@
 				B19016232CC15B4D00E3F12E /* Constants.swift */,
 				14D570C82C5F38890011E668 /* BoringViewModel.swift */,
 				14D570CA2C5F4B2C0011E668 /* BatteryStatusViewModel.swift */,
+				65A7119A1D184FD9AF0917AD /* NotchNotification.swift */,
 				1153BD902D986DB300979FB0 /* PlaybackState.swift */,
 			);
 			path = models;
+			sourceTree = "<group>";
+		};
+		825D0BEFDEC04F488769322B /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				AD26844018D14759B62A7712 /* NotificationsView.swift */,
+			);
+			path = Notifications;
 			sourceTree = "<group>";
 		};
 		9A0887332C7AFF7E00C160EA /* Tabs */ = {
@@ -827,7 +844,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1640;
-				LastUpgradeCheck = 1640;
+				LastUpgradeCheck = 2610;
 				TargetAttributes = {
 					11F7484E2EC9AABA00F841DB = {
 						CreatedOnToolsVersion = 16.4;
@@ -845,6 +862,7 @@
 			knownRegions = (
 				en,
 				Base,
+				ko,
 			);
 			mainGroup = 14CEF4092C5CAED200855D72;
 			packageReferences = (
@@ -1017,6 +1035,9 @@
 				14288E0C2C6F8EC000B9F80C /* AppIcons.swift in Sources */,
 				B1C448982C972CC4001F0858 /* ListItemPopover.swift in Sources */,
 				B19016242CC15B5000E3F12E /* Constants.swift in Sources */,
+				30EAFFC29C71475389877537 /* NotchNotification.swift in Sources */,
+				A355ED9C43544DB3A924F720 /* NotificationCenterManager.swift in Sources */,
+				705CCFF1D4BE4AC5873095BB /* NotificationsView.swift in Sources */,
 				1100290C2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift in Sources */,
 				11CFC6632E09918400748C80 /* MusicControllerSelectionView.swift in Sources */,
 				B1F0A0022E60000100000001 /* BrightnessManager.swift in Sources */,
@@ -1043,7 +1064,8 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 271;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = D2RJHY3R6Z;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BoringNotchXPCHelper/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BoringNotchXPCHelper;
@@ -1068,7 +1090,8 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 271;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = D2RJHY3R6Z;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BoringNotchXPCHelper/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BoringNotchXPCHelper;
@@ -1143,6 +1166,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = targeted;
@@ -1202,6 +1226,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 5.0;
@@ -1214,6 +1239,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				AUTOMATION_APPLE_EVENTS = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = boringNotch/boringNotch.entitlements;
@@ -1224,10 +1250,16 @@
 				CURRENT_PROJECT_VERSION = 271;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"boringNotch/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = D2RJHY3R6Z;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = YES;
+				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SELECTED_FILES = readwrite;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/mediaremote-adapter",
@@ -1268,6 +1300,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				AUTOMATION_APPLE_EVENTS = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = boringNotch/boringNotch.entitlements;
@@ -1278,9 +1311,15 @@
 				CURRENT_PROJECT_VERSION = 271;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"boringNotch/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = D2RJHY3R6Z;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = YES;
+				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
+				ENABLE_USER_SELECTED_FILES = readwrite;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/mediaremote-adapter",

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -347,6 +347,8 @@ struct ContentView: View {
                         NotchHomeView(albumArtNamespace: albumArtNamespace)
                     case .shelf:
                         ShelfView()
+                    case .notifications:
+                        NotificationsView()
                     }
                 }
                 .transition(

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -901,6 +901,16 @@
         }
       }
     },
+    "%lld day%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld day%2$@"
+          }
+        }
+      }
+    },
     "%lld%%" : {
       "localizations" : {
         "ar" : {
@@ -2802,6 +2812,9 @@
         }
       }
     },
+    "Authorization" : {
+
+    },
     "Auto-scroll to next event" : {
       "localizations" : {
         "ar" : {
@@ -4002,6 +4015,9 @@
         }
       }
     },
+    "Calendar & reminders" : {
+
+    },
     "Calendar access is denied. Please enable it in System Settings." : {
       "localizations" : {
         "ar" : {
@@ -4301,6 +4317,9 @@
           }
         }
       }
+    },
+    "Categories" : {
+
     },
     "Change media with horizontal gestures" : {
       "localizations" : {
@@ -5201,6 +5220,9 @@
           }
         }
       }
+    },
+    "Clear all notifications" : {
+
     },
     "Clear slot" : {
       "localizations" : {
@@ -7102,6 +7124,12 @@
         }
       }
     },
+    "Delivery" : {
+
+    },
+    "Delivery style" : {
+
+    },
     "Description" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -8706,6 +8734,9 @@
           }
         }
       }
+    },
+    "Enable notifications" : {
+
     },
     "Enable shelf" : {
       "localizations" : {
@@ -11208,6 +11239,9 @@
         }
       }
     },
+    "History" : {
+
+    },
     "Hover delay" : {
       "localizations" : {
         "ar" : {
@@ -11708,6 +11742,9 @@
         }
       }
     },
+    "Info" : {
+
+    },
     "Inline" : {
       "localizations" : {
         "ar" : {
@@ -11908,6 +11945,9 @@
           }
         }
       }
+    },
+    "Keep history" : {
+
     },
     "Layout Preview" : {
       "localizations" : {
@@ -15510,6 +15550,9 @@
         }
       }
     },
+    "Notifications" : {
+
+    },
     "Open Calendar Settings" : {
       "localizations" : {
         "ar" : {
@@ -15609,6 +15652,9 @@
           }
         }
       }
+    },
+    "Open macOS settings" : {
+
     },
     "Open Notch" : {
       "localizations" : {
@@ -16209,6 +16255,9 @@
           }
         }
       }
+    },
+    "Play sound" : {
+
     },
     "Plugged In" : {
       "localizations" : {
@@ -17710,6 +17759,9 @@
         }
       }
     },
+    "Request permission" : {
+
+    },
     "Reset to Defaults" : {
       "localizations" : {
         "ar" : {
@@ -17809,6 +17861,9 @@
           }
         }
       }
+    },
+    "Respect Do Not Disturb / Focus" : {
+
     },
     "Restart" : {
       "extractionState" : "stale",
@@ -23614,6 +23669,18 @@
           }
         }
       }
+    },
+    "모두 읽음" : {
+
+    },
+    "배터리와 시스템 이벤트를 한 곳에서 확인하세요." : {
+
+    },
+    "비우기" : {
+
+    },
+    "알림이 비활성화되어 있어요. 설정에서 켜주세요." : {
+
     }
   },
   "version" : "1.0"

--- a/boringNotch/MediaControllers/AppleMusicController.swift
+++ b/boringNotch/MediaControllers/AppleMusicController.swift
@@ -117,9 +117,9 @@ class AppleMusicController: MediaControllerProtocol {
 
     func setFavorite(_ favorite: Bool) async {
         let script = """
-        tell application \"Music\"
+        tell application "Music"
             try
-                set favorited of current track to " + (favorite ? "true" : "false") + "
+                set favorited of current track to \(favorite)
             end try
         end tell
         """

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -16,7 +16,12 @@ struct BoringHeader: View {
     var body: some View {
         HStack(spacing: 0) {
             HStack {
-                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
+                let shouldShowTabs =
+                Defaults[.enableNotifications]
+                || coordinator.alwaysShowTabs
+                || (Defaults[.boringShelf] && !tvm.isEmpty)
+
+                if shouldShowTabs {
                     TabSelectionView()
                 } else if vm.notchState == .open {
                     EmptyView()

--- a/boringNotch/components/Notifications/NotificationsView.swift
+++ b/boringNotch/components/Notifications/NotificationsView.swift
@@ -1,0 +1,167 @@
+import Defaults
+import SwiftUI
+
+struct NotificationsView: View {
+    @ObservedObject var manager = NotificationCenterManager.shared
+    @Default(.enableNotifications) var enableNotifications
+    @Default(.showBatteryNotifications) var showBatteryNotifications
+    @Default(.showCalendarNotifications) var showCalendarNotifications
+    @Default(.showShelfNotifications) var showShelfNotifications
+    @Default(.showSystemNotifications) var showSystemNotifications
+    @Default(.showInfoNotifications) var showInfoNotifications
+
+    // Keep the open notch height consistent across tabs, even when notifications are disabled/empty.
+    private let minContentHeight: CGFloat = 240
+
+    private let formatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+
+            if !enableNotifications {
+                Text("알림이 비활성화되어 있어요. 설정에서 켜주세요.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 12)
+            } else if filteredNotifications.isEmpty {
+                HStack {
+                    Spacer()
+                    EmptyStateView(message: "표시할 알림이 없어요")
+                    Spacer()
+                }
+                .padding(.vertical, 20)
+            } else {
+                ScrollView {
+                    VStack(spacing: 10) {
+                        ForEach(filteredNotifications) { notification in
+                            NotificationRow(
+                                notification: notification,
+                                formatter: formatter
+                            )
+                            .onTapGesture {
+                                manager.markAsRead(notification.id)
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+        .padding(14)
+        .frame(minHeight: minContentHeight, alignment: .topLeading)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Notifications")
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                    Text("배터리와 시스템 이벤트를 한 곳에서 확인하세요.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                HStack(spacing: 8) {
+                    Button("모두 읽음") {
+                        manager.markAllRead()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+
+                    Button("비우기") {
+                        manager.clear()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+        }
+    }
+
+    private var filteredNotifications: [NotchNotification] {
+        let enabledCategories = Set([
+            showBatteryNotifications ? NotchNotificationCategory.battery : nil,
+            showCalendarNotifications ? NotchNotificationCategory.calendar : nil,
+            showShelfNotifications ? NotchNotificationCategory.shelf : nil,
+            showSystemNotifications ? NotchNotificationCategory.system : nil,
+            showInfoNotifications ? NotchNotificationCategory.info : nil
+        ].compactMap { $0 })
+
+        return manager.notifications.filter { enabledCategories.contains($0.category) }
+    }
+}
+
+private struct NotificationRow: View {
+    let notification: NotchNotification
+    let formatter: RelativeDateTimeFormatter
+
+    private var relativeDate: String {
+        formatter.localizedString(for: notification.date, relativeTo: Date())
+    }
+
+    private var iconColor: Color {
+        switch notification.category {
+        case .battery:
+            return .green
+        case .calendar:
+            return .cyan
+        case .shelf:
+            return .orange
+        case .system:
+            return .yellow
+        case .info:
+            return .blue
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: notification.category.iconName)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(iconColor)
+                .frame(width: 26, height: 26)
+                .padding(6)
+                .background(.black.opacity(0.35))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(notification.title)
+                        .foregroundStyle(.white)
+                        .fontWeight(.semibold)
+                    Spacer()
+                    Text(relativeDate)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(notification.message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(notification.isRead ? Color.black.opacity(0.2) : Color(nsColor: .controlAccentColor).opacity(0.18))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(notification.isRead ? Color.white.opacity(0.08) : Color(nsColor: .controlAccentColor).opacity(0.4), lineWidth: 1)
+        )
+    }
+}
+

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -16,6 +16,7 @@ struct TabModel: Identifiable {
 
 let tabs = [
     TabModel(label: "Home", icon: "house.fill", view: .home),
+    TabModel(label: "Notifications", icon: "bell.fill", view: .notifications),
     TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
 ]
 

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -27,6 +27,7 @@ public enum NotchState {
 public enum NotchViews {
     case home
     case shelf
+    case notifications
 }
 
 enum SettingsEnum {

--- a/boringNotch/managers/NotificationCenterManager.swift
+++ b/boringNotch/managers/NotificationCenterManager.swift
@@ -1,0 +1,184 @@
+//
+//  NotificationCenterManager.swift
+//  boringNotch
+//
+//  Created by tyler_song on 2025-12-08.
+//
+
+import Combine
+import Defaults
+import Foundation
+import UserNotifications
+
+@MainActor
+final class NotificationCenterManager: NSObject, ObservableObject {
+    static let shared = NotificationCenterManager()
+
+    @Published private(set) var notifications: [NotchNotification] = []
+    @Published private(set) var authorizationStatus: UNAuthorizationStatus = .notDetermined
+
+    private let center = UNUserNotificationCenter.current()
+    private let storageLimit = 200
+    private var cancellables: Set<AnyCancellable> = []
+
+    private override init() {
+        super.init()
+        loadStoredNotifications()
+        pruneExpiredNotifications()
+        refreshAuthorizationStatus()
+        observeRetentionChanges()
+    }
+
+    func addNotification(
+        title: String,
+        message: String,
+        category: NotchNotificationCategory,
+        deliverToSystem: Bool = true
+    ) {
+        guard Defaults[.enableNotifications] else { return }
+        guard isCategoryEnabled(category) else { return }
+
+        let newNotification = NotchNotification(
+            title: title,
+            message: message,
+            category: category
+        )
+
+        notifications.insert(newNotification, at: 0)
+        trimToLimit()
+        pruneExpiredNotifications()
+        persist()
+
+        guard shouldDeliverToSystem(deliverToSystem) else { return }
+        sendSystemNotification(for: newNotification)
+    }
+
+    func markAsRead(_ id: UUID) {
+        if let index = notifications.firstIndex(where: { $0.id == id }) {
+            notifications[index].isRead = true
+            persist()
+        }
+    }
+
+    func markAllRead() {
+        notifications = notifications.map { item in
+            var updated = item
+            updated.isRead = true
+            return updated
+        }
+        persist()
+    }
+
+    func clear() {
+        notifications.removeAll()
+        persist()
+    }
+
+    func refreshAuthorizationStatus() {
+        center.getNotificationSettings { [weak self] settings in
+            DispatchQueue.main.async {
+                self?.authorizationStatus = settings.authorizationStatus
+            }
+        }
+    }
+
+    func requestAuthorizationIfNeeded() {
+        guard authorizationStatus == .notDetermined else { return }
+        center.requestAuthorization(options: [.alert, .sound, .badge]) { [weak self] _, _ in
+            self?.refreshAuthorizationStatus()
+        }
+    }
+
+    private func loadStoredNotifications() {
+        notifications = Defaults[.storedNotifications]
+            .sorted(by: { $0.date > $1.date })
+    }
+
+    private func persist() {
+        Defaults[.storedNotifications] = notifications
+    }
+
+    private func trimToLimit() {
+        if notifications.count > storageLimit {
+            notifications = Array(notifications.prefix(storageLimit))
+        }
+    }
+
+    private func pruneExpiredNotifications() {
+        let days = Defaults[.notificationRetentionDays]
+        let now = Date()
+        let threshold = now.addingTimeInterval(TimeInterval(-days) * 24 * 60 * 60)
+        notifications = notifications.filter { $0.date >= threshold }
+    }
+
+    private func shouldDeliverToSystem(_ requested: Bool) -> Bool {
+        guard requested else { return false }
+        guard Defaults[.notificationDeliveryStyle] == .banner else { return false }
+        if Defaults[.respectDoNotDisturb], isFocusModeLikelyActive() {
+            return false
+        }
+        return Defaults[.enableNotifications]
+    }
+
+    private func isCategoryEnabled(_ category: NotchNotificationCategory) -> Bool {
+        switch category {
+        case .battery:
+            return Defaults[.showBatteryNotifications]
+        case .calendar:
+            return Defaults[.showCalendarNotifications]
+        case .shelf:
+            return Defaults[.showShelfNotifications]
+        case .system:
+            return Defaults[.showSystemNotifications]
+        case .info:
+            return Defaults[.showInfoNotifications]
+        }
+    }
+
+    private func sendSystemNotification(for notification: NotchNotification) {
+        center.getNotificationSettings { [weak self] settings in
+            guard let self else { return }
+
+            if settings.authorizationStatus == .notDetermined {
+                self.requestAuthorizationIfNeeded()
+            }
+
+            guard settings.authorizationStatus == .authorized else { return }
+
+            let content = UNMutableNotificationContent()
+            content.title = notification.title
+            content.body = notification.message
+            if Defaults[.notificationSoundEnabled] {
+                content.sound = .default
+            }
+            content.categoryIdentifier = notification.category.rawValue
+
+            let request = UNNotificationRequest(
+                identifier: notification.id.uuidString,
+                content: content,
+                trigger: nil
+            )
+
+            self.center.add(request)
+        }
+    }
+
+    private func isFocusModeLikelyActive() -> Bool {
+        let domain = "com.apple.ncprefs" as CFString
+        if let enabled = CFPreferencesCopyAppValue("dndEnabled" as CFString, domain) as? Bool {
+            return enabled
+        }
+        return false
+    }
+
+    private func observeRetentionChanges() {
+        Defaults.publisher(.notificationRetentionDays)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.pruneExpiredNotifications()
+                self.persist()
+            }
+            .store(in: &cancellables)
+    }
+}
+

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -36,6 +36,23 @@ enum HideNotchOption: String, Defaults.Serializable {
     case never
 }
 
+// Notification delivery styles
+enum NotificationDeliveryStyle: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case inAppOnly = "In-App Only"
+    case banner = "Banner"
+
+    var id: String { rawValue }
+
+    var description: String {
+        switch self {
+        case .inAppOnly:
+            return "Show in notch only"
+        case .banner:
+            return "Send to macOS Notification Center"
+        }
+    }
+}
+
 // Define notification names at file scope
 extension Notification.Name {
     static let mediaControllerChanged = Notification.Name("mediaControllerChanged")
@@ -74,6 +91,22 @@ extension Defaults.Keys {
     static let showOnAllDisplays = Key<Bool>("showOnAllDisplays", default: false)
     static let automaticallySwitchDisplay = Key<Bool>("automaticallySwitchDisplay", default: true)
     static let releaseName = Key<String>("releaseName", default: "Flying Rabbit 🐇🪽")
+    
+    // MARK: Notifications
+    static let enableNotifications = Key<Bool>("enableNotifications", default: true)
+    static let showBatteryNotifications = Key<Bool>("showBatteryNotifications", default: true)
+    static let showCalendarNotifications = Key<Bool>("showCalendarNotifications", default: true)
+    static let showShelfNotifications = Key<Bool>("showShelfNotifications", default: true)
+    static let showSystemNotifications = Key<Bool>("showSystemNotifications", default: true)
+    static let showInfoNotifications = Key<Bool>("showInfoNotifications", default: true)
+    static let notificationDeliveryStyle = Key<NotificationDeliveryStyle>(
+        "notificationDeliveryStyle",
+        default: .banner
+    )
+    static let notificationSoundEnabled = Key<Bool>("notificationSoundEnabled", default: true)
+    static let respectDoNotDisturb = Key<Bool>("respectDoNotDisturb", default: true)
+    static let notificationRetentionDays = Key<Int>("notificationRetentionDays", default: 7)
+    static let storedNotifications = Key<[NotchNotification]>("storedNotifications", default: [])
     
     // MARK: Behavior
     static let minimumHoverDuration = Key<TimeInterval>("minimumHoverDuration", default: 0.3)

--- a/boringNotch/models/NotchNotification.swift
+++ b/boringNotch/models/NotchNotification.swift
@@ -1,0 +1,75 @@
+//
+//  NotchNotification.swift
+//  boringNotch
+//
+//  Created by tyler_song on 2025-12-08.
+//
+
+import Defaults
+import Foundation
+
+enum NotchNotificationCategory: String, CaseIterable, Identifiable, Codable, Defaults.Serializable {
+    case battery
+    case calendar
+    case shelf
+    case system
+    case info
+
+    var id: String { rawValue }
+
+    var iconName: String {
+        switch self {
+        case .battery:
+            return "bolt.fill"
+        case .calendar:
+            return "calendar"
+        case .shelf:
+            return "tray.full.fill"
+        case .system:
+            return "gearshape.fill"
+        case .info:
+            return "info.circle.fill"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .battery:
+            return "Battery"
+        case .calendar:
+            return "Calendar"
+        case .shelf:
+            return "Shelf"
+        case .system:
+            return "System"
+        case .info:
+            return "Info"
+        }
+    }
+}
+
+struct NotchNotification: Identifiable, Codable, Hashable, Defaults.Serializable {
+    let id: UUID
+    let title: String
+    let message: String
+    let date: Date
+    let category: NotchNotificationCategory
+    var isRead: Bool
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        message: String,
+        date: Date = Date(),
+        category: NotchNotificationCategory,
+        isRead: Bool = false
+    ) {
+        self.id = id
+        self.title = title
+        self.message = message
+        self.date = date
+        self.category = category
+        self.isRead = isRead
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a notifications tab in the notch UI and hook it to the coordinator
- introduce NotificationCenterManager and NotchNotification model for in-app + macOS banner delivery with retention
- expose notification settings (categories, delivery style, sound, DND, history) and document the feature

## Testing
- [x] Not tested (manual verification needed)