### PR TITLE
feat: Implements a real time waveform visualizer using Apple Accelerate for FFT

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		B1D6FD432C6603730015F173 /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D6FD422C6603730015F173 /* SoftwareUpdater.swift */; };
 		B1F0A0022E60000100000001 /* BrightnessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0A0012E60000100000001 /* BrightnessManager.swift */; };
 		B1FEB4992C7686630066EBBC /* PanGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FEB4982C7686630066EBBC /* PanGesture.swift */; };
+		F1F2A0A100000000000000F1 /* AudioCaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */; };
 		F38DE6482D8243E7008B5C6D /* BatteryActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -336,6 +337,7 @@
 		B1D6FD422C6603730015F173 /* SoftwareUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdater.swift; sourceTree = "<group>"; };
 		B1F0A0012E60000100000001 /* BrightnessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrightnessManager.swift; sourceTree = "<group>"; };
 		B1FEB4982C7686630066EBBC /* PanGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanGesture.swift; sourceTree = "<group>"; };
+		F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureManager.swift; sourceTree = "<group>"; };
 		F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryActivityManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -609,6 +611,7 @@
 				F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */,
 				112FB7342CCF16F70015238C /* NotchSpaceManager.swift */,
 				147163992C5D35FF0068B555 /* MusicManager.swift */,
+				F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */,
 				149E0B962C737D00006418B1 /* WebcamManager.swift */,
 				14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */,
 			);
@@ -1035,6 +1038,7 @@
 				14C08BC12C8E03AD000F8AA0 /* NSImage+Extensions.swift in Sources */,
 				149E0B9A2C737D40006418B1 /* WebcamView.swift in Sources */,
 				1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */,
+				F1F2A0A100000000000000F1 /* AudioCaptureManager.swift in Sources */,
 				B1B112932C6A577E00093D8F /* MouseTracker.swift in Sources */,
 				B1C448962C9712C4001F0858 /* ActionBar.swift in Sources */,
 				118EBE312E9717DB00D54B5A /* URL+SecurityScoped.swift in Sources */,
@@ -1310,6 +1314,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				AUTOMATION_APPLE_EVENTS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = boringNotch/boringNotch.entitlements;
@@ -1323,6 +1328,12 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1343,11 +1354,17 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.2;
 				MARKETING_VERSION = "2.8-beta.0";
 				PRODUCT_BUNDLE_IDENTIFIER = theboringteam.boringnotch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
+				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 5.0;
@@ -1364,6 +1381,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				AUTOMATION_APPLE_EVENTS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = boringNotch/boringNotch.entitlements;
@@ -1377,6 +1395,12 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/mediaremote-adapter",
@@ -1396,11 +1420,17 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.2;
 				MARKETING_VERSION = "2.8-beta.0";
 				PRODUCT_BUNDLE_IDENTIFIER = theboringteam.boringnotch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
+				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 5.0;

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -93,7 +93,7 @@ struct ContentView: View {
             && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle)
             && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed
         {
-            chinWidth += (2 * max(0, displayClosedNotchHeight - 12) + 20)
+            chinWidth += (2 * max(0, displayClosedNotchHeight - 12) + 20 + 2 * liveActivityEdgeMargin + 2)
         } else if !coordinator.expandingView.show && vm.notchState == .closed
             && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace]
             && !vm.hideOnClosed
@@ -490,8 +490,7 @@ struct ContentView: View {
                         && coordinator.expandingView.type == .music
                         && Defaults[.sneakPeekStyles] == .inline)
                         ? 380
-                        : vm.closedNotchSize.width
-                            + -cornerRadiusInsets.closed.top
+                        : vm.closedNotchSize.width - 4 + (2 * liveActivityEdgeMargin)
                 )
 
             HStack {
@@ -501,7 +500,7 @@ struct ContentView: View {
                     ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.5)
                     : Color.gray
                 )
-                .frame(width: 16, height: 12)
+                .frame(width: 18, height: 12)
             }
             .frame(
                 width: max(

--- a/boringNotch/Info.plist
+++ b/boringNotch/Info.plist
@@ -7,6 +7,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSAudioCaptureUsageDescription</key>
+	<string>boring.notch analyzes audio from your music app to draw a real-time waveform in the notch. Audio is processed locally and never leaves your Mac.</string>
 	<key>SUEnableDownloaderService</key>
 	<true/>
 	<key>SUEnableInstallerLauncherService</key>

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -8141,6 +8141,9 @@
         }
       }
     },
+    "Real-time audio waveform" : {
+
+    },
     "Release name" : {
       "localizations" : {
         "cs" : {
@@ -10788,6 +10791,9 @@
           }
         }
       }
