### PR TITLE
Feature/lyrics shimmer and visualizer

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		14E9FEAE2C7325770062E83F /* Button+Bouncing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E9FEAD2C7325770062E83F /* Button+Bouncing.swift */; };
 		14FC6E502C7DED5600C7BEA5 /* DataTypes+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FC6E4F2C7DED5600C7BEA5 /* DataTypes+Extensions.swift */; };
 		507266DB2C908E2E00A2D00D /* HoverButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507266DA2C908E2E00A2D00D /* HoverButton.swift */; };
+		5476A6092F253836000EE200 /* AudioSpectrumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5476A6082F253836000EE200 /* AudioSpectrumView.swift */; };
 		5917FD112E57891600E87F1C /* MediaKeyInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5917FD102E57891600E87F1C /* MediaKeyInterceptor.swift */; };
 		5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */; };
 		59D8C23C2E589FAA00147B33 /* VolumeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D8C23B2E589FAA00147B33 /* VolumeManager.swift */; };
@@ -277,6 +278,7 @@
 		14E9FEAD2C7325770062E83F /* Button+Bouncing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Button+Bouncing.swift"; sourceTree = "<group>"; };
 		14FC6E4F2C7DED5600C7BEA5 /* DataTypes+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataTypes+Extensions.swift"; sourceTree = "<group>"; };
 		507266DA2C908E2E00A2D00D /* HoverButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverButton.swift; sourceTree = "<group>"; };
+		5476A6082F253836000EE200 /* AudioSpectrumView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSpectrumView.swift; sourceTree = "<group>"; };
 		5917FD102E57891600E87F1C /* MediaKeyInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaKeyInterceptor.swift; sourceTree = "<group>"; };
 		5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationRelauncher.swift; sourceTree = "<group>"; };
 		59D8C23B2E589FAA00147B33 /* VolumeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeManager.swift; sourceTree = "<group>"; };
@@ -584,6 +586,7 @@
 				14CEF41B2C5CAED400855D72 /* Preview Content */,
 				112FB72F2CCF12CC0015238C /* private */,
 				11CC44A12CEE614100C7244B /* BoringViewCoordinator.swift */,
+				5476A6082F253836000EE200 /* AudioSpectrumView.swift */,
 			);
 			path = boringNotch;
 			sourceTree = "<group>";
@@ -967,6 +970,7 @@
 				B1C4489B2C97376A001F0858 /* TipStore.swift in Sources */,
 				1153BD912D986DB300979FB0 /* PlaybackState.swift in Sources */,
 				B1A78C822C8BA08100BD51B0 /* FullscreenMediaDetection.swift in Sources */,
+				5476A6092F253836000EE200 /* AudioSpectrumView.swift in Sources */,
 				14E9FEAE2C7325770062E83F /* Button+Bouncing.swift in Sources */,
 				14D570C92C5F38890011E668 /* BoringViewModel.swift in Sources */,
 				14D570BC2C5E98EB0011E668 /* generic.swift in Sources */,

