### PR TITLE
Fix notch content alignment

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -225,6 +225,7 @@ struct ContentView: View {
         }
         .padding(.bottom, 8)
         .frame(maxWidth: windowSize.width, maxHeight: windowSize.height, alignment: .top)
+        .ignoresSafeArea(.all)
         .compositingGroup()
         .scaleEffect(
             x: gestureScale,


### PR DESCRIPTION
<img width="849" height="171" alt="image" src="https://github.com/user-attachments/assets/b53524a8-f6f0-4c14-b84e-7d1ce56f9435" />

## Summary
- ignore safe area in notch content container so expanded panel is anchored to the top edge
- fixes the visual gap where the open notch appeared shifted downward on some displays

## Testing
- xcodebuild -project boringNotch.xcodeproj -scheme boringNotch -configuration Debug -sdk macosx build
- manual verification on macOS 26.4 beta 2
