### PR TITLE
Add clipboard history tab

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CB01CB092E0C100100CB0005 /* ClipboardSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB01CB082E0C100100CB0005 /* ClipboardSettingsView.swift */; };
+		CB01CB022E0C100100CB0001 /* ClipboardHistoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB01CB012E0C100100CB0001 /* ClipboardHistoryManager.swift */; };
+		CB01CB042E0C100100CB0002 /* ClipboardItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB01CB032E0C100100CB0002 /* ClipboardItem.swift */; };
+		CB01CB062E0C100100CB0003 /* ClipboardHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB01CB052E0C100100CB0003 /* ClipboardHistoryView.swift */; };
 		1100290C2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1100290B2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift */; };
 		110029272E84FD4C00035A57 /* TemporaryFileStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110029262E84FD4C00035A57 /* TemporaryFileStorageService.swift */; };
 		1100292A2E8691B400035A57 /* FileShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110029292E8691B400035A57 /* FileShareView.swift */; };
@@ -195,6 +199,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		CB01CB082E0C100100CB0005 /* ClipboardSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardSettingsView.swift; sourceTree = "<group>"; };
+		CB01CB012E0C100100CB0001 /* ClipboardHistoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardHistoryManager.swift; sourceTree = "<group>"; };
+		CB01CB032E0C100100CB0002 /* ClipboardItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardItem.swift; sourceTree = "<group>"; };
+		CB01CB052E0C100100CB0003 /* ClipboardHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardHistoryView.swift; sourceTree = "<group>"; };
 		1100290B2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSItemProvider+LoadHelpers.swift"; sourceTree = "<group>"; };
 		110029262E84FD4C00035A57 /* TemporaryFileStorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryFileStorageService.swift; sourceTree = "<group>"; };
 		110029292E8691B400035A57 /* FileShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileShareView.swift; sourceTree = "<group>"; };
@@ -534,6 +542,7 @@
 				11DB266F2EDD0CDF001EA0CF /* SettingsHelpers.swift */,
 				11DB26702EDD0CDF001EA0CF /* ShelfSettingsView.swift */,
 				11DB26712EDD0CDF001EA0CF /* ShortcutsSettingsView.swift */,
+				CB01CB082E0C100100CB0005 /* ClipboardSettingsView.swift */,
 				64FA50FA2F4D6F9E00008A28 /* WebcamSettingsView.swift */,
 			);
 			path = Views;
@@ -585,6 +594,8 @@
 			children = (
 				11985BDF2F37A3C800F81585 /* OSD */,
 				B141C23B2CA5F50900AC8CC8 /* Onboarding */,
+				CB01CB072E0C100100CB0004 /* Clipboard */,
+				B1C448992C97375A001F0858 /* Tips */,
 				14C08BB72C8DE49E000F8AA0 /* Calendar */,
 				9A987A042C73CA66005CA465 /* Shelf */,
 				149E0B982C737D26006418B1 /* Webcam */,
@@ -601,11 +612,20 @@
 			path = components;
 			sourceTree = "<group>";
 		};
