### PR TITLE
feat: introduce lunar calendar support

### DIFF
--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -1809,6 +1809,23 @@
         }
       }
     },
+    "Alternative calendars" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternative calendars"
+          }
+        }
+      }
+    },
+    "Always alternate" : {
+
+    },
+    "Always default" : {
+
+    },
     "Always show full event titles" : {
       "localizations" : {
         "ar" : {
@@ -3421,6 +3438,17 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "日历访问被拒绝。请在系统设置中启用它。"
+          }
+        }
+      }
+    },
+    "Calendar subtitle display" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calendar subtitle display"
           }
         }
       }
@@ -10666,6 +10694,9 @@
           }
         }
       }
+    },
+    "Lunar" : {
+
     },
     "Made with 🫶🏻 by not so boring not.people" : {
       "localizations" : {
@@ -19051,6 +19082,9 @@
           }
         }
       }
+    },
+    "Tap to switch" : {
+
     },
     "Time to Full Charge: %lld min" : {
       "localizations" : {

--- a/boringNotch/components/Calendar/BoringCalendar.swift
+++ b/boringNotch/components/Calendar/BoringCalendar.swift
@@ -233,6 +233,34 @@ struct CalendarView: View {
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject private var calendarManager = CalendarManager.shared
     @State private var selectedDate = Date()
+    @Default(.calendarSubtitleDisplayMode) var displayMode
+    @Default(.alternativeCalendar) var alternativeCalendar
+    @Default(.calendarIsShowingAlternate) var isShowingAlternate
+
+    private var shouldShowAlternate: Bool {
+        switch displayMode {
+        case .alwaysDefault:
+            return false
+        case .alwaysAlternate:
+            return true
+        case .tapToSwitch:
+            return isShowingAlternate
+        }
+    }
+
+    // A hidden view strictly for sizing
+    private func subtitleSizingView(date: Date) -> some View {
+        ZStack {
+            Text(date.formatted(.dateTime.year()))
+            switch alternativeCalendar {
+            case .lunar:
+                Text(date.formatted(.dateTime.lunar()))
+            }
+        }
+        .font(.title3)
+        .fontWeight(.light)
+        .fixedSize() // Ensure it takes up its natural calculated size
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -242,10 +270,34 @@ struct CalendarView: View {
                         .font(.title3)
                         .fontWeight(.semibold)
                         .foregroundColor(.white)
-                    Text(selectedDate.formatted(.dateTime.year()))
+                    
+                    ZStack(alignment: .leading) {
+                        // Invisible layer to reserve space for the widest possible content
+                        subtitleSizingView(date: selectedDate)
+                            .hidden()
+                            
+                        // Visible content
+                        Group {
+                            if shouldShowAlternate {
+                                switch alternativeCalendar {
+                                case .lunar:
+                                    Text(selectedDate.formatted(.dateTime.lunar()))
+                                }
+                            } else {
+                                Text(selectedDate.formatted(.dateTime.year()))
+                            }
+                        }
                         .font(.title3)
                         .fontWeight(.light)
                         .foregroundColor(Color(white: 0.65))
+                        .onTapGesture {
+                            if displayMode == .tapToSwitch {
+                                withAnimation(.smooth(duration: 0.2)) {
+                                    isShowingAlternate.toggle()
+                                }
+                            }
+                        }
+                    }
                 }
 
                 ZStack(alignment: .top) {

--- a/boringNotch/components/Settings/Views/CalendarSettingsView.swift
+++ b/boringNotch/components/Settings/Views/CalendarSettingsView.swift
@@ -15,6 +15,8 @@ struct CalendarSettings: View {
     @Default(.hideCompletedReminders) var hideCompletedReminders
     @Default(.hideAllDayEvents) var hideAllDayEvents
     @Default(.autoScrollToNextEvent) var autoScrollToNextEvent
+    @Default(.calendarSubtitleDisplayMode) var calendarSubtitleDisplayMode
+    @Default(.alternativeCalendar) var alternativeCalendar
 
     var body: some View {
         Form {
@@ -33,6 +35,23 @@ struct CalendarSettings: View {
             Defaults.Toggle(key: .showFullEventTitles) {
                 Text("Always show full event titles")
             }
+            
+            Picker("Calendar subtitle display", selection: $calendarSubtitleDisplayMode) {
+                ForEach(CalendarSubtitleDisplayMode.allCases) { item in
+                    Text(item.localizedString).tag(item)
+                }
+            }
+            .pickerStyle(.menu)
+            
+            if calendarSubtitleDisplayMode != .alwaysDefault {
+                Picker("Alternative calendars", selection: $alternativeCalendar) {
+                    ForEach(AlternativeCalendarType.allCases) { item in
+                        Text(item.localizedString).tag(item)
+                    }
+                }
+                .pickerStyle(.menu)
+            }
+
             Section(header: Text("Calendars")) {
                 if calendarManager.calendarAuthorizationStatus != .fullAccess {
                     Text("Calendar access is denied. Please enable it in System Settings.")

--- a/boringNotch/extensions/DataTypes+Extensions.swift
+++ b/boringNotch/extensions/DataTypes+Extensions.swift
@@ -42,6 +42,31 @@ extension Date {
     }
 }
 
+struct LunarDateStyle: FormatStyle {
+    func format(_ value: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Foundation.Calendar(identifier: .chinese)
+        formatter.locale = Locale(identifier: "zh_CN")
+        formatter.dateStyle = .long
+        formatter.timeStyle = .none
+        
+        let fullDate = formatter.string(from: value)
+        
+        if let yearRange = fullDate.range(of: "年") {
+            let extracted = String(fullDate[yearRange.upperBound...])
+            return extracted
+        }
+        
+        return fullDate
+    }
+}
+
+extension Date.FormatStyle {
+    func lunar() -> LunarDateStyle {
+        LunarDateStyle()
+    }
+}
+
 extension NSSize {
     var s: String { "\(width.i)×\(height.i)" }
     

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -134,6 +134,38 @@ enum OSDControlSource: String, CaseIterable, Identifiable, Defaults.Serializable
     }
 }
 
+enum CalendarSubtitleDisplayMode: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case alwaysDefault
+    case alwaysAlternate
+    case tapToSwitch
+    
+    var id: String { self.rawValue }
+    
+    var localizedString: String {
+        switch self {
+        case .alwaysDefault:
+            return NSLocalizedString("Always default", comment: "")
+        case .alwaysAlternate:
+            return NSLocalizedString("Always alternate", comment: "")
+        case .tapToSwitch:
+            return NSLocalizedString("Tap to switch", comment: "")
+        }
+    }
+}
+
+enum AlternativeCalendarType: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case lunar = "Lunar"
+    
+    var id: String { self.rawValue }
+    
+    var localizedString: String {
+        switch self {
+        case .lunar:
+            return NSLocalizedString("Lunar", comment: "")
+        }
+    }
+}
+
 extension Defaults.Keys {
     // MARK: General
     static let menubarIcon = Key<Bool>("menubarIcon", default: true)
@@ -245,6 +277,10 @@ extension Defaults.Keys {
     static let hideAllDayEvents = Key<Bool>("hideAllDayEvents", default: false)
     static let showFullEventTitles = Key<Bool>("showFullEventTitles", default: false)
     static let autoScrollToNextEvent = Key<Bool>("autoScrollToNextEvent", default: true)
+    
+    static let calendarSubtitleDisplayMode = Key<CalendarSubtitleDisplayMode>("calendarSubtitleDisplayMode", default: .alwaysDefault)
+    static let alternativeCalendar = Key<AlternativeCalendarType>("alternativeCalendar", default: .lunar)
+    static let calendarIsShowingAlternate = Key<Bool>("calendarIsShowingAlternate", default: false)
     
     // MARK: Fullscreen Media Detection
     static let hideNotchOption = Key<HideNotchOption>("hideNotchOption", default: .nowPlayingOnly)


### PR DESCRIPTION
## 🔧Settings UI

- **Added "Calendar subtitle display" option** with three modes:
    - **Always default**: Keeps the original year display (e.g., "2026").
    - **Always alternate**: Permanently displays the alternate calendar.
    - **Tap to switch**: Allows users to toggle between the year and the alternate calendar by tapping the subtitle.
- **Added conditional "Alternate Calendar" Picker**: This picker appears only when "Always alternate" or "Tap to switch" is selected.

    > **Note on Localization**: Currently, **this feature only supports the Lunar Calendar**. Since there is no standard or intuitive way to express Lunar dates in non-Chinese languages (e.g., it defaults to strings with ambiguous meanings like `mo1 14` in English), **therefore the Lunar display is locked to Simplified Chinese** to ensure clarity and accuracy.

## 📅Calendar View

- **Layout Optimization**: Implemented a fixed-width hidden view strategy using `ZStack`. This ensures the UI remains rock-solid and prevents any layout "jitter" or shifting when toggling between the year and Lunar text.
- **State Persistence**: The toggle state (`calendarIsShowingAlternate`) is now persisted. Even after closing the window or restarting the app, it will remember the last selection in "Tap to switch" mode.

## 📃Localization

- Added localization objects for all new settings in `Localizable.xcstrings`.
- **Note**: I have not added translations for non-default languages (**including Simplified Chinese, which I am most familiar with**) yet, as **I believe** all translation work should be officially handled via **Crowdin** to maintain project standards.

## 📷Screenshots

<div align="center">

<img width="812" alt="image" src="https://github.com/user-attachments/assets/1752bee1-563a-4fdb-a4dd-5fd7e30b8d1e" />

<img width="812" alt="image" src="https://github.com/user-attachments/assets/7b5b4090-ab42-4647-9d2a-6153f4c6fcd2" />

<img width="812" alt="image" src="https://github.com/user-attachments/assets/3cc6617f-a8de-447e-9a58-e22d31ac1a51" />

<img width="640" alt="image" src="https://github.com/user-attachments/assets/64cadfb1-e187-4a16-9644-62f2a76dab64" />

<img width="640" alt="image" src="https://github.com/user-attachments/assets/b2ae61ac-f6db-4f05-b27a-e18a1c6bcc84" />

</div>