### PR TITLE
Resolve source app icons for helper bundle media sources

### DIFF
--- a/boringNotch/helpers/AppIcons.swift
+++ b/boringNotch/helpers/AppIcons.swift
@@ -9,53 +9,95 @@ import SwiftUI
 import AppKit
 
 struct AppIcons {
-    
+
     func getIcon(file path: String) -> NSImage? {
         guard FileManager.default.fileExists(atPath: path)
         else { return nil }
-        
+
         return NSWorkspace.shared.icon(forFile: path)
     }
-    
+
     func getIcon(bundleID: String) -> NSImage? {
-        guard let path = NSWorkspace.shared.urlForApplication(
-            withBundleIdentifier: bundleID
-        )?.absoluteString
-        else { return nil }
-        
-        return getIcon(file: path)
+        resolvedAppIcon(for: bundleID)
     }
-    
-        /// Easily read Info.plist as a Dictionary from any bundle by accessing .infoDictionary on Bundle
+
+    /// Easily read Info.plist as a Dictionary from any bundle by accessing .infoDictionary on Bundle
     func bundle(forBundleID: String) -> Bundle? {
         guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: forBundleID)
         else { return nil }
-        
+
         return Bundle(url: url)
     }
-    
+
 }
 
 func AppIcon(for bundleID: String) -> Image {
-    let workspace = NSWorkspace.shared
-    
-    if let appURL = workspace.urlForApplication(withBundleIdentifier: bundleID) {
-        let appIcon = workspace.icon(forFile: appURL.path)
+    if let appIcon = resolvedAppIcon(for: bundleID) {
         return Image(nsImage: appIcon)
     }
-    
-    return Image(nsImage: workspace.icon(for: .applicationBundle))
+
+    return Image(nsImage: NSWorkspace.shared.icon(for: .applicationBundle))
 }
 
 
 func AppIconAsNSImage(for bundleID: String) -> NSImage? {
-    let workspace = NSWorkspace.shared
-    
-    if let appURL = workspace.urlForApplication(withBundleIdentifier: bundleID) {
-        let appIcon = workspace.icon(forFile: appURL.path)
+    if let appIcon = resolvedAppIcon(for: bundleID) {
         appIcon.size = NSSize(width: 256, height: 256)
         return appIcon
     }
     return nil
 }
 
+private func resolvedAppIcon(for bundleID: String?) -> NSImage? {
+    guard let bundleID, !bundleID.isEmpty else { return nil }
+
+    for candidateURL in candidateApplicationURLs(for: bundleID) {
+        guard let appBundleURL = outermostAppBundleURL(from: candidateURL) else { continue }
+        guard FileManager.default.fileExists(atPath: appBundleURL.path) else { continue }
+
+        return NSWorkspace.shared.icon(forFile: appBundleURL.path)
+    }
+
+    return nil
+}
+
+private func candidateApplicationURLs(for bundleID: String) -> [URL] {
+    let workspace = NSWorkspace.shared
+    var candidates: [URL] = []
+    var seenPaths = Set<String>()
+
+    func append(_ url: URL?) {
+        guard let url else { return }
+        let path = url.standardizedFileURL.path
+        guard !path.isEmpty, seenPaths.insert(path).inserted else { return }
+        candidates.append(url)
+    }
+
+    append(workspace.urlForApplication(withBundleIdentifier: bundleID))
+
+    for application in NSRunningApplication.runningApplications(withBundleIdentifier: bundleID) {
+        append(application.bundleURL)
+        append(application.executableURL)
+    }
+
+    return candidates
+}
+
+private func outermostAppBundleURL(from url: URL) -> URL? {
+    var currentURL = url.standardizedFileURL
+    var resolvedURL: URL?
+
+    while currentURL.path != "/" && !currentURL.path.isEmpty {
+        if currentURL.pathExtension.caseInsensitiveCompare("app") == .orderedSame {
+            resolvedURL = currentURL
+        }
+
+        let parentURL = currentURL.deletingLastPathComponent()
+        if parentURL.path == currentURL.path {
+            break
+        }
+        currentURL = parentURL
+    }
+
+    return resolvedURL
+}


### PR DESCRIPTION

<img width="161" height="93" alt="Screenshot 2026-04-19 at 5 31 17 PM" src="https://github.com/user-attachments/assets/4b98f4bb-c7c5-448c-b817-f182371b7bfe" />
## Summary
- resolve source app icons through a shared helper used by both SwiftUI and NSImage paths
- include running application bundle and executable URLs as icon lookup candidates
- normalize nested helper bundle paths back to the outermost `.app` so browser helper processes still show the main app icon

## Why
Some now-playing sources can report helper-process bundle identifiers instead of the primary app bundle. In those cases the notch badge can fall back to the generic app icon even though the real source app is installed and running. This change keeps the existing badge UI intact and only hardens icon resolution so helper-backed browser/media sources resolve to the main app icon more reliably.

## Testing
- `xcodebuild -project boringNotch.xcodeproj -scheme boringNotch -destination 'platform=macOS' build`
- reproduced a Chrome YouTube audio session locally and confirmed the fix path targets Chrome helper bundle layouts under `Google Chrome.app`

## Notes
- no playback state or controller contracts were changed
- no layout, sizing, or interaction behavior was changed; this is a narrow icon-resolution fix
- I do not have a clean screenshot from the debug build because the local environment kept exposing the installed app to the UI automation layer instead of the built branch binary