### PR TITLE
feat(media): implement customizable live activity visibility and timeout logic

### DIFF
--- a/.github/workflows/base_ref_check_comment.yml
+++ b/.github/workflows/base_ref_check_comment.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Create, update, delete, or skip policy comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,6 @@ build/
 *.ipa
 *.xcarchive
 *.dSYM
-
+*MAP.md
+*JOURNAL.md
+*documentation.md

--- a/boringNotch/BoringViewCoordinator.swift
+++ b/boringNotch/BoringViewCoordinator.swift
@@ -206,7 +206,7 @@ class BoringViewCoordinator: ObservableObject {
     }
 
     func toggleSneakPeek(
-        status: Bool, type: SneakContentType, duration: TimeInterval = 1.5, value: CGFloat = 0,
+        status: Bool, type: SneakContentType, duration: TimeInterval = 2.0, value: CGFloat = 0,
         icon: String = ""
     ) {
         sneakPeekDuration = duration
@@ -230,7 +230,7 @@ class BoringViewCoordinator: ObservableObject {
         }
     }
 
-    private var sneakPeekDuration: TimeInterval = 1.5
+    private var sneakPeekDuration: TimeInterval = 2.0
     private var sneakPeekTask: Task<Void, Never>?
 
     // Helper function to manage sneakPeek timer using Swift Concurrency
@@ -243,7 +243,7 @@ class BoringViewCoordinator: ObservableObject {
             await MainActor.run {
                 withAnimation {
                     self.toggleSneakPeek(status: false, type: .music)
-                    self.sneakPeekDuration = 1.5
+                    self.sneakPeekDuration = 2.0
                 }
             }
         }
