### PR TITLE
Improve fetching of application icons for share providers

### DIFF
--- a/boringNotch/components/Shelf/Services/QuickShareService.swift
+++ b/boringNotch/components/Shelf/Services/QuickShareService.swift
@@ -11,87 +11,52 @@ import UniformTypeIdentifiers
 
 /// Dynamic representation of a sharing provider discovered at runtime
 struct QuickShareProvider: Identifiable, Hashable, Sendable {
+    static let airDropId = "AirDrop"
+    static let systemShareMenuId = "System Share Menu"
+    static let systemShareMenu = QuickShareProvider(id: systemShareMenuId, supportsRawText: true)
+
     var id: String
     var supportsRawText: Bool
 }
 
-class QuickShareService: ObservableObject {
-    static let shared = QuickShareService()
-    
-    @Published var availableProviders: [QuickShareProvider] = []
-    @Published var isPickerOpen = false
-    private var cachedServices: [String: NSSharingService] = [:]
-    private var cachedIcons: [String: NSImage] = [:]
-    private var cachedApplicationURLsByName: [String: URL]?
-    // Hold security-scoped URLs during sharing
-    private var sharingAccessingURLs: [URL] = []
-    private var lifecycleDelegate: SharingLifecycleDelegate?
-   
-    init() {
-        Task {
-            await discoverAvailableProviders()
-        }
-    }
-    
-    // MARK: - Icon Retrieval
+private actor ApplicationIconIndex {
+    private var cachedURLsByName: [String: URL]?
 
-    @MainActor
-    func icon(for providerId: String, size: CGFloat) -> NSImage? {
-        if let cachedIcon = cachedIcons[providerId] {
-            return resizedIcon(cachedIcon, to: size)
-        }
-
-        if let providerIcon = applicationIcon(for: providerId) {
-            cachedIcons[providerId] = providerIcon
-            return resizedIcon(providerIcon, to: size)
-        }
-
-        // For system share menu, return a generic share icon
-        if providerId == "System Share Menu" {
-            return NSImage(systemSymbolName: "square.and.arrow.up", accessibilityDescription: "Share")
-        }
-        
-        // Try to get icon from cached service
-        if let service = cachedServices[providerId] {
-            return resizedIcon(service.image, to: size)
-        }
-
-        return nil
-    }
-
-    private func applicationIcon(for providerId: String) -> NSImage? {
-        guard let applicationURL = applicationURLsByName()[normalizedApplicationName(providerId)] else {
-            return nil
-        }
-        return NSWorkspace.shared.icon(forFile: applicationURL.path)
-    }
-
-    private func applicationURLsByName() -> [String: URL] {
-        if let cachedApplicationURLsByName {
-            return cachedApplicationURLsByName
+    func urlsByName() -> [String: URL] {
+        if let cachedURLsByName {
+            return cachedURLsByName
         }
 
         var urlsByName: [String: URL] = [:]
-        for root in applicationSearchRoots {
-            indexApplications(in: root, into: &urlsByName)
+        for root in Self.applicationSearchRoots {
+            Self.indexApplications(in: root, into: &urlsByName)
         }
 
-        cachedApplicationURLsByName = urlsByName
+        cachedURLsByName = urlsByName
         return urlsByName
     }
 
-    private var applicationSearchRoots: [URL] {
-        [
+    static func normalizedApplicationName(_ name: String) -> String {
+        name
+            .replacingOccurrences(of: ".app", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+    }
+
+    private static var applicationSearchRoots: [URL] {
+        var roots = FileManager.default.urls(for: .applicationDirectory, in: .userDomainMask)
+        roots.append(contentsOf: [
             URL(fileURLWithPath: "/Applications", isDirectory: true),
             URL(fileURLWithPath: "/System/Applications", isDirectory: true),
             URL(fileURLWithPath: "/System/Applications/Utilities", isDirectory: true),
             URL(fileURLWithPath: "/System/Library/CoreServices/Applications", isDirectory: true),
             URL(fileURLWithPath: "/System/Library/CoreServices/Finder.app/Contents/Applications", isDirectory: true),
             URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer/Applications", isDirectory: true)
-        ]
+        ])
+        return roots
     }
 
-    private func indexApplications(in root: URL, into urlsByName: inout [String: URL]) {
+    private static func indexApplications(in root: URL, into urlsByName: inout [String: URL]) {
         guard FileManager.default.fileExists(atPath: root.path),
               let enumerator = FileManager.default.enumerator(
                 at: root,
@@ -106,7 +71,7 @@ class QuickShareService: ObservableObject {
         }
     }
 
-    private func indexApplication(_ applicationURL: URL, into urlsByName: inout [String: URL]) {
+    private static func indexApplication(_ applicationURL: URL, into urlsByName: inout [String: URL]) {
         cacheApplicationName(applicationURL.deletingPathExtension().lastPathComponent, for: applicationURL, in: &urlsByName)
 
         if let localizedName = try? applicationURL.resourceValues(forKeys: [.localizedNameKey]).localizedName {
@@ -124,17 +89,77 @@ class QuickShareService: ObservableObject {
         }
     }
 
-    private func cacheApplicationName(_ name: String, for applicationURL: URL, in urlsByName: inout [String: URL]) {
+    private static func cacheApplicationName(_ name: String, for applicationURL: URL, in urlsByName: inout [String: URL]) {
         let normalizedName = normalizedApplicationName(name)
         guard !normalizedName.isEmpty, urlsByName[normalizedName] == nil else { return }
         urlsByName[normalizedName] = applicationURL
     }
+}
 
-    private func normalizedApplicationName(_ name: String) -> String {
-        name
-            .replacingOccurrences(of: ".app", with: "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+final class QuickShareService: ObservableObject {
+    static let shared = QuickShareService()
+
+    @Published var availableProviders: [QuickShareProvider] = []
+    @Published var isPickerOpen = false
+    private var cachedApplicationURLsByName: [String: URL]?
+    private var cachedServices: [String: NSSharingService] = [:]
+    private var cachedIcons: [String: NSImage] = [:]
+    private let applicationIconIndex = ApplicationIconIndex()
+    private var isApplicationIconCacheLoading = false
+    // Hold security-scoped URLs during sharing
+    private var sharingAccessingURLs: [URL] = []
+    private var lifecycleDelegate: SharingLifecycleDelegate?
+
+    init() {
+        Task {
+            await discoverAvailableProviders()
+        }
+    }
+
+    // MARK: - Icon Retrieval
+
+    @MainActor
+    func icon(for providerId: String, size: CGFloat) -> NSImage? {
+        if let cachedIcon = cachedIcons[providerId] {
+            return resizedIcon(cachedIcon, to: size)
+        }
+
+        if let providerIcon = applicationIcon(for: providerId) {
+            cachedIcons[providerId] = providerIcon
+            return resizedIcon(providerIcon, to: size)
+        }
+
+        warmApplicationIconCacheIfNeeded()
+
+        // For system share menu, return a generic share icon
+        if providerId == QuickShareProvider.systemShareMenuId {
+            return NSImage(systemSymbolName: "square.and.arrow.up", accessibilityDescription: "Share")
+        }
+
+        // Try to get icon from cached service
+        if let service = cachedServices[providerId] {
+            return resizedIcon(service.image, to: size)
+        }
+
+        return nil
+    }
+
+    private func applicationIcon(for providerId: String) -> NSImage? {
+        guard let applicationURL = cachedApplicationURLsByName?[ApplicationIconIndex.normalizedApplicationName(providerId)] else {
+            return nil
+        }
+        return NSWorkspace.shared.icon(forFile: applicationURL.path)
+    }
+
+    @MainActor
+    private func warmApplicationIconCacheIfNeeded() {
+        guard cachedApplicationURLsByName == nil, !isApplicationIconCacheLoading else { return }
+        isApplicationIconCacheLoading = true
+
+        Task(priority: .utility) { @MainActor in
+            cachedApplicationURLsByName = await applicationIconIndex.urlsByName()
+            isApplicationIconCacheLoading = false
+        }
     }
     
     private func resizedIcon(_ image: NSImage, to size: CGFloat) -> NSImage {
@@ -172,16 +197,17 @@ class QuickShareService: ObservableObject {
             }
         }
         
-        if let idx = providers.firstIndex(where: { $0.id == "AirDrop" }) {
+        if let idx = providers.firstIndex(where: { $0.id == QuickShareProvider.airDropId }) {
             let ad = providers.remove(at: idx)
             providers.insert(ad, at: 0)
         }
 
-        if !providers.contains(where: { $0.id == "System Share Menu" }) {
-            providers.append(QuickShareProvider(id: "System Share Menu", supportsRawText: true))
+        if !providers.contains(where: { $0.id == QuickShareProvider.systemShareMenuId }) {
+            providers.append(.systemShareMenu)
         }
 
-        self.availableProviders = providers
+        availableProviders = providers
+        warmApplicationIconCacheIfNeeded()
 
     }
     
@@ -315,9 +341,9 @@ extension QuickShareProvider {
     static var defaultProvider: QuickShareProvider {
         let svc = QuickShareService.shared
 
-        if let airdrop = svc.availableProviders.first(where: { $0.id == "AirDrop" }) {
+        if let airdrop = svc.availableProviders.first(where: { $0.id == QuickShareProvider.airDropId }) {
             return airdrop
         }
-        return svc.availableProviders.first ?? QuickShareProvider(id: "System Share Menu", supportsRawText: true)
+        return svc.availableProviders.first ?? .systemShareMenu
     }
 }

--- a/boringNotch/components/Shelf/Services/QuickShareService.swift
+++ b/boringNotch/components/Shelf/Services/QuickShareService.swift
@@ -22,6 +22,7 @@ class QuickShareService: ObservableObject {
     @Published var isPickerOpen = false
     private var cachedServices: [String: NSSharingService] = [:]
     private var cachedIcons: [String: NSImage] = [:]
+    private var cachedApplicationURLsByName: [String: URL]?
     // Hold security-scoped URLs during sharing
     private var sharingAccessingURLs: [URL] = []
     private var lifecycleDelegate: SharingLifecycleDelegate?
@@ -36,23 +37,104 @@ class QuickShareService: ObservableObject {
 
     @MainActor
     func icon(for providerId: String, size: CGFloat) -> NSImage? {
-        // Return cached icon if available
         if let cachedIcon = cachedIcons[providerId] {
             return resizedIcon(cachedIcon, to: size)
         }
-        
-        // Try to get icon from cached service
-        if let service = cachedServices[providerId] {
-            cachedIcons[providerId] = service.image
-            return resizedIcon(service.image, to: size)
+
+        if let providerIcon = applicationIcon(for: providerId) {
+            cachedIcons[providerId] = providerIcon
+            return resizedIcon(providerIcon, to: size)
         }
-        
+
         // For system share menu, return a generic share icon
         if providerId == "System Share Menu" {
             return NSImage(systemSymbolName: "square.and.arrow.up", accessibilityDescription: "Share")
         }
         
+        // Try to get icon from cached service
+        if let service = cachedServices[providerId] {
+            return resizedIcon(service.image, to: size)
+        }
+
         return nil
+    }
+
+    private func applicationIcon(for providerId: String) -> NSImage? {
+        guard let applicationURL = applicationURLsByName()[normalizedApplicationName(providerId)] else {
+            return nil
+        }
+        return NSWorkspace.shared.icon(forFile: applicationURL.path)
+    }
+
+    private func applicationURLsByName() -> [String: URL] {
+        if let cachedApplicationURLsByName {
+            return cachedApplicationURLsByName
+        }
+
+        var urlsByName: [String: URL] = [:]
+        for root in applicationSearchRoots {
+            indexApplications(in: root, into: &urlsByName)
+        }
+
+        cachedApplicationURLsByName = urlsByName
+        return urlsByName
+    }
+
+    private var applicationSearchRoots: [URL] {
+        [
+            URL(fileURLWithPath: "/Applications", isDirectory: true),
+            URL(fileURLWithPath: "/System/Applications", isDirectory: true),
+            URL(fileURLWithPath: "/System/Applications/Utilities", isDirectory: true),
+            URL(fileURLWithPath: "/System/Library/CoreServices/Applications", isDirectory: true),
+            URL(fileURLWithPath: "/System/Library/CoreServices/Finder.app/Contents/Applications", isDirectory: true),
+            URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer/Applications", isDirectory: true)
+        ]
+    }
+
+    private func indexApplications(in root: URL, into urlsByName: inout [String: URL]) {
+        guard FileManager.default.fileExists(atPath: root.path),
+              let enumerator = FileManager.default.enumerator(
+                at: root,
+                includingPropertiesForKeys: [.isApplicationKey, .localizedNameKey],
+                options: [.skipsHiddenFiles, .skipsPackageDescendants]
+              ) else {
+            return
+        }
+
+        for case let url as URL in enumerator where url.pathExtension == "app" {
+            indexApplication(url, into: &urlsByName)
+        }
+    }
+
+    private func indexApplication(_ applicationURL: URL, into urlsByName: inout [String: URL]) {
+        cacheApplicationName(applicationURL.deletingPathExtension().lastPathComponent, for: applicationURL, in: &urlsByName)
+
+        if let localizedName = try? applicationURL.resourceValues(forKeys: [.localizedNameKey]).localizedName {
+            cacheApplicationName(localizedName, for: applicationURL, in: &urlsByName)
+        }
+
+        guard let bundle = Bundle(url: applicationURL) else { return }
+
+        if let bundleName = bundle.object(forInfoDictionaryKey: "CFBundleName") as? String {
+            cacheApplicationName(bundleName, for: applicationURL, in: &urlsByName)
+        }
+
+        if let displayName = bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String {
+            cacheApplicationName(displayName, for: applicationURL, in: &urlsByName)
+        }
+    }
+
+    private func cacheApplicationName(_ name: String, for applicationURL: URL, in urlsByName: inout [String: URL]) {
+        let normalizedName = normalizedApplicationName(name)
+        guard !normalizedName.isEmpty, urlsByName[normalizedName] == nil else { return }
+        urlsByName[normalizedName] = applicationURL
+    }
+
+    private func normalizedApplicationName(_ name: String) -> String {
+        name
+            .replacingOccurrences(of: ".app", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
     }
     
     private func resizedIcon(_ image: NSImage, to size: CGFloat) -> NSImage {
@@ -87,7 +169,6 @@ class QuickShareService: ObservableObject {
             if !providers.contains(provider) {
                 providers.append(provider)
                 cachedServices[title] = svc
-                cachedIcons[title] = svc.image
             }
         }
         

--- a/boringNotch/components/Shelf/Views/FileShareView.swift
+++ b/boringNotch/components/Shelf/Views/FileShareView.swift
@@ -20,7 +20,7 @@ struct FileShareView: View {
     @State private var isProcessing = false
     
     private var selectedProvider: QuickShareProvider {
-        quickShare.availableProviders.first(where: { $0.id == quickShareProvider }) ?? QuickShareProvider(id: "System Share Menu", supportsRawText: true)
+        quickShare.availableProviders.first(where: { $0.id == quickShareProvider }) ?? .systemShareMenu
     }
 
     var body: some View {


### PR DESCRIPTION
This pull request enhances the `QuickShareService` in `boringNotch/components/Shelf/Services/QuickShareService.swift` to improve how application icons are retrieved and cached for sharing providers. The main changes introduce a more robust mechanism for finding and caching application icons by indexing installed applications and normalizing their names, which helps ensure the correct icon is displayed for each provider.