### PR TITLE
Add file stacking visual feedback for multi-item drag operations

### DIFF
--- a/boringNotch/components/Shelf/ViewModels/ShelfSelectionModel.swift
+++ b/boringNotch/components/Shelf/ViewModels/ShelfSelectionModel.swift
@@ -63,6 +63,11 @@ final class ShelfSelectionModel: ObservableObject {
         selectedIDs = Set(rangeIDs)
     }
 
+    func selectAll(in items: [ShelfItem]) {
+        selectedIDs = Set(items.map { $0.id })
+        lastAnchorID = items.first?.id
+    }
+
     func clear() {
         selectedIDs.removeAll()
         lastAnchorID = nil

--- a/boringNotch/components/Shelf/Views/ShelfItemView.swift
+++ b/boringNotch/components/Shelf/Views/ShelfItemView.swift
@@ -175,14 +175,32 @@ private struct DraggableClickHandler<Content: View>: NSViewRepresentable {
     }
     
     private func renderDragPreview() -> NSImage {
+        // Check if multiple items are selected
+        let selectedItems = ShelfSelectionModel.shared.selectedItems(in: ShelfStateViewModel.shared.items)
+
+        if selectedItems.count > 1 && selectedItems.contains(where: { $0.id == item.id }) {
+            // Render stacked preview for multi-item drag
+            // Use icons for simplicity and performance
+            let thumbnails = selectedItems.prefix(3).map { $0.icon }
+
+            let stackedContent = StackedDragPreviewView(thumbnails: Array(thumbnails), count: selectedItems.count)
+            let stackedRenderer = ImageRenderer(content: stackedContent)
+            stackedRenderer.scale = NSScreen.main?.backingScaleFactor ?? 2.0
+
+            if let nsImage = stackedRenderer.nsImage {
+                return nsImage
+            }
+        }
+
+        // Render single item preview
         let content = dragPreviewContent()
         let renderer = ImageRenderer(content: content)
         renderer.scale = NSScreen.main?.backingScaleFactor ?? 2.0
-        
+
         if let nsImage = renderer.nsImage {
             return nsImage
         }
-        
+
         // Fallback to icon if rendering fails
         return viewModel.thumbnail ?? item.icon
     }

--- a/boringNotch/components/Shelf/Views/ShelfView.swift
+++ b/boringNotch/components/Shelf/Views/ShelfView.swift
@@ -76,6 +76,13 @@ struct ShelfView: View {
             }
             .contentShape(Rectangle())
             .onTapGesture { selection.clear() }
+            .background(
+                KeyboardEventHandler(
+                    onCommandA: {
+                        selection.selectAll(in: tvm.items)
+                    }
+                )
+            )
     }
 
     var content: some View {
@@ -111,6 +118,36 @@ struct ShelfView: View {
         }
         .onAppear {
             ShelfStateViewModel.shared.cleanupInvalidItems()
+        }
+    }
+}
+
+// MARK: - Keyboard Event Handler
+private struct KeyboardEventHandler: NSViewRepresentable {
+    let onCommandA: () -> Void
+
+    func makeNSView(context: Context) -> KeyEventView {
+        let view = KeyEventView()
+        view.onCommandA = onCommandA
+        return view
+    }
+
+    func updateNSView(_ nsView: KeyEventView, context: Context) {
+        nsView.onCommandA = onCommandA
+    }
+
+    final class KeyEventView: NSView {
+        var onCommandA: (() -> Void)?
+
+        override var acceptsFirstResponder: Bool { true }
+
+        override func performKeyEquivalent(with event: NSEvent) -> Bool {
+            // Check for Command+A (Select All)
+            if event.modifierFlags.contains(.command) && event.charactersIgnoringModifiers == "a" {
+                onCommandA?()
+                return true
+            }
+            return super.performKeyEquivalent(with: event)
         }
     }
 }

--- a/boringNotch/components/Shelf/Views/StackedDragPreviewView.swift
+++ b/boringNotch/components/Shelf/Views/StackedDragPreviewView.swift
@@ -1,0 +1,105 @@
+//
+//  StackedDragPreviewView.swift
+//  boringNotch
+//
+//  Created for Issue #890 - File Stacking / Group Dragging Feature
+//
+
+import SwiftUI
+import AppKit
+
+struct StackedDragPreviewView: View {
+    let thumbnails: [NSImage]
+    let count: Int
+
+    private let cardWidth: CGFloat = 56
+    private let cardHeight: CGFloat = 56
+    private let stackOffset: CGFloat = 3
+    private let maxStackLayers: Int = 3
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 4) {
+            // Stacked cards with count badge
+            ZStack(alignment: .topTrailing) {
+                // Stack layers (up to 3)
+                ForEach(0..<min(maxStackLayers, thumbnails.count), id: \.self) { index in
+                    let reverseIndex = min(maxStackLayers, thumbnails.count) - 1 - index
+
+                    Image(nsImage: thumbnails[min(reverseIndex, thumbnails.count - 1)])
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: cardWidth, height: cardHeight)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .opacity(opacityForLayer(reverseIndex))
+                        .offset(
+                            x: CGFloat(reverseIndex) * stackOffset,
+                            y: CGFloat(reverseIndex) * stackOffset
+                        )
+                }
+
+                // Count badge
+                if count > 1 {
+                    Text("\(count)")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 3)
+                        .background(
+                            Capsule()
+                                .fill(Color.accentColor)
+                        )
+                        .offset(x: 8, y: -8)
+                }
+            }
+            .frame(
+                width: cardWidth + CGFloat(min(maxStackLayers - 1, 2)) * stackOffset,
+                height: cardHeight + CGFloat(min(maxStackLayers - 1, 2)) * stackOffset
+            )
+
+            // Label showing item count
+            Text(count == 1 ? "1 item" : "\(count) items")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(.white)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
+                .background(RoundedRectangle(cornerRadius: 4).fill(Color.accentColor))
+                .frame(alignment: .top)
+        }
+        .frame(width: 105)
+    }
+
+    private func opacityForLayer(_ layer: Int) -> Double {
+        switch layer {
+        case 0: return 1.0
+        case 1: return 0.85
+        case 2: return 0.7
+        default: return 0.6
+        }
+    }
+}
+
+// Preview for development
+#Preview {
+    VStack(spacing: 20) {
+        StackedDragPreviewView(
+            thumbnails: [
+                NSImage(systemSymbolName: "doc.fill", accessibilityDescription: nil)!,
+                NSImage(systemSymbolName: "photo.fill", accessibilityDescription: nil)!,
+                NSImage(systemSymbolName: "video.fill", accessibilityDescription: nil)!
+            ],
+            count: 3
+        )
+
+        StackedDragPreviewView(
+            thumbnails: [
+                NSImage(systemSymbolName: "doc.fill", accessibilityDescription: nil)!
+            ],
+            count: 5
+        )
+    }
+    .padding()
+    .background(Color.gray.opacity(0.3))
+}


### PR DESCRIPTION
Implements Dropover/Yoink-style stacked card preview when dragging multiple items from the shelf. Users can now clearly see when dragging multiple files with a visual stack, count badge, and "N items" label. Also adds Cmd+A keyboard shortcut to select all shelf items.

Changes:
- Add StackedDragPreviewView component with up to 3 stacked layers
- Modify drag preview rendering to detect multi-selection
- Add selectAll() method to ShelfSelectionModel
- Implement Cmd+A keyboard handler in ShelfView

Fixes #890