### PR TITLE
Center-align long Quick Share provider name in FileShareView

### DIFF
--- a/boringNotch/components/Shelf/Views/FileShareView.swift
+++ b/boringNotch/components/Shelf/Views/FileShareView.swift
@@ -86,6 +86,7 @@ struct FileShareView: View {
                 Text(selectedProvider.id)
                     .font(.system(.headline, design: .rounded))
                     .foregroundColor(.white.opacity(0.8))
+                    .multilineTextAlignment(.center)
 
             }
             .padding(18)


### PR DESCRIPTION
This change ensures that longer Quick Share provider names (e.g., “System Share Menu”) remain visually centered within the share drop area UI.

• Added .multilineTextAlignment(.center) to the Text(selectedProvider.id) in FileShareView.

Before the change:
<img width="652" height="209" alt="Screenshot 2025-12-28 at 03 05 07" src="https://github.com/user-attachments/assets/2b90d456-b617-404c-ab4a-03ed9516c51b" />

After the change:
<img width="652" height="209" alt="Screenshot 2025-12-28 at 03 04 40" src="https://github.com/user-attachments/assets/da38027f-9bb9-47cf-ae85-c539ca8065a2" />

