### PR TITLE
Feat/music player UI hidden

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -390,6 +390,7 @@ struct ContentView: View {
                         ShelfView()
                     }
                 }
+                .frame(maxHeight: .infinity, alignment: .top)
                 .transition(
                     .scale(scale: 0.8, anchor: .top)
                     .combined(with: .opacity)

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -90,12 +90,13 @@ struct ContentView: View {
         {
             chinWidth = 640
         } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music)
-            && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle)
+            && vm.notchState == .closed && musicManager.isMusicAppActive
+            && (musicManager.isPlaying || !musicManager.isPlayerIdle)
             && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed
         {
             chinWidth += (2 * max(0, displayClosedNotchHeight - 12) + 20)
         } else if !coordinator.expandingView.show && vm.notchState == .closed
-            && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace]
+            && !musicManager.isMusicAppActive && Defaults[.showNotHumanFace]
             && !vm.hideOnClosed
         {
             chinWidth += (2 * max(0, displayClosedNotchHeight - 12) + 20)
@@ -318,11 +319,13 @@ struct ContentView: View {
                               gestureProgress: $gestureProgress
                           )
                               .transition(.opacity)
-                      } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music) && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed {
+                      } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music) && vm.notchState == .closed && musicManager.isMusicAppActive && (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed {
                           MusicLiveActivity()
                               .frame(alignment: .center)
-                      } else if !coordinator.expandingView.show && vm.notchState == .closed && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {
+                              .transition(.opacity.combined(with: .scale(scale: 0.8)))
+                      } else if !coordinator.expandingView.show && vm.notchState == .closed && !musicManager.isMusicAppActive && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {
                           BoringFaceAnimation()
+                              .transition(.opacity.combined(with: .scale(scale: 0.8)))
                        } else if vm.notchState == .open {
                            BoringHeader()
                                .frame(height: max(24, displayClosedNotchHeight))

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -7395,6 +7395,9 @@
     "Normalize gesture direction" : {
 
     },
+    "No music app active" : {
+
+    },
     "Not charging" : {
       "localizations" : {
         "cs" : {
@@ -7690,6 +7693,9 @@
           }
         }
       }
+    },
+    "Open a music app to see playback controls" : {
+
     },
     "Open Calendar Settings" : {
       "localizations" : {

--- a/boringNotch/MediaControllers/NowPlayingController.swift
+++ b/boringNotch/MediaControllers/NowPlayingController.swift
@@ -144,7 +144,12 @@ final class NowPlayingController: ObservableObject, MediaControllerProtocol {
     }
 
     func isActive() -> Bool {
-        return true
+        // Check if the currently tracked app (from playback state) is running
+        let bundleID = playbackState.bundleIdentifier
+        if bundleID.isEmpty {
+            return false
+        }
+        return NSWorkspace.shared.runningApplications.contains { $0.bundleIdentifier == bundleID }
     }
     
     func toggleShuffle() async {

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -399,6 +399,7 @@ struct NotchHomeView: View {
     @ObservedObject var webcamManager = WebcamManager.shared
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @ObservedObject var musicManager = MusicManager.shared
     let albumArtNamespace: Namespace.ID
 
     var body: some View {
@@ -414,14 +415,33 @@ struct NotchHomeView: View {
     private var shouldShowCamera: Bool {
         Defaults[.showMirror] && webcamManager.cameraAvailable && vm.isCameraExpanded
     }
+    
+    /// Determines if the music player should be visible based on whether a music app is active
+    private var shouldShowMusicPlayer: Bool {
+        musicManager.isMusicAppActive
+    }
+    
+    /// Calculate the width for calendar when music player is hidden
+    private var calendarWidthWhenMusicHidden: CGFloat {
+        shouldShowCamera ? 280 : 400
+    }
 
     private var mainContent: some View {
         HStack(alignment: .top, spacing: (shouldShowCamera && Defaults[.showCalendar]) ? 10 : 15) {
-            MusicPlayerView(albumArtNamespace: albumArtNamespace)
+            // Music Player - only show when a music app is active
+            if shouldShowMusicPlayer {
+                MusicPlayerView(albumArtNamespace: albumArtNamespace)
+                    .transition(.asymmetric(
+                        insertion: .opacity.combined(with: .scale(scale: 0.9, anchor: .leading)).combined(with: .move(edge: .leading)),
+                        removal: .opacity.combined(with: .scale(scale: 0.9, anchor: .leading)).combined(with: .move(edge: .leading))
+                    ))
+            }
 
             if Defaults[.showCalendar] {
                 CalendarView()
-                    .frame(width: shouldShowCamera ? 170 : 215)
+                    .frame(width: shouldShowMusicPlayer 
+                           ? (shouldShowCamera ? 170 : 215)
+                           : calendarWidthWhenMusicHidden)
                     .onHover { isHovering in
                         vm.isHoveringCalendar = isHovering
                     }
@@ -436,9 +456,39 @@ struct NotchHomeView: View {
                     .blur(radius: vm.notchState == .closed ? 20 : 0)
                     .animation(.interactiveSpring(response: 0.32, dampingFraction: 0.76, blendDuration: 0), value: shouldShowCamera)
             }
+            
+            // When no music app is active and neither calendar nor camera is shown,
+            // show an empty state or placeholder
+            if !shouldShowMusicPlayer && !Defaults[.showCalendar] && !shouldShowCamera {
+                EmptyMusicPlaceholder()
+                    .transition(.opacity)
+            }
         }
+        .animation(.smooth(duration: 0.35), value: shouldShowMusicPlayer)
         .transition(.asymmetric(insertion: .opacity.combined(with: .move(edge: .top)), removal: .opacity))
         .blur(radius: vm.notchState == .closed ? 30 : 0)
+    }
+}
+
+/// A placeholder view shown when no music app is active and no other widgets are enabled
+private struct EmptyMusicPlaceholder: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "music.note")
+                .font(.system(size: 32, weight: .light))
+                .foregroundStyle(.secondary)
+            
+            Text("No music app active")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            
+            Text("Open a music app to see playback controls")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
     }
 }
 


### PR DESCRIPTION
This pull request introduces a smarter approach to detecting whether a music app is currently active, and updates the UI to show or hide music-related widgets accordingly. It adds a placeholder view when no music app is running, improves transitions, and refines the logic for displaying music and calendar widgets. The changes also include infrastructure for monitoring music app activity and new localizations for the empty music state.

**Codebase and State Management Improvements:**

* Added and cleaned up state management for music app monitoring tasks and cancellation in `MusicManager.destroy()`.
* Refactored calendar widget sizing logic to account for the presence or absence of the music player, making the UI more adaptive.