@@ -281,7 +281,7 @@ class BoringViewCoordinator: ObservableObject {
         didSet {
             if expandingView.show {
                 expandingViewTask?.cancel()
-                let duration: TimeInterval = (expandingView.type == .download ? 2 : 3)
+                let duration: TimeInterval = 2.0
                 let currentType = expandingView.type
                 expandingViewTask = Task { [weak self] in
                     try? await Task.sleep(for: .seconds(duration))

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -38,6 +38,9 @@ struct ContentView: View {
     @Default(.showNotHumanFace) var showNotHumanFace
     @Default(.hideLiveActivityAfterTimeout) var hideLiveActivityAfterTimeout
 
+    @Default(.openNotchWidth) var openNotchWidth
+    @Default(.openNotchHeight) var openNotchHeight
+
     // Shared interactive spring for movement/resizing to avoid conflicting animations
     private let animationSpring = Animation.interactiveSpring(response: 0.38, dampingFraction: 0.8, blendDuration: 0)
 
@@ -206,7 +209,7 @@ struct ContentView: View {
             }
         }
         .padding(.bottom, 8)
-        .frame(maxWidth: windowSize.width, maxHeight: windowSize.height, alignment: .top)
+        .frame(maxWidth: getWindowSize().width, maxHeight: getWindowSize().height, alignment: .top)
         .compositingGroup()
         .scaleEffect(
             x: gestureScale,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -40,6 +40,8 @@ struct ContentView: View {
 
     @Default(.openNotchWidth) var openNotchWidth
     @Default(.openNotchHeight) var openNotchHeight
+    @Default(.liveActivityWidthMode) var liveActivityWidthMode
+    @Default(.liveActivityWidth) var liveActivityWidth
 
     // Shared interactive spring for movement/resizing to avoid conflicting animations
     private let animationSpring = Animation.interactiveSpring(response: 0.38, dampingFraction: 0.8, blendDuration: 0)
@@ -64,6 +66,13 @@ struct ContentView: View {
 
     private var computedChinWidth: CGFloat {
         var chinWidth: CGFloat = vm.closedNotchSize.width
+        
+        let extraWidth: CGFloat
+        if liveActivityWidthMode == .custom {
+            extraWidth = CGFloat(liveActivityWidth)
+        } else {
+            extraWidth = (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
+        }
 
         if coordinator.expandingView.type == .battery && coordinator.expandingView.show
             && vm.notchState == .closed && Defaults[.showPowerStatusNotifications]
@@ -75,12 +84,12 @@ struct ContentView: View {
             && (hideLiveActivityAfterTimeout ? musicManager.showNotchLiveActivity : true)
             && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed
         {
-            chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
+            chinWidth += extraWidth
         } else if !coordinator.expandingView.show && vm.notchState == .closed
             && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace]
             && !vm.hideOnClosed
         {
-            chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
+            chinWidth += extraWidth
         }
 
         return chinWidth
@@ -295,7 +304,7 @@ struct ContentView: View {
                               .transition(.opacity)
                       } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music) && vm.notchState == .closed && musicManager.isPlaying && (hideLiveActivityAfterTimeout ? musicManager.showNotchLiveActivity : true) && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed {
                           MusicLiveActivity()
-                              .frame(alignment: .center)
+                              .frame(width: computedChinWidth, alignment: .center)
                       } else if !coordinator.expandingView.show && vm.notchState == .closed && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {
                           BoringFaceAnimation()
                        } else if vm.notchState == .open {
@@ -446,12 +455,11 @@ struct ContentView: View {
                     }
                 )
                 .frame(
-                    width: (coordinator.expandingView.show
+                    maxWidth: (coordinator.expandingView.show
                         && coordinator.expandingView.type == .music
                         && Defaults[.sneakPeekStyles] == .inline)
                         ? 380
-                        : vm.closedNotchSize.width
-                            + -cornerRadiusInsets.closed.top
+                        : .infinity
                 )
 
             HStack {

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -36,6 +36,7 @@ struct ContentView: View {
     @Default(.useMusicVisualizer) var useMusicVisualizer
 
     @Default(.showNotHumanFace) var showNotHumanFace
+    @Default(.hideLiveActivityAfterTimeout) var hideLiveActivityAfterTimeout
 
     // Shared interactive spring for movement/resizing to avoid conflicting animations
     private let animationSpring = Animation.interactiveSpring(response: 0.38, dampingFraction: 0.8, blendDuration: 0)
@@ -66,7 +67,9 @@ struct ContentView: View {
         {
             chinWidth = 640
         } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music)
-            && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle)
+            && vm.notchState == .closed
+            && musicManager.isPlaying
+            && (hideLiveActivityAfterTimeout ? musicManager.showNotchLiveActivity : true)
             && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed
         {
             chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
@@ -287,7 +290,7 @@ struct ContentView: View {
                       } else if coordinator.sneakPeek.show && Defaults[.inlineHUD] && (coordinator.sneakPeek.type != .music) && (coordinator.sneakPeek.type != .battery) && vm.notchState == .closed {
                           InlineHUD(type: $coordinator.sneakPeek.type, value: $coordinator.sneakPeek.value, icon: $coordinator.sneakPeek.icon, hoverAnimation: $isHovering, gestureProgress: $gestureProgress)
                               .transition(.opacity)
-                      } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music) && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed {
+                      } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music) && vm.notchState == .closed && musicManager.isPlaying && (hideLiveActivityAfterTimeout ? musicManager.showNotchLiveActivity : true) && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed {
                           MusicLiveActivity()
                               .frame(alignment: .center)
                       } else if !coordinator.expandingView.show && vm.notchState == .closed && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -402,97 +402,116 @@ struct ContentView: View {
 
     @ViewBuilder
     func MusicLiveActivity() -> some View {
-        HStack {
-            Image(nsImage: musicManager.albumArt)
-                .resizable()
-                .clipped()
-                .clipShape(
-                    RoundedRectangle(
-                        cornerRadius: MusicPlayerImageSizes.cornerRadiusInset.closed)
-                )
-                .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
-                .frame(
-                    width: max(0, vm.effectiveClosedNotchHeight - 12),
-                    height: max(0, vm.effectiveClosedNotchHeight - 12)
-                )
+        GeometryReader { geo in
+            HStack(spacing: 0) {
+                let artSize = max(0, vm.effectiveClosedNotchHeight - 12)
+                // Right side equalizer/visualizer width (same as artSize)
+                let rightSize = artSize
+                // The black center covering the physical notch
+                let centerWidth = vm.closedNotchSize.width
+                // Remaining space for marquee: total - art - center - right - internal paddings
+                let marqueeWidth = max(20, geo.size.width - artSize - centerWidth - rightSize - 24)
 
-            Rectangle()
-                .fill(.black)
-                .overlay(
-                    HStack(alignment: .top) {
-                        if coordinator.expandingView.show
-                            && coordinator.expandingView.type == .music
-                        {
-                            MarqueeText(
-                                .constant(musicManager.songTitle),
-                                textColor: Defaults[.coloredSpectrogram]
-                                    ? Color(nsColor: musicManager.avgColor) : Color.gray,
-                                minDuration: 0.4,
-                                frameWidth: 100
-                            )
-                            .opacity(
-                                (coordinator.expandingView.show
-                                    && Defaults[.sneakPeekStyles] == .inline)
-                                    ? 1 : 0
-                            )
-                            Spacer(minLength: vm.closedNotchSize.width)
-                            // Song Artist
-                            Text(musicManager.artistName)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-                                .foregroundStyle(
-                                    Defaults[.coloredSpectrogram]
-                                        ? Color(nsColor: musicManager.avgColor)
-                                        : Color.gray
+                // Album art
+                Image(nsImage: musicManager.albumArt)
+                    .resizable()
+                    .clipped()
+                    .clipShape(
+                        RoundedRectangle(
+                            cornerRadius: MusicPlayerImageSizes.cornerRadiusInset.closed)
+                    )
+                    .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
+                    .frame(width: artSize, height: artSize)
+                    .padding(.leading, 4)
+
+                // Song title marquee — always shown in Custom mode
+                if liveActivityWidthMode == .custom {
+                    MarqueeText(
+                        .constant(musicManager.songTitle + " — " + musicManager.artistName),
+                        font: .system(size: 13, weight: .semibold),
+                        textColor: .white,
+                        backgroundColor: .black,
+                        minDuration: 2.0,
+                        frameWidth: marqueeWidth
+                    )
+                    .frame(width: marqueeWidth)
+                    .padding(.horizontal, 8)
+                    .opacity((coordinator.expandingView.show && Defaults[.sneakPeekStyles] == .inline) ? 0 : 1)
+                }
+
+                // Black spacer that visually covers the physical notch center area
+                Rectangle()
+                    .fill(.black)
+                    .overlay(
+                        HStack(alignment: .top) {
+                            if coordinator.expandingView.show
+                                && coordinator.expandingView.type == .music
+                            {
+                                MarqueeText(
+                                    .constant(musicManager.songTitle),
+                                    textColor: Defaults[.coloredSpectrogram]
+                                        ? Color(nsColor: musicManager.avgColor) : Color.gray,
+                                    minDuration: 0.4,
+                                    frameWidth: 100
                                 )
                                 .opacity(
                                     (coordinator.expandingView.show
-                                        && coordinator.expandingView.type == .music
                                         && Defaults[.sneakPeekStyles] == .inline)
                                         ? 1 : 0
                                 )
+                                Spacer(minLength: vm.closedNotchSize.width)
+                                Text(musicManager.artistName)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                                    .foregroundStyle(
+                                        Defaults[.coloredSpectrogram]
+                                            ? Color(nsColor: musicManager.avgColor)
+                                            : Color.gray
+                                    )
+                                    .opacity(
+                                        (coordinator.expandingView.show
+                                            && coordinator.expandingView.type == .music
+                                            && Defaults[.sneakPeekStyles] == .inline)
+                                            ? 1 : 0
+                                    )
+                            }
                         }
-                    }
-                )
-                .frame(
-                    maxWidth: (coordinator.expandingView.show
-                        && coordinator.expandingView.type == .music
-                        && Defaults[.sneakPeekStyles] == .inline)
-                        ? 380
-                        : .infinity
-                )
+                    )
+                    .frame(
+                        maxWidth: (coordinator.expandingView.show
+                            && coordinator.expandingView.type == .music
+                            && Defaults[.sneakPeekStyles] == .inline)
+                            ? 380
+                            : (liveActivityWidthMode == .custom ? centerWidth : .infinity)
+                    )
 
-            HStack {
-                if useMusicVisualizer {
-                    Rectangle()
-                        .fill(
-                            Defaults[.coloredSpectrogram]
-                                ? Color(nsColor: musicManager.avgColor).gradient
-                                : Color.gray.gradient
-                        )
-                        .frame(width: 50, alignment: .center)
-                        .matchedGeometryEffect(id: "spectrum", in: albumArtNamespace)
-                        .mask {
-                            AudioSpectrumView(isPlaying: $musicManager.isPlaying)
-                                .frame(width: 16, height: 12)
-                        }
-                } else {
-                    LottieAnimationContainer()
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // Right side: equalizer / visualizer
+                HStack {
+                    if useMusicVisualizer {
+                        Rectangle()
+                            .fill(
+                                Defaults[.coloredSpectrogram]
+                                    ? Color(nsColor: musicManager.avgColor).gradient
+                                    : Color.gray.gradient
+                            )
+                            .frame(width: 50, alignment: .center)
+                            .matchedGeometryEffect(id: "spectrum", in: albumArtNamespace)
+                            .mask {
+                                AudioSpectrumView(isPlaying: $musicManager.isPlaying)
+                                    .frame(width: 16, height: 12)
+                            }
+                    } else {
+                        LottieAnimationContainer()
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
                 }
+                .frame(
+                    width: max(0, rightSize + gestureProgress / 2),
+                    height: max(0, artSize),
+                    alignment: .center
+                )
+                .padding(.trailing, 4)
             }
-            .frame(
-                width: max(
-                    0,
-                    vm.effectiveClosedNotchHeight - 12
-                        + gestureProgress / 2
-                ),
-                height: max(
-                    0,
-                    vm.effectiveClosedNotchHeight - 12
-                ),
-                alignment: .center
-            )
         }
         .frame(
             height: vm.effectiveClosedNotchHeight,

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -16019,6 +16019,12 @@
         }
       }
     },
+    "Opened notch height - %.0f" : {
+
+    },
+    "Opened notch width - %.0f" : {
+
+    },
     "Option key behaviour" : {
       "localizations" : {
         "ar" : {

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -501,6 +501,9 @@
         }
       }
     },
+    "%.1f seconds" : {
+
+    },
     "%.1fs" : {
       "localizations" : {
         "ar" : {
@@ -10907,6 +10910,12 @@
           }
         }
       }
+    },
+    "Hide live activity after a short timeout" : {
+
+    },
+    "Hide timeout" : {
+
     },
     "Hide title bar" : {
       "localizations" : {

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -2805,6 +2805,9 @@
         }
       }
     },
+    "Auto (Match Content)" : {
+
+    },
     "Auto-scroll to next event" : {
       "localizations" : {
         "ar" : {
@@ -9411,6 +9414,9 @@
         }
       }
     },
+    "Extra Width - %.0f" : {
+
+    },
     "Files dropped on the shelf will be shared via this service" : {
       "localizations" : {
         "ar" : {
@@ -12017,6 +12023,9 @@
           }
         }
       }
+    },
+    "Live Activity Width" : {
+
     },
     "Lottie JSON URL" : {
       "localizations" : {
@@ -17824,6 +17833,9 @@
           }
         }
       }
+    },
+    "Reset Width to Default" : {
+
     },
     "Restart" : {
       "extractionState" : "stale",

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -360,7 +360,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 self.coordinator.toggleSneakPeek(
                     status: !self.coordinator.sneakPeek.show,
                     type: .music,
-                    duration: 3.0
+                    duration: 2.0
                 )
             }
         }

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -196,8 +196,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard let uuid = screen.displayUUID else { return }
         
         let screenFrame = screen.frame
-        let notchHeight = openNotchSize.height
-        let notchWidth = openNotchSize.width
+        let notchHeight = getOpenNotchSize().height
+        let notchWidth = getOpenNotchSize().width
         
         // Create notch region at the top-center of the screen where an open notch would occupy
         let notchRegion = CGRect(
@@ -232,7 +232,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func createBoringNotchWindow(for screen: NSScreen, with viewModel: BoringViewModel) -> NSWindow {
-        let rect = NSRect(x: 0, y: 0, width: windowSize.width, height: windowSize.height)
+        let rect = NSRect(x: 0, y: 0, width: getWindowSize().width, height: getWindowSize().height)
         let styleMask: NSWindow.StyleMask = [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow]
         
         let window = BoringNotchSkyLightWindow(contentRect: rect, styleMask: styleMask, backing: .buffered, defer: false)
@@ -270,12 +270,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             window.alphaValue = 0
         }
 
+        let size = getWindowSize()
         let screenFrame = screen.frame
-        window.setFrameOrigin(
-            NSPoint(
-                x: screenFrame.origin.x + (screenFrame.width / 2) - window.frame.width / 2,
-                y: screenFrame.origin.y + screenFrame.height - window.frame.height
-            ))
+        let newFrame = NSRect(
+            x: screenFrame.origin.x + (screenFrame.width / 2) - size.width / 2,
+            y: screenFrame.origin.y + screenFrame.height - size.height,
+            width: size.width,
+            height: size.height
+        )
+        
+        window.setFrame(newFrame, display: true)
         window.alphaValue = 1
     }
 
@@ -294,6 +298,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor in
                 self?.adjustWindowPosition(changeAlpha: true)
                 self?.setupDragDetectors()
+            }
+        }
+        
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ForceOpenNotch"), object: nil, queue: nil
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            Task { @MainActor in
+                for viewModel in self.viewModels.values {
+                    if viewModel.notchState != .open { viewModel.open() }
+                }
+                if self.vm.notchState != .open { self.vm.open() }
             }
         }
 

--- a/boringNotch/components/Live activities/MarqueeTextView.swift
+++ b/boringNotch/components/Live activities/MarqueeTextView.swift
@@ -28,13 +28,14 @@ struct MarqueeText: View {
     let nsFont: NSFont.TextStyle
     let textColor: Color
     let backgroundColor: Color
+    /// Initial pause before scrolling starts (does NOT repeat between loops)
     let minDuration: Double
     let frameWidth: CGFloat
-    
+
     @State private var animate = false
     @State private var textSize: CGSize = .zero
     @State private var offset: CGFloat = 0
-    
+
     init(_ text: Binding<String>, font: Font = .body, nsFont: NSFont.TextStyle = .body, textColor: Color = .primary, backgroundColor: Color = .clear, minDuration: Double = 3.0, frameWidth: CGFloat = 200) {
         _text = text
         self.font = font
@@ -44,15 +45,24 @@ struct MarqueeText: View {
         self.minDuration = minDuration
         self.frameWidth = frameWidth
     }
-    
+
+    private let spacing: CGFloat = 24
+
     private var needsScrolling: Bool {
         textSize.width > frameWidth
     }
-    
+
+    // Seamless loop: the gap between the two copies equals `spacing`,
+    // so when the first copy exits the left edge, the second copy is already
+    // right behind it on the right — no jump, no pause between loops.
+    private var loopOffset: CGFloat {
+        -(textSize.width + spacing)
+    }
+
     var body: some View {
-        GeometryReader { geometry in
+        GeometryReader { _ in
             ZStack(alignment: .leading) {
-                HStack(spacing: 20) {
+                HStack(spacing: spacing) {
                     Text(text)
                     Text(text)
                         .opacity(needsScrolling ? 1 : 0)
@@ -61,33 +71,56 @@ struct MarqueeText: View {
                 .font(font)
                 .foregroundColor(textColor)
                 .fixedSize(horizontal: true, vertical: false)
-                .offset(x: self.animate ? offset : 0)
+                .offset(x: animate ? loopOffset : 0)
+                // Continuous animation — NO .delay() here so there is no pause
+                // between loop iterations.
                 .animation(
-                    self.animate ?
-                        .linear(duration: Double(textSize.width / 30))
-                        .delay(minDuration)
-                        .repeatForever(autoreverses: false) : .none,
-                    value: self.animate
+                    animate
+                        ? .linear(duration: Double(max(textSize.width, 1) / 40))
+                              .repeatForever(autoreverses: false)
+                        : .none,
+                    value: animate
                 )
                 .background(backgroundColor)
                 .modifier(MeasureSizeModifier())
                 .onPreferenceChange(SizePreferenceKey.self) { size in
-                    self.textSize = CGSize(width: size.width / 2, height: NSFont.preferredFont(forTextStyle: nsFont).pointSize)
+                    self.textSize = CGSize(
+                        width: (size.width - spacing) / 2,
+                        height: NSFont.preferredFont(forTextStyle: nsFont).pointSize
+                    )
                     self.animate = false
                     self.offset = 0
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.01){
+                    // Apply the initial delay ONCE before the infinite loop starts.
+                    DispatchQueue.main.asyncAfter(deadline: .now() + max(minDuration, 0.05)) {
                         if needsScrolling {
                             self.animate = true
-                            self.offset = -(textSize.width + 10)
-                            
                         }
                     }
                 }
             }
             .frame(width: frameWidth, alignment: .leading)
             .clipped()
+            // Fade edges: text fades to clear on both sides for a polished look.
+            .mask(
+                HStack(spacing: 0) {
+                    LinearGradient(
+                        gradient: Gradient(colors: [backgroundColor, textColor.opacity(1)]),
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                    .frame(width: needsScrolling ? min(18, frameWidth * 0.12) : 0)
+
+                    Rectangle()
+
+                    LinearGradient(
+                        gradient: Gradient(colors: [textColor.opacity(1), backgroundColor]),
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                    .frame(width: needsScrolling ? min(18, frameWidth * 0.12) : 0)
+                }
+            )
         }
         .frame(height: textSize.height * 1.3)
-        
     }
 }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -132,7 +132,6 @@ struct GeneralSettings: View {
         guard let uuid = screen.displayUUID else { return nil }
         return (uuid, screen.localizedName)
     }
-    @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var coordinator = BoringViewCoordinator.shared
 
     @Default(.mirrorShape) var mirrorShape
@@ -143,6 +142,8 @@ struct GeneralSettings: View {
     @Default(.nonNotchHeightMode) var nonNotchHeightMode
     @Default(.notchHeight) var notchHeight
     @Default(.notchHeightMode) var notchHeightMode
+    @Default(.openNotchWidth) var openNotchWidth
+    @Default(.openNotchHeight) var openNotchHeight
     @Default(.showOnAllDisplays) var showOnAllDisplays
     @Default(.automaticallySwitchDisplay) var automaticallySwitchDisplay
     @Default(.enableGestures) var enableGestures
@@ -255,6 +256,34 @@ struct GeneralSettings: View {
                             name: Notification.Name.notchHeightChanged, object: nil)
                     }
                 }
+
+                Divider()
+
+                Slider(value: $openNotchWidth, in: 300...1200, step: 10) {
+                    Text("Opened notch width - \(openNotchWidth, specifier: "%.0f")")
+                }
+                .onChange(of: openNotchWidth) {
+                    NotificationCenter.default.post(name: Notification.Name("ForceOpenNotch"), object: nil)
+                    NotificationCenter.default.post(name: .notchHeightChanged, object: nil)
+                }
+
+                Slider(value: $openNotchHeight, in: 100...800, step: 10) {
+                    Text("Opened notch height - \(openNotchHeight, specifier: "%.0f")")
+                }
+                .onChange(of: openNotchHeight) {
+                    NotificationCenter.default.post(name: Notification.Name("ForceOpenNotch"), object: nil)
+                    NotificationCenter.default.post(name: .notchHeightChanged, object: nil)
+                }
+
+                Button("Reset to Defaults") {
+                    openNotchWidth = 640.0
+                    openNotchHeight = 190.0
+                    NotificationCenter.default.post(name: Notification.Name("ForceOpenNotch"), object: nil)
+                    NotificationCenter.default.post(name: .notchHeightChanged, object: nil)
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.accentColor)
+                .padding(.top, 4)
             } header: {
                 Text("Notch sizing")
             }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -144,6 +144,8 @@ struct GeneralSettings: View {
     @Default(.notchHeightMode) var notchHeightMode
     @Default(.openNotchWidth) var openNotchWidth
     @Default(.openNotchHeight) var openNotchHeight
+    @Default(.liveActivityWidthMode) var liveActivityWidthMode
+    @Default(.liveActivityWidth) var liveActivityWidth
     @Default(.showOnAllDisplays) var showOnAllDisplays
     @Default(.automaticallySwitchDisplay) var automaticallySwitchDisplay
     @Default(.enableGestures) var enableGestures
@@ -284,6 +286,34 @@ struct GeneralSettings: View {
                 .buttonStyle(.plain)
                 .foregroundColor(.accentColor)
                 .padding(.top, 4)
+                
+                Divider()
+                
+                Picker("Live Activity Width", selection: $liveActivityWidthMode) {
+                    Text("Auto (Match Content)").tag(Defaults.Keys.LiveActivityWidthMode.auto)
+                    Text("Custom").tag(Defaults.Keys.LiveActivityWidthMode.custom)
+                }
+                .onChange(of: liveActivityWidthMode) {
+                    NotificationCenter.default.post(name: .notchHeightChanged, object: nil)
+                }
+                
+                if liveActivityWidthMode == .custom {
+                    Slider(value: $liveActivityWidth, in: 20...600, step: 5) {
+                        Text("Extra Width - \(liveActivityWidth, specifier: "%.0f")")
+                    }
+                    .onChange(of: liveActivityWidth) {
+                        NotificationCenter.default.post(name: .notchHeightChanged, object: nil)
+                    }
+                    
+                    Button("Reset Width to Default") {
+                        liveActivityWidthMode = .auto
+                        liveActivityWidth = 80.0
+                        NotificationCenter.default.post(name: .notchHeightChanged, object: nil)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.accentColor)
+                    .padding(.top, 4)
+                }
             } header: {
                 Text("Notch sizing")
             }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -598,6 +598,8 @@ struct Media: View {
     @Default(.hideNotchOption) var hideNotchOption
     @Default(.enableSneakPeek) private var enableSneakPeek
     @Default(.sneakPeekStyles) var sneakPeekStyles
+    @Default(.hideLiveActivityAfterTimeout) var hideLiveActivityAfterTimeout
+    @Default(.liveActivityTimeout) var liveActivityTimeout
 
     @Default(.enableLyrics) var enableLyrics
 
@@ -644,6 +646,24 @@ struct Media: View {
                     "Show music live activity",
                     isOn: $coordinator.musicLiveActivityEnabled.animation()
                 )
+                Toggle("Hide live activity after a short timeout", isOn: $hideLiveActivityAfterTimeout.animation())
+                    .disabled(!coordinator.musicLiveActivityEnabled)
+                
+                if hideLiveActivityAfterTimeout {
+                    HStack {
+                        Stepper(value: $liveActivityTimeout, in: 1...15, step: 0.5) {
+                            HStack {
+                                Text("Hide timeout")
+                                Spacer()
+                                Text("\(liveActivityTimeout, specifier: "%.1f") seconds")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .padding(.leading, 16)
+                    .disabled(!coordinator.musicLiveActivityEnabled)
+                }
+
                 Toggle("Show sneak peek on playback changes", isOn: $enableSneakPeek)
                 Picker("Sneak Peek Style", selection: $sneakPeekStyles) {
                     ForEach(SneakPeekStyle.allCases) { style in

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -68,6 +68,9 @@ class MusicManager: ObservableObject {
     @Published var isTransitioning: Bool = false
     private var transitionWorkItem: DispatchWorkItem?
 
+    @Published var showNotchLiveActivity: Bool = false
+    private var liveActivityTask: Task<Void, Never>?
+
     // MARK: - Initialization
     init() {
         // Listen for changes to the default controller preference
@@ -191,6 +194,7 @@ class MusicManager: ObservableObject {
 
             if state.isPlaying && !state.title.isEmpty && !state.artist.isEmpty {
                 self.updateSneakPeek()
+                self.triggerNotchLiveActivity()
             }
         }
 
@@ -230,6 +234,7 @@ class MusicManager: ObservableObject {
             // Only update sneak peek if there's actual content and something changed
             if !state.title.isEmpty && !state.artist.isEmpty && state.isPlaying {
                 self.updateSneakPeek()
+                self.triggerNotchLiveActivity()
             }
 
             // Fetch lyrics on content change
@@ -588,6 +593,22 @@ class MusicManager: ObservableObject {
                 coordinator.toggleSneakPeek(status: true, type: .music)
             } else {
                 coordinator.toggleExpandingView(status: true, type: .music)
+            }
+        }
+    }
+
+    func triggerNotchLiveActivity() {
+        liveActivityTask?.cancel()
+        withAnimation(.smooth) {
+            self.showNotchLiveActivity = true
+        }
+        liveActivityTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(Defaults[.liveActivityTimeout]))
+            guard let self = self, !Task.isCancelled else { return }
+            await MainActor.run {
+                withAnimation(.smooth) {
+                    self.showNotchLiveActivity = false
+                }
             }
         }
     }

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -65,6 +65,17 @@ class BoringViewModel: NSObject, ObservableObject {
             }
             .assign(to: \.anyDropZoneTargeting, on: self)
             .store(in: &cancellables)
+            
+        NotificationCenter.default.addObserver(
+            forName: .notchHeightChanged, object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            if self.notchState == .open {
+                withAnimation(self.animationLibrary.animation) {
+                    self.notchSize = getOpenNotchSize()
+                }
+            }
+        }
         
         setupDetectorObserver()
     }
@@ -190,7 +201,7 @@ class BoringViewModel: NSObject, ObservableObject {
     }
 
     func open() {
-        self.notchSize = openNotchSize
+        self.notchSize = getOpenNotchSize()
         self.notchState = .open
         
         // Force music information update when notch is opened

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -133,6 +133,13 @@ extension Defaults.Keys {
     // MARK: Notch Sizing
     static let openNotchWidth = Key<Double>("openNotchWidth", default: 640.0)
     static let openNotchHeight = Key<Double>("openNotchHeight", default: 190.0)
+    
+    enum LiveActivityWidthMode: String, Codable, Defaults.Serializable {
+        case auto
+        case custom
+    }
+    static let liveActivityWidthMode = Key<LiveActivityWidthMode>("liveActivityWidthMode", default: .auto)
+    static let liveActivityWidth = Key<Double>("liveActivityWidth", default: 80.0)
 
     static let enableLyrics = Key<Bool>("enableLyrics", default: true)
     static let musicControlSlots = Key<[MusicControlButton]>(

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -125,6 +125,8 @@ extension Defaults.Keys {
     // MARK: Media playback
     static let coloredSpectrogram = Key<Bool>("coloredSpectrogram", default: true)
     static let enableSneakPeek = Key<Bool>("enableSneakPeek", default: false)
+    static let hideLiveActivityAfterTimeout = Key<Bool>("hideLiveActivityAfterTimeout", default: true)
+    static let liveActivityTimeout = Key<Double>("liveActivityTimeout", default: 2.0)
     static let sneakPeekStyles = Key<SneakPeekStyle>("sneakPeekStyles", default: .standard)
     static let waitInterval = Key<Double>("waitInterval", default: 3)
     static let showShuffleAndRepeat = Key<Bool>("showShuffleAndRepeat", default: false)

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -130,7 +130,11 @@ extension Defaults.Keys {
     static let sneakPeekStyles = Key<SneakPeekStyle>("sneakPeekStyles", default: .standard)
     static let waitInterval = Key<Double>("waitInterval", default: 3)
     static let showShuffleAndRepeat = Key<Bool>("showShuffleAndRepeat", default: false)
-    static let enableLyrics = Key<Bool>("enableLyrics", default: false)
+    // MARK: Notch Sizing
+    static let openNotchWidth = Key<Double>("openNotchWidth", default: 640.0)
+    static let openNotchHeight = Key<Double>("openNotchHeight", default: 190.0)
+
+    static let enableLyrics = Key<Bool>("enableLyrics", default: true)
     static let musicControlSlots = Key<[MusicControlButton]>(
         "musicControlSlots",
         default: MusicControlButton.defaultLayout

--- a/boringNotch/sizing/matters.swift
+++ b/boringNotch/sizing/matters.swift
@@ -13,8 +13,14 @@ let downloadSneakSize: CGSize = .init(width: 65, height: 1)
 let batterySneakSize: CGSize = .init(width: 160, height: 1)
 
 let shadowPadding: CGFloat = 20
-let openNotchSize: CGSize = .init(width: 640, height: 190)
-let windowSize: CGSize = .init(width: openNotchSize.width, height: openNotchSize.height + shadowPadding)
+@MainActor func getOpenNotchSize() -> CGSize {
+    return .init(width: CGFloat(Defaults[.openNotchWidth]), height: CGFloat(Defaults[.openNotchHeight]))
+}
+
+@MainActor func getWindowSize() -> CGSize {
+    let size = getOpenNotchSize()
+    return .init(width: size.width, height: size.height + shadowPadding)
+}
 let cornerRadiusInsets: (opened: (top: CGFloat, bottom: CGFloat), closed: (top: CGFloat, bottom: CGFloat)) = (opened: (top: 19, bottom: 24), closed: (top: 6, bottom: 14))
 
 enum MusicPlayerImageSizes {


### PR DESCRIPTION
- Customizable Visibility: Added hideLiveActivityAfterTimeout setting (Settings -> Media) to toggle between temporary (auto-hide) and persistent Live Activity modes during media playback.
- Customizable Timeout: Added liveActivityTimeout setting with a UI Stepper (1-15s) to allow users to define exactly how long the Live Activity remains visible in temporary mode.
- Strict State Enforcement: Refactored ContentView visibility conditions to strictly observe musicManager.isPlaying. The Live Activity now hides immediately on pause, eliminating the previous idle delay.
- UI Redraw Bugfix: Bound hideLiveActivityAfterTimeout via @Default in ContentView to ensure instant UI updates when toggling the setting, removing the need to manually hover the notch to trigger a redraw.
- Consistent Defaults: Updated standard pop-up (sneakPeek and expandingView) timeouts to a consistent 2.0 seconds.