### PR TITLE
Remove semver dependency from release version parsing

### DIFF
--- a/.github/scripts/extract_version.py
+++ b/.github/scripts/extract_version.py
@@ -11,11 +11,14 @@ from argparse import ArgumentParser
 
 
 SEMVER_RE = re.compile(r"v?[0-9]+\.[0-9]+(?:\.[0-9]+)?(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?")
-PRERELEASE_ID = r"(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+NUMERIC_IDENTIFIER = r"(?:0|[1-9][0-9]*)"
+ALPHANUMERIC_IDENTIFIER = r"(?:[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"
+PRERELEASE_IDENTIFIER = rf"(?:{NUMERIC_IDENTIFIER}|{ALPHANUMERIC_IDENTIFIER})"
+BUILD_IDENTIFIER = r"(?:[0-9A-Za-z-]+)"
 NORMALIZED_SEMVER_RE = re.compile(
-    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
-    rf"(?:-({PRERELEASE_ID}(?:\.{PRERELEASE_ID})*))?"
-    r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+    rf"^({NUMERIC_IDENTIFIER})\.({NUMERIC_IDENTIFIER})\.({NUMERIC_IDENTIFIER})"
+    rf"(?:-({PRERELEASE_IDENTIFIER}(?:\.{PRERELEASE_IDENTIFIER})*))?"
+    rf"(?:\+({BUILD_IDENTIFIER}(?:\.{BUILD_IDENTIFIER})*))?$"
 )
 
 

--- a/.github/scripts/extract_version.py
+++ b/.github/scripts/extract_version.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 import json
 import os
 import re
-import semver
 import subprocess
 import sys
 from argparse import ArgumentParser
 
 
 SEMVER_RE = re.compile(r"v?[0-9]+\.[0-9]+(?:\.[0-9]+)?(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?")
+PRERELEASE_ID = r"(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+NORMALIZED_SEMVER_RE = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+    rf"(?:-({PRERELEASE_ID}(?:\.{PRERELEASE_ID})*))?"
+    r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
 
 
 def find_first_valid(text: str):
@@ -20,11 +25,9 @@ def find_first_valid(text: str):
         # Normalize for parsing: 2.7 -> 2.7.0, 2.7-beta -> 2.7.0-beta
         # Regex: look for X.Y at start, not followed by .Z
         normalized = re.sub(r"^([0-9]+\.[0-9]+)(?![0-9]*\.)", r"\1.0", s)
-        try:
-            parsed = semver.VersionInfo.parse(normalized)
+        parsed = NORMALIZED_SEMVER_RE.fullmatch(normalized)
+        if parsed:
             return s, parsed
-        except Exception:
-            continue
     return None, None
 
 
@@ -51,7 +54,7 @@ def main(argv=None) -> int:
 
     version, parsed = find_first_valid(comment)
 
-    beta = getattr(parsed, "prerelease", None)
+    beta = bool(parsed and parsed.group(4))
 
     # Write GitHub Actions outputs if available (GITHUB_OUTPUT)
     write_github_output(version, bool(beta))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,6 @@ jobs:
           COMMENT: ${{ github.event.comment.body }}
         run: |
           set -euo pipefail
-          python3 -m pip install --upgrade --no-cache-dir semver
           export projname="${{ env.PROJECT_NAME }}"
           OUTPUT=$(python3 .github/scripts/extract_version.py -c "$COMMENT")
           VERSION=$(awk -F= '/^version=/{print $2; exit}' <<<"$OUTPUT")


### PR DESCRIPTION
This pull request updates the `.github/scripts/extract_version.py` script to remove its dependency on the `semver` Python package. Instead, it now uses a custom regular expression to parse and validate semantic version strings. This change simplifies the workflow by eliminating the need to install an extra dependency during CI runs.