### PR TITLE
Show battery health

### DIFF
--- a/boringNotch/components/Live activities/BoringBattery.swift
+++ b/boringNotch/components/Live activities/BoringBattery.swift
@@ -90,7 +90,7 @@ struct BatteryMenuView: View {
     var isPluggedIn: Bool
     var isCharging: Bool
     var levelBattery: Float
-    var maxCapacity: Float
+    var maxCapacity: Float?
     var timeToFullCharge: Int
     var isInLowPowerMode: Bool
     var onDismiss: () -> Void
@@ -119,9 +119,15 @@ struct BatteryMenuView: View {
             }
             
             VStack(alignment: .leading, spacing: 8) {
-                Text("Max Capacity: \(Int(maxCapacity))%")
-                    .font(.subheadline)
-                    .fontWeight(.regular)
+                if let maxCapacity {
+                    Text("Max Capacity: \(Int(maxCapacity))%")
+                        .font(.subheadline)
+                        .fontWeight(.regular)
+                } else {
+                    Text("Max Capacity: Not Available")
+                        .font(.subheadline)
+                        .fontWeight(.regular)
+                }
                 if isInLowPowerMode {
                     Label("Low Power Mode", systemImage: "bolt.circle")
                         .font(.subheadline)
@@ -182,7 +188,7 @@ struct BoringBatteryView: View {
     var isInLowPowerMode: Bool = false
     var isPluggedIn: Bool = false
     var levelBattery: Float = 0
-    var maxCapacity: Float = 0
+    var maxCapacity: Float?
     var timeToFullCharge: Int = 0
     @State var isForNotification: Bool = false
     

--- a/boringNotch/managers/BatteryActivityManager.swift
+++ b/boringNotch/managers/BatteryActivityManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import IOKit
 import IOKit.ps
 
 /// Manages and monitors battery status changes on the device
@@ -8,7 +9,7 @@ class BatteryActivityManager {
     static let shared = BatteryActivityManager()
 
     var onBatteryLevelChange: ((Float) -> Void)?
-    var onMaxCapacityChange: ((Float) -> Void)?
+    var onMaxCapacityChange: ((Float?) -> Void)?
     var onPowerModeChange: ((Bool) -> Void)?
     var onPowerSourceChange: ((Bool) -> Void)?
     var onChargingChange: ((Bool) -> Void)?
@@ -51,7 +52,7 @@ class BatteryActivityManager {
         case lowPowerModeChanged(isEnabled: Bool)
         case isChargingChanged(isCharging: Bool)
         case timeToFullChargeChanged(time: Int)
-        case maxCapacityChanged(capacity: Float)
+        case maxCapacityChanged(capacity: Float?)
         case error(description: String)
     }
 
@@ -65,7 +66,7 @@ class BatteryActivityManager {
         isPluggedIn: false,
         isCharging: false,
         currentCapacity: 0,
-        maxCapacity: 0,
+        maxCapacity: nil,
         isInLowPowerMode: false,
         timeToFullCharge: 0
     )
@@ -208,7 +209,7 @@ class BatteryActivityManager {
                 isPluggedIn: false,
                 isCharging: false,
                 currentCapacity: 0,
-                maxCapacity: 0,
+                maxCapacity: nil,
                 isInLowPowerMode: false,
                 timeToFullCharge: 0
             )
@@ -241,10 +242,6 @@ class BatteryActivityManager {
                 throw BatteryError.batteryParameterMissing("Current capacity")
             }
             
-            guard let maxCapacity = description[kIOPSMaxCapacityKey] as? Float else {
-                throw BatteryError.batteryParameterMissing("Max capacity")
-            }
-            
             guard let isCharging = description["Is Charging"] as? Bool else {
                 throw BatteryError.batteryParameterMissing("Charging state")
             }
@@ -258,7 +255,7 @@ class BatteryActivityManager {
                 isPluggedIn: powerSource == kIOPSACPowerValue,
                 isCharging: isCharging,
                 currentCapacity: currentCapacity,
-                maxCapacity: maxCapacity,
+                maxCapacity: getBatteryHealthCapacity(),
                 isInLowPowerMode: ProcessInfo.processInfo.isLowPowerModeEnabled,
                 timeToFullCharge: 0
             )
@@ -283,6 +280,43 @@ class BatteryActivityManager {
             print("⚠️ Error: Unexpected error getting battery info - \(error.localizedDescription)")
             return defaultBatteryInfo
         }
+    }
+
+    /// Reads the user-visible battery health capacity from the smart battery registry.
+    private func getBatteryHealthCapacity() -> Float? {
+        let batteryService = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("AppleSmartBattery"))
+        guard batteryService != IO_OBJECT_NULL else { return nil }
+        defer { IOObjectRelease(batteryService) }
+
+        var properties: Unmanaged<CFMutableDictionary>?
+        guard IORegistryEntryCreateCFProperties(batteryService, &properties, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+              let batteryProperties = properties?.takeRetainedValue() as? [String: Any],
+              let designCapacity = capacityValue(in: batteryProperties, forKey: "DesignCapacity"),
+              designCapacity > 0,
+              let fullChargeCapacity = capacityValue(in: batteryProperties, forKey: "NominalChargeCapacity")
+                ?? capacityValue(in: batteryProperties, forKey: "AppleRawMaxCapacity"),
+              fullChargeCapacity > 0 else {
+            return nil
+        }
+
+        let healthPercentage = (fullChargeCapacity / designCapacity) * 100
+        return min(max((healthPercentage / 5).rounded() * 5, 0), 100)
+    }
+
+    private func capacityValue(in properties: [String: Any], forKey key: String) -> Float? {
+        if let number = properties[key] as? NSNumber {
+            return number.floatValue
+        }
+        if let value = properties[key] as? Float {
+            return value
+        }
+        if let value = properties[key] as? Double {
+            return Float(value)
+        }
+        if let value = properties[key] as? Int {
+            return Float(value)
+        }
+        return nil
     }
     
     /// Adds an observer to listen to battery changes
@@ -323,7 +357,7 @@ struct BatteryInfo {
     var isPluggedIn: Bool
     var isCharging: Bool
     var currentCapacity: Float
-    var maxCapacity: Float
+    var maxCapacity: Float?
     var isInLowPowerMode: Bool
     var timeToFullCharge: Int
 }

--- a/boringNotch/models/BatteryStatusViewModel.swift
+++ b/boringNotch/models/BatteryStatusViewModel.swift
@@ -14,7 +14,7 @@ class BatteryStatusViewModel: ObservableObject {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
 
     @Published private(set) var levelBattery: Float = 0.0
-    @Published private(set) var maxCapacity: Float = 0.0
+    @Published private(set) var maxCapacity: Float?
     @Published private(set) var isPluggedIn: Bool = false
     @Published private(set) var isCharging: Bool = false
     @Published private(set) var isInLowPowerMode: Bool = false
@@ -25,7 +25,7 @@ class BatteryStatusViewModel: ObservableObject {
     enum LastStatus: Equatable {
         case plugged(Bool)
         case lowPower(Bool)
-        case charging(isCharging: Bool, level: Float, maxCapacity: Float)
+        case charging(isCharging: Bool, level: Float)
     }
 
     var statusText: LocalizedStringKey {
@@ -35,11 +35,11 @@ class BatteryStatusViewModel: ObservableObject {
         case .lowPower(let enabled):
             let key = enabled ? "Low Power: On" : "Low Power: Off"
             return LocalizedStringKey(key)
-        case .charging(let isCharging, let level, let max):
+        case .charging(let isCharging, let level):
             if isCharging {
                 return LocalizedStringKey("Charging battery")
             }
-            if level < max {
+            if level < 100 {
                 return LocalizedStringKey("Not charging")
             }
             return LocalizedStringKey("Full charge")
@@ -102,14 +102,12 @@ class BatteryStatusViewModel: ObservableObject {
 
         case .isChargingChanged(let isCharging):
             print("🔌 Charging: \(isCharging ? "Yes" : "No")")
-            print("maxCapacity: \(self.maxCapacity)")
+            print("maxCapacity: \(self.maxCapacity.map { "\($0)" } ?? "Unavailable")")
             print("levelBattery: \(self.levelBattery)")
             self.notifyImportanChangeStatus()
             withAnimation {
                 self.isCharging = isCharging
-                self.lastStatus = .charging(isCharging: isCharging,
-                                             level: self.levelBattery,
-                                             maxCapacity: self.maxCapacity)
+                self.lastStatus = .charging(isCharging: isCharging, level: self.levelBattery)
             }
 
         case .timeToFullChargeChanged(let time):
@@ -119,7 +117,7 @@ class BatteryStatusViewModel: ObservableObject {
             }
 
         case .maxCapacityChanged(let capacity):
-            print("🔋 Max capacity: \(capacity)")
+            print("🔋 Max capacity: \(capacity.map { "\($0)" } ?? "Unavailable")")
             withAnimation {
                 self.maxCapacity = capacity
             }


### PR DESCRIPTION
This pull request updates how battery health (maximum capacity) is handled and displayed throughout the app, making it optional to account for cases where the value is not available. It also introduces a more accurate method to retrieve battery health using the IOKit framework. The changes ensure that the UI reflects when max capacity information is not available, and all relevant types and view models are updated to support an optional value for max capacity.