### PR TITLE
fix: correct typo in Ko-Fi link URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://discord.gg/c8JXA7qrPm">
     <img src="https://dcbadge.limes.pink/api/server/https://discord.gg/c8JXA7qrPm?style=flat" alt="Discord Badge" />
   </a>
-  <a href="ttps://ko-fi.com/brandonhimpfen">
+  <a href="https://ko-fi.com/brandonhimpfen">
     <img src="https://srv-cdn.himpfen.io/badges/kofi/kofi-flat.svg" alt="Ko-Fi" />
   </a>
 </p>


### PR DESCRIPTION
## Summary
Fixed a typo in README.md where the Ko-Fi badge link was missing the 'h' in `https://`.

### Before
```html
<a href="ttps://ko-fi.com/brandonhimpfen">
```

### After
```html
<a href="https://ko-fi.com/brandonhimpfen">
```

This caused the link to be broken for users clicking on the Ko-Fi badge.