### PR TITLE
Fix album art aspect ratio for non-square images

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -388,16 +388,17 @@ struct ContentView: View {
         HStack {
             Image(nsImage: musicManager.albumArt)
                 .resizable()
+                .scaledToFill()
+                .frame(
+                    width: max(0, vm.effectiveClosedNotchHeight - 12),
+                    height: max(0, vm.effectiveClosedNotchHeight - 12)
+                )
                 .clipped()
                 .clipShape(
                     RoundedRectangle(
                         cornerRadius: MusicPlayerImageSizes.cornerRadiusInset.closed)
                 )
                 .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
-                .frame(
-                    width: max(0, vm.effectiveClosedNotchHeight - 12),
-                    height: max(0, vm.effectiveClosedNotchHeight - 12)
-                )
 
             Rectangle()
                 .fill(.black)

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -41,6 +41,9 @@ struct AlbumArtView: View {
     private var albumArtBackground: some View {
         Image(nsImage: musicManager.albumArt)
             .resizable()
+            .scaledToFill()
+            .frame(width: MusicPlayerImageSizes.size.opened.width,
+                   height: MusicPlayerImageSizes.size.opened.height)
             .clipped()
             .clipShape(
                 RoundedRectangle(
@@ -48,7 +51,6 @@ struct AlbumArtView: View {
                         ? MusicPlayerImageSizes.cornerRadiusInset.opened
                         : MusicPlayerImageSizes.cornerRadiusInset.closed)
             )
-            .aspectRatio(1, contentMode: .fit)
             .scaleEffect(x: 1.3, y: 1.4)
             .rotationEffect(.degrees(92))
             .blur(radius: 40)
@@ -74,7 +76,8 @@ struct AlbumArtView: View {
 
     private var albumArtDarkOverlay: some View {
         Rectangle()
-            .aspectRatio(1, contentMode: .fit)
+            .frame(width: MusicPlayerImageSizes.size.opened.width,
+                   height: MusicPlayerImageSizes.size.opened.height)
             .foregroundColor(Color.black)
             .opacity(musicManager.isPlaying ? 0 : 0.8)
             .blur(radius: 50)
@@ -84,8 +87,9 @@ struct AlbumArtView: View {
     private var albumArtImage: some View {
         Image(nsImage: musicManager.albumArt)
             .resizable()
-            .aspectRatio(1, contentMode: .fit)
-            .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
+            .scaledToFill()
+            .frame(width: MusicPlayerImageSizes.size.opened.width,
+                   height: MusicPlayerImageSizes.size.opened.height)
             .clipped()
             .clipShape(
                 RoundedRectangle(
@@ -93,6 +97,7 @@ struct AlbumArtView: View {
                         ? MusicPlayerImageSizes.cornerRadiusInset.opened
                         : MusicPlayerImageSizes.cornerRadiusInset.closed)
             )
+            .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Change from `aspectRatio(1, contentMode: .fit)` to `scaledToFill()` with explicit frame sizing
- Prevents 16:9 video thumbnails (e.g. YouTube) from being squeezed/distorted
- Images now crop to fill the square rather than being squished

Fixes #960

## Changes
- `NotchHomeView.swift`: Updated `albumArtImage`, `albumArtBackground`, and `albumArtDarkOverlay` views
- `ContentView.swift`: Updated `MusicLiveActivity` album art display

## Test plan
- [x] Play a YouTube video in browser and verify the thumbnail displays without distortion (cropped, not squeezed)
- [x] Play music from Apple Music/Spotify to ensure square album art still displays correctly
- [x] Check both expanded (opened) and collapsed (closed) notch states
- [x] Verify the blur background effect still works correctly