### PR TITLE
Normalize scroll direction for natural scrolling in ScrollMonitor

### DIFF
--- a/boringNotch/extensions/PanGesture.swift
+++ b/boringNotch/extensions/PanGesture.swift
@@ -127,9 +127,16 @@ private struct ScrollMonitor: NSViewRepresentable {
             let isAxisDominant: Bool = direction.isHorizontal ? (absDX >= axisDominanceFactor * absDY) : (absDY >= axisDominanceFactor * absDX)
             guard isAxisDominant else { return }
 
+            // Normalize to the physical scroll direction so macOS “Natural scrolling”
+            // does not invert the gesture semantics.
+            let deviceDirectionMultiplier: CGFloat = event.isDirectionInvertedFromDevice ? -1 : 1
+            
             // Scale non-precise (mouse wheel) scrolling deltas so they feel similar to
             // trackpad gestures.
-            let raw = direction.signed(deltaX: event.scrollingDeltaX, deltaY: event.scrollingDeltaY)
+            let raw = direction.signed(
+                deltaX: event.scrollingDeltaX * deviceDirectionMultiplier,
+                deltaY: event.scrollingDeltaY * deviceDirectionMultiplier
+            )
             let scale: CGFloat = event.hasPreciseScrollingDeltas ? 1 : 8
             let s = raw * scale
             guard s.magnitude > noiseThreshold else { return }


### PR DESCRIPTION
**What happened / Steps to reproduce**
With Natural Scrolling disabled in System Settings → Trackpad → Scroll & Zoom, the gesture direction in the app becomes reversed (two-finger swipe up opens the notch), which is unintuitive — users expect the same physical gesture to always open the notch.
**What did you expect to happen?**
Swiping down should open the notch and swiping up should close it — regardless of the system’s scroll preference.
**Solution**
Updated gesture handling logic to normalize scrolling delta values with isDirectionInvertedFromDevice so that gesture direction is based on physical swipe direction, not the system’s natural scroll preference.
This ensures intuitive, consistent gesture behavior whether natural scrolling is ON or OFF.
**Related issue**
Fixes #918(https://github.com/TheBoredTeam/boring.notch/issues/918)