### PR TITLE
Made transitions between lyrics smoother

### DIFF
--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -3,7 +3,7 @@
 //  boringNotch
 //
 //  Created by Hugo Persson on 2024-08-18.
-//  Modified by Harsh Vardhan Goswami & Richard Kunkli & Mustafa Ramadan
+//  Modified by Harsh Vardhan Goswami & Richard Kunkli & Mustafa Ramadan & Dimitris Chatzigeorgiou
 //
 
 import Combine
@@ -173,17 +173,17 @@ struct MusicControlsView: View {
                         let v = scalar.value
                         return v >= 0x0600 && v <= 0x06FF
                     }
-                    MarqueeText(
-                        .constant(line),
-                        font: .subheadline,
-                        nsFont: .subheadline,
-                        textColor: musicManager.isFetchingLyrics ? .gray.opacity(0.7) : .gray,
-                        frameWidth: width
-                    )
-                    .font(isPersian ? .custom("Vazirmatn-Regular", size: NSFont.preferredFont(forTextStyle: .subheadline).pointSize) : .subheadline)
-                    .lineLimit(1)
-                    .opacity(musicManager.isPlaying ? 1 : 0)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                        
+                    Text(line)
+                        .font(isPersian ? .custom("Vazirmatn-Regular", size: NSFont.preferredFont(forTextStyle: .subheadline).pointSize) : .subheadline)
+                        .lineLimit(1)
+                        .opacity(musicManager.isPlaying ? 1 : 0)
+                        .transition(.asymmetric(
+                            insertion: .opacity.combined(with: .move(edge: .bottom)),
+                            removal: .opacity.combined(with: .move(edge: .top))
+                        ))
+                        .id(line)
+                        .animation(.easeInOut(duration: 0.5), value: line)
                 }
             }
         }


### PR DESCRIPTION
## Description

While using the app, I noticed that the lyric animations were snapping instead of transitioning smoothly. This led me to realize that the transition was not being triggered correctly.

### Changes

- Added a new transition style for lyric changes.
- Added a unique `.id()` modifier to each lyric line so the transition can be properly triggered.
- Removed the marquee text from the lyrics, since it was causing the animations to glitch.

### Notes / Future Work

A possible future improvement would be to reintroduce the marquee text with a controlled timing system. If the marquee speed is synced to the lyric duration, it could reset its position cleanly and avoid causing `GeometryReader` layout glitches.

https://github.com/user-attachments/assets/bb283a2f-86ab-4307-bcb9-7e141ecb5aab