+    },
+    "Uses Accelerate FFT on the playing app's audio. Requires audio capture permission and macOS 14.2+. Uses slightly more CPU." : {
+
     },
     "Using System Accent" : {
       "localizations" : {

--- a/boringNotch/boringNotch.entitlements
+++ b/boringNotch/boringNotch.entitlements
@@ -6,9 +6,9 @@
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
-	<key>com.apple.security.device.camera</key>
+	<key>com.apple.security.device.audio-input</key>
 	<true/>
-	<key>com.apple.security.personal-information.calendars</key>
+	<key>com.apple.security.device.camera</key>
 	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>
 	<true/>
@@ -19,6 +19,8 @@
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.personal-information.calendars</key>
 	<true/>
 	<key>com.apple.security.temporary-exception.apple-events</key>
 	<array>

--- a/boringNotch/components/Music/MusicVisualizer.swift
+++ b/boringNotch/components/Music/MusicVisualizer.swift
@@ -6,6 +6,7 @@
 //
 import AppKit
 import Cocoa
+import Combine
 import Defaults
 import SwiftUI
 
@@ -14,6 +15,12 @@ class AudioSpectrum: NSView {
     private var isPlaying = false
     private var useRealtime = false
     private var tintColor: NSColor = .systemBlue
+    private var lastTintColor: NSColor?
+
+    private var levelsCancellable: AnyCancellable?
+    private var lastAppliedLevels: [Float]
+    private static let levelChangeThreshold: Float = 0.005
+    private static let minBarScale: CGFloat = 0.12
 
     private let barWidth: CGFloat = 2
     private let barCount = AudioCaptureManager.barCount
@@ -21,12 +28,14 @@ class AudioSpectrum: NSView {
     private let totalHeight: CGFloat = 14
 
     override init(frame frameRect: NSRect) {
+        self.lastAppliedLevels = [Float](repeating: 0, count: AudioCaptureManager.barCount)
         super.init(frame: frameRect)
         wantsLayer = true
         setupBars()
     }
 
     required init?(coder: NSCoder) {
+        self.lastAppliedLevels = [Float](repeating: 0, count: AudioCaptureManager.barCount)
         super.init(coder: coder)
         wantsLayer = true
         setupBars()
@@ -145,6 +154,8 @@ class AudioSpectrum: NSView {
     func setUseRealtime(_ enabled: Bool) {
         guard useRealtime != enabled else { return }
         useRealtime = enabled
+        // Force the next incoming frame through the threshold guard.
+        for i in 0..<lastAppliedLevels.count { lastAppliedLevels[i] = -1 }
         guard isPlaying else { return }
         if enabled {
             stopRandomAnimating()
@@ -159,19 +170,38 @@ class AudioSpectrum: NSView {
         }
     }
 
-    func setLevels(_ values: [CGFloat]) {
+    func attach(to manager: AudioCaptureManager) {
+        guard levelsCancellable == nil else { return }
+        levelsCancellable = manager.levelsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] values in
+                self?.applyLevels(values)
+            }
+    }
+
+    private func applyLevels(_ values: [Float]) {
         guard isPlaying, useRealtime, values.count == barCount else { return }
+        var maxDelta: Float = 0
+        for i in 0..<barCount {
+            let d = abs(values[i] - lastAppliedLevels[i])
+            if d > maxDelta { maxDelta = d }
+        }
+        guard maxDelta >= Self.levelChangeThreshold else { return }
         CATransaction.begin()
         CATransaction.setAnimationDuration(0.033)
         CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .linear))
-        for (i, barLayer) in barLayers.enumerated() {
-            let clamped = max(0.12, min(1.0, values[i]))
-            barLayer.transform = CATransform3DMakeScale(1.0, clamped, 1.0)
+        for i in 0..<barCount {
+            let v = values[i]
+            lastAppliedLevels[i] = v
+            let clamped = max(Self.minBarScale, min(1.0, CGFloat(v)))
+            barLayers[i].transform = CATransform3DMakeScale(1.0, clamped, 1.0)
         }
         CATransaction.commit()
     }
 
     func setTintColor(_ color: NSColor) {
+        if let last = lastTintColor, last.isEqual(color) { return }
+        lastTintColor = color
         tintColor = color
         let colors = [color.withAlphaComponent(0.6).cgColor, color.cgColor]
         barLayers.forEach { $0.colors = colors }
@@ -182,16 +212,14 @@ struct AudioSpectrumView: NSViewRepresentable {
     let isPlaying: Bool
     let tintColor: Color
     @Default(.realtimeAudioWaveform) var realtimeEnabled: Bool
-    @ObservedObject var audioCapture = AudioCaptureManager.shared
+    @ObservedObject private var audioCapture = AudioCaptureManager.shared
 
     func makeNSView(context: Context) -> AudioSpectrum {
         let spectrum = AudioSpectrum()
+        spectrum.attach(to: audioCapture)
         spectrum.setTintColor(NSColor(tintColor))
         spectrum.setUseRealtime(realtimeEnabled && audioCapture.isCapturing)
         spectrum.setPlaying(isPlaying)
-        if realtimeEnabled && audioCapture.isCapturing {
-            spectrum.setLevels(audioCapture.levels)
-        }
         return spectrum
     }
 
@@ -199,9 +227,6 @@ struct AudioSpectrumView: NSViewRepresentable {
         nsView.setTintColor(NSColor(tintColor))
         nsView.setUseRealtime(realtimeEnabled && audioCapture.isCapturing)
         nsView.setPlaying(isPlaying)
-        if realtimeEnabled && audioCapture.isCapturing {
-            nsView.setLevels(audioCapture.levels)
-        }
     }
 }
 

--- a/boringNotch/components/Music/MusicVisualizer.swift
+++ b/boringNotch/components/Music/MusicVisualizer.swift
@@ -6,24 +6,26 @@
 //
 import AppKit
 import Cocoa
+import Defaults
 import SwiftUI
 
 class AudioSpectrum: NSView {
     private var barLayers: [CAGradientLayer] = []
     private var isPlaying = false
+    private var useRealtime = false
     private var tintColor: NSColor = .systemBlue
-    
+
     private let barWidth: CGFloat = 2
-    private let barCount = 4
-    private let spacing: CGFloat = 2
+    private let barCount = AudioCaptureManager.barCount
+    private let spacing: CGFloat = 1
     private let totalHeight: CGFloat = 14
-    
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
         setupBars()
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         wantsLayer = true
@@ -31,7 +33,7 @@ class AudioSpectrum: NSView {
     }
 
     private func setupBars() {
-        let totalWidth = CGFloat(barCount) * (barWidth + spacing)
+        let totalWidth = CGFloat(barCount) * barWidth + CGFloat(barCount - 1) * spacing
         if frame.width < totalWidth {
             frame.size = CGSize(width: totalWidth, height: totalHeight)
         }
@@ -39,8 +41,8 @@ class AudioSpectrum: NSView {
         for i in 0..<barCount {
             let xPosition = CGFloat(i) * (barWidth + spacing)
             let barLayer = CAGradientLayer()
-            barLayer.frame = CGRect(x: xPosition, y: 0, width: barWidth, height: totalHeight)
             barLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+            barLayer.bounds = CGRect(x: 0, y: 0, width: barWidth, height: barWidth)
             barLayer.position = CGPoint(x: xPosition + barWidth / 2, y: totalHeight / 2)
             barLayer.cornerRadius = barWidth / 2
             barLayer.contentsScale = scale
@@ -48,15 +50,45 @@ class AudioSpectrum: NSView {
             barLayer.startPoint = CGPoint(x: 0.5, y: 0)
             barLayer.endPoint = CGPoint(x: 0.5, y: 1)
             barLayer.colors = [tintColor.withAlphaComponent(0.6).cgColor, tintColor.cgColor]
-            barLayer.transform = CATransform3DMakeScale(1.0, 0.3, 1.0)
             layer?.addSublayer(barLayer)
             barLayers.append(barLayer)
         }
     }
 
-    private func startAnimating() {
+    private func expandBars(animated: Bool) {
+        CATransaction.begin()
+        if animated {
+            CATransaction.setAnimationDuration(0.3)
+            CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
+        } else {
+            CATransaction.setDisableActions(true)
+        }
         for (index, barLayer) in barLayers.enumerated() {
-            animateBar(barLayer, delay: Double(index) * 0.1)
+            let x = CGFloat(index) * (barWidth + spacing)
+            barLayer.bounds = CGRect(x: 0, y: 0, width: barWidth, height: totalHeight)
+            barLayer.position = CGPoint(x: x + barWidth / 2, y: totalHeight / 2)
+            barLayer.transform = CATransform3DMakeScale(1.0, 0.3, 1.0)
+        }
+        CATransaction.commit()
+    }
+
+    private func collapseBarsToDots() {
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(0.3)
+        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
+        for (index, barLayer) in barLayers.enumerated() {
+            barLayer.removeAnimation(forKey: "scaleAnimation")
+            barLayer.transform = CATransform3DIdentity
+            let x = CGFloat(index) * (barWidth + spacing)
+            barLayer.bounds = CGRect(x: 0, y: 0, width: barWidth, height: barWidth)
+            barLayer.position = CGPoint(x: x + barWidth / 2, y: totalHeight / 2)
+        }
+        CATransaction.commit()
+    }
+
+    private func startRandomAnimating() {
+        for (index, barLayer) in barLayers.enumerated() {
+            animateBar(barLayer, delay: Double(index) * 0.08)
         }
     }
 
@@ -68,9 +100,7 @@ class AudioSpectrum: NSView {
         let numSteps = 50
         let startValue = CGFloat.random(in: 0.3...1.0)
         for i in 0...numSteps {
-            if i == 0 {
-                values.append(startValue)
-            } else if i == numSteps {
+            if i == 0 || i == numSteps {
                 values.append(startValue)
             } else {
                 values.append(CGFloat.random(in: 0.3...1.0))
@@ -93,22 +123,52 @@ class AudioSpectrum: NSView {
         barLayer.add(animation, forKey: "scaleAnimation")
     }
 
-    private func stopAnimating() {
-        isPlaying = false
-        CATransaction.begin()
-        CATransaction.setAnimationDuration(0.3)
-        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
+    private func stopRandomAnimating() {
         for barLayer in barLayers {
             barLayer.removeAnimation(forKey: "scaleAnimation")
-            barLayer.transform = CATransform3DMakeScale(1.0, 0.35, 1.0)
         }
-        CATransaction.commit()
     }
 
     func setPlaying(_ playing: Bool) {
         guard isPlaying != playing else { return }
         isPlaying = playing
-        playing ? startAnimating() : stopAnimating()
+        if playing {
+            expandBars(animated: true)
+            if !useRealtime {
+                startRandomAnimating()
+            }
+        } else {
+            collapseBarsToDots()
+        }
+    }
+
+    func setUseRealtime(_ enabled: Bool) {
+        guard useRealtime != enabled else { return }
+        useRealtime = enabled
+        guard isPlaying else { return }
+        if enabled {
+            stopRandomAnimating()
+        } else {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            for barLayer in barLayers {
+                barLayer.transform = CATransform3DMakeScale(1.0, 0.3, 1.0)
+            }
+            CATransaction.commit()
+            startRandomAnimating()
+        }
+    }
+
+    func setLevels(_ values: [CGFloat]) {
+        guard isPlaying, useRealtime, values.count == barCount else { return }
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(0.033)
+        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .linear))
+        for (i, barLayer) in barLayers.enumerated() {
+            let clamped = max(0.12, min(1.0, values[i]))
+            barLayer.transform = CATransform3DMakeScale(1.0, clamped, 1.0)
+        }
+        CATransaction.commit()
     }
 
     func setTintColor(_ color: NSColor) {
@@ -121,17 +181,27 @@ class AudioSpectrum: NSView {
 struct AudioSpectrumView: NSViewRepresentable {
     let isPlaying: Bool
     let tintColor: Color
-    
+    @Default(.realtimeAudioWaveform) var realtimeEnabled: Bool
+    @ObservedObject var audioCapture = AudioCaptureManager.shared
+
     func makeNSView(context: Context) -> AudioSpectrum {
         let spectrum = AudioSpectrum()
         spectrum.setTintColor(NSColor(tintColor))
+        spectrum.setUseRealtime(realtimeEnabled && audioCapture.isCapturing)
         spectrum.setPlaying(isPlaying)
+        if realtimeEnabled && audioCapture.isCapturing {
+            spectrum.setLevels(audioCapture.levels)
+        }
         return spectrum
     }
-    
+
     func updateNSView(_ nsView: AudioSpectrum, context: Context) {
         nsView.setTintColor(NSColor(tintColor))
+        nsView.setUseRealtime(realtimeEnabled && audioCapture.isCapturing)
         nsView.setPlaying(isPlaying)
+        if realtimeEnabled && audioCapture.isCapturing {
+            nsView.setLevels(audioCapture.levels)
+        }
     }
 }
 
@@ -139,7 +209,7 @@ struct AudioSpectrumView: NSViewRepresentable {
     ZStack {
         Color.black
         AudioSpectrumView(isPlaying: true, tintColor: .green)
-            .frame(width: 20, height: 14)
+            .frame(width: 18, height: 14)
     }
     .padding()
 }

--- a/boringNotch/components/Settings/Views/AppearanceSettingsView.swift
+++ b/boringNotch/components/Settings/Views/AppearanceSettingsView.swift
@@ -30,6 +30,14 @@ struct Appearance: View {
                 Defaults.Toggle(key: .coloredSpectrogram) {
                     Text("Colored spectrogram")
                 }
+                Defaults.Toggle(key: .realtimeAudioWaveform) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Real-time audio waveform")
+                        Text("Uses Accelerate FFT on the playing app's audio. Requires audio capture permission and macOS 14.2+. Uses slightly more CPU.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
                 Defaults.Toggle(key: .playerColorTinting) {
                     Text("Player tinting")
                 }

--- a/boringNotch/managers/AudioCaptureManager.swift
+++ b/boringNotch/managers/AudioCaptureManager.swift
@@ -1,0 +1,453 @@
+//
+//  AudioCaptureManager.swift
+//  boringNotch
+//
+//  Captures audio from the currently-playing music app via Core Audio
+//  Process Tap (macOS 14.2+), runs an FFT via Accelerate, and publishes
+//  6 log-spaced magnitude bands for the visualizer.
+//
+
+import Accelerate
+import AppKit
+import AudioToolbox
+import Combine
+import CoreAudio
+import Defaults
+import Foundation
+import os
+
+final class AudioCaptureManager: ObservableObject {
+    static let shared = AudioCaptureManager()
+
+    static let barCount = 6
+    private static let fftSize = 1024
+    private static let log2n: vDSP_Length = 10
+    private static let ringCapacity = 4096
+    private static let floorDB: Float = -50
+    private static let ceilDB: Float = -25
+    private static let referenceHz: Double = 1000
+
+    @Published private(set) var levels: [CGFloat] = Array(repeating: 0, count: AudioCaptureManager.barCount)
+    @Published private(set) var isCapturing: Bool = false
+
+    private var cancellables = Set<AnyCancellable>()
+
+    private var tapObjectID: AudioObjectID = kAudioObjectUnknown
+    private var aggregateDeviceID: AudioDeviceID = 0
+    private var ioProcID: AudioDeviceIOProcID?
+    private var currentPID: pid_t = 0
+    private var sampleRate: Double = 48_000
+
+    private let ringBuffer: UnsafeMutablePointer<Float>
+    private var ringWrite: Int = 0
+    private let ringLock = OSAllocatedUnfairLock()
+
+    private let fft: vDSP.FFT<DSPSplitComplex>
+    private let hannWindow: [Float]
+    private let windowPowerScalar: Float
+    private var samplesBuf: [Float]
+    private var windowedBuf: [Float]
+    private var realBuf: [Float]
+    private var imagBuf: [Float]
+    private var powBuf: [Float]
+    private var smoothed: [Float]
+    private var bandRanges: [Range<Int>] = []
+    private var pinkCompensationDB: [Float] = []
+
+    private let fftQueue = DispatchQueue(label: "com.boringnotch.audiocapture.fft", qos: .userInitiated)
+    private var fftTimer: DispatchSourceTimer?
+
+    private init() {
+        ringBuffer = UnsafeMutablePointer<Float>.allocate(capacity: Self.ringCapacity)
+        ringBuffer.initialize(repeating: 0, count: Self.ringCapacity)
+
+        guard let setup = vDSP.FFT(log2n: Self.log2n, radix: .radix2, ofType: DSPSplitComplex.self) else {
+            fatalError("Failed to create vDSP.FFT setup")
+        }
+        fft = setup
+        let window = vDSP.window(
+            ofType: Float.self,
+            usingSequence: .hanningDenormalized,
+            count: Self.fftSize,
+            isHalfWindow: false
+        )
+        hannWindow = window
+        // Parseval-style normalization so full-scale input lands near 0 dBFS.
+        // Factor of 2 folds the one-sided real FFT back to total power.
+        let windowPowerGain = vDSP.sum(vDSP.multiply(window, window))
+        windowPowerScalar = 2.0 / (Float(Self.fftSize) * windowPowerGain)
+        samplesBuf = [Float](repeating: 0, count: Self.fftSize)
+        windowedBuf = [Float](repeating: 0, count: Self.fftSize)
+        realBuf = [Float](repeating: 0, count: Self.fftSize / 2)
+        imagBuf = [Float](repeating: 0, count: Self.fftSize / 2)
+        powBuf = [Float](repeating: 0, count: Self.fftSize / 2)
+        smoothed = [Float](repeating: 0, count: Self.barCount)
+
+        computeBandRanges(sampleRate: sampleRate)
+        observeState()
+    }
+
+    deinit {
+        teardownCapture()
+        ringBuffer.deinitialize(count: Self.ringCapacity)
+        ringBuffer.deallocate()
+    }
+
+    // MARK: - State observation
+
+    private func observeState() {
+        let music = MusicManager.shared
+        let enabledPublisher = Defaults.publisher(.realtimeAudioWaveform)
+            .map(\.newValue)
+            .prepend(Defaults[.realtimeAudioWaveform])
+
+        Publishers.CombineLatest3(music.$isPlaying, music.$bundleIdentifier, enabledPublisher)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isPlaying, bundleID, enabled in
+                self?.evaluate(isPlaying: isPlaying, bundleID: bundleID, enabled: enabled)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func evaluate(isPlaying: Bool, bundleID: String?, enabled: Bool) {
+        guard #available(macOS 14.2, *),
+              enabled, isPlaying,
+              let bundleID, !bundleID.isEmpty,
+              let pid = resolvePID(forBundleID: bundleID) else {
+            if isCapturing { stopCapture() }
+            return
+        }
+        if isCapturing && pid == currentPID { return }
+        if isCapturing { stopCapture() }
+        startCapture(pid: pid)
+    }
+
+    private func resolvePID(forBundleID bundleID: String) -> pid_t? {
+        NSRunningApplication
+            .runningApplications(withBundleIdentifier: bundleID)
+            .first?
+            .processIdentifier
+    }
+
+    // MARK: - Capture lifecycle
+
+    @available(macOS 14.2, *)
+    private func startCapture(pid: pid_t) {
+        currentPID = pid
+
+        guard let processObjectID = translatePIDToAudioObject(pid: pid) else {
+            NSLog("[AudioCaptureManager] Failed to translate PID \(pid) to AudioObjectID")
+            return
+        }
+
+        let tapDescription = CATapDescription(monoMixdownOfProcesses: [processObjectID])
+        tapDescription.muteBehavior = .unmuted
+        tapDescription.isPrivate = true
+        tapDescription.isExclusive = false
+
+        var newTapID: AudioObjectID = kAudioObjectUnknown
+        let tapStatus = AudioHardwareCreateProcessTap(tapDescription, &newTapID)
+        guard tapStatus == noErr, newTapID != kAudioObjectUnknown else {
+            NSLog("[AudioCaptureManager] AudioHardwareCreateProcessTap failed: \(tapStatus)")
+            return
+        }
+        tapObjectID = newTapID
+
+        guard let tapUID = getAudioObjectStringProperty(
+            objectID: tapObjectID,
+            selector: kAudioTapPropertyUID
+        ) else {
+            NSLog("[AudioCaptureManager] Failed to read tap UID")
+            cleanupTap()
+            return
+        }
+
+        var streamFormat = AudioStreamBasicDescription()
+        var formatSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        var formatAddr = AudioObjectPropertyAddress(
+            mSelector: kAudioTapPropertyFormat,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let fmtStatus = AudioObjectGetPropertyData(
+            tapObjectID, &formatAddr, 0, nil, &formatSize, &streamFormat
+        )
+        if fmtStatus == noErr, streamFormat.mSampleRate > 0 {
+            sampleRate = streamFormat.mSampleRate
+            computeBandRanges(sampleRate: sampleRate)
+        }
+
+        let aggregateUID = "com.boringnotch.audiotap.\(UUID().uuidString)"
+        let aggregateDescription: [String: Any] = [
+            kAudioAggregateDeviceNameKey: "boringNotchTapAggregate",
+            kAudioAggregateDeviceUIDKey: aggregateUID,
+            kAudioAggregateDeviceMainSubDeviceKey: "",
+            kAudioAggregateDeviceIsPrivateKey: 1,
+            kAudioAggregateDeviceIsStackedKey: 0,
+            kAudioAggregateDeviceTapAutoStartKey: 1,
+            kAudioAggregateDeviceTapListKey: [
+                [
+                    kAudioSubTapUIDKey: tapUID,
+                    kAudioSubTapDriftCompensationKey: 0
+                ]
+            ]
+        ]
+
+        var newAggID: AudioDeviceID = 0
+        let aggStatus = AudioHardwareCreateAggregateDevice(
+            aggregateDescription as CFDictionary, &newAggID
+        )
+        guard aggStatus == noErr, newAggID != 0 else {
+            NSLog("[AudioCaptureManager] AudioHardwareCreateAggregateDevice failed: \(aggStatus)")
+            cleanupTap()
+            return
+        }
+        aggregateDeviceID = newAggID
+
+        var newIOProc: AudioDeviceIOProcID?
+        let ioStatus = AudioDeviceCreateIOProcIDWithBlock(
+            &newIOProc, aggregateDeviceID, fftQueue
+        ) { [weak self] _, inInputData, _, _, _ in
+            self?.handleInputBuffer(inInputData)
+        }
+        guard ioStatus == noErr, let ioProc = newIOProc else {
+            NSLog("[AudioCaptureManager] AudioDeviceCreateIOProcIDWithBlock failed: \(ioStatus)")
+            cleanupAggregate()
+            cleanupTap()
+            return
+        }
+        ioProcID = ioProc
+
+        let startStatus = AudioDeviceStart(aggregateDeviceID, ioProc)
+        guard startStatus == noErr else {
+            NSLog("[AudioCaptureManager] AudioDeviceStart failed: \(startStatus)")
+            AudioDeviceDestroyIOProcID(aggregateDeviceID, ioProc)
+            ioProcID = nil
+            cleanupAggregate()
+            cleanupTap()
+            return
+        }
+
+        startFFTTimer()
+        isCapturing = true
+    }
+
+    private func stopCapture() {
+        stopFFTTimer()
+        teardownCapture()
+        currentPID = 0
+        ringLock.lock()
+        ringBuffer.update(repeating: 0, count: Self.ringCapacity)
+        ringWrite = 0
+        ringLock.unlock()
+        smoothed = [Float](repeating: 0, count: Self.barCount)
+        let zeros = Array<CGFloat>(repeating: 0, count: Self.barCount)
+        DispatchQueue.main.async { [weak self] in
+            self?.levels = zeros
+            self?.isCapturing = false
+        }
+    }
+
+    private func teardownCapture() {
+        if aggregateDeviceID != 0, let proc = ioProcID {
+            AudioDeviceStop(aggregateDeviceID, proc)
+            AudioDeviceDestroyIOProcID(aggregateDeviceID, proc)
+        }
+        ioProcID = nil
+        cleanupAggregate()
+        cleanupTap()
+    }
+
+    private func cleanupAggregate() {
+        if aggregateDeviceID != 0 {
+            AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            aggregateDeviceID = 0
+        }
+    }
+
+    private func cleanupTap() {
+        guard tapObjectID != kAudioObjectUnknown else { return }
+        if #available(macOS 14.2, *) {
+            AudioHardwareDestroyProcessTap(tapObjectID)
+        }
+        tapObjectID = kAudioObjectUnknown
+    }
+
+    // MARK: - IO proc
+
+    private func handleInputBuffer(_ bufferList: UnsafePointer<AudioBufferList>) {
+        let mutableBL = UnsafeMutablePointer(mutating: bufferList)
+        let abl = UnsafeMutableAudioBufferListPointer(mutableBL)
+        guard let first = abl.first, let rawData = first.mData else { return }
+        // Tap is configured with monoMixdownOfProcesses, so we always receive one channel.
+        assert(first.mNumberChannels == 1)
+        let frameCount = Int(first.mDataByteSize) / MemoryLayout<Float>.size
+        guard frameCount > 0 else { return }
+        let src = rawData.assumingMemoryBound(to: Float.self)
+
+        ringLock.lock()
+        let cap = Self.ringCapacity
+        let write = ringWrite
+        let firstCount = min(frameCount, cap - write)
+        memcpy(ringBuffer.advanced(by: write), src, firstCount * MemoryLayout<Float>.size)
+        if firstCount < frameCount {
+            memcpy(
+                ringBuffer,
+                src.advanced(by: firstCount),
+                (frameCount - firstCount) * MemoryLayout<Float>.size
+            )
+        }
+        ringWrite = (write + frameCount) % cap
+        ringLock.unlock()
+    }
+
+    // MARK: - FFT loop
+
+    private func startFFTTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: fftQueue)
+        timer.schedule(deadline: .now(), repeating: .milliseconds(33))
+        timer.setEventHandler { [weak self] in self?.processFFT() }
+        fftTimer = timer
+        timer.resume()
+    }
+
+    private func stopFFTTimer() {
+        fftTimer?.cancel()
+        fftTimer = nil
+    }
+
+    private func processFFT() {
+        let n = Self.fftSize
+
+        ringLock.lock()
+        let cap = Self.ringCapacity
+        let end = ringWrite
+        let start = (end - n + cap) % cap
+        samplesBuf.withUnsafeMutableBufferPointer { dst in
+            guard let base = dst.baseAddress else { return }
+            if start + n <= cap {
+                memcpy(base, ringBuffer.advanced(by: start), n * MemoryLayout<Float>.size)
+            } else {
+                let firstCount = cap - start
+                memcpy(base, ringBuffer.advanced(by: start), firstCount * MemoryLayout<Float>.size)
+                memcpy(
+                    base.advanced(by: firstCount),
+                    ringBuffer,
+                    (n - firstCount) * MemoryLayout<Float>.size
+                )
+            }
+        }
+        ringLock.unlock()
+
+        vDSP.multiply(samplesBuf, hannWindow, result: &windowedBuf)
+
+        let halfN = n / 2
+        realBuf.withUnsafeMutableBufferPointer { rPtr in
+            imagBuf.withUnsafeMutableBufferPointer { iPtr in
+                var split = DSPSplitComplex(realp: rPtr.baseAddress!, imagp: iPtr.baseAddress!)
+                windowedBuf.withUnsafeBufferPointer { wPtr in
+                    wPtr.baseAddress!.withMemoryRebound(to: DSPComplex.self, capacity: halfN) { cPtr in
+                        vDSP_ctoz(cPtr, 2, &split, 1, vDSP_Length(halfN))
+                    }
+                }
+                fft.forward(input: split, output: &split)
+                // vDSP packs DC in realp[0] and Nyquist in imagp[0]; zero both
+                // so they can't pollute the sub-bass band.
+                rPtr[0] = 0
+                iPtr[0] = 0
+                vDSP.squareMagnitudes(split, result: &powBuf)
+            }
+        }
+        vDSP.multiply(windowPowerScalar, powBuf, result: &powBuf)
+
+        let floorDB = Self.floorDB
+        let ceilDB = Self.ceilDB
+        let dbRange = ceilDB - floorDB
+        var bars = [Float](repeating: 0, count: Self.barCount)
+        for (i, range) in bandRanges.enumerated() where !range.isEmpty {
+            let meanPow = vDSP.sum(powBuf[range]) / Float(range.count)
+            let db = 10 * log10f(max(meanPow, 1e-12)) + pinkCompensationDB[i]
+            let clamped = max(floorDB, min(ceilDB, db))
+            bars[i] = (clamped - floorDB) / dbRange
+        }
+
+        for i in 0..<Self.barCount {
+            let target = bars[i]
+            let decayed = smoothed[i] * 0.82
+            smoothed[i] = target > decayed ? (decayed + (target - decayed) * 0.6) : decayed
+        }
+
+        let cgLevels = smoothed.map { CGFloat(max(0, min(1, $0))) }
+        DispatchQueue.main.async { [weak self] in
+            self?.levels = cgLevels
+        }
+    }
+
+    private func computeBandRanges(sampleRate: Double) {
+        let halfN = Self.fftSize / 2
+        let nyquist = sampleRate / 2
+        let minHz: Double = 60
+        let maxHz: Double = min(16_000, nyquist - 1)
+        guard maxHz > minHz else {
+            bandRanges = Array(repeating: 0..<0, count: Self.barCount)
+            pinkCompensationDB = Array(repeating: 0, count: Self.barCount)
+            return
+        }
+        let logMin = log(minHz)
+        let logMax = log(maxHz)
+        var ranges: [Range<Int>] = []
+        var pinks: [Float] = []
+        for i in 0..<Self.barCount {
+            let startHz = exp(logMin + (logMax - logMin) * Double(i) / Double(Self.barCount))
+            let endHz = exp(logMin + (logMax - logMin) * Double(i + 1) / Double(Self.barCount))
+            let startBin = max(1, Int((startHz / nyquist) * Double(halfN)))
+            let endBin = max(startBin + 1, min(halfN, Int((endHz / nyquist) * Double(halfN))))
+            ranges.append(startBin..<endBin)
+            let centerHz = sqrt(startHz * endHz)
+            pinks.append(Float(3.0 * log2(centerHz / Self.referenceHz)))
+        }
+        bandRanges = ranges
+        pinkCompensationDB = pinks
+    }
+
+    // MARK: - Core Audio helpers
+
+    private func translatePIDToAudioObject(pid: pid_t) -> AudioObjectID? {
+        var pidVal = pid
+        var processObject: AudioObjectID = kAudioObjectUnknown
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyTranslatePIDToProcessObject,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &addr,
+            UInt32(MemoryLayout<pid_t>.size),
+            &pidVal,
+            &size,
+            &processObject
+        )
+        guard status == noErr, processObject != kAudioObjectUnknown else { return nil }
+        return processObject
+    }
+
+    private func getAudioObjectStringProperty(
+        objectID: AudioObjectID,
+        selector: AudioObjectPropertySelector
+    ) -> String? {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size = UInt32(MemoryLayout<CFString?>.size)
+        var cfStr: CFString?
+        let status = withUnsafeMutablePointer(to: &cfStr) { ptr in
+            AudioObjectGetPropertyData(objectID, &addr, 0, nil, &size, ptr)
+        }
+        guard status == noErr, let cfStr = cfStr else { return nil }
+        return cfStr as String
+    }
+}

--- a/boringNotch/managers/AudioCaptureManager.swift
+++ b/boringNotch/managers/AudioCaptureManager.swift
@@ -27,7 +27,7 @@ final class AudioCaptureManager: ObservableObject {
     private static let ceilDB: Float = -25
     private static let referenceHz: Double = 1000
 
-    @Published private(set) var levels: [CGFloat] = Array(repeating: 0, count: AudioCaptureManager.barCount)
+    let levelsPublisher = PassthroughSubject<[Float], Never>()
     @Published private(set) var isCapturing: Bool = false
 
     private var cancellables = Set<AnyCancellable>()
@@ -51,6 +51,8 @@ final class AudioCaptureManager: ObservableObject {
     private var imagBuf: [Float]
     private var powBuf: [Float]
     private var smoothed: [Float]
+    private var barsBuf: [Float]
+    private var lastPublishedBuf: [Float]
     private var bandRanges: [Range<Int>] = []
     private var pinkCompensationDB: [Float] = []
 
@@ -82,6 +84,9 @@ final class AudioCaptureManager: ObservableObject {
         imagBuf = [Float](repeating: 0, count: Self.fftSize / 2)
         powBuf = [Float](repeating: 0, count: Self.fftSize / 2)
         smoothed = [Float](repeating: 0, count: Self.barCount)
+        barsBuf = [Float](repeating: 0, count: Self.barCount)
+        // Seed with a sentinel so the first real frame always publishes.
+        lastPublishedBuf = [Float](repeating: -1, count: Self.barCount)
 
         computeBandRanges(sampleRate: sampleRate)
         observeState()
@@ -240,11 +245,16 @@ final class AudioCaptureManager: ObservableObject {
         ringBuffer.update(repeating: 0, count: Self.ringCapacity)
         ringWrite = 0
         ringLock.unlock()
-        smoothed = [Float](repeating: 0, count: Self.barCount)
-        let zeros = Array<CGFloat>(repeating: 0, count: Self.barCount)
+        for i in 0..<Self.barCount {
+            smoothed[i] = 0
+            barsBuf[i] = 0
+            lastPublishedBuf[i] = -1
+        }
+        let zeros = [Float](repeating: 0, count: Self.barCount)
         DispatchQueue.main.async { [weak self] in
-            self?.levels = zeros
-            self?.isCapturing = false
+            guard let self else { return }
+            self.levelsPublisher.send(zeros)
+            self.isCapturing = false
         }
     }
 
@@ -363,24 +373,40 @@ final class AudioCaptureManager: ObservableObject {
         let floorDB = Self.floorDB
         let ceilDB = Self.ceilDB
         let dbRange = ceilDB - floorDB
-        var bars = [Float](repeating: 0, count: Self.barCount)
-        for (i, range) in bandRanges.enumerated() where !range.isEmpty {
-            let meanPow = vDSP.sum(powBuf[range]) / Float(range.count)
-            let db = 10 * log10f(max(meanPow, 1e-12)) + pinkCompensationDB[i]
-            let clamped = max(floorDB, min(ceilDB, db))
-            bars[i] = (clamped - floorDB) / dbRange
+        powBuf.withUnsafeBufferPointer { pPtr in
+            guard let base = pPtr.baseAddress else { return }
+            for i in 0..<Self.barCount {
+                let range = bandRanges[i]
+                guard !range.isEmpty else { barsBuf[i] = 0; continue }
+                var sum: Float = 0
+                vDSP_sve(base.advanced(by: range.lowerBound), 1, &sum, vDSP_Length(range.count))
+                let meanPow = sum / Float(range.count)
+                let db = 10 * log10f(max(meanPow, 1e-12)) + pinkCompensationDB[i]
+                let clamped = max(floorDB, min(ceilDB, db))
+                barsBuf[i] = (clamped - floorDB) / dbRange
+            }
         }
 
+        var maxDelta: Float = 0
         for i in 0..<Self.barCount {
-            let target = bars[i]
+            let target = barsBuf[i]
             let decayed = smoothed[i] * 0.82
-            smoothed[i] = target > decayed ? (decayed + (target - decayed) * 0.6) : decayed
+            let next = target > decayed ? (decayed + (target - decayed) * 0.6) : decayed
+            smoothed[i] = next
+            let clipped = max(0, min(1, next))
+            barsBuf[i] = clipped
+            let delta = abs(clipped - lastPublishedBuf[i])
+            if delta > maxDelta { maxDelta = delta }
         }
 
-        let cgLevels = smoothed.map { CGFloat(max(0, min(1, $0))) }
-        DispatchQueue.main.async { [weak self] in
-            self?.levels = cgLevels
+        // Skip the hop to main + Combine fan-out when nothing perceptible changed.
+        // Stacks with the view-side threshold to collapse idle cost toward zero.
+        guard maxDelta > 1e-4 else { return }
+        for i in 0..<Self.barCount {
+            lastPublishedBuf[i] = barsBuf[i]
         }
+        let snapshot = barsBuf
+        levelsPublisher.send(snapshot)
     }
 
     private func computeBandRanges(sampleRate: Double) {

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -190,6 +190,7 @@ extension Defaults.Keys {
     
     // MARK: Media playback
     static let coloredSpectrogram = Key<Bool>("coloredSpectrogram", default: true)
+    static let realtimeAudioWaveform = Key<Bool>("realtimeAudioWaveform", default: false)
     static let enableSneakPeek = Key<Bool>("enableSneakPeek", default: false)
     static let sneakPeekStyles = Key<SneakPeekStyle>("sneakPeekStyles", default: .standard)
     static let waitInterval = Key<Double>("waitInterval", default: 3)

--- a/boringNotch/sizing/matters.swift
+++ b/boringNotch/sizing/matters.swift
@@ -17,6 +17,11 @@ let openNotchSize: CGSize = .init(width: 640, height: 190)
 let windowSize: CGSize = .init(width: openNotchSize.width, height: openNotchSize.height + shadowPadding)
 let cornerRadiusInsets: (opened: (top: CGFloat, bottom: CGFloat), closed: (top: CGFloat, bottom: CGFloat)) = (opened: (top: 19, bottom: 24), closed: (top: 6, bottom: 14))
 
+// Horizontal gap between closed-state live-activity content (album art / waveform)
+// and the physical notch edge. Without this margin the hardware bezel clips the
+// adjacent content since the spacer rect used to be narrower than the physical notch.
+let liveActivityEdgeMargin: CGFloat = 8
+
 enum MusicPlayerImageSizes {
     static let cornerRadiusInset: (opened: CGFloat, closed: CGFloat) = (opened: 13.0, closed: 4.0)
     static let size = (opened: CGSize(width: 90, height: 90), closed: CGSize(width: 20, height: 20))


### PR DESCRIPTION
This PR implements a FFT (Fast Fourier Transform) backend for the waveform visualizer widget in the notch that models the actual audio values instead of synthetic (random) data as the visualizer currently does. This works in real time using Apple's Accelerate framework which works in-place and is hardware accelerated.

It looks like this:

https://github.com/user-attachments/assets/4e7195f1-c52d-44b6-a470-59780ebb0766

Current metrics show the following resource usage on my machine. The power usage metrics are the same:

Randomized Waveform:
- 70MB Memory
- 0.4-2% CPU Utilization

Realtime Waveform:
- 75MB Memory
- 1-1.6% CPU Utilization

This PR also fixed an issue with album covers being clipped on my machine (maybe different notch widths). If this needs to be moved to a different PR or implemented differently, please let me know!