### PR TITLE
Improve localization for settings strings

### DIFF
--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -10333,6 +10333,9 @@
     "Interaction" : {
 
     },
+    "Launch at login" : {
+
+    },
     "Layout Preview" : {
       "localizations" : {
         "ar" : {
@@ -14143,8 +14146,52 @@
         }
       }
     },
+    "option_key_no_action" : {
+      "comment" : "Option (⌥) key behavior: No action",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No action"
+          }
+        }
+      }
+    },
+    "option_key_open_system_settings" : {
+      "comment" : "Option (⌥) key behavior: Open System Settings",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open System Settings"
+          }
+        }
+      }
+    },
+    "option_key_show_osd" : {
+      "comment" : "Option (⌥) key behavior: Show OSD",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show OSD"
+          }
+        }
+      }
+    },
     "OSD" : {
 
+    },
+    "osd_sources_built_in" : {
+      "comment" : "OSD Sources: Built-in",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Built-in"
+          }
+        }
+      }
     },
     "OSD.ValueLabel" : {
       "comment" : "Label for OSD value slider"
@@ -14248,6 +14295,9 @@
           }
         }
       }
+    },
+    "Player tinting" : {
+
     },
     "Plugged In" : {
       "localizations" : {
@@ -18028,6 +18078,39 @@
         }
       }
     },
+    "slider_color_accent" : {
+      "comment" : "Slider color option: accent color",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accent color"
+          }
+        }
+      }
+    },
+    "slider_color_album_art" : {
+      "comment" : "Slider color option: match album art",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Match album art"
+          }
+        }
+      }
+    },
+    "slider_color_white" : {
+      "comment" : "Slider color option: white",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "White"
+          }
+        }
+      }
+    },
     "Sneak Peek shows the media title and artist under the notch for a few seconds." : {
       "localizations" : {
         "ar" : {
@@ -18224,6 +18307,28 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Sneak Peek 样式"
+          }
+        }
+      }
+    },
+    "sneak_peek_inline" : {
+      "comment" : "Sneak Peek style: Inline",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inline"
+          }
+        }
+      }
+    },
+    "sneak_peek_standard" : {
+      "comment" : "Sneak Peek style: Default",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default"
           }
         }
       }