+		CB01CB072E0C100100CB0004 /* Clipboard */ = {
+			isa = PBXGroup;
+			children = (
+				CB01CB052E0C100100CB0003 /* ClipboardHistoryView.swift */,
+			);
+			path = Clipboard;
+			sourceTree = "<group>";
+		};
 		147163B52C5D804B0068B555 /* managers */ = {
 			isa = PBXGroup;
 			children = (
 				11DB26652EDD0BE1001EA0CF /* LyricsService.swift */,
 				11D58EA12E760AE100FA8377 /* ImageService.swift */,
+				CB01CB012E0C100100CB0001 /* ClipboardHistoryManager.swift */,
 				F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */,
 				112FB7342CCF16F70015238C /* NotchSpaceManager.swift */,
 				147163992C5D35FF0068B555 /* MusicManager.swift */,
@@ -720,6 +740,7 @@
 			isa = PBXGroup;
 			children = (
 				11F748812ECB07A400F841DB /* MusicControlButton.swift */,
+				CB01CB032E0C100100CB0002 /* ClipboardItem.swift */,
 				118D1FD02E98FF5F00A2FF63 /* SharingStateManager.swift */,
 				1163988E2DF5CC870052E6AF /* CalendarModel.swift */,
 				1163988C2DF5CAB40052E6AF /* EventModel.swift */,
@@ -1116,6 +1137,10 @@
 				1100290C2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift in Sources */,
 				11CFC6632E09918400748C80 /* MusicControllerSelectionView.swift in Sources */,
 				B1F0A0022E60000100000001 /* BrightnessManager.swift in Sources */,
+				CB01CB092E0C100100CB0005 /* ClipboardSettingsView.swift in Sources */,
+				CB01CB022E0C100100CB0001 /* ClipboardHistoryManager.swift in Sources */,
+				CB01CB042E0C100100CB0002 /* ClipboardItem.swift in Sources */,
+				CB01CB062E0C100100CB0003 /* ClipboardHistoryView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -385,6 +385,8 @@ struct ContentView: View {
                         NotchHomeView(albumArtNamespace: albumArtNamespace)
                     case .shelf:
                         ShelfView()
+                    case .clipboard:
+                        ClipboardHistoryView()
                     }
                 }
                 .transition(

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -87,6 +87,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             screenUnlockedObserver = nil
         }
         MusicManager.shared.destroy()
+        ClipboardHistoryManager.shared.stopMonitoring()
         cleanupDragDetectors()
         cleanupWindows()
         BetterDisplayManager.shared.stopObserving()
@@ -384,6 +385,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        KeyboardShortcuts.onKeyDown(for: .clipboardHistoryPanel) { [weak self] in
+            guard let self = self, Defaults[.showClipboard] else { return }
+            let mouseLocation = NSEvent.mouseLocation
+
+            var viewModel = self.vm
+
+            if Defaults[.showOnAllDisplays] {
+                for screen in NSScreen.screens {
+                    if screen.frame.contains(mouseLocation) {
+                        if let uuid = screen.displayUUID, let screenViewModel = self.viewModels[uuid] {
+                            viewModel = screenViewModel
+                            break
+                        }
+                    }
+                }
+            }
+
+            if viewModel.notchState == .closed {
+                viewModel.open()
+            }
+            self.coordinator.currentView = .clipboard
+        }
+
         KeyboardShortcuts.onKeyDown(for: .toggleNotchOpen) { [weak self] in
             Task { [weak self] in
                 guard let self = self else { return }
@@ -443,6 +467,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         setupDragDetectors()
+
+        if Defaults[.showClipboard] {
+            ClipboardHistoryManager.shared.startMonitoring()
+        }
 
         if coordinator.firstLaunch {
             DispatchQueue.main.async {

--- a/boringNotch/components/Clipboard/ClipboardHistoryView.swift
+++ b/boringNotch/components/Clipboard/ClipboardHistoryView.swift
@@ -1,0 +1,168 @@
+//
+//  ClipboardHistoryView.swift
+//  boringNotch
+//
+//  Created on 2026-04-13.
+//
+
+import SwiftUI
+
+struct ClipboardHistoryView: View {
+    @StateObject private var clipboardManager = ClipboardHistoryManager.shared
+    @State private var copiedItemID: UUID?
+
+    var body: some View {
+        Group {
+            if clipboardManager.items.isEmpty {
+                emptyState
+            } else {
+                clipboardList
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "clipboard")
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(.white, .gray)
+                .imageScale(.large)
+                .font(.title)
+
+            Text("No clipboard history")
+                .foregroundStyle(.gray)
+                .font(.system(.title3, design: .rounded))
+                .fontWeight(.medium)
+
+            Text("Copy something to get started")
+                .foregroundStyle(.gray.opacity(0.6))
+                .font(.caption)
+        }
+    }
+
+    private var clipboardList: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Clipboard History")
+                    .font(.system(.headline, design: .rounded))
+                    .foregroundStyle(.white)
+                Spacer()
+                Button {
+                    withAnimation(.smooth) {
+                        clipboardManager.clearHistory()
+                    }
+                } label: {
+                    Text("Clear")
+                        .font(.caption)
+                        .foregroundStyle(.gray)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            .padding(.bottom, 8)
+
+            ScrollView(.vertical) {
+                VStack(spacing: 6) {
+                    ForEach(clipboardManager.items) { item in
+                        ClipboardItemRow(
+                            item: item,
+                            isCopied: copiedItemID == item.id
+                        ) {
+                            clipboardManager.copyAndPaste(item)
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                copiedItemID = item.id
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                                withAnimation {
+                                    if copiedItemID == item.id {
+                                        copiedItemID = nil
+                                    }
+                                }
+                            }
+                        }
+                        .transition(.asymmetric(
+                            insertion: .move(edge: .top).combined(with: .opacity),
+                            removal: .opacity
+                        ))
+                    }
+                }
+            }
+            .scrollIndicators(.never)
+        }
+        .padding()
+    }
+}
+
+struct ClipboardItemRow: View {
+    let item: ClipboardItem
+    let isCopied: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 10) {
+                itemIcon
+
+                VStack(alignment: .leading, spacing: 2) {
+                    itemPreview
+                    Text(item.timestamp, style: .relative)
+                        .font(.caption2)
+                        .foregroundStyle(.gray.opacity(0.7))
+                }
+
+                Spacer()
+
+                if isCopied {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .transition(.scale.combined(with: .opacity))
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isCopied ? Color.green.opacity(0.1) : Color.white.opacity(0.05))
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+
+    @ViewBuilder
+    private var itemIcon: some View {
+        switch item.kind {
+        case .image(let image):
+            Image(nsImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 28, height: 28)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+        default:
+            Image(systemName: item.icon)
+                .font(.system(size: 14))
+                .foregroundStyle(.gray)
+                .frame(width: 28, height: 28)
+        }
+    }
+
+    @ViewBuilder
+    private var itemPreview: some View {
+        switch item.kind {
+        case .text:
+            Text(item.preview)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.white)
+                .lineLimit(2)
+        case .image:
+            Text("Image")
+                .font(.caption)
+                .foregroundStyle(.white)
+        case .fileURL:
+            Text(item.preview)
+                .font(.caption)
+                .foregroundStyle(.white)
+                .lineLimit(1)
+        }
+    }
+}

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -16,7 +16,7 @@ struct BoringHeader: View {
     var body: some View {
         HStack(spacing: 0) {
             HStack {
-                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
+                if ((!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf]) || Defaults[.showClipboard] {
                     TabSelectionView()
                 } else if vm.notchState == .open {
                     EmptyView()

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -46,6 +46,9 @@ struct SettingsView: View {
                 NavigationLink(value: "Mirror") {
                     Label("Mirror", systemImage: "camera")
                 }
+                NavigationLink(value: "Clipboard") {
+                    Label("Clipboard", systemImage: "doc.on.clipboard")
+                }
                 NavigationLink(value: "Shortcuts") {
                     Label("Shortcuts", systemImage: "keyboard")
                 }
@@ -79,6 +82,8 @@ struct SettingsView: View {
                     Shelf()
                 case "Mirror":
                     MirrorSettings()
+                case "Clipboard":
+                    ClipboardSettings()
                 case "Shortcuts":
                     Shortcuts()
                 case "Advanced":

--- a/boringNotch/components/Settings/Views/ClipboardSettingsView.swift
+++ b/boringNotch/components/Settings/Views/ClipboardSettingsView.swift
@@ -1,0 +1,29 @@
+//
+//  ClipboardSettingsView.swift
+//  boringNotch
+//
+//  Created on 2026-04-13.
+//
+
+import Defaults
+import SwiftUI
+
+struct ClipboardSettings: View {
+    @Default(.showClipboard) var showClipboard
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Enable clipboard history", isOn: $showClipboard)
+            } header: {
+                Text("General")
+            } footer: {
+                Text("Tracks the last 5 items you copied. History is cleared when the app restarts.")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Clipboard")
+    }
+}

--- a/boringNotch/components/Settings/Views/ShortcutsSettingsView.swift
+++ b/boringNotch/components/Settings/Views/ShortcutsSettingsView.swift
@@ -26,6 +26,16 @@ struct Shortcuts: View {
             Section {
                 KeyboardShortcuts.Recorder("Toggle Notch Open:", name: .toggleNotchOpen)
             }
+            Section {
+                KeyboardShortcuts.Recorder("Clipboard History:", name: .clipboardHistoryPanel)
+            } header: {
+                Text("Clipboard")
+            } footer: {
+                Text("Opens the notch and switches to the Clipboard History tab.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
         }
         .accentColor(.effectiveAccent)
         .navigationTitle("Shortcuts")

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -16,7 +16,8 @@ struct TabModel: Identifiable {
 
 let tabs = [
     TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
+    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf),
+    TabModel(label: "Clipboard", icon: "doc.on.clipboard.fill", view: .clipboard)
 ]
 
 struct TabSelectionView: View {

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -21,6 +21,7 @@ public enum NotchState {
 public enum NotchViews {
     case home
     case shelf
+    case clipboard
 }
 
 enum DownloadIndicatorStyle: String, Defaults.Serializable {

--- a/boringNotch/managers/ClipboardHistoryManager.swift
+++ b/boringNotch/managers/ClipboardHistoryManager.swift
@@ -1,0 +1,129 @@
+//
+//  ClipboardHistoryManager.swift
+//  boringNotch
+//
+//  Created on 2026-04-13.
+//
+
+import AppKit
+import Combine
+import Foundation
+
+class ClipboardHistoryManager: ObservableObject {
+    static let shared = ClipboardHistoryManager()
+
+    @Published var items: [ClipboardItem] = []
+
+    private let maxItems = 5
+    private let pollInterval: TimeInterval = 0.5
+    private var lastChangeCount: Int
+    private var timer: Timer?
+    private var skipNextChange: Bool = false
+
+    private init() {
+        lastChangeCount = NSPasteboard.general.changeCount
+    }
+
+    func startMonitoring() {
+        guard timer == nil else { return }
+        timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
+            self?.checkForChanges()
+        }
+    }
+
+    func stopMonitoring() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func checkForChanges() {
+        let currentChangeCount = NSPasteboard.general.changeCount
+        guard currentChangeCount != lastChangeCount else { return }
+        lastChangeCount = currentChangeCount
+
+        if skipNextChange {
+            skipNextChange = false
+            return
+        }
+
+        captureClipboard()
+    }
+
+    private func captureClipboard() {
+        let pasteboard = NSPasteboard.general
+
+        if let fileURLs = pasteboard.readObjects(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) as? [URL],
+           let url = fileURLs.first {
+            addItem(.fileURL(url))
+            return
+        }
+
+        if let image = NSImage(pasteboard: pasteboard) {
+            addItem(.image(image))
+            return
+        }
+
+        if let string = pasteboard.string(forType: .string), !string.isEmpty {
+            addItem(.text(string))
+            return
+        }
+    }
+
+    private func addItem(_ kind: ClipboardItemKind) {
+        let item = ClipboardItem(kind: kind, timestamp: Date())
+
+        // Remove duplicate if same content already exists
+        items.removeAll { existing in
+            existing.kind == item.kind
+        }
+
+        items.insert(item, at: 0)
+
+        if items.count > maxItems {
+            items = Array(items.prefix(maxItems))
+        }
+    }
+
+    func copyToClipboard(_ item: ClipboardItem) {
+        skipNextChange = true
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+
+        switch item.kind {
+        case .text(let string):
+            pasteboard.setString(string, forType: .string)
+        case .image(let image):
+            if let tiffData = image.tiffRepresentation {
+                pasteboard.setData(tiffData, forType: .tiff)
+            }
+        case .fileURL(let url):
+            pasteboard.writeObjects([url as NSURL])
+        }
+    }
+
+    func copyAndPaste(_ item: ClipboardItem) {
+        copyToClipboard(item)
+
+        // Small delay to let the pasteboard update, then simulate Cmd+V
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.simulatePaste()
+        }
+    }
+
+    private func simulatePaste() {
+        let source = CGEventSource(stateID: .hidSystemState)
+
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true)  // 0x09 = 'V'
+        keyDown?.flags = .maskCommand
+
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)
+        keyUp?.flags = .maskCommand
+
+        keyDown?.post(tap: .cghidEventTap)
+        keyUp?.post(tap: .cghidEventTap)
+    }
+
+    func clearHistory() {
+        items.removeAll()
+    }
+}

--- a/boringNotch/models/ClipboardItem.swift
+++ b/boringNotch/models/ClipboardItem.swift
@@ -1,0 +1,64 @@
+//
+//  ClipboardItem.swift
+//  boringNotch
+//
+//  Created on 2026-04-13.
+//
+
+import AppKit
+import Foundation
+
+enum ClipboardItemKind: Equatable {
+    case text(String)
+    case image(NSImage)
+    case fileURL(URL)
+
+    static func == (lhs: ClipboardItemKind, rhs: ClipboardItemKind) -> Bool {
+        switch (lhs, rhs) {
+        case (.text(let a), .text(let b)):
+            return a == b
+        case (.fileURL(let a), .fileURL(let b)):
+            return a == b
+        case (.image, .image):
+            return false
+        default:
+            return false
+        }
+    }
+}
+
+struct ClipboardItem: Identifiable, Equatable {
+    let id: UUID = UUID()
+    let kind: ClipboardItemKind
+    let timestamp: Date
+
+    var preview: String {
+        switch kind {
+        case .text(let string):
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.count > 80 {
+                return String(trimmed.prefix(80)) + "..."
+            }
+            return trimmed
+        case .image:
+            return "Image"
+        case .fileURL(let url):
+            return url.lastPathComponent
+        }
+    }
+
+    var icon: String {
+        switch kind {
+        case .text:
+            return "doc.plaintext"
+        case .image:
+            return "photo"
+        case .fileURL:
+            return "doc"
+        }
+    }
+
+    static func == (lhs: ClipboardItem, rhs: ClipboardItem) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -231,6 +231,9 @@ extension Defaults.Keys {
     static let osdBrightnessSource = Key<OSDControlSource>("osdBrightnessSource", default: .builtin)
     static let osdVolumeSource = Key<OSDControlSource>("osdVolumeSource", default: .builtin)
     
+    // MARK: Clipboard
+    static let showClipboard = Key<Bool>("showClipboard", default: true)
+
     // MARK: Shelf
     static let boringShelf = Key<Bool>("boringShelf", default: true)
     static let openShelfByDefault = Key<Bool>("openShelfByDefault", default: true)


### PR DESCRIPTION
## Summary

- Adds a new **Clipboard** tab to the notch that keeps track of the last 5 things you copied (text, images, file URLs)
- Clicking an item re-copies it and automatically pastes it into the active app
- The existing `Shift+Cmd+C` shortcut opens the notch directly on the clipboard tab
- New settings page under Settings > Clipboard to toggle the feature on/off
- Shortcut is configurable under Settings > Shortcuts

## How it works

- `ClipboardHistoryManager` polls `NSPasteboard.general.changeCount` every 0.5s to detect new copies
- Stores up to 5 items in memory (no disk persistence, clears on restart for privacy)
- Deduplicates entries so the same content doesn't appear twice
- When pasting, it uses `CGEvent` to simulate `Cmd+V` after writing to the pasteboard
- Self-writes are skipped so re-copying from history doesn't create a duplicate entry

## New files

- `boringNotch/models/ClipboardItem.swift` - data model
- `boringNotch/managers/ClipboardHistoryManager.swift` - pasteboard monitoring and paste logic
- `boringNotch/components/Clipboard/ClipboardHistoryView.swift` - UI for the tab
- `boringNotch/components/Settings/Views/ClipboardSettingsView.swift` - settings toggle

## Test plan

- [ ] Copy several different things (text, files, images) and verify they show up in the Clipboard tab
- [ ] Click an item and verify it pastes into the frontmost app
- [ ] Verify duplicates are removed when copying the same content again
- [ ] Verify the history caps at 5 items
- [ ] Press Shift+Cmd+C and confirm the notch opens on the Clipboard tab
- [ ] Toggle the feature off in Settings > Clipboard and verify the tab still works gracefully
- [ ] Restart the app and confirm history is cleared