--- a/boringNotch/AudioSpectrumView.swift
+++ b/boringNotch/AudioSpectrumView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct AudioSpectrumView: View {
+    @Binding var isPlaying: Bool
+    @State private var phases: [Double] = Array(repeating: 0, count: 8)
+
+    private let barCount = 8
+
+    var body: some View {
+        GeometryReader { geo in
+            let barWidth = max(1, geo.size.width / CGFloat(barCount * 2))
+            HStack(alignment: .bottom, spacing: barWidth) {
+                ForEach(0..<barCount, id: \.self) { idx in
+                    Capsule()
+                        .fill(.white)
+                        .frame(width: barWidth, height: barHeight(for: idx, in: geo.size))
+                        .animation(.easeInOut(duration: 0.25), value: phases[idx])
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+            .onAppear { start() }
+            .onChange(of: isPlaying) { _, newValue in
+                if newValue { start() } else { stop() }
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func barHeight(for index: Int, in size: CGSize) -> CGFloat {
+        let base = size.height * 0.2
+        let variable = size.height * 0.8 * CGFloat(abs(sin(phases[index])))
+        return max(1, min(size.height, base + variable))
+    }
+
+    private func start() {
+        guard isPlaying else { return }
+        // Kick off a simple timer-driven animation by randomizing phases periodically
+        withAnimation(.easeInOut(duration: 0.25)) {
+            for i in phases.indices { phases[i] = Double.random(in: 0...(.pi * 2)) }
+        }
+        scheduleTick()
+    }
+
+    private func stop() {
+        withAnimation(.easeOut(duration: 0.3)) {
+            for i in phases.indices { phases[i] = 0 }
+        }
+    }
+
+    private func scheduleTick() {
+        guard isPlaying else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            guard isPlaying else { return }
+            withAnimation(.easeInOut(duration: 0.25)) {
+                for i in phases.indices { phases[i] += Double.random(in: 0.5...1.5) }
+            }
+            scheduleTick()
+        }
+    }
+}
+
+#Preview {
+    StatefulPreviewWrapper(true) { isPlaying in
+        AudioSpectrumView(isPlaying: isPlaying)
+            .frame(width: 100, height: 30)
+            .background(Color.black)
+            .preferredColorScheme(.dark)
+    }
+}
+
+// Helper for binding previews
+struct StatefulPreviewWrapper<Value, Content: View>: View {
+    @State var value: Value
+    var content: (Binding<Value>) -> Content
+    init(_ value: Value, content: @escaping (Binding<Value>) -> Content) {
+        _value = State(initialValue: value)
+        self.content = content
+    }
+    var body: some View { content($value) }
+}

--- a/boringNotch/components/Music/MusicVisualizer.swift
+++ b/boringNotch/components/Music/MusicVisualizer.swift
@@ -3,97 +3,199 @@
 //  boringNotch
 //
 //  Created by Harsh Vardhan  Goswami  on 02/08/24.
-//
+//  Updated by Yuvraj Soni
 import AppKit
 import Cocoa
 import SwiftUI
 
 class AudioSpectrum: NSView {
-    private var barLayers: [CAShapeLayer] = []
+    private var barShapeLayers: [CAShapeLayer] = []
+    private var barGradientLayers: [CAGradientLayer] = []
     private var barScales: [CGFloat] = []
     private var isPlaying: Bool = true
     private var animationTimer: Timer?
-    
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
         setupBars()
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         wantsLayer = true
         setupBars()
     }
 
+    // MARK: - UI Setup
     private func setupBars() {
-        let barWidth: CGFloat = 2
-        let barCount = 4
-        let spacing: CGFloat = barWidth
-        let totalWidth = CGFloat(barCount) * (barWidth + spacing)
-        let totalHeight: CGFloat = 14
+        layer?.sublayers?.removeAll()
+
+        // ✅ 3 Lines like a music indicator
+        let barCount = 3
+
+        // Make bars thicker and spacing clean
+        let barWidth: CGFloat = 3.5
+        let spacing: CGFloat = 3.0
+
+        // Height of the whole widget
+        let totalHeight: CGFloat = 16
+
+        let totalWidth = CGFloat(barCount) * barWidth + CGFloat(barCount - 1) * spacing
         frame.size = CGSize(width: totalWidth, height: totalHeight)
 
         for i in 0 ..< barCount {
             let xPosition = CGFloat(i) * (barWidth + spacing)
-            let barLayer = CAShapeLayer()
-            barLayer.frame = CGRect(x: xPosition, y: 0, width: barWidth, height: totalHeight)
-            barLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
-            barLayer.position = CGPoint(x: xPosition + barWidth / 2, y: totalHeight / 2)
-            barLayer.fillColor = NSColor.white.cgColor
-            barLayer.backgroundColor = NSColor.white.cgColor
-            barLayer.allowsGroupOpacity = false
-            barLayer.masksToBounds = true
-            let path = NSBezierPath(roundedRect: CGRect(x: 0, y: 0, width: barWidth, height: totalHeight),
-                                    xRadius: barWidth / 2,
-                                    yRadius: barWidth / 2)
-            barLayer.path = path.cgPath
-            barLayers.append(barLayer)
-            barScales.append(0.35)
-            layer?.addSublayer(barLayer)
+
+            // ✅ Shape layer (this makes the rounded pill bar)
+            let shape = CAShapeLayer()
+            shape.frame = CGRect(x: xPosition, y: 0, width: barWidth, height: totalHeight)
+            shape.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+            shape.position = CGPoint(x: xPosition + barWidth / 2, y: totalHeight / 2)
+            shape.masksToBounds = true
+
+            let roundedPath = NSBezierPath(
+                roundedRect: CGRect(x: 0, y: 0, width: barWidth, height: totalHeight),
+                xRadius: barWidth / 2,
+                yRadius: barWidth / 2
+            )
+            shape.path = roundedPath.cgPath
+
+            // ✅ Gradient layer (this is the shiny color inside)
+            let gradient = CAGradientLayer()
+            gradient.frame = shape.bounds
+
+            // Vertical gradient for shine
+            gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+            gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+
+            // ✅ More premium colors
+            let dim = NSColor.white.withAlphaComponent(0.25).cgColor
+            let mid = NSColor.white.withAlphaComponent(0.55).cgColor
+            let shine = NSColor.white.withAlphaComponent(1.0).cgColor
+
+            // ✅ Longer shine band
+            gradient.colors = [
+                dim,
+                mid,
+                shine,
+                mid,
+                dim
+            ]
+
+            // Longer spread = more long reflection feel
+            gradient.locations = [
+                0.0,
+                0.40,
+                0.55,
+                0.70,
+                1.0
+            ]
+
+            // ✅ Mask gradient inside the rounded bar
+            gradient.mask = shape
+
+            // Store and add
+            barShapeLayers.append(shape)
+            barGradientLayers.append(gradient)
+            barScales.append(0.30)
+
+            layer?.addSublayer(gradient)
+
+            // ✅ Shine animation (slow and long)
+            addLongShineAnimation(to: gradient, delay: Double(i) * 0.18)
         }
+
+        resetBars()
     }
-    
+
+    // MARK: - Shine Animation (Long + Smooth)
+    private func addLongShineAnimation(to gradient: CAGradientLayer, delay: Double = 0) {
+
+        // ✅ Moving shine effect by shifting gradient locations
+        let shineAnim = CABasicAnimation(keyPath: "locations")
+
+        // Wider movement distance = longer shine travel
+        shineAnim.fromValue = [-0.8, -0.35, 0.0, 0.25, 0.6]
+        shineAnim.toValue   = [0.4, 0.75, 1.0, 1.25, 1.7]
+
+        // Slower = smoother + premium
+        shineAnim.duration = 2.3
+        shineAnim.repeatCount = .infinity
+        shineAnim.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+
+        shineAnim.beginTime = CACurrentMediaTime() + delay
+        shineAnim.isRemovedOnCompletion = false
+
+        gradient.add(shineAnim, forKey: "longShine")
+    }
+
+    // MARK: - Bar Animation
     private func startAnimating() {
         guard animationTimer == nil else { return }
-        animationTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: true) { [weak self] _ in
+
+        animationTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
             self?.updateBars()
         }
     }
-    
+
     private func stopAnimating() {
         animationTimer?.invalidate()
         animationTimer = nil
         resetBars()
     }
-    
+
     private func updateBars() {
-        for (i, barLayer) in barLayers.enumerated() {
+        for (i, barLayer) in barShapeLayers.enumerated() {
+
             let currentScale = barScales[i]
-            let targetScale = CGFloat.random(in: 0.35 ... 1.0)
+
+            // ✅ Better natural movement values for 3 bars
+            let targetScale: CGFloat
+            if i == 0 {
+                targetScale = CGFloat.random(in: 0.35...0.95)
+            } else if i == 1 {
+                targetScale = CGFloat.random(in: 0.45...1.0)
+            } else {
+                targetScale = CGFloat.random(in: 0.30...0.85)
+            }
+
             barScales[i] = targetScale
+
             let animation = CABasicAnimation(keyPath: "transform.scale.y")
             animation.fromValue = currentScale
             animation.toValue = targetScale
-            animation.duration = 0.3
+            animation.duration = 0.22
+
+            // Smooth bounce vibe
+            animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
             animation.autoreverses = true
+
+            // Keep it visually stable
             animation.fillMode = .forwards
             animation.isRemovedOnCompletion = false
+
             if #available(macOS 13.0, *) {
-                animation.preferredFrameRateRange = CAFrameRateRange(minimum: 24, maximum: 24, preferred: 24)
+                animation.preferredFrameRateRange = CAFrameRateRange(minimum: 30, maximum: 60, preferred: 60)
             }
+
             barLayer.add(animation, forKey: "scaleY")
         }
     }
-    
+
     private func resetBars() {
-        for (i, barLayer) in barLayers.enumerated() {
+        for (i, barLayer) in barShapeLayers.enumerated() {
             barLayer.removeAllAnimations()
-            barLayer.transform = CATransform3DMakeScale(1, 0.35, 1)
-            barScales[i] = 0.35
+            barLayer.transform = CATransform3DMakeScale(1, 0.30, 1)
+            barScales[i] = 0.30
+
+            // ✅ Keep shine running even when paused (optional)
+            // If you want shine to stop on pause, uncomment next line:
+            // barGradientLayers[i].removeAnimation(forKey: "longShine")
         }
     }
-    
+
+    // MARK: - Control
     func setPlaying(_ playing: Bool) {
         isPlaying = playing
         if isPlaying {
@@ -104,22 +206,23 @@ class AudioSpectrum: NSView {
     }
 }
 
-struct AudioSpectrumView: NSViewRepresentable {
+struct AudioSpectrumWrapperView: NSViewRepresentable {
     @Binding var isPlaying: Bool
-    
+
     func makeNSView(context: Context) -> AudioSpectrum {
         let spectrum = AudioSpectrum()
         spectrum.setPlaying(isPlaying)
         return spectrum
     }
-    
+
     func updateNSView(_ nsView: AudioSpectrum, context: Context) {
         nsView.setPlaying(isPlaying)
     }
 }
 
 #Preview {
-    AudioSpectrumView(isPlaying: .constant(true))
-        .frame(width: 16, height: 20)
+    AudioSpectrumWrapperView(isPlaying: .constant(true))
+        .frame(width: 28, height: 18)
         .padding()
+        .background(Color.black)
 }

--- a/boringNotch/components/Music/ShinyText.swift
+++ b/boringNotch/components/Music/ShinyText.swift
@@ -1,0 +1,259 @@
+
+//
+//  ShinyText.swift
+//  boringNotch
+//
+//
+// create by Yuvraj soni (25/01/2026)
+
+import SwiftUI
+
+public struct ShinyText: View {
+    public enum Direction { case left, right }
+
+    let text: String
+
+    var disabled: Bool = false
+    var speed: Double = 2.0
+    var color: Color = Color(hex: "#b5b5b5")
+    var shineColor: Color = .white
+    var spread: Double = 120
+    var yoyo: Bool = false
+    var pauseOnHover: Bool = false
+    var direction: Direction = .left
+    var delay: Double = 0.0
+    var font: Font? = nil
+    // ✅ NEW: If you want perfect sync (e.g., lyrics), provide external progress/time
+    var externalProgress01: Double? = nil   // 0...1
+    var externalTime: Double? = nil         // seconds
+
+    // Wider + smoother shine
+    var wideBand: Double = 0.42
+    var softEdges: Double = 0.22
+
+    @State private var isPaused: Bool = false
+    @State private var pauseStart: Date? = nil
+    @State private var pausedTotal: TimeInterval = 0
+
+    private var animationDuration: Double { max(0.01, speed) }
+    private var delayDuration: Double { max(0.0, delay) }
+
+    public init(
+        _ text: String,
+        disabled: Bool = false,
+        speed: Double = 2.0,
+        color: Color = Color(hex: "#b5b5b5"),
+        shineColor: Color = .white,
+        spread: Double = 120,
+        yoyo: Bool = false,
+        pauseOnHover: Bool = false,
+        direction: Direction = .left,
+        delay: Double = 0.0,
+        font: Font? = nil,
+        wideBand: Double = 0.42,
+        softEdges: Double = 0.22,
+        externalProgress01: Double? = nil,
+        externalTime: Double? = nil
+    ) {
+        self.text = text
+        self.disabled = disabled
+        self.speed = speed
+        self.color = color
+        self.shineColor = shineColor
+        self.spread = spread
+        self.yoyo = yoyo
+        self.pauseOnHover = pauseOnHover
+        self.direction = direction
+        self.delay = delay
+        self.font = font
+        self.wideBand = wideBand
+        self.softEdges = softEdges
+        self.externalProgress01 = externalProgress01
+        self.externalTime = externalTime
+    }
+
+    // MARK: - Progress (0...1)
+    private func computeProgress01(elapsed: Double) -> Double {
+        let anim = animationDuration
+        let del = delayDuration
+
+        if yoyo {
+            let cycle = anim + del
+            let full = cycle * 2
+            let t = elapsed.truncatingRemainder(dividingBy: full)
+
+            if t < anim {
+                let p = t / anim
+                return direction == .left ? p : (1.0 - p)
+            } else if t < cycle {
+                return direction == .left ? 1.0 : 0.0
+            } else if t < cycle + anim {
+                let rt = t - cycle
+                let p = 1.0 - (rt / anim)
+                return direction == .left ? p : (1.0 - p)
+            } else {
+                return direction == .left ? 0.0 : 1.0
+            }
+        } else {
+            let cycle = anim + del
+            let t = elapsed.truncatingRemainder(dividingBy: cycle)
+
+            if t < anim {
+                let p = t / anim
+                return direction == .left ? p : (1.0 - p)
+            } else {
+                return direction == .left ? 1.0 : 0.0
+            }
+        }
+    }
+
+    // MARK: - Wide Shine Gradient Stops
+    private func gradientStops(progress01: Double) -> [Gradient.Stop] {
+        let p = max(0.0, min(1.0, progress01))
+
+        let halfBand = max(0.05, min(0.49, wideBand / 2.0))
+        let edge = max(0.01, min(0.49, softEdges))
+
+        let leftOuter = max(0.0, p - halfBand - edge)
+        let leftInner = max(0.0, p - halfBand)
+        let rightInner = min(1.0, p + halfBand)
+        let rightOuter = min(1.0, p + halfBand + edge)
+
+        var stops: [Gradient.Stop] = [
+            .init(color: color, location: 0.0),
+            .init(color: color, location: leftOuter),
+            .init(color: shineColor.opacity(0.55), location: leftInner),
+            .init(color: shineColor.opacity(1.0), location: p),
+            .init(color: shineColor.opacity(0.55), location: rightInner),
+            .init(color: color, location: rightOuter),
+            .init(color: color, location: 1.0)
+        ]
+
+        stops = stops
+            .filter { $0.location >= 0.0 && $0.location <= 1.0 }
+            .sorted { $0.location < $1.location }
+
+        return stops
+    }
+
+    private func startPointEndPoint(angleDegrees: Double) -> (UnitPoint, UnitPoint) {
+        let theta = angleDegrees * .pi / 180.0
+        let dx = cos(theta)
+        let dy = sin(theta)
+
+        let sx = 0.5 - dx * 0.5
+        let sy = 0.5 - dy * 0.5
+        let ex = 0.5 + dx * 0.5
+        let ey = 0.5 + dy * 0.5
+
+        return (UnitPoint(x: sx, y: sy), UnitPoint(x: ex, y: ey))
+    }
+
+    public var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { context in
+            let now = context.date
+
+            // ✅ stable time (no state mutation in render)
+            let t = now.timeIntervalSinceReferenceDate
+
+            // pause logic
+            let effectiveTime: Double
+            if disabled {
+                effectiveTime = 0
+            } else if isPaused {
+                effectiveTime = (pauseStart?.timeIntervalSinceReferenceDate ?? t) - pausedTotal
+            } else {
+                effectiveTime = t - pausedTotal
+            }
+
+            let progress01: Double
+            if let p = externalProgress01 {
+                progress01 = max(0.0, min(1.0, p))
+            } else if let tExternal = externalTime {
+                progress01 = computeProgress01(elapsed: max(0.0, tExternal))
+            } else {
+                progress01 = computeProgress01(elapsed: effectiveTime)
+            }
+
+            let stops = gradientStops(progress01: progress01)
+            let (sp, ep) = startPointEndPoint(angleDegrees: spread)
+
+            Text(text)
+                .font(font)
+                .foregroundStyle(.clear)
+                .overlay(
+                    LinearGradient(
+                        gradient: Gradient(stops: stops),
+                        startPoint: sp,
+                        endPoint: ep
+                    )
+                )
+                .mask(
+                    Text(text).font(font)
+                )
+        }
+        .onHover { hovering in
+            // If externally driven, don't pause internally
+            if externalProgress01 != nil || externalTime != nil { return }
+
+            guard pauseOnHover else { return }
+
+            if hovering {
+                if !isPaused {
+                    isPaused = true
+                    pauseStart = Date()
+                }
+            } else {
+                if isPaused {
+                    isPaused = false
+                    if let start = pauseStart {
+                        pausedTotal += Date().timeIntervalSince(start)
+                    }
+                    pauseStart = nil
+                }
+            }
+        }
+        .onChange(of: direction) { _, _ in
+            pausedTotal = 0
+            pauseStart = nil
+            isPaused = false
+        }
+    }
+}
+
+private extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3:
+            (a, r, g, b) = (255,
+                            (int >> 8) * 17,
+                            (int >> 4 & 0xF) * 17,
+                            (int & 0xF) * 17)
+        case 6:
+            (a, r, g, b) = (255,
+                            int >> 16,
+                            int >> 8 & 0xFF,
+                            int & 0xFF)
+        case 8:
+            (a, r, g, b) = (int >> 24,
+                            int >> 16 & 0xFF,
+                            int >> 8 & 0xFF,
+                            int & 0xFF)
+        default:
+            (a, r, g, b) = (255, 0, 0, 0)
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}


### PR DESCRIPTION
A shimmer/shine effect on the currently active lyric line (synced lyrics), designed to feel more premium and readable.
A refined closed-notch music indicator that shows 3 animated bars with a longer “shine” reflection effect.
What changed
Lyrics shine effect
Adds/updates a shiny gradient text effect for lyrics.
Shine appears when playback is active and synced lyrics are available.
Increased shine length + richer white highlight, with a slightly darker base for better contrast.
Closed-notch visualizer
Updates the closed-notch right-side music indicator to a 3-bar design.
Adds a smooth “long shine” gradient reflection and improved bar motion.
Files touched (high level)
boringNotch/components/Notch/NotchHomeView.swift
boringNotch/components/Music/ShinyText.swift
boringNotch/components/Music/MusicVisualizer.swift
boringNotch.xcodeproj/project.pbxproj (target/project changes from adding/updating files)
Testing
Built and ran on macOS (Xcode).
Verified:
Lyrics line updates with playback time and shimmer renders correctly.
No synced lyrics → normal lyric display fallback.
Closed-notch visualizer shows 3 bars and animates while playing.