--- a/boringNotch/components/Settings/Views/AppearanceSettingsView.swift
+++ b/boringNotch/components/Settings/Views/AppearanceSettingsView.swift
@@ -32,14 +32,15 @@ struct Appearance: View {
                 Defaults.Toggle(key: .coloredSpectrogram) {
                     Text("Colored spectrogram")
                 }
-                Defaults
-                    .Toggle("Player tinting", key: .playerColorTinting)
+                Defaults.Toggle(key: .playerColorTinting) {
+                    Text("Player tinting")
+                }
                 Defaults.Toggle(key: .lightingEffect) {
                     Text("Enable blur effect behind album art")
                 }
                 Picker("Slider color", selection: $sliderColor) {
                     ForEach(SliderColorEnum.allCases, id: \.self) { option in
-                        Text(option.rawValue)
+                        Text(option.localizedString)
                     }
                 }
             } header: {

--- a/boringNotch/components/Settings/Views/GeneralSettingsView.swift
+++ b/boringNotch/components/Settings/Views/GeneralSettingsView.swift
@@ -39,7 +39,9 @@ struct GeneralSettings: View {
                     Text("Show menu bar icon")
                 }
                 .tint(.effectiveAccent)
-                LaunchAtLogin.Toggle("Launch at login")
+                LaunchAtLogin.Toggle() {
+                    Text("Launch at login")
+                }
                 Defaults.Toggle(key: .showOnAllDisplays) {
                     Text("Show on all displays")
                 }

--- a/boringNotch/components/Settings/Views/MediaSettingsView.swift
+++ b/boringNotch/components/Settings/Views/MediaSettingsView.swift
@@ -64,7 +64,7 @@ struct Media: View {
                 Toggle("Show sneak peek on playback changes", isOn: $enableSneakPeek)
                 Picker("Sneak Peek Style", selection: $sneakPeekStyles) {
                     ForEach(SneakPeekStyle.allCases) { style in
-                        Text(style.rawValue).tag(style)
+                        Text(style.localizedString).tag(style)
                     }
                 }
                 HStack {

--- a/boringNotch/components/Settings/Views/OSDSettingsView.swift
+++ b/boringNotch/components/Settings/Views/OSDSettingsView.swift
@@ -44,7 +44,7 @@ struct OSDSettings: View {
                     SettingsRow("Brightness Source") {
                         Picker("", selection: $osdBrightnessSourceDefault) {
                             ForEach(OSDControlSource.allCases) { source in
-                                Text(source.rawValue).tag(source)
+                                Text(source.localizedString).tag(source)
                             }
                         }
                         .pickerStyle(.menu)
@@ -63,7 +63,7 @@ struct OSDSettings: View {
                         Picker("", selection: $osdVolumeSourceDefault) {
                             // Lunar does not support volume control so hide it from the picker
                             ForEach(OSDControlSource.allCases.filter { $0 != .lunar }) { source in
-                                Text(source.rawValue).tag(source)
+                                Text(source.localizedString).tag(source)
                             }
                         }
                         .pickerStyle(.menu)
@@ -73,7 +73,7 @@ struct OSDSettings: View {
                     }
 
                     SettingsRow("Keyboard Source", help: "Keyboard brightness currently supports the built-in source only.") {
-                        Text(OSDControlSource.builtin.rawValue)
+                        Text(OSDControlSource.builtin.localizedString)
                     }
                     if !isAccessibilityAuthorized {
                         HStack(alignment: .center, spacing: 12) {
@@ -132,7 +132,7 @@ struct OSDSettings: View {
                     SettingsRow("Option (⌥) Key Behavior") {
                         Picker("", selection: $optionKeyActionDefault) {
                             ForEach(OptionKeyAction.allCases) { action in
-                                Text(action.rawValue).tag(action)
+                                Text(action.localizedString).tag(action)
                             }
                         }
                         .pickerStyle(.menu)

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -46,7 +46,18 @@ enum WindowHeightMode: String, Defaults.Serializable {
 }
 
 enum SliderColorEnum: String, CaseIterable, Defaults.Serializable {
-    case white = "White"
-    case albumArt = "Match album art"
-    case accent = "Accent color"
+    case white
+    case albumArt
+    case accent
+    
+    var localizedString: String {
+        switch self {
+        case .white:
+            return NSLocalizedString("slider_color_white", comment: "Slider color option: white")
+        case .albumArt:
+            return NSLocalizedString("slider_color_album_art", comment: "Slider color option: match album art")
+        case .accent:
+            return NSLocalizedString("slider_color_accent", comment: "Slider color option: accent color")
+        }
+    }
 }

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -66,28 +66,59 @@ enum MediaControllerType: String, CaseIterable, Identifiable, Defaults.Serializa
 
 // Sneak peek styles for selection in settings
 enum SneakPeekStyle: String, CaseIterable, Identifiable, Defaults.Serializable {
-    case standard = "Default"
-    case inline = "Inline"
+    case standard
+    case inline
     
     var id: String { self.rawValue }
+    
+    var localizedString: String {
+        switch self {
+        case .standard:
+            return NSLocalizedString("sneak_peek_standard", comment: "Sneak Peek style: Default")
+        case .inline:
+            return NSLocalizedString("sneak_peek_inline", comment: "Sneak Peek style: Inline")
+        }
+    }
 }
 
 // Action to perform when Option (⌥) is held while pressing media keys
 enum OptionKeyAction: String, CaseIterable, Identifiable, Defaults.Serializable {
-    case openSettings = "Open System Settings"
-    case showOSD = "Show OSD"
-    case none = "No Action"
+    case openSettings
+    case showOSD
+    case none
 
     var id: String { self.rawValue }
+    
+    var localizedString: String {
+        switch self {
+        case .openSettings:
+            return NSLocalizedString("option_key_open_system_settings", comment: "Option (⌥) key behavior: Open System Settings")
+        case .showOSD:
+            return NSLocalizedString("option_key_show_osd", comment: "Option (⌥) key behavior: Show OSD")
+        case .none:
+            return NSLocalizedString("option_key_no_action", comment: "Option (⌥) key behavior: No action")
+        }
+    }
 }
 
 // Source/provider for OSD control (user-facing: "Source")
 enum OSDControlSource: String, CaseIterable, Identifiable, Defaults.Serializable {
-    case builtin = "Built-in"
+    case builtin
     case betterDisplay = "BetterDisplay"
     case lunar = "Lunar"
 
     var id: String { self.rawValue }
+    
+    var localizedString: String {
+        switch self {
+        case .builtin:
+            return NSLocalizedString("osd_sources_built_in", comment: "OSD Sources: Built-in")
+        case .betterDisplay:
+            return "BetterDisplay"
+        case .lunar:
+            return "Lunar"
+        }
+    }
 }
 
 extension Defaults.Keys {


### PR DESCRIPTION
Introduces `localizedString` computed properties for various enums (e.g., slider colors, OSD sources, sneak peek styles, option key actions). Updates settings views to utilize these localized strings, improving internationalization.

Refactors `Toggle` components to explicitly use `Text` views for their labels, allowing for easier localization of these UI elements. Adds new localization keys to support these changes.

Addresses #1073