### PR TITLE
Fix Calendar UI and clickable area

### DIFF
--- a/boringNotch/components/Calendar/BoringCalendar.swift
+++ b/boringNotch/components/Calendar/BoringCalendar.swift
@@ -275,8 +275,6 @@ struct CalendarView: View {
                 EventListView(events: calendarManager.events)
             }
         }
-        .listRowBackground(Color.clear)
-        .frame(height: 120)
         .onChange(of: selectedDate) {
             Task {
                 await calendarManager.updateCurrentDate(selectedDate)


### PR DESCRIPTION
### Issues
* Misaligned calendar labels.
* Wrong clickable area for calendar days.
  * Only clicks on labels were detected, not the ones between both labels.

### Fixes
* Aligned labels.
* Removed unnecessary fixed height.
* Specified a rectangle content shape for buttons.

### Preview
| | Old | New |
| --- | --- | --- |
| **Note** | - | Month & Year labels are now aligned with the other day labels |
| **Preview** | <img src="https://github.com/user-attachments/assets/dd9802f1-cdb1-4873-89a6-06962526c633" alt="Old Notch showing calendar" /> | <img src="https://github.com/user-attachments/assets/3646b095-f2b1-4ba5-9570-a55ca668cda9" alt="New Notch showing improved calendar UI" /> |
