### PR TITLE
Guard shelf state and stabilize settings tab selection

### DIFF
--- a/boringNotch/BoringViewCoordinator.swift
+++ b/boringNotch/BoringViewCoordinator.swift
@@ -99,6 +99,7 @@ class BoringViewCoordinator: ObservableObject {
     @Published var optionKeyPressed: Bool = true
     private var accessibilityObserver: Any?
     private var osdReplacementCancellable: AnyCancellable?
+    private var boringShelfCancellable: AnyCancellable?
     private var osdSourceCancellables: [AnyCancellable] = []
 
     private init() {
@@ -162,6 +163,15 @@ class BoringViewCoordinator: ObservableObject {
             Defaults.publisher(.osdBrightnessSource).sink { [weak self] _ in Task { @MainActor in self?.applyOSDSources() } },
             Defaults.publisher(.osdVolumeSource).sink { [weak self] _ in Task { @MainActor in self?.applyOSDSources() } }
         ]
+        boringShelfCancellable = Defaults.publisher(.boringShelf)
+            .sink { [weak self] change in
+                Task { @MainActor in
+                    guard let self = self else { return }
+                    if !change.newValue && self.currentView == .shelf {
+                        self.currentView = .home
+                    }
+                }
+            }
 
         Task { @MainActor in
             helloAnimationRunning = firstLaunch

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -254,7 +254,7 @@ struct ContentView: View {
             anyDropDebounceTask?.cancel()
 
             if isTargeted {
-                if vm.notchState == .closed {
+                if Defaults[.boringShelf] && vm.notchState == .closed {
                     if doOpen() {
                         coordinator.currentView = .shelf
                     }

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -249,6 +249,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func handleDragEntersNotchRegion(onScreen screen: NSScreen) {
+        guard Defaults[.boringShelf] else { return }
         guard let uuid = screen.displayUUID else { return }
         
         if Defaults[.showOnAllDisplays], let viewModel = viewModels[uuid] {

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -9,8 +9,56 @@ import Sparkle
 import SwiftUI
 import SwiftUIIntrospect
 
+private enum SettingsTab: String, CaseIterable, Identifiable {
+    case general
+    case appearance
+    case media
+    case calendar
+    case osd
+    case battery
+    case shelf
+    case mirror
+    case shortcuts
+    case advanced
+    case about
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .general: "General"
+        case .appearance: "Appearance"
+        case .media: "Media"
+        case .calendar: "Calendar"
+        case .osd: "OSD"
+        case .battery: "Battery"
+        case .shelf: "Shelf"
+        case .mirror: "Mirror"
+        case .shortcuts: "Shortcuts"
+        case .advanced: "Advanced"
+        case .about: "About"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .general: "gear"
+        case .appearance: "eye"
+        case .media: "play.laptopcomputer"
+        case .calendar: "calendar"
+        case .osd: "dial.medium.fill"
+        case .battery: "battery.100.bolt"
+        case .shelf: "books.vertical"
+        case .mirror: "camera"
+        case .shortcuts: "keyboard"
+        case .advanced: "gearshape.2"
+        case .about: "info.circle"
+        }
+    }
+}
+
 struct SettingsView: View {
-    @State private var selectedTab = "General"
+    @State private var selectedTab: SettingsTab = .general
     @State private var accentColorUpdateTrigger = UUID()
 
     let updaterController: SPUStandardUpdaterController?
@@ -22,38 +70,9 @@ struct SettingsView: View {
     var body: some View {
         NavigationSplitView {
             List(selection: $selectedTab) {
-                NavigationLink(value: "General") {
-                    Label("General", systemImage: "gear")
-                }
-                NavigationLink(value: "Appearance") {
-                    Label("Appearance", systemImage: "eye")
-                }
-                NavigationLink(value: "Media") {
-                    Label("Media", systemImage: "play.laptopcomputer")
-                }
-                NavigationLink(value: "Calendar") {
-                    Label("Calendar", systemImage: "calendar")
-                }
-                NavigationLink(value: "OSD") {
-                    Label("OSD", systemImage: "dial.medium.fill")
-                }
-                NavigationLink(value: "Battery") {
-                    Label("Battery", systemImage: "battery.100.bolt")
-                }
-                NavigationLink(value: "Shelf") {
-                    Label("Shelf", systemImage: "books.vertical")
-                }
-                NavigationLink(value: "Mirror") {
-                    Label("Mirror", systemImage: "camera")
-                }
-                NavigationLink(value: "Shortcuts") {
-                    Label("Shortcuts", systemImage: "keyboard")
-                }
-                NavigationLink(value: "Advanced") {
-                    Label("Advanced", systemImage: "gearshape.2")
-                }
-                NavigationLink(value: "About") {
-                    Label("About", systemImage: "info.circle")
+                ForEach(SettingsTab.allCases) { tab in
+                    Label(tab.title, systemImage: tab.systemImage)
+                        .tag(tab)
                 }
             }
             .listStyle(SidebarListStyle())
@@ -63,27 +82,27 @@ struct SettingsView: View {
         } detail: {
             Group {
                 switch selectedTab {
-                case "General":
+                case .general:
                     GeneralSettings()
-                case "Appearance":
+                case .appearance:
                     Appearance()
-                case "Media":
+                case .media:
                     Media()
-                case "Calendar":
+                case .calendar:
                     CalendarSettings()
-                case "OSD":
+                case .osd:
                     OSDSettings()
-                case "Battery":
+                case .battery:
                     Charge()
-                case "Shelf":
+                case .shelf:
                     Shelf()
-                case "Mirror":
+                case .mirror:
                     MirrorSettings()
-                case "Shortcuts":
+                case .shortcuts:
                     Shortcuts()
-                case "Advanced":
+                case .advanced:
                     Advanced()
-                case "About":
+                case .about:
                     if let controller = updaterController {
                         About(updaterController: controller)
                     } else {
@@ -93,8 +112,6 @@ struct SettingsView: View {
                                 startingUpdater: false, updaterDelegate: nil,
                                 userDriverDelegate: nil))
                     }
-                default:
-                    GeneralSettings()
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -223,7 +223,7 @@ class BoringViewModel: NSObject, ObservableObject {
 
         // Set the current view to shelf if it contains files and the user enables openShelfByDefault
         // Otherwise, if the user has not enabled openLastShelfByDefault, set the view to home
-    if !ShelfStateViewModel.shared.isEmpty && Defaults[.openShelfByDefault] {
+        if Defaults[.boringShelf] && !ShelfStateViewModel.shared.isEmpty && Defaults[.openShelfByDefault] {
             coordinator.currentView = .shelf
         } else if !coordinator.openLastTabByDefault {
             coordinator.currentView = .home


### PR DESCRIPTION
This pull request introduces improvements to the shelf feature and refactors the settings navigation in the application. Enabling or restricting shelf-related behaviors based on the new `boringShelf` setting, and refactoring the settings sidebar to use a type-safe enum for tabs instead of string literals, which improves maintainability and scalability.