### PR TITLE
README: Remove deprecated --no-quarantine flag from Homebrew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Then open the app normally.
 
 ### Option 2: Install via Homebrew
 
-You can also install using [Homebrew](https://brew.sh).
+You can also install using [Homebrew](https://brew.sh). The Homebrew installation automatically bypasses the macOS security warning described above.
 
 ```bash
 brew install --cask TheBoredTeam/boring-notch/boring-notch


### PR DESCRIPTION
## Summary
- Removes the deprecated `--no-quarantine` flag from the Homebrew install command
- Updates the surrounding description that referenced the flag
- The flag has been deprecated by Homebrew with no replacement and will be fully removed in a future version

Closes #1106

## Test plan
- [ ] Verify `brew install --cask TheBoredTeam/boring-notch/boring-notch` installs successfully without the flag
