### PR TITLE
Fix album art aspect ratio to prevent distortion

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -388,16 +388,13 @@ struct ContentView: View {
         HStack {
             Image(nsImage: musicManager.albumArt)
                 .resizable()
-                .clipped()
-                .clipShape(
-                    RoundedRectangle(
-                        cornerRadius: MusicPlayerImageSizes.cornerRadiusInset.closed)
-                )
-                .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
+                .scaledToFill()
                 .frame(
                     width: max(0, vm.effectiveClosedNotchHeight - 12),
                     height: max(0, vm.effectiveClosedNotchHeight - 12)
                 )
+                .clipShape(RoundedRectangle(cornerRadius: MusicPlayerImageSizes.cornerRadiusInset.closed))
+                .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
 
             Rectangle()
                 .fill(.black)

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -82,17 +82,22 @@ struct AlbumArtView: View {
                 
 
     private var albumArtImage: some View {
-        Image(nsImage: musicManager.albumArt)
-            .resizable()
-            .aspectRatio(1, contentMode: .fit)
-            .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
-            .clipped()
-            .clipShape(
-                RoundedRectangle(
-                    cornerRadius: Defaults[.cornerRadiusScaling]
-                        ? MusicPlayerImageSizes.cornerRadiusInset.opened
-                        : MusicPlayerImageSizes.cornerRadiusInset.closed)
-            )
+        GeometryReader { geo in
+            Image(nsImage: musicManager.albumArt)
+                .resizable()
+                .scaledToFill()
+                .frame(width: geo.size.width, height: geo.size.width)
+                .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
+                .clipShape(
+                    RoundedRectangle(
+                        cornerRadius: Defaults[.cornerRadiusScaling]
+                            ? MusicPlayerImageSizes.cornerRadiusInset.opened
+                            : MusicPlayerImageSizes.cornerRadiusInset.closed
+                    )
+                )
+                .clipped()
+        }
+        .aspectRatio(1, contentMode: .fit)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Fix album art aspect ratio distortion

### Changes
Fixed an issue where album art wasn't maintaining its aspect ratio properly, causing non-square artwork to appear stretched or distorted.

### The Issue
The album art display was using `.clipped()` and `.aspectRatio(1, contentMode: .fit)` which didn't handle non-square images well. This resulted in distorted album artwork in both the live activity bar and the expanded view.

### What I Changed

**ContentView.swift (MusicLiveActivity)**
- Changed from `.clipped()` to `.scaledToFill()` before setting frame
- This ensures the image fills the frame while maintaining aspect ratio

**NotchHomeView.swift (albumArtImage)**
- Wrapped the image in a `GeometryReader` to get proper dimensions
- Switched to `.scaledToFill()` with explicit frame sizing
- The image now crops properly instead of stretching

Both changes preserve the existing `matchedGeometryEffect` animations, so transitions still look smooth.

### Before / After

**Before:**
<img width="640" height="209" alt="Screenshot 2568-12-12 at 22 47 14" src="https://github.com/user-attachments/assets/95f906ae-05bf-4eaa-b3d6-9f5a8e6c908c" />
<img width="264" height="35" alt="Screenshot 2568-12-12 at 22 47 18" src="https://github.com/user-attachments/assets/faa984b5-5302-4f9f-9d4b-23ab0874bbe5" />

**After:**
<img width="640" height="209" alt="Screenshot 2568-12-12 at 22 46 25" src="https://github.com/user-attachments/assets/6d1e0190-b82e-4429-ad97-6222546f0ac2" />
<img width="264" height="35" alt="Screenshot 2568-12-12 at 22 46 29" src="https://github.com/user-attachments/assets/882aec26-6c6b-4b78-8996-89a7a08fc1c5" />

Tested with a few different album covers to make sure everything looks correct.