### PR TITLE
Preserve thumbnail aspect ratios to prevent distortion

### DIFF
--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -48,7 +48,7 @@ struct AlbumArtView: View {
                         ? MusicPlayerImageSizes.cornerRadiusInset.opened
                         : MusicPlayerImageSizes.cornerRadiusInset.closed)
             )
-            .aspectRatio(1, contentMode: .fit)
+            .aspectRatio(contentMode: .fit)
             .scaleEffect(x: 1.3, y: 1.4)
             .rotationEffect(.degrees(92))
             .blur(radius: 40)
@@ -74,7 +74,7 @@ struct AlbumArtView: View {
 
     private var albumArtDarkOverlay: some View {
         Rectangle()
-            .aspectRatio(1, contentMode: .fit)
+            .aspectRatio(contentMode: .fit)
             .foregroundColor(Color.black)
             .opacity(musicManager.isPlaying ? 0 : 0.8)
             .blur(radius: 50)
@@ -84,7 +84,7 @@ struct AlbumArtView: View {
     private var albumArtImage: some View {
         Image(nsImage: musicManager.albumArt)
             .resizable()
-            .aspectRatio(1, contentMode: .fit)
+            .aspectRatio(contentMode: .fit)
             .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
             .clipped()
             .clipShape(


### PR DESCRIPTION
This change updates the thumbnail rendering to respect each image’s natural aspect ratio, preventing stretching and distortion. Previously, the view enforced a 1:1 aspect ratio using .aspectRatio(1, contentMode: .fit), which caused non-square images to appear squished or letterboxed. By switching to .aspectRatio(contentMode: .fit), the layout now preserves the intrinsic aspect ratio of thumbnails while still fitting them within the available space.

Before the change:
<img height="180" alt="Screenshot 2025-12-28 at 02 34 26" src="https://github.com/user-attachments/assets/115d83ec-f7e9-412d-a94f-25abc5d81e90" />

After the change:
<img height="180" alt="Screenshot 2025-12-28 at 02 34 08" src="https://github.com/user-attachments/assets/c8aceba0-b1ee-4970-ad1c-d636fc218d2e" />

