### PR TITLE
Show hours and minutes in Time to Full Charge for Battery

### DIFF
--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -10595,66 +10595,66 @@
         }
       }
     },
-    "Time to Full Charge: %lld min" : {
+    "Time to Full Charge: %@" : {
       "localizations" : {
         "cs" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Čas do plného nabití: %lld min"
+            "value" : "Čas do plného nabití: %@"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zeit bis zur vollen Ladung: %lld min"
+            "value" : "Zeit bis zur vollen Ladung: %@"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Time to Full Charge: %lld min"
+            "value" : "Time to Full Charge: %@"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tiempo para recarga completa: %lld min"
+            "value" : "Tiempo para recarga completa: %@"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Temps avant la charge complète : %lld min"
+            "value" : "Temps avant la charge complète : %@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tempo alla carica completa: %lld min"
+            "value" : "Tempo alla carica completa: %@"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "완충 까지 남은 시간: %lld 분"
+            "value" : "완충 까지 남은 시간: %@"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Czas do pełnego naładowania: %lld min"
+            "value" : "Czas do pełnego naładowania: %@"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tam Şarj Süresi: %lld dakika"
+            "value" : "Tam Şarj Süresi: %@"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "充电时间：%lld 分钟"
+            "value" : "充电时间：%@"
           }
         }
       }

--- a/boringNotch/components/Live activities/BoringBattery.swift
+++ b/boringNotch/components/Live activities/BoringBattery.swift
@@ -97,6 +97,14 @@ struct BatteryMenuView: View {
 
     @Environment(\.openURL) private var openURL
 
+    private var formattedTimeToFullCharge: String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        formatter.zeroFormattingBehavior = .dropAll
+        return formatter.string(from: TimeInterval(timeToFullCharge * 60)) ?? ""
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
 
@@ -130,7 +138,7 @@ struct BatteryMenuView: View {
                         .fontWeight(.regular)
                 }
                 if timeToFullCharge > 0 {
-                    Label("Time to Full Charge: \(timeToFullCharge) min", systemImage: "clock")
+                    Label("Time to Full Charge: \(formattedTimeToFullCharge)", systemImage: "clock")
                         .font(.subheadline)
                         .fontWeight(.regular)
                 }


### PR DESCRIPTION
## What                                                                                                                                                           
                                                                                                                                                                 
The Time to Full Charge label in the battery popover now shows hours and minutes for durations over an hour, instead of the raw minute count. Unit words are rendered via DateComponentsFormatter so they follow the user's locale.                                                                                        
                                                                                                                                                                 
### Examples (English):                                                                                                                                            
  - 30 min remaining → 30 min
  - 60 min remaining → 1 hr                                                                                                                                      
  - 90 min remaining → 1 hr, 30 min
  - 120 min remaining → 2 hr                                                                                                                                     
   
## Why                                                                                                                                                            
                  
Before this change, a battery 90 minutes from full displayed Time to Full Charge: 90 min, which is awkward for anything over an hour. Hand-rolling the hour/minute split would also have locked the unit words (hr, min) to English; using DateComponentsFormatter instead lets macOS localize them (Std./Min., 시간/분, etc.).                                                                                                                                                
                  
## Changes                                                                                                                                                        
   
- boringNotch/components/Live activities/BoringBattery.swift: adds a formattedTimeToFullCharge computed property on BatteryMenuView using DateComponentsFormatter with .abbreviated style, [.hour, .minute] units, and .dropAll zero-handling. The existing Label consumes the formatted string.
- boringNotch/Localizable.xcstrings: replaces the Time to Full Charge: %lld min key with Time to Full Charge: %@, since the %@ now carries the full locale-formatted time string (unit words included). Only the English source string is included here — translations will come via Crowdin.                      
 
## Testing                                                                                                                                                        
                  
Ran in Xcode under English, German, French, Korean, and Chinese (Simplified) via the scheme's App Language / App Region settings. Spot-checked charging times of 30, 60, 90, and 120 minutes — all four .dropAll branches render as expected, and the 280 pt popover width accommodates the longer German/French output without truncation.

## Before:
<img width="273" height="215" alt="Screenshot 2026-04-17 at 4 03 46 PM" src="https://github.com/user-attachments/assets/fa3d441c-55c7-4a62-be85-8e834e4696ba" />

## After:

<img width="270" height="220" alt="Screenshot 2026-04-17 at 4 05 08 PM" src="https://github.com/user-attachments/assets/b1dd92bd-d610-4892-b209-c006a5d8b9ba" />