### PR TITLE
Feature to reduce height of notch for non-notch screens

### DIFF
--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -11708,6 +11708,12 @@
         }
       }
     },
+    "Inactive notch height" : {
+
+    },
+    "Inactive notch sizing (For non-notch displays)" : {
+
+    },
     "Inline" : {
       "localizations" : {
         "ar" : {
@@ -22314,6 +22320,9 @@
           }
         }
       }
+    },
+    "Use smaller height when inactive" : {
+
     },
     "Use your macOS system accent color" : {
       "localizations" : {

--- a/boringNotch/models/BatteryStatusViewModel.swift
+++ b/boringNotch/models/BatteryStatusViewModel.swift
@@ -21,7 +21,8 @@ class BatteryStatusViewModel: ObservableObject {
     @Published private(set) var isInitial: Bool = false
     @Published private(set) var timeToFullCharge: Int = 0
     @Published private(set) var statusText: String = ""
-
+    @Published var hasActiveBatteryNotification: Bool = false
+    
     private let managerBattery = BatteryActivityManager.shared
     private var managerBatteryId: Int?
 
@@ -123,7 +124,12 @@ class BatteryStatusViewModel: ObservableObject {
     private func notifyImportanChangeStatus(delay: Double = 0.0) {
         Task {
             try? await Task.sleep(for: .seconds(delay))
+            self.hasActiveBatteryNotification = true
             self.coordinator.toggleExpandingView(status: true, type: .battery)
+            
+            // Auto-hide after a delay (e.g., 5 seconds)
+            try? await Task.sleep(for: .seconds(5))
+            self.hasActiveBatteryNotification = false
         }
     }
 

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -93,6 +93,8 @@ extension Defaults.Keys {
     //static let openLastTabByDefault = Key<Bool>("openLastTabByDefault", default: false)
     static let showOnLockScreen = Key<Bool>("showOnLockScreen", default: false)
     static let hideFromScreenRecording = Key<Bool>("hideFromScreenRecording", default: false)
+    static let inactiveNotchHeight = Key<CGFloat>("inactiveNotchHeight", default: 32)
+    static let useInactiveNotchHeight = Key<Bool>("useInactiveNotchHeight", default: false)
     
     // MARK: Appearance
     static let showEmojis = Key<Bool>("showEmojis", default: false)


### PR DESCRIPTION
Added a feature to reduce height of the notch when it is inactive for non-notch displays. Also height adjusts automatically when there is live activity or not

feat: implement dynamic notch height based on live activity state

- Add `effectiveClosedNotchHeight` computed property to adjust notch size
  based on music playback state
- Introduce `inactiveNotchSize` for smaller notch when no media is playing
- Implement fullscreen detection to hide notch when apps are fullscreen
- Add reactive height adjustments that respond to MusicManager playback state
- Optimize notch visibility with `hideOnClosed` property combining fullscreen
  status and user preferences
- Update chin height calculation to account for inactive state
- Improve screen-specific notch rendering with UUID-based tracking

This creates a more dynamic and context-aware notch that conserves screen
space when idle while expanding for active media controls.