### PR TITLE
Fix Apple Music favorite setting syntax in setFavorite method

### DIFF
--- a/boringNotch/MediaControllers/AppleMusicController.swift
+++ b/boringNotch/MediaControllers/AppleMusicController.swift
@@ -117,9 +117,9 @@ class AppleMusicController: MediaControllerProtocol {
 
     func setFavorite(_ favorite: Bool) async {
         let script = """
-        tell application \"Music\"
+        tell application "Music"
             try
-                set favorited of current track to " + (favorite ? "true" : "false") + "
+                set favorited of current track to \(favorite)
             end try
         end tell
         """


### PR DESCRIPTION
Fixed incorrect syntax in the setFavorite method that caused Apple Music favorites to not work. Updated the request format to match Apple Music API expectations.