### PR TITLE
Use explicit play/pause for Now Playing - fix plexamp control 

### DIFF
--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -250,7 +250,11 @@ struct MusicControlsView: View {
             }
         case .playPause:
             HoverButton(icon: musicManager.isPlaying ? "pause.fill" : "play.fill", scale: .large) {
-                MusicManager.shared.togglePlay()
+                if musicManager.isPlaying {
+                    MusicManager.shared.pause()
+                } else {
+                    MusicManager.shared.play()
+                }
             }
         case .next:
             HoverButton(icon: "forward.fill", scale: .medium) {


### PR DESCRIPTION
Play/Pause was acting likt it was double-click very fast in apps like plexamp