### PR TITLE
feat: Display lyrics on closed notch state under music activity

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -3,7 +3,7 @@
 //  boringNotchApp
 //
 //  Created by Harsh Vardhan Goswami  on 02/08/24
-//  Modified by Richard Kunkli on 24/08/2024.
+//  Modified by Richard Kunkli on 24/08/2024 + Edwin Salcedo on 19/02/2026.
 //
 
 import AVFoundation
@@ -414,109 +414,154 @@ struct ContentView: View {
 
     @ViewBuilder
     func MusicLiveActivity() -> some View {
-        HStack(spacing: 0) {
-            // Closed-mode album art: scale padding and corner radius according to cornerRadiusScaleFactor
-            let baseArtSize = displayClosedNotchHeight - 12
-            let scaledArtSize: CGFloat = {
-                if let scale = cornerRadiusScaleFactor {
-                    return displayClosedNotchHeight - 12 * scale
-                }
-                return baseArtSize
-            }()
+        // Closed-mode album art: scale padding and corner radius according to cornerRadiusScaleFactor
+        let baseArtSize = displayClosedNotchHeight - 12
+        let scaledArtSize: CGFloat = {
+            if let scale = cornerRadiusScaleFactor {
+                return displayClosedNotchHeight - 12 * scale
+            }
+            return baseArtSize
+        }()
+        
+        let closedCornerRadius: CGFloat = {
+            let base = MusicPlayerImageSizes.cornerRadiusInset.closed
+            if let scale = cornerRadiusScaleFactor {
+                return max(0, base * scale)
+            }
+            return base
+        }()
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                Image(nsImage: musicManager.albumArt)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .clipShape(
+                        RoundedRectangle(
+                            cornerRadius: closedCornerRadius)
+                    )
+                    .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
+                    .frame(
+                        width: scaledArtSize,
+                        height: scaledArtSize
+                    )
 
-            let closedCornerRadius: CGFloat = {
-                let base = MusicPlayerImageSizes.cornerRadiusInset.closed
-                if let scale = cornerRadiusScaleFactor {
-                    return max(0, base * scale)
-                }
-                return base
-            }()
-
-            Image(nsImage: musicManager.albumArt)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .clipShape(
-                    RoundedRectangle(
-                        cornerRadius: closedCornerRadius)
-                )
-                .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
-                .frame(
-                    width: scaledArtSize,
-                    height: scaledArtSize
-                )
-
-            Rectangle()
-                .fill(.black)
-                .overlay(
-                    HStack(alignment: .top) {
-                        if coordinator.expandingView.show
-                            && coordinator.expandingView.type == .music
-                        {
-                            MarqueeText(
-                                musicManager.songTitle,
-                                color: Defaults[.coloredSpectrogram]
-                                    ? Color(nsColor: musicManager.avgColor) : Color.gray,
-                                delayDuration: 0.4,
-                                frameWidth: 100
-                            )
-                            .opacity(
-                                (coordinator.expandingView.show
-                                    && Defaults[.sneakPeekStyles] == .inline)
-                                    ? 1 : 0
-                            )
-                            Spacer(minLength: vm.closedNotchSize.width)
-                            // Song Artist
-                            Text(musicManager.artistName)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-                                .foregroundStyle(
-                                    Defaults[.coloredSpectrogram]
-                                        ? Color(nsColor: musicManager.avgColor)
-                                        : Color.gray
+                Rectangle()
+                    .fill(.black)
+                    .overlay(
+                        HStack(alignment: .top) {
+                            if coordinator.expandingView.show
+                                && coordinator.expandingView.type == .music
+                            {
+                                MarqueeText(
+                                    musicManager.songTitle,
+                                    color: Defaults[.coloredSpectrogram]
+                                        ? Color(nsColor: musicManager.avgColor) : Color.gray,
+                                    delayDuration: 0.4,
+                                    frameWidth: 100
                                 )
                                 .opacity(
                                     (coordinator.expandingView.show
-                                        && coordinator.expandingView.type == .music
                                         && Defaults[.sneakPeekStyles] == .inline)
                                         ? 1 : 0
                                 )
+                                Spacer(minLength: vm.closedNotchSize.width)
+                                // Song Artist
+                                Text(musicManager.artistName)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                                    .foregroundStyle(
+                                        Defaults[.coloredSpectrogram]
+                                            ? Color(nsColor: musicManager.avgColor)
+                                            : Color.gray
+                                    )
+                                    .opacity(
+                                        (coordinator.expandingView.show
+                                            && coordinator.expandingView.type == .music
+                                            && Defaults[.sneakPeekStyles] == .inline)
+                                            ? 1 : 0
+                                    )
+                            }
                         }
-                    }
-                )
-                .frame(
-                    width: (coordinator.expandingView.show
-                        && coordinator.expandingView.type == .music
-                        && Defaults[.sneakPeekStyles] == .inline)
-                        ? 380
-                        : vm.closedNotchSize.width
-                            + -cornerRadiusInsets.closed.top
-                )
+                    )
+                    .frame(
+                        width: (coordinator.expandingView.show
+                            && coordinator.expandingView.type == .music
+                            && Defaults[.sneakPeekStyles] == .inline)
+                            ? 380
+                            : vm.closedNotchSize.width
+                                + -cornerRadiusInsets.closed.top
+                    )
 
-            HStack {
-                AudioSpectrumView(
-                    isPlaying: musicManager.isPlaying,
-                    tintColor: Defaults[.coloredSpectrogram]
-                    ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.5)
-                    : Color.gray
+                HStack {
+                    AudioSpectrumView(
+                        isPlaying: musicManager.isPlaying,
+                        tintColor: Defaults[.coloredSpectrogram]
+                        ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.5)
+                        : Color.gray
+                    )
+                    .frame(width: 16, height: 12)
+                }
+                .frame(
+                    width: max(
+                        0,
+                        displayClosedNotchHeight - 12
+                            + gestureProgress / 2
+                    ),
+                    height: max(
+                        0,
+                        displayClosedNotchHeight - 12
+                    ),
+                    alignment: .center
                 )
-                .frame(width: 16, height: 12)
             }
             .frame(
-                width: max(
-                    0,
-                    displayClosedNotchHeight - 12
-                        + gestureProgress / 2
-                ),
-                height: max(
-                    0,
-                    displayClosedNotchHeight - 12
-                ),
+                height: displayClosedNotchHeight,
                 alignment: .center
             )
+            
+            if Defaults[.enableLyricsOnClosedNotch] && !coordinator.sneakPeek.show {
+                TimelineView(.animation(minimumInterval: 0.25)) { timeline in
+                    let currentElapsed: Double = {
+                        guard musicManager.isPlaying else { return musicManager.elapsedTime }
+                        let delta = timeline.date.timeIntervalSince(musicManager.timestampDate)
+                        let progressed = musicManager.elapsedTime + (delta * musicManager.playbackRate)
+                        return min(max(progressed, 0), musicManager.songDuration)
+                    }()
+                    let line: String = {
+                        if LyricsService.shared.isFetchingLyrics { return "Loading lyrics…" }
+                        if !LyricsService.shared.syncedLyrics.isEmpty {
+                            return LyricsService.shared.lyricLine(at: currentElapsed)
+                        }
+                        let trimmed = musicManager.currentLyrics.trimmingCharacters(in: .whitespacesAndNewlines)
+                        return trimmed.isEmpty ? "No lyrics found" : trimmed.replacingOccurrences(of: "\n", with: " ")
+                    }()
+                    let isPersian = line.unicodeScalars.contains { scalar in
+                        let v = scalar.value
+                        return v >= 0x0600 && v <= 0x06FF
+                    }
+                    GeometryReader { geo in
+                        MarqueeText(
+                            line,
+                            font: .subheadline,
+                            color: musicManager.isFetchingLyrics ? .gray.opacity(0.7) : .gray,
+                            frameWidth: geo.size.width
+                        )                        
+                    }
+                    .font(isPersian ? .custom("Vazirmatn-Regular", size: NSFont.preferredFont(forTextStyle: .subheadline).pointSize) : .subheadline)
+                    .lineLimit(1)
+                    .opacity(musicManager.isPlaying ? 1 : 0)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
         }
         .frame(
-            height: displayClosedNotchHeight,
-            alignment: .center
+            // Based on width sizes from the inner HStack -> Album art + Rectangle Overlay + AudioSpectrumView
+            // Probably a better way to calulcate that width
+            width: scaledArtSize +
+            (vm.closedNotchSize.width + -cornerRadiusInsets.closed.top) +
+            (displayClosedNotchHeight - 12 + gestureProgress / 2),
+            // Extra height to display lyrics
+            height: Defaults[.enableLyricsOnClosedNotch] ? displayClosedNotchHeight + 16 : displayClosedNotchHeight
         )
     }
 

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -544,19 +544,26 @@ struct ContentView: View {
                             line,
                             font: .subheadline,
                             color: musicManager.isFetchingLyrics ? .gray.opacity(0.7) : .gray,
+                            delayDuration: 1.0,
                             frameWidth: geo.size.width
                         )                        
                     }
                     .font(isPersian ? .custom("Vazirmatn-Regular", size: NSFont.preferredFont(forTextStyle: .subheadline).pointSize) : .subheadline)
                     .lineLimit(1)
                     .opacity(musicManager.isPlaying ? 1 : 0)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                    .transition(
+                        .asymmetric(
+                            insertion: .opacity.combined(with: .move(edge: .bottom)),
+                            removal: .opacity.animation(.easeIn(duration: 0.2)).combined(with: .move(edge: .top))
+                        )
+                    )
+                    .id(line)
+                    .animation(.easeInOut(duration: 0.5), value: line)
                 }
             }
         }
         .frame(
             // Based on width sizes from the inner HStack -> Album art + Rectangle Overlay + AudioSpectrumView
-            // Probably a better way to calulcate that width
             width: scaledArtSize +
             (vm.closedNotchSize.width + -cornerRadiusInsets.closed.top) +
             (displayClosedNotchHeight - 12 + gestureProgress / 2),

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -17170,6 +17170,9 @@
         }
       }
     },
+    "Show lyrics on closed notch" : {
+
+    },
     "Show menu bar icon" : {
       "localizations" : {
         "ar" : {

--- a/boringNotch/components/Settings/Views/MediaSettingsView.swift
+++ b/boringNotch/components/Settings/Views/MediaSettingsView.swift
@@ -102,6 +102,12 @@ struct Media: View {
                         customBadge(text: "Beta")
                     }
                 }
+                Defaults.Toggle(key: .enableLyricsOnClosedNotch) {
+                    HStack {
+                        Text("Show lyrics on closed notch")
+                        customBadge(text: "Beta")
+                    }
+                }
             } header: {
                 Text("Media controls")
             }  footer: {

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -193,6 +193,7 @@ extension Defaults.Keys {
     static let waitInterval = Key<Double>("waitInterval", default: 3)
     static let showShuffleAndRepeat = Key<Bool>("showShuffleAndRepeat", default: false)
     static let enableLyrics = Key<Bool>("enableLyrics", default: false)
+    static let enableLyricsOnClosedNotch = Key<Bool>("enableLyricsOnClosedNotch", default: false)
     static let musicControlSlots = Key<[MusicControlButton]>(
         "musicControlSlots",
         default: MusicControlButton.defaultLayout


### PR DESCRIPTION
# Displays lyrics under the MusicActivity while the notch is in the closed state.
<img width="622" height="124" alt="boringNotch_closedNotchLyrics" src="https://github.com/user-attachments/assets/a4df3113-1b52-4b54-903e-996fef52affc" />

## What was changed and why
- Added a new Default key "enableLyricsOnClosedNotch"
- Added a toggle within media settings
- In ContentView I modified MusicLiveActivity to be inside a VStack so that I could display the lyrics under

### Considerations
- Looks a little weird since it dips below context menu bar
- Transitioning from open to closed state looks off since lyrics appear instantly
- Possibly center the lyrics?