### PR TITLE
Enhance audio visualizer with FFT option

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -1354,7 +1354,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.2;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = "2.8-beta.0";
 				PRODUCT_BUNDLE_IDENTIFIER = theboringteam.boringnotch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1420,7 +1420,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.2;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = "2.8-beta.0";
 				PRODUCT_BUNDLE_IDENTIFIER = theboringteam.boringnotch;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		B1D6FD432C6603730015F173 /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D6FD422C6603730015F173 /* SoftwareUpdater.swift */; };
 		B1F0A0022E60000100000001 /* BrightnessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0A0012E60000100000001 /* BrightnessManager.swift */; };
 		B1FEB4992C7686630066EBBC /* PanGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FEB4982C7686630066EBBC /* PanGesture.swift */; };
+		F1F2A0A100000000000000F1 /* AudioCaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */; };
 		F38DE6482D8243E7008B5C6D /* BatteryActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -336,6 +337,7 @@
 		B1D6FD422C6603730015F173 /* SoftwareUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdater.swift; sourceTree = "<group>"; };
 		B1F0A0012E60000100000001 /* BrightnessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrightnessManager.swift; sourceTree = "<group>"; };
 		B1FEB4982C7686630066EBBC /* PanGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanGesture.swift; sourceTree = "<group>"; };
+		F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureManager.swift; sourceTree = "<group>"; };
 		F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryActivityManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -609,6 +611,7 @@
 				F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */,
 				112FB7342CCF16F70015238C /* NotchSpaceManager.swift */,
 				147163992C5D35FF0068B555 /* MusicManager.swift */,
+				F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */,
 				149E0B962C737D00006418B1 /* WebcamManager.swift */,
 				14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */,
 			);
@@ -1035,6 +1038,7 @@
 				14C08BC12C8E03AD000F8AA0 /* NSImage+Extensions.swift in Sources */,
 				149E0B9A2C737D40006418B1 /* WebcamView.swift in Sources */,
 				1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */,
+				F1F2A0A100000000000000F1 /* AudioCaptureManager.swift in Sources */,
 				B1B112932C6A577E00093D8F /* MouseTracker.swift in Sources */,
 				B1C448962C9712C4001F0858 /* ActionBar.swift in Sources */,
 				118EBE312E9717DB00D54B5A /* URL+SecurityScoped.swift in Sources */,
@@ -1310,6 +1314,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				AUTOMATION_APPLE_EVENTS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = boringNotch/boringNotch.entitlements;
@@ -1323,6 +1328,12 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1343,11 +1354,17 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.2;
 				MARKETING_VERSION = "2.8-beta.0";
 				PRODUCT_BUNDLE_IDENTIFIER = theboringteam.boringnotch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
+				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 5.0;
@@ -1364,6 +1381,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				AUTOMATION_APPLE_EVENTS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = boringNotch/boringNotch.entitlements;
@@ -1377,6 +1395,12 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/mediaremote-adapter",
@@ -1396,11 +1420,17 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.2;
 				MARKETING_VERSION = "2.8-beta.0";
 				PRODUCT_BUNDLE_IDENTIFIER = theboringteam.boringnotch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
+				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 5.0;

--- a/boringNotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/boringNotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/swiftui-introspect",
       "state" : {
-        "revision" : "26986a57e31c813f98262ddb62d4b07d40008535",
-        "version" : "26.0.1"
+        "revision" : "807f73ce09a9b9723f12385e592b4e0aaebd3336",
+        "version" : "1.3.0"
       }
     }
   ],

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -96,7 +96,7 @@ struct ContentView: View {
             && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle)
             && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed
         {
-            chinWidth += (2 * max(0, displayClosedNotchHeight - 12) + 20)
+            chinWidth += (2 * max(0, displayClosedNotchHeight - 12) + 20 + 2 * liveActivityEdgeMargin + 2)
         } else if !coordinator.expandingView.show && vm.notchState == .closed
             && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace]
             && !vm.hideOnClosed
@@ -507,8 +507,7 @@ struct ContentView: View {
                         && coordinator.expandingView.type == .music
                         && Defaults[.sneakPeekStyles] == .inline)
                         ? 380
-                        : vm.closedNotchSize.width
-                            + -cornerRadiusInsets.closed.top
+                        : vm.closedNotchSize.width - 4 + (2 * liveActivityEdgeMargin)
                 )
 
             HStack {
@@ -518,7 +517,7 @@ struct ContentView: View {
                     ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.5)
                     : Color.gray
                 )
-                .frame(width: 16, height: 12)
+                .frame(width: 18, height: 12)
             }
             .frame(
                 width: max(

--- a/boringNotch/Info.plist
+++ b/boringNotch/Info.plist
@@ -11,6 +11,8 @@
 	<string>Boring Notch</string>
 	<key>SUEnableAutomaticChecks</key>
 	<false/>
+	<key>NSAudioCaptureUsageDescription</key>
+	<string>boring.notch analyzes audio from your music app to draw a real-time waveform in the notch. Audio is processed locally and never leaves your Mac.</string>
 	<key>SUEnableDownloaderService</key>
 	<true/>
 	<key>SUEnableInstallerLauncherService</key>

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -10026,6 +10026,9 @@
     "Real-time audio waveform" : {
 
     },
+    "Requires macOS 14.2 or later. Update macOS to enable real-time audio waveform." : {
+
+    },
     "Release name" : {
       "localizations" : {
         "cs" : {
@@ -13386,7 +13389,7 @@
         }
       }
     },
-    "Uses Accelerate FFT on the playing app's audio. Requires audio capture permission and macOS 14.2+. Uses slightly more CPU." : {
+    "Uses Accelerate FFT on the playing app's audio. Requires audio capture permission and uses slightly more CPU." : {
 
     },
     "Using System Accent" : {

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -10023,6 +10023,9 @@
         }
       }
     },
+    "Real-time audio waveform" : {
+
+    },
     "Release name" : {
       "localizations" : {
         "cs" : {
@@ -13382,6 +13385,9 @@
           }
         }
       }
+    },
+    "Uses Accelerate FFT on the playing app's audio. Requires audio capture permission and macOS 14.2+. Uses slightly more CPU." : {
+
     },
     "Using System Accent" : {
       "localizations" : {

--- a/boringNotch/MediaControllers/NowPlayingController.swift
+++ b/boringNotch/MediaControllers/NowPlayingController.swift
@@ -231,6 +231,24 @@ final class NowPlayingController: ObservableObject, MediaControllerProtocol {
         let diff = update.diff ?? false
 
         var newPlaybackState = PlaybackState(bundleIdentifier: playbackState.bundleIdentifier)
+        let resolvedBundleIdentifier = (
+            payload.parentApplicationBundleIdentifier ??
+            payload.bundleIdentifier ??
+            (diff ? self.playbackState.bundleIdentifier : "")
+        )
+        let captureBundleFallbackIdentifiers: [String]
+        if diff {
+            captureBundleFallbackIdentifiers =
+                resolvedBundleIdentifier != self.playbackState.bundleIdentifier
+                ? [resolvedBundleIdentifier]
+                : self.playbackState.effectiveAudioCaptureBundleIdentifiers
+        } else {
+            captureBundleFallbackIdentifiers = [resolvedBundleIdentifier]
+        }
+        let captureBundleIdentifiers = Self.audioCaptureBundleIdentifiers(
+            sourceBundleIdentifier: payload.bundleIdentifier,
+            fallbackBundleIdentifiers: captureBundleFallbackIdentifiers
+        )
         
         newPlaybackState.title = payload.title ?? (diff ? self.playbackState.title : "")
         newPlaybackState.artist = payload.artist ?? (diff ? self.playbackState.artist : "")
@@ -285,11 +303,8 @@ final class NowPlayingController: ObservableObject, MediaControllerProtocol {
 
         newPlaybackState.playbackRate = payload.playbackRate ?? (diff ? self.playbackState.playbackRate : 1.0)
         newPlaybackState.isPlaying = payload.playing ?? (diff ? self.playbackState.isPlaying : false)
-        newPlaybackState.bundleIdentifier = (
-            payload.parentApplicationBundleIdentifier ??
-            payload.bundleIdentifier ??
-            (diff ? self.playbackState.bundleIdentifier : "")
-        )
+        newPlaybackState.bundleIdentifier = resolvedBundleIdentifier
+        newPlaybackState.audioCaptureBundleIdentifiers = captureBundleIdentifiers
         
         newPlaybackState.volume = payload.volume ?? (diff ? self.playbackState.volume : 0.5)
         
@@ -323,6 +338,23 @@ final class NowPlayingController: ObservableObject, MediaControllerProtocol {
          }
      }
     
+}
+
+private extension NowPlayingController {
+    static func audioCaptureBundleIdentifiers(
+        sourceBundleIdentifier: String?,
+        fallbackBundleIdentifiers: [String]
+    ) -> [String] {
+        let preferred = sourceBundleIdentifier.map { [$0] } ?? fallbackBundleIdentifiers
+        let normalized = preferred.filter { !$0.isEmpty }
+
+        var seen = Set<String>()
+        return normalized.filter { bundleID in
+            guard !seen.contains(bundleID) else { return false }
+            seen.insert(bundleID)
+            return true
+        }
+    }
 }
 
 struct NowPlayingUpdate: Codable {

--- a/boringNotch/MediaControllers/NowPlayingController.swift
+++ b/boringNotch/MediaControllers/NowPlayingController.swift
@@ -346,14 +346,7 @@ private extension NowPlayingController {
         fallbackBundleIdentifiers: [String]
     ) -> [String] {
         let preferred = sourceBundleIdentifier.map { [$0] } ?? fallbackBundleIdentifiers
-        let normalized = preferred.filter { !$0.isEmpty }
-
-        var seen = Set<String>()
-        return normalized.filter { bundleID in
-            guard !seen.contains(bundleID) else { return false }
-            seen.insert(bundleID)
-            return true
-        }
+        return preferred.normalizedBundleIdentifiers
     }
 }
 

--- a/boringNotch/boringNotch.entitlements
+++ b/boringNotch/boringNotch.entitlements
@@ -6,9 +6,9 @@
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
-	<key>com.apple.security.device.camera</key>
+	<key>com.apple.security.device.audio-input</key>
 	<true/>
-	<key>com.apple.security.personal-information.calendars</key>
+	<key>com.apple.security.device.camera</key>
 	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>
 	<true/>
@@ -19,6 +19,8 @@
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.personal-information.calendars</key>
 	<true/>
 	<key>com.apple.security.temporary-exception.apple-events</key>
 	<array>

--- a/boringNotch/components/Music/MusicVisualizer.swift
+++ b/boringNotch/components/Music/MusicVisualizer.swift
@@ -6,6 +6,7 @@
 //
 import AppKit
 import Cocoa
+import Combine
 import Defaults
 import SwiftUI
 
@@ -14,6 +15,12 @@ class AudioSpectrum: NSView {
     private var isPlaying = false
     private var useRealtime = false
     private var tintColor: NSColor = .systemBlue
+    private var lastTintColor: NSColor?
+
+    private var levelsCancellable: AnyCancellable?
+    private var lastAppliedLevels: [Float]
+    private static let levelChangeThreshold: Float = 0.005
+    private static let minBarScale: CGFloat = 0.12
 
     private let barWidth: CGFloat = 2
     private let barCount = AudioCaptureManager.barCount
@@ -21,12 +28,14 @@ class AudioSpectrum: NSView {
     private let totalHeight: CGFloat = 14
 
     override init(frame frameRect: NSRect) {
+        self.lastAppliedLevels = [Float](repeating: 0, count: AudioCaptureManager.barCount)
         super.init(frame: frameRect)
         wantsLayer = true
         setupBars()
     }
 
     required init?(coder: NSCoder) {
+        self.lastAppliedLevels = [Float](repeating: 0, count: AudioCaptureManager.barCount)
         super.init(coder: coder)
         wantsLayer = true
         setupBars()
@@ -145,6 +154,8 @@ class AudioSpectrum: NSView {
     func setUseRealtime(_ enabled: Bool) {
         guard useRealtime != enabled else { return }
         useRealtime = enabled
+        // Force the next incoming frame through the threshold guard.
+        for i in 0..<lastAppliedLevels.count { lastAppliedLevels[i] = -1 }
         guard isPlaying else { return }
         if enabled {
             stopRandomAnimating()
@@ -159,19 +170,38 @@ class AudioSpectrum: NSView {
         }
     }
 
-    func setLevels(_ values: [CGFloat]) {
+    func attach(to manager: AudioCaptureManager) {
+        guard levelsCancellable == nil else { return }
+        levelsCancellable = manager.levelsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] values in
+                self?.applyLevels(values)
+            }
+    }
+
+    private func applyLevels(_ values: [Float]) {
         guard isPlaying, useRealtime, values.count == barCount else { return }
+        var maxDelta: Float = 0
+        for i in 0..<barCount {
+            let d = abs(values[i] - lastAppliedLevels[i])
+            if d > maxDelta { maxDelta = d }
+        }
+        guard maxDelta >= Self.levelChangeThreshold else { return }
         CATransaction.begin()
         CATransaction.setAnimationDuration(0.033)
         CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .linear))
-        for (i, barLayer) in barLayers.enumerated() {
-            let clamped = max(0.12, min(1.0, values[i]))
-            barLayer.transform = CATransform3DMakeScale(1.0, clamped, 1.0)
+        for i in 0..<barCount {
+            let v = values[i]
+            lastAppliedLevels[i] = v
+            let clamped = max(Self.minBarScale, min(1.0, CGFloat(v)))
+            barLayers[i].transform = CATransform3DMakeScale(1.0, clamped, 1.0)
         }
         CATransaction.commit()
     }
 
     func setTintColor(_ color: NSColor) {
+        if let last = lastTintColor, last.isEqual(color) { return }
+        lastTintColor = color
         tintColor = color
         let colors = [color.withAlphaComponent(0.6).cgColor, color.cgColor]
         barLayers.forEach { $0.colors = colors }
@@ -182,16 +212,14 @@ struct AudioSpectrumView: NSViewRepresentable {
     let isPlaying: Bool
     let tintColor: Color
     @Default(.realtimeAudioWaveform) var realtimeEnabled: Bool
-    @ObservedObject var audioCapture = AudioCaptureManager.shared
+    @ObservedObject private var audioCapture = AudioCaptureManager.shared
 
     func makeNSView(context: Context) -> AudioSpectrum {
         let spectrum = AudioSpectrum()
+        spectrum.attach(to: audioCapture)
         spectrum.setTintColor(NSColor(tintColor))
         spectrum.setUseRealtime(realtimeEnabled && audioCapture.isCapturing)
         spectrum.setPlaying(isPlaying)
-        if realtimeEnabled && audioCapture.isCapturing {
-            spectrum.setLevels(audioCapture.levels)
-        }
         return spectrum
     }
 
@@ -199,9 +227,6 @@ struct AudioSpectrumView: NSViewRepresentable {
         nsView.setTintColor(NSColor(tintColor))
         nsView.setUseRealtime(realtimeEnabled && audioCapture.isCapturing)
         nsView.setPlaying(isPlaying)
-        if realtimeEnabled && audioCapture.isCapturing {
-            nsView.setLevels(audioCapture.levels)
-        }
     }
 }
 

--- a/boringNotch/components/Music/MusicVisualizer.swift
+++ b/boringNotch/components/Music/MusicVisualizer.swift
@@ -6,24 +6,26 @@
 //
 import AppKit
 import Cocoa
+import Defaults
 import SwiftUI
 
 class AudioSpectrum: NSView {
     private var barLayers: [CAGradientLayer] = []
     private var isPlaying = false
+    private var useRealtime = false
     private var tintColor: NSColor = .systemBlue
-    
+
     private let barWidth: CGFloat = 2
-    private let barCount = 4
-    private let spacing: CGFloat = 2
+    private let barCount = AudioCaptureManager.barCount
+    private let spacing: CGFloat = 1
     private let totalHeight: CGFloat = 14
-    
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
         setupBars()
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         wantsLayer = true
@@ -31,7 +33,7 @@ class AudioSpectrum: NSView {
     }
 
     private func setupBars() {
-        let totalWidth = CGFloat(barCount) * (barWidth + spacing)
+        let totalWidth = CGFloat(barCount) * barWidth + CGFloat(barCount - 1) * spacing
         if frame.width < totalWidth {
             frame.size = CGSize(width: totalWidth, height: totalHeight)
         }
@@ -39,8 +41,8 @@ class AudioSpectrum: NSView {
         for i in 0..<barCount {
             let xPosition = CGFloat(i) * (barWidth + spacing)
             let barLayer = CAGradientLayer()
-            barLayer.frame = CGRect(x: xPosition, y: 0, width: barWidth, height: totalHeight)
             barLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+            barLayer.bounds = CGRect(x: 0, y: 0, width: barWidth, height: barWidth)
             barLayer.position = CGPoint(x: xPosition + barWidth / 2, y: totalHeight / 2)
             barLayer.cornerRadius = barWidth / 2
             barLayer.contentsScale = scale
@@ -48,15 +50,45 @@ class AudioSpectrum: NSView {
             barLayer.startPoint = CGPoint(x: 0.5, y: 0)
             barLayer.endPoint = CGPoint(x: 0.5, y: 1)
             barLayer.colors = [tintColor.withAlphaComponent(0.6).cgColor, tintColor.cgColor]
-            barLayer.transform = CATransform3DMakeScale(1.0, 0.3, 1.0)
             layer?.addSublayer(barLayer)
             barLayers.append(barLayer)
         }
     }
 
-    private func startAnimating() {
+    private func expandBars(animated: Bool) {
+        CATransaction.begin()
+        if animated {
+            CATransaction.setAnimationDuration(0.3)
+            CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
+        } else {
+            CATransaction.setDisableActions(true)
+        }
         for (index, barLayer) in barLayers.enumerated() {
-            animateBar(barLayer, delay: Double(index) * 0.1)
+            let x = CGFloat(index) * (barWidth + spacing)
+            barLayer.bounds = CGRect(x: 0, y: 0, width: barWidth, height: totalHeight)
+            barLayer.position = CGPoint(x: x + barWidth / 2, y: totalHeight / 2)
+            barLayer.transform = CATransform3DMakeScale(1.0, 0.3, 1.0)
+        }
+        CATransaction.commit()
+    }
+
+    private func collapseBarsToDots() {
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(0.3)
+        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
+        for (index, barLayer) in barLayers.enumerated() {
+            barLayer.removeAnimation(forKey: "scaleAnimation")
+            barLayer.transform = CATransform3DIdentity
+            let x = CGFloat(index) * (barWidth + spacing)
+            barLayer.bounds = CGRect(x: 0, y: 0, width: barWidth, height: barWidth)
+            barLayer.position = CGPoint(x: x + barWidth / 2, y: totalHeight / 2)
+        }
+        CATransaction.commit()
+    }
+
+    private func startRandomAnimating() {
+        for (index, barLayer) in barLayers.enumerated() {
+            animateBar(barLayer, delay: Double(index) * 0.08)
         }
     }
 
@@ -68,9 +100,7 @@ class AudioSpectrum: NSView {
         let numSteps = 50
         let startValue = CGFloat.random(in: 0.3...1.0)
         for i in 0...numSteps {
-            if i == 0 {
-                values.append(startValue)
-            } else if i == numSteps {
+            if i == 0 || i == numSteps {
                 values.append(startValue)
             } else {
                 values.append(CGFloat.random(in: 0.3...1.0))
@@ -93,22 +123,52 @@ class AudioSpectrum: NSView {
         barLayer.add(animation, forKey: "scaleAnimation")
     }
 
-    private func stopAnimating() {
-        isPlaying = false
-        CATransaction.begin()
-        CATransaction.setAnimationDuration(0.3)
-        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
+    private func stopRandomAnimating() {
         for barLayer in barLayers {
             barLayer.removeAnimation(forKey: "scaleAnimation")
-            barLayer.transform = CATransform3DMakeScale(1.0, 0.35, 1.0)
         }
-        CATransaction.commit()
     }
 
     func setPlaying(_ playing: Bool) {
         guard isPlaying != playing else { return }
         isPlaying = playing
-        playing ? startAnimating() : stopAnimating()
+        if playing {
+            expandBars(animated: true)
+            if !useRealtime {
+                startRandomAnimating()
+            }
+        } else {
+            collapseBarsToDots()
+        }
+    }
+
+    func setUseRealtime(_ enabled: Bool) {
+        guard useRealtime != enabled else { return }
+        useRealtime = enabled
+        guard isPlaying else { return }
+        if enabled {
+            stopRandomAnimating()
+        } else {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            for barLayer in barLayers {
+                barLayer.transform = CATransform3DMakeScale(1.0, 0.3, 1.0)
+            }
+            CATransaction.commit()
+            startRandomAnimating()
+        }
+    }
+
+    func setLevels(_ values: [CGFloat]) {
+        guard isPlaying, useRealtime, values.count == barCount else { return }
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(0.033)
+        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .linear))
+        for (i, barLayer) in barLayers.enumerated() {
+            let clamped = max(0.12, min(1.0, values[i]))
+            barLayer.transform = CATransform3DMakeScale(1.0, clamped, 1.0)
+        }
+        CATransaction.commit()
     }
 
     func setTintColor(_ color: NSColor) {
@@ -121,17 +181,27 @@ class AudioSpectrum: NSView {
 struct AudioSpectrumView: NSViewRepresentable {
     let isPlaying: Bool
     let tintColor: Color
-    
+    @Default(.realtimeAudioWaveform) var realtimeEnabled: Bool
+    @ObservedObject var audioCapture = AudioCaptureManager.shared
+
     func makeNSView(context: Context) -> AudioSpectrum {
         let spectrum = AudioSpectrum()
         spectrum.setTintColor(NSColor(tintColor))
+        spectrum.setUseRealtime(realtimeEnabled && audioCapture.isCapturing)
         spectrum.setPlaying(isPlaying)
+        if realtimeEnabled && audioCapture.isCapturing {
+            spectrum.setLevels(audioCapture.levels)
+        }
         return spectrum
     }
-    
+
     func updateNSView(_ nsView: AudioSpectrum, context: Context) {
         nsView.setTintColor(NSColor(tintColor))
+        nsView.setUseRealtime(realtimeEnabled && audioCapture.isCapturing)
         nsView.setPlaying(isPlaying)
+        if realtimeEnabled && audioCapture.isCapturing {
+            nsView.setLevels(audioCapture.levels)
+        }
     }
 }
 
@@ -139,7 +209,7 @@ struct AudioSpectrumView: NSViewRepresentable {
     ZStack {
         Color.black
         AudioSpectrumView(isPlaying: true, tintColor: .green)
-            .frame(width: 20, height: 14)
+            .frame(width: 18, height: 14)
     }
     .padding()
 }

--- a/boringNotch/components/Music/MusicVisualizer.swift
+++ b/boringNotch/components/Music/MusicVisualizer.swift
@@ -6,18 +6,17 @@
 //
 import AppKit
 import Cocoa
-import Combine
 import Defaults
 import SwiftUI
 
-class AudioSpectrum: NSView {
+class AudioSpectrum: NSView, AudioCaptureLevelsConsumer {
     private var barLayers: [CAGradientLayer] = []
     private var isPlaying = false
     private var useRealtime = false
     private var tintColor: NSColor = .systemBlue
     private var lastTintColor: NSColor?
 
-    private var levelsCancellable: AnyCancellable?
+    private weak var attachedManager: AudioCaptureManager?
     private var lastAppliedLevels: [Float]
     private static let levelChangeThreshold: Float = 0.005
     private static let minBarScale: CGFloat = 0.12
@@ -39,6 +38,10 @@ class AudioSpectrum: NSView {
         super.init(coder: coder)
         wantsLayer = true
         setupBars()
+    }
+
+    deinit {
+        attachedManager?.clearLevelsConsumer(self)
     }
 
     private func setupBars() {
@@ -171,12 +174,20 @@ class AudioSpectrum: NSView {
     }
 
     func attach(to manager: AudioCaptureManager) {
-        guard levelsCancellable == nil else { return }
-        levelsCancellable = manager.levelsPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] values in
-                self?.applyLevels(values)
-            }
+        guard attachedManager !== manager else { return }
+        attachedManager?.clearLevelsConsumer(self)
+        attachedManager = manager
+        manager.setLevelsConsumer(self)
+    }
+
+    func syncCurrentLevels(from manager: AudioCaptureManager) {
+        guard attachedManager === manager,
+              let values = manager.latestLevelsSnapshot() else { return }
+        applyLevels(values)
+    }
+
+    func audioCaptureManager(_ manager: AudioCaptureManager, didProduceLevels values: [Float]) {
+        applyLevels(values)
     }
 
     private func applyLevels(_ values: [Float]) {
@@ -188,8 +199,7 @@ class AudioSpectrum: NSView {
         }
         guard maxDelta >= Self.levelChangeThreshold else { return }
         CATransaction.begin()
-        CATransaction.setAnimationDuration(0.033)
-        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .linear))
+        CATransaction.setDisableActions(true)
         for i in 0..<barCount {
             let v = values[i]
             lastAppliedLevels[i] = v
@@ -216,10 +226,11 @@ struct AudioSpectrumView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> AudioSpectrum {
         let spectrum = AudioSpectrum()
-        spectrum.attach(to: audioCapture)
         spectrum.setTintColor(NSColor(tintColor))
         spectrum.setUseRealtime(realtimeEnabled && audioCapture.isCapturing)
         spectrum.setPlaying(isPlaying)
+        spectrum.attach(to: audioCapture)
+        spectrum.syncCurrentLevels(from: audioCapture)
         return spectrum
     }
 
@@ -227,6 +238,7 @@ struct AudioSpectrumView: NSViewRepresentable {
         nsView.setTintColor(NSColor(tintColor))
         nsView.setUseRealtime(realtimeEnabled && audioCapture.isCapturing)
         nsView.setPlaying(isPlaying)
+        nsView.syncCurrentLevels(from: audioCapture)
     }
 }
 

--- a/boringNotch/components/Music/MusicVisualizer.swift
+++ b/boringNotch/components/Music/MusicVisualizer.swift
@@ -20,6 +20,8 @@ class AudioSpectrum: NSView, AudioCaptureLevelsConsumer {
     private var lastAppliedLevels: [Float]
     private static let levelChangeThreshold: Float = 0.005
     private static let minBarScale: CGFloat = 0.12
+    private static let idleBarScale: CGFloat = 0.3
+    private static let animationKey = "scaleAnimation"
 
     private let barWidth: CGFloat = 2
     private let barCount = AudioCaptureManager.barCount
@@ -51,11 +53,9 @@ class AudioSpectrum: NSView, AudioCaptureLevelsConsumer {
         }
         let scale = NSScreen.main?.backingScaleFactor ?? 2.0
         for i in 0..<barCount {
-            let xPosition = CGFloat(i) * (barWidth + spacing)
             let barLayer = CAGradientLayer()
             barLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
-            barLayer.bounds = CGRect(x: 0, y: 0, width: barWidth, height: barWidth)
-            barLayer.position = CGPoint(x: xPosition + barWidth / 2, y: totalHeight / 2)
+            applyFrame(to: barLayer, at: i, height: barWidth)
             barLayer.cornerRadius = barWidth / 2
             barLayer.contentsScale = scale
             barLayer.shouldRasterize = false
@@ -76,10 +76,8 @@ class AudioSpectrum: NSView, AudioCaptureLevelsConsumer {
             CATransaction.setDisableActions(true)
         }
         for (index, barLayer) in barLayers.enumerated() {
-            let x = CGFloat(index) * (barWidth + spacing)
-            barLayer.bounds = CGRect(x: 0, y: 0, width: barWidth, height: totalHeight)
-            barLayer.position = CGPoint(x: x + barWidth / 2, y: totalHeight / 2)
-            barLayer.transform = CATransform3DMakeScale(1.0, 0.3, 1.0)
+            applyFrame(to: barLayer, at: index, height: totalHeight)
+            barLayer.transform = CATransform3DMakeScale(1.0, Self.idleBarScale, 1.0)
         }
         CATransaction.commit()
     }
@@ -89,11 +87,9 @@ class AudioSpectrum: NSView, AudioCaptureLevelsConsumer {
         CATransaction.setAnimationDuration(0.3)
         CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
         for (index, barLayer) in barLayers.enumerated() {
-            barLayer.removeAnimation(forKey: "scaleAnimation")
+            barLayer.removeAnimation(forKey: Self.animationKey)
             barLayer.transform = CATransform3DIdentity
-            let x = CGFloat(index) * (barWidth + spacing)
-            barLayer.bounds = CGRect(x: 0, y: 0, width: barWidth, height: barWidth)
-            barLayer.position = CGPoint(x: x + barWidth / 2, y: totalHeight / 2)
+            applyFrame(to: barLayer, at: index, height: barWidth)
         }
         CATransaction.commit()
     }
@@ -132,12 +128,12 @@ class AudioSpectrum: NSView, AudioCaptureLevelsConsumer {
         CATransaction.setDisableActions(true)
         barLayer.transform = CATransform3DMakeScale(1.0, startValue, 1.0)
         CATransaction.commit()
-        barLayer.add(animation, forKey: "scaleAnimation")
+        barLayer.add(animation, forKey: Self.animationKey)
     }
 
     private func stopRandomAnimating() {
         for barLayer in barLayers {
-            barLayer.removeAnimation(forKey: "scaleAnimation")
+            barLayer.removeAnimation(forKey: Self.animationKey)
         }
     }
 
@@ -166,7 +162,7 @@ class AudioSpectrum: NSView, AudioCaptureLevelsConsumer {
             CATransaction.begin()
             CATransaction.setDisableActions(true)
             for barLayer in barLayers {
-                barLayer.transform = CATransform3DMakeScale(1.0, 0.3, 1.0)
+                barLayer.transform = CATransform3DMakeScale(1.0, Self.idleBarScale, 1.0)
             }
             CATransaction.commit()
             startRandomAnimating()
@@ -215,6 +211,12 @@ class AudioSpectrum: NSView, AudioCaptureLevelsConsumer {
         tintColor = color
         let colors = [color.withAlphaComponent(0.6).cgColor, color.cgColor]
         barLayers.forEach { $0.colors = colors }
+    }
+
+    private func applyFrame(to barLayer: CALayer, at index: Int, height: CGFloat) {
+        let x = CGFloat(index) * (barWidth + spacing)
+        barLayer.bounds = CGRect(x: 0, y: 0, width: barWidth, height: height)
+        barLayer.position = CGPoint(x: x + barWidth / 2, y: totalHeight / 2)
     }
 }
 

--- a/boringNotch/components/Onboarding/OnboardingView.swift
+++ b/boringNotch/components/Onboarding/OnboardingView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import AVFoundation
+import Defaults
 import Sparkle
 
 enum OnboardingStep {
@@ -14,6 +15,7 @@ enum OnboardingStep {
     case cameraPermission
     case calendarPermission
     case remindersPermission
+    case audioCapturePermission
     case accessibilityPermission
     case musicPermission
     case softwareUpdatePermission
@@ -93,17 +95,42 @@ struct OnboardingView: View {
                             Task {
                                 await requestRemindersPermission()
                                 withAnimation(.easeInOut(duration: 0.6)) {
-                                    step = .accessibilityPermission
+                                    step = nextStepAfterReminders()
                                 }
                             }
                         },
                         onSkip: {
                             withAnimation(.easeInOut(duration: 0.6)) {
-                                step = .accessibilityPermission
+                                step = nextStepAfterReminders()
                             }
                         }
                     )
                     .transition(.opacity)
+
+            case .audioCapturePermission:
+                PermissionRequestView(
+                    icon: Image(systemName: "waveform"),
+                    title: "Enable Real-Time Audio",
+                    description: "Boring Notch can analyze the audio playing from your music app to draw a live FFT waveform in the notch, with only a minimal impact on CPU usage.",
+                    privacyNote: "Audio is processed locally for the visualizer and never recorded, stored, or shared.",
+                    onAllow: {
+                        Task {
+                            let granted = await requestAudioCapturePermission()
+                            if granted {
+                                Defaults[.realtimeAudioWaveform] = true
+                            }
+                            withAnimation(.easeInOut(duration: 0.6)) {
+                                step = .accessibilityPermission
+                            }
+                        }
+                    },
+                    onSkip: {
+                        withAnimation(.easeInOut(duration: 0.6)) {
+                            step = .accessibilityPermission
+                        }
+                    }
+                )
+                .transition(.opacity)
                 
             case .accessibilityPermission:
                 PermissionRequestView(
@@ -169,6 +196,17 @@ struct OnboardingView: View {
 
     func requestRemindersPermission() async {
         _ = try? await calendarService.requestAccess(to: .reminder)
+    }
+
+    func requestAudioCapturePermission() async -> Bool {
+        await AudioCaptureManager.shared.requestAudioCapturePermission()
+    }
+
+    func nextStepAfterReminders() -> OnboardingStep {
+        if #available(macOS 14.2, *) {
+            return .audioCapturePermission
+        }
+        return .accessibilityPermission
     }
     
 }

--- a/boringNotch/components/Settings/Views/AppearanceSettingsView.swift
+++ b/boringNotch/components/Settings/Views/AppearanceSettingsView.swift
@@ -14,6 +14,14 @@ struct Appearance: View {
 
     let icons: [String] = ["logo2"]
     @State private var selectedIcon: String = "logo2"
+
+    private var realtimeAudioWaveformSupported: Bool {
+        if #available(macOS 14.2, *) {
+            return true
+        }
+        return false
+    }
+
     var body: some View {
         Form {
             Section {
@@ -33,11 +41,18 @@ struct Appearance: View {
                 Defaults.Toggle(key: .realtimeAudioWaveform) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Real-time audio waveform")
-                        Text("Uses Accelerate FFT on the playing app's audio. Requires audio capture permission and macOS 14.2+. Uses slightly more CPU.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                        Group {
+                            if realtimeAudioWaveformSupported {
+                                Text("Uses Accelerate FFT on the playing app's audio. Requires audio capture permission and uses slightly more CPU.")
+                            } else {
+                                Text("Requires macOS 14.2 or later. Update macOS to enable real-time audio waveform.")
+                            }
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                     }
                 }
+                .disabled(!realtimeAudioWaveformSupported)
                 Defaults.Toggle(key: .playerColorTinting) {
                     Text("Player tinting")
                 }

--- a/boringNotch/components/Settings/Views/AppearanceSettingsView.swift
+++ b/boringNotch/components/Settings/Views/AppearanceSettingsView.swift
@@ -30,6 +30,14 @@ struct Appearance: View {
                 Defaults.Toggle(key: .coloredSpectrogram) {
                     Text("Colored spectrogram")
                 }
+                Defaults.Toggle(key: .realtimeAudioWaveform) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Real-time audio waveform")
+                        Text("Uses Accelerate FFT on the playing app's audio. Requires audio capture permission and macOS 14.2+. Uses slightly more CPU.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
                 Defaults.Toggle(key: .playerColorTinting) {
                     Text("Player tinting")
                 }

--- a/boringNotch/managers/AudioCaptureManager.swift
+++ b/boringNotch/managers/AudioCaptureManager.swift
@@ -12,9 +12,14 @@ import AppKit
 import AudioToolbox
 import Combine
 import CoreAudio
+import Darwin
 import Defaults
 import Foundation
 import os
+
+protocol AudioCaptureLevelsConsumer: AnyObject {
+    func audioCaptureManager(_ manager: AudioCaptureManager, didProduceLevels values: [Float])
+}
 
 final class AudioCaptureManager: ObservableObject {
     static let shared = AudioCaptureManager()
@@ -23,12 +28,14 @@ final class AudioCaptureManager: ObservableObject {
     private static let fftSize = 1024
     private static let log2n: vDSP_Length = 10
     private static let ringCapacity = 4096
-    private static let floorDB: Float = -50
-    private static let ceilDB: Float = -25
+    private static let fftIntervalMilliseconds = 33
+    private static let fftLeewayMilliseconds = 0
+    private static let floorDB: Float = -58
+    private static let ceilDB: Float = -14
     private static let referenceHz: Double = 1000
+    private static let pinkCompensationSlopePerOctave: Double = 3.0
     private static let fftQueueKey = DispatchSpecificKey<Void>()
 
-    let levelsPublisher = PassthroughSubject<[Float], Never>()
     @Published private(set) var isCapturing: Bool = false
 
     private var cancellables = Set<AnyCancellable>()
@@ -36,12 +43,15 @@ final class AudioCaptureManager: ObservableObject {
     private var tapObjectID: AudioObjectID = kAudioObjectUnknown
     private var aggregateDeviceID: AudioDeviceID = 0
     private var ioProcID: AudioDeviceIOProcID?
-    private var currentPID: pid_t = 0
+    private var currentPIDs: [pid_t] = []
     private var sampleRate: Double = 48_000
 
     private let ringBuffer: UnsafeMutablePointer<Float>
     private var ringWrite: Int = 0
     private let ringLock = OSAllocatedUnfairLock()
+    private let levelsConsumerLock = OSAllocatedUnfairLock()
+    private let levelsConsumers = NSHashTable<AnyObject>.weakObjects()
+    private var latestLevels: [Float]?
 
     private let fft: vDSP.FFT<DSPSplitComplex>
     private let hannWindow: [Float]
@@ -100,6 +110,24 @@ final class AudioCaptureManager: ObservableObject {
         ringBuffer.deallocate()
     }
 
+    func setLevelsConsumer(_ consumer: AudioCaptureLevelsConsumer) {
+        levelsConsumerLock.lock()
+        defer { levelsConsumerLock.unlock() }
+        levelsConsumers.add(consumer)
+    }
+
+    func clearLevelsConsumer(_ consumer: AudioCaptureLevelsConsumer) {
+        levelsConsumerLock.lock()
+        defer { levelsConsumerLock.unlock() }
+        levelsConsumers.remove(consumer)
+    }
+
+    func latestLevelsSnapshot() -> [Float]? {
+        levelsConsumerLock.lock()
+        defer { levelsConsumerLock.unlock() }
+        return latestLevels
+    }
+
     // MARK: - State observation
 
     private func observeState() {
@@ -107,47 +135,164 @@ final class AudioCaptureManager: ObservableObject {
         let enabledPublisher = Defaults.publisher(.realtimeAudioWaveform)
             .map(\.newValue)
             .prepend(Defaults[.realtimeAudioWaveform])
+            .removeDuplicates()
 
-        Publishers.CombineLatest3(music.$isPlaying, music.$bundleIdentifier, enabledPublisher)
+        Publishers.CombineLatest4(
+            music.$isPlaying.removeDuplicates(),
+            music.$bundleIdentifier.removeDuplicates(),
+            music.$audioCaptureBundleIdentifiers.removeDuplicates(),
+            enabledPublisher
+        )
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] isPlaying, bundleID, enabled in
-                self?.evaluate(isPlaying: isPlaying, bundleID: bundleID, enabled: enabled)
+            .sink { [weak self] isPlaying, bundleID, captureBundleIDs, enabled in
+                self?.evaluate(
+                    isPlaying: isPlaying,
+                    displayBundleID: bundleID,
+                    captureBundleIDs: captureBundleIDs,
+                    enabled: enabled
+                )
             }
             .store(in: &cancellables)
     }
 
-    private func evaluate(isPlaying: Bool, bundleID: String?, enabled: Bool) {
+    private func evaluate(
+        isPlaying: Bool,
+        displayBundleID: String?,
+        captureBundleIDs: [String],
+        enabled: Bool
+    ) {
         guard #available(macOS 14.2, *),
               enabled, isPlaying,
-              let bundleID, !bundleID.isEmpty,
-              let pid = resolvePID(forBundleID: bundleID) else {
+              let resolvedDisplayBundleID = displayBundleID,
+              !resolvedDisplayBundleID.isEmpty else {
             if isCapturing { stopCapture() }
             return
         }
-        if isCapturing && pid == currentPID { return }
+        let resolvedPIDs = resolvePIDs(
+            displayBundleID: resolvedDisplayBundleID,
+            captureBundleIDs: captureBundleIDs
+        )
+        guard !resolvedPIDs.isEmpty else {
+            if isCapturing { stopCapture() }
+            return
+        }
+        if isCapturing && resolvedPIDs == currentPIDs { return }
         if isCapturing { stopCapture() }
-        startCapture(pid: pid)
+        startCapture(pids: resolvedPIDs)
     }
 
-    private func resolvePID(forBundleID bundleID: String) -> pid_t? {
-        NSRunningApplication
-            .runningApplications(withBundleIdentifier: bundleID)
-            .first?
-            .processIdentifier
+    private func resolvePIDs(displayBundleID: String, captureBundleIDs: [String]) -> [pid_t] {
+        let displayApps = NSRunningApplication.runningApplications(withBundleIdentifier: displayBundleID)
+        let displayNames = Set(displayApps.compactMap(\.localizedName))
+        let displayBundlePaths = Set(displayApps.compactMap(displayBundlePath(for:)))
+
+        let bundleIDs = Array(
+            Set(captureBundleIDs + [displayBundleID])
+        ).sorted()
+
+        var pidsByBundleID: [(pid: pid_t, bundleID: String)] = []
+        for bundleID in bundleIDs {
+            let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+            let requireDisplayAppTie = bundleID != displayBundleID && runningApps.count > 1
+            for app in runningApps {
+                guard shouldInclude(
+                    app: app,
+                    requireDisplayAppTie: requireDisplayAppTie,
+                    displayNames: displayNames,
+                    displayBundlePaths: displayBundlePaths
+                ) else { continue }
+                pidsByBundleID.append((pid: app.processIdentifier, bundleID: bundleID))
+            }
+        }
+
+        if pidsByBundleID.isEmpty {
+            return NSRunningApplication
+                .runningApplications(withBundleIdentifier: displayBundleID)
+                .map(\.processIdentifier)
+                .sorted()
+        }
+
+        let deduped = Dictionary(uniqueKeysWithValues: pidsByBundleID.map { ($0.pid, $0.bundleID) })
+        return deduped.keys.sorted()
+    }
+
+    private func shouldInclude(
+        app: NSRunningApplication,
+        requireDisplayAppTie: Bool,
+        displayNames: Set<String>,
+        displayBundlePaths: Set<String>
+    ) -> Bool {
+        guard requireDisplayAppTie else { return true }
+        if belongsToDisplayApplication(app, displayBundlePaths: displayBundlePaths) {
+            return true
+        }
+        guard let localizedName = app.localizedName, !displayNames.isEmpty else { return false }
+        return displayNames.contains { localizedName.localizedCaseInsensitiveContains($0) }
+    }
+
+    private func belongsToDisplayApplication(
+        _ app: NSRunningApplication,
+        displayBundlePaths: Set<String>
+    ) -> Bool {
+        guard !displayBundlePaths.isEmpty else { return false }
+
+        if let bundlePath = displayBundlePath(for: app),
+           displayBundlePaths.contains(where: { pathContainsApp($0, candidatePath: bundlePath) }) {
+            return true
+        }
+
+        guard let executablePath = executablePath(forPID: app.processIdentifier) else { return false }
+        return displayBundlePaths.contains { pathContainsApp($0, candidatePath: executablePath) }
+    }
+
+    private func displayBundlePath(for app: NSRunningApplication) -> String? {
+        if let bundlePath = app.bundleURL?.standardizedFileURL.path {
+            return bundlePath
+        }
+        guard let executablePath = executablePath(forPID: app.processIdentifier) else { return nil }
+        return outermostAppBundlePath(containing: executablePath)
+    }
+
+    private func executablePath(forPID pid: pid_t) -> String? {
+        var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+        let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+        guard length > 0 else { return nil }
+        return URL(fileURLWithPath: String(cString: buffer)).standardizedFileURL.path
+    }
+
+    private func outermostAppBundlePath(containing executablePath: String) -> String? {
+        let normalizedPath = URL(fileURLWithPath: executablePath).standardizedFileURL.path
+        let components = normalizedPath.split(separator: "/")
+        guard let appIndex = components.firstIndex(where: { $0.hasSuffix(".app") }) else { return nil }
+        return "/" + components[...appIndex].joined(separator: "/")
+    }
+
+    private func pathContainsApp(_ appPath: String, candidatePath: String) -> Bool {
+        let normalizedAppPath = URL(fileURLWithPath: appPath).standardizedFileURL.path
+        let normalizedCandidatePath = URL(fileURLWithPath: candidatePath).standardizedFileURL.path
+        return normalizedCandidatePath == normalizedAppPath
+            || normalizedCandidatePath.hasPrefix(normalizedAppPath + "/")
     }
 
     // MARK: - Capture lifecycle
 
     @available(macOS 14.2, *)
-    private func startCapture(pid: pid_t) {
-        currentPID = pid
-
-        guard let processObjectID = translatePIDToAudioObject(pid: pid) else {
-            NSLog("[AudioCaptureManager] Failed to translate PID \(pid) to AudioObjectID")
+    private func startCapture(pids: [pid_t]) {
+        let attachedProcesses = pids.compactMap { pid -> (pid: pid_t, objectID: AudioObjectID)? in
+            guard let objectID = translatePIDToAudioObject(pid: pid) else {
+                NSLog("[AudioCaptureManager] Failed to translate PID \(pid) to AudioObjectID")
+                return nil
+            }
+            return (pid: pid, objectID: objectID)
+        }
+        guard !attachedProcesses.isEmpty else {
+            currentPIDs.removeAll(keepingCapacity: true)
             return
         }
+        let resolvedProcessObjectIDs = attachedProcesses.map(\.objectID)
+        currentPIDs = attachedProcesses.map(\.pid)
 
-        let tapDescription = CATapDescription(monoMixdownOfProcesses: [processObjectID])
+        let tapDescription = CATapDescription(monoMixdownOfProcesses: resolvedProcessObjectIDs)
         tapDescription.muteBehavior = .unmuted
         tapDescription.isPrivate = true
         tapDescription.isExclusive = false
@@ -156,6 +301,7 @@ final class AudioCaptureManager: ObservableObject {
         let tapStatus = AudioHardwareCreateProcessTap(tapDescription, &newTapID)
         guard tapStatus == noErr, newTapID != kAudioObjectUnknown else {
             NSLog("[AudioCaptureManager] AudioHardwareCreateProcessTap failed: \(tapStatus)")
+            currentPIDs.removeAll(keepingCapacity: true)
             return
         }
         tapObjectID = newTapID
@@ -165,6 +311,7 @@ final class AudioCaptureManager: ObservableObject {
             selector: kAudioTapPropertyUID
         ) else {
             NSLog("[AudioCaptureManager] Failed to read tap UID")
+            currentPIDs.removeAll(keepingCapacity: true)
             cleanupTap()
             return
         }
@@ -206,6 +353,7 @@ final class AudioCaptureManager: ObservableObject {
         )
         guard aggStatus == noErr, newAggID != 0 else {
             NSLog("[AudioCaptureManager] AudioHardwareCreateAggregateDevice failed: \(aggStatus)")
+            currentPIDs.removeAll(keepingCapacity: true)
             cleanupTap()
             return
         }
@@ -219,6 +367,7 @@ final class AudioCaptureManager: ObservableObject {
         }
         guard ioStatus == noErr, let ioProc = newIOProc else {
             NSLog("[AudioCaptureManager] AudioDeviceCreateIOProcIDWithBlock failed: \(ioStatus)")
+            currentPIDs.removeAll(keepingCapacity: true)
             cleanupAggregate()
             cleanupTap()
             return
@@ -230,6 +379,7 @@ final class AudioCaptureManager: ObservableObject {
             NSLog("[AudioCaptureManager] AudioDeviceStart failed: \(startStatus)")
             AudioDeviceDestroyIOProcID(aggregateDeviceID, ioProc)
             ioProcID = nil
+            currentPIDs.removeAll(keepingCapacity: true)
             cleanupAggregate()
             cleanupTap()
             return
@@ -242,7 +392,7 @@ final class AudioCaptureManager: ObservableObject {
     private func stopCapture() {
         stopFFTTimer()
         teardownCapture()
-        currentPID = 0
+        currentPIDs.removeAll(keepingCapacity: true)
         syncOnFFTQueue {
             ringLock.lock()
             ringBuffer.update(repeating: 0, count: Self.ringCapacity)
@@ -255,10 +405,15 @@ final class AudioCaptureManager: ObservableObject {
             }
         }
         let zeros = [Float](repeating: 0, count: Self.barCount)
-        DispatchQueue.main.async { [weak self] in
+        let publishStoppedState = { [weak self] in
             guard let self else { return }
-            self.levelsPublisher.send(zeros)
             self.isCapturing = false
+            self.publishLevels(zeros)
+        }
+        if Thread.isMainThread {
+            publishStoppedState()
+        } else {
+            DispatchQueue.main.sync(execute: publishStoppedState)
         }
     }
 
@@ -301,6 +456,13 @@ final class AudioCaptureManager: ObservableObject {
 
         ringLock.lock()
         let cap = Self.ringCapacity
+        if frameCount >= cap {
+            let newestFrames = src.advanced(by: frameCount - cap)
+            memcpy(ringBuffer, newestFrames, cap * MemoryLayout<Float>.size)
+            ringWrite = 0
+            ringLock.unlock()
+            return
+        }
         let write = ringWrite
         let firstCount = min(frameCount, cap - write)
         memcpy(ringBuffer.advanced(by: write), src, firstCount * MemoryLayout<Float>.size)
@@ -319,7 +481,11 @@ final class AudioCaptureManager: ObservableObject {
 
     private func startFFTTimer() {
         let timer = DispatchSource.makeTimerSource(queue: fftQueue)
-        timer.schedule(deadline: .now(), repeating: .milliseconds(33))
+        timer.schedule(
+            deadline: .now(),
+            repeating: .milliseconds(Self.fftIntervalMilliseconds),
+            leeway: .milliseconds(Self.fftLeewayMilliseconds)
+        )
         timer.setEventHandler { [weak self] in self?.processFFT() }
         fftTimer = timer
         timer.resume()
@@ -402,8 +568,8 @@ final class AudioCaptureManager: ObservableObject {
         var maxDelta: Float = 0
         for i in 0..<Self.barCount {
             let target = barsBuf[i]
-            let decayed = smoothed[i] * 0.82
-            let next = target > decayed ? (decayed + (target - decayed) * 0.6) : decayed
+            let decayed = smoothed[i] * 0.86
+            let next = target > decayed ? (decayed + (target - decayed) * 0.58) : decayed
             smoothed[i] = next
             let clipped = max(0, min(1, next))
             barsBuf[i] = clipped
@@ -411,14 +577,33 @@ final class AudioCaptureManager: ObservableObject {
             if delta > maxDelta { maxDelta = delta }
         }
 
-        // Skip the hop to main + Combine fan-out when nothing perceptible changed.
-        // Stacks with the view-side threshold to collapse idle cost toward zero.
+        // Skip main-thread delivery when nothing perceptible changed.
         guard maxDelta > 1e-4 else { return }
         for i in 0..<Self.barCount {
             lastPublishedBuf[i] = barsBuf[i]
         }
-        let snapshot = barsBuf
-        levelsPublisher.send(snapshot)
+        publishLevels(barsBuf)
+    }
+
+    private func publishLevels(_ values: [Float]) {
+        levelsConsumerLock.lock()
+        latestLevels = values
+        let consumers = levelsConsumers.allObjects.compactMap { $0 as? AudioCaptureLevelsConsumer }
+        levelsConsumerLock.unlock()
+        guard !consumers.isEmpty else { return }
+
+        let deliverLevels = { [weak self] in
+            guard let self else { return }
+            for consumer in consumers {
+                consumer.audioCaptureManager(self, didProduceLevels: values)
+            }
+        }
+
+        if Thread.isMainThread {
+            deliverLevels()
+        } else {
+            DispatchQueue.main.async(execute: deliverLevels)
+        }
     }
 
     private func computeBandRanges(sampleRate: Double) {
@@ -442,7 +627,7 @@ final class AudioCaptureManager: ObservableObject {
             let endBin = max(startBin + 1, min(halfN, Int((endHz / nyquist) * Double(halfN))))
             ranges.append(startBin..<endBin)
             let centerHz = sqrt(startHz * endHz)
-            pinks.append(Float(3.0 * log2(centerHz / Self.referenceHz)))
+            pinks.append(Float(Self.pinkCompensationSlopePerOctave * log2(centerHz / Self.referenceHz)))
         }
         bandRanges = ranges
         pinkCompensationDB = pinks

--- a/boringNotch/managers/AudioCaptureManager.swift
+++ b/boringNotch/managers/AudioCaptureManager.swift
@@ -137,6 +137,21 @@ final class AudioCaptureManager: ObservableObject {
         return latestLevels
     }
 
+    func requestAudioCapturePermission() async -> Bool {
+        guard #available(macOS 14.2, *) else { return false }
+
+        return await withCheckedContinuation { continuation in
+            lifecycleQueue.async { [weak self] in
+                guard let self else {
+                    continuation.resume(returning: false)
+                    return
+                }
+
+                continuation.resume(returning: self.performPermissionProbeOnLifecycleQueue())
+            }
+        }
+    }
+
     // MARK: - State observation
 
     private func observeState() {
@@ -423,6 +438,102 @@ final class AudioCaptureManager: ObservableObject {
 
     private var captureIsConfigured: Bool {
         ioProcID != nil || aggregateDeviceID != 0 || tapObjectID != kAudioObjectUnknown
+    }
+
+    @available(macOS 14.2, *)
+    private func performPermissionProbeOnLifecycleQueue() -> Bool {
+        dispatchPrecondition(condition: .onQueue(lifecycleQueue))
+
+        if captureIsConfigured {
+            stopCaptureOnLifecycleQueue()
+        }
+
+        let excludedProcessIDs = translatePIDToAudioObject(pid: getpid()).map { [$0] } ?? []
+        let tapDescription = CATapDescription(monoGlobalTapButExcludeProcesses: excludedProcessIDs)
+        tapDescription.name = "Boring Notch Audio Permission Probe"
+        tapDescription.muteBehavior = .unmuted
+        tapDescription.isPrivate = true
+
+        var probeTapID: AudioObjectID = kAudioObjectUnknown
+        let tapStatus = AudioHardwareCreateProcessTap(tapDescription, &probeTapID)
+        guard tapStatus == noErr, probeTapID != kAudioObjectUnknown else {
+            NSLog("[AudioCaptureManager] Permission probe tap creation failed: \(tapStatus)")
+            return false
+        }
+        defer {
+            let status = AudioHardwareDestroyProcessTap(probeTapID)
+            if status != noErr, !Self.allowedAlreadyDestroyedStatuses.contains(status) {
+                NSLog("[AudioCaptureManager] Permission probe tap cleanup failed: \(status)")
+            }
+        }
+
+        guard let tapUID = getAudioObjectStringProperty(objectID: probeTapID, selector: kAudioTapPropertyUID) else {
+            NSLog("[AudioCaptureManager] Permission probe failed to read tap UID")
+            return false
+        }
+
+        let aggregateUID = "com.boringnotch.permissionprobe.\(UUID().uuidString)"
+        let aggregateDescription: [String: Any] = [
+            kAudioAggregateDeviceNameKey: "Boring Notch Audio Permission Probe",
+            kAudioAggregateDeviceUIDKey: aggregateUID,
+            kAudioAggregateDeviceMainSubDeviceKey: "",
+            kAudioAggregateDeviceIsPrivateKey: 1,
+            kAudioAggregateDeviceIsStackedKey: 0,
+            kAudioAggregateDeviceTapListKey: [
+                [
+                    kAudioSubTapUIDKey: tapUID,
+                    kAudioSubTapDriftCompensationKey: 0
+                ]
+            ]
+        ]
+
+        var probeAggregateID: AudioDeviceID = 0
+        let aggregateStatus = AudioHardwareCreateAggregateDevice(
+            aggregateDescription as CFDictionary,
+            &probeAggregateID
+        )
+        guard aggregateStatus == noErr, probeAggregateID != 0 else {
+            NSLog("[AudioCaptureManager] Permission probe aggregate creation failed: \(aggregateStatus)")
+            return false
+        }
+        defer {
+            let status = AudioHardwareDestroyAggregateDevice(probeAggregateID)
+            if status != noErr, !Self.allowedAlreadyDestroyedStatuses.contains(status) {
+                NSLog("[AudioCaptureManager] Permission probe aggregate cleanup failed: \(status)")
+            }
+        }
+
+        var probeIOProc: AudioDeviceIOProcID?
+        let ioStatus = AudioDeviceCreateIOProcIDWithBlock(
+            &probeIOProc,
+            probeAggregateID,
+            ioQueue
+        ) { _, _, _, _, _ in }
+        guard ioStatus == noErr, let ioProc = probeIOProc else {
+            NSLog("[AudioCaptureManager] Permission probe IO proc creation failed: \(ioStatus)")
+            return false
+        }
+        defer {
+            let status = AudioDeviceDestroyIOProcID(probeAggregateID, ioProc)
+            if status != noErr {
+                NSLog("[AudioCaptureManager] Permission probe IO proc cleanup failed: \(status)")
+            }
+        }
+
+        let startStatus = AudioDeviceStart(probeAggregateID, ioProc)
+        guard startStatus == noErr else {
+            NSLog("[AudioCaptureManager] Permission probe start failed: \(startStatus)")
+            return false
+        }
+
+        Thread.sleep(forTimeInterval: 0.25)
+
+        let stopStatus = AudioDeviceStop(probeAggregateID, ioProc)
+        if stopStatus != noErr {
+            NSLog("[AudioCaptureManager] Permission probe stop failed: \(stopStatus)")
+        }
+
+        return true
     }
 
     private func syncOnLifecycleQueue(_ work: () -> Void) {

--- a/boringNotch/managers/AudioCaptureManager.swift
+++ b/boringNotch/managers/AudioCaptureManager.swift
@@ -35,6 +35,11 @@ final class AudioCaptureManager: ObservableObject {
     private static let referenceHz: Double = 1000
     private static let pinkCompensationSlopePerOctave: Double = 3.0
     private static let fftQueueKey = DispatchSpecificKey<Void>()
+    private static let lifecycleQueueKey = DispatchSpecificKey<Void>()
+    private static let allowedAlreadyDestroyedStatuses: Set<OSStatus> = [
+        kAudioHardwareBadObjectError,
+        kAudioHardwareUnknownPropertyError
+    ]
 
     @Published private(set) var isCapturing: Bool = false
 
@@ -68,6 +73,8 @@ final class AudioCaptureManager: ObservableObject {
     private var pinkCompensationDB: [Float] = []
 
     private let fftQueue = DispatchQueue(label: "com.boringnotch.audiocapture.fft", qos: .userInitiated)
+    private let ioQueue = DispatchQueue(label: "com.boringnotch.audiocapture.io", qos: .userInteractive)
+    private let lifecycleQueue = DispatchQueue(label: "com.boringnotch.audiocapture.lifecycle", qos: .userInitiated)
     private var fftTimer: DispatchSourceTimer?
 
     private init() {
@@ -100,12 +107,15 @@ final class AudioCaptureManager: ObservableObject {
         lastPublishedBuf = [Float](repeating: -1, count: Self.barCount)
 
         fftQueue.setSpecific(key: Self.fftQueueKey, value: ())
+        lifecycleQueue.setSpecific(key: Self.lifecycleQueueKey, value: ())
         computeBandRanges(sampleRate: sampleRate)
         observeState()
     }
 
     deinit {
-        teardownCapture()
+        syncOnLifecycleQueue {
+            stopCaptureOnLifecycleQueue()
+        }
         ringBuffer.deinitialize(count: Self.ringCapacity)
         ringBuffer.deallocate()
     }
@@ -165,7 +175,9 @@ final class AudioCaptureManager: ObservableObject {
               enabled, isPlaying,
               let resolvedDisplayBundleID = displayBundleID,
               !resolvedDisplayBundleID.isEmpty else {
-            if isCapturing { stopCapture() }
+            lifecycleQueue.async { [weak self] in
+                self?.stopCaptureOnLifecycleQueue()
+            }
             return
         }
         let resolvedPIDs = resolvePIDs(
@@ -173,12 +185,14 @@ final class AudioCaptureManager: ObservableObject {
             captureBundleIDs: captureBundleIDs
         )
         guard !resolvedPIDs.isEmpty else {
-            if isCapturing { stopCapture() }
+            lifecycleQueue.async { [weak self] in
+                self?.stopCaptureOnLifecycleQueue()
+            }
             return
         }
-        if isCapturing && resolvedPIDs == currentPIDs { return }
-        if isCapturing { stopCapture() }
-        startCapture(pids: resolvedPIDs)
+        lifecycleQueue.async { [weak self] in
+            self?.startCaptureOnLifecycleQueue(pids: resolvedPIDs)
+        }
     }
 
     private func resolvePIDs(displayBundleID: String, captureBundleIDs: [String]) -> [pid_t] {
@@ -277,7 +291,13 @@ final class AudioCaptureManager: ObservableObject {
     // MARK: - Capture lifecycle
 
     @available(macOS 14.2, *)
-    private func startCapture(pids: [pid_t]) {
+    private func startCaptureOnLifecycleQueue(pids: [pid_t]) {
+        dispatchPrecondition(condition: .onQueue(lifecycleQueue))
+        if ioProcID != nil, pids == currentPIDs { return }
+        if captureIsConfigured {
+            stopCaptureOnLifecycleQueue()
+        }
+
         let attachedProcesses = pids.compactMap { pid -> (pid: pid_t, objectID: AudioObjectID)? in
             guard let objectID = translatePIDToAudioObject(pid: pid) else {
                 NSLog("[AudioCaptureManager] Failed to translate PID \(pid) to AudioObjectID")
@@ -326,10 +346,22 @@ final class AudioCaptureManager: ObservableObject {
         let fmtStatus = AudioObjectGetPropertyData(
             tapObjectID, &formatAddr, 0, nil, &formatSize, &streamFormat
         )
-        if fmtStatus == noErr, streamFormat.mSampleRate > 0 {
-            sampleRate = streamFormat.mSampleRate
-            computeBandRanges(sampleRate: sampleRate)
+        guard fmtStatus == noErr else {
+            NSLog("[AudioCaptureManager] Failed to read tap format: \(fmtStatus)")
+            currentPIDs.removeAll(keepingCapacity: true)
+            cleanupTap()
+            return
         }
+        guard validateTapFormat(streamFormat) else {
+            NSLog("[AudioCaptureManager] Unsupported tap format: \(streamFormat)")
+            currentPIDs.removeAll(keepingCapacity: true)
+            cleanupTap()
+            return
+        }
+        if streamFormat.mSampleRate > 0 {
+            sampleRate = streamFormat.mSampleRate
+        }
+        computeBandRanges(sampleRate: sampleRate)
 
         let aggregateUID = "com.boringnotch.audiotap.\(UUID().uuidString)"
         let aggregateDescription: [String: Any] = [
@@ -361,7 +393,7 @@ final class AudioCaptureManager: ObservableObject {
 
         var newIOProc: AudioDeviceIOProcID?
         let ioStatus = AudioDeviceCreateIOProcIDWithBlock(
-            &newIOProc, aggregateDeviceID, fftQueue
+            &newIOProc, aggregateDeviceID, ioQueue
         ) { [weak self] _, inInputData, _, _, _ in
             self?.handleInputBuffer(inInputData)
         }
@@ -377,7 +409,7 @@ final class AudioCaptureManager: ObservableObject {
         let startStatus = AudioDeviceStart(aggregateDeviceID, ioProc)
         guard startStatus == noErr else {
             NSLog("[AudioCaptureManager] AudioDeviceStart failed: \(startStatus)")
-            AudioDeviceDestroyIOProcID(aggregateDeviceID, ioProc)
+            destroyIOProc(ioProc)
             ioProcID = nil
             currentPIDs.removeAll(keepingCapacity: true)
             cleanupAggregate()
@@ -386,10 +418,24 @@ final class AudioCaptureManager: ObservableObject {
         }
 
         startFFTTimer()
-        isCapturing = true
+        setCapturing(true)
     }
 
-    private func stopCapture() {
+    private var captureIsConfigured: Bool {
+        ioProcID != nil || aggregateDeviceID != 0 || tapObjectID != kAudioObjectUnknown
+    }
+
+    private func syncOnLifecycleQueue(_ work: () -> Void) {
+        if DispatchQueue.getSpecific(key: Self.lifecycleQueueKey) != nil {
+            work()
+        } else {
+            lifecycleQueue.sync(execute: work)
+        }
+    }
+
+    private func stopCaptureOnLifecycleQueue() {
+        dispatchPrecondition(condition: .onQueue(lifecycleQueue))
+        guard captureIsConfigured else { return }
         stopFFTTimer()
         teardownCapture()
         currentPIDs.removeAll(keepingCapacity: true)
@@ -405,41 +451,61 @@ final class AudioCaptureManager: ObservableObject {
             }
         }
         let zeros = [Float](repeating: 0, count: Self.barCount)
-        let publishStoppedState = { [weak self] in
-            guard let self else { return }
-            self.isCapturing = false
-            self.publishLevels(zeros)
-        }
-        if Thread.isMainThread {
-            publishStoppedState()
-        } else {
-            DispatchQueue.main.sync(execute: publishStoppedState)
-        }
+        setCapturing(false)
+        publishLevels(zeros)
     }
 
     private func teardownCapture() {
         if aggregateDeviceID != 0, let proc = ioProcID {
-            AudioDeviceStop(aggregateDeviceID, proc)
-            AudioDeviceDestroyIOProcID(aggregateDeviceID, proc)
+            let stopStatus = AudioDeviceStop(aggregateDeviceID, proc)
+            if stopStatus != noErr {
+                NSLog("[AudioCaptureManager] AudioDeviceStop failed during teardown: \(stopStatus)")
+            }
+            destroyIOProc(proc)
         }
         ioProcID = nil
         cleanupAggregate()
         cleanupTap()
     }
 
+    private func destroyIOProc(_ proc: AudioDeviceIOProcID) {
+        guard aggregateDeviceID != 0 else { return }
+        let status = AudioDeviceDestroyIOProcID(aggregateDeviceID, proc)
+        if status != noErr {
+            NSLog("[AudioCaptureManager] AudioDeviceDestroyIOProcID failed: \(status)")
+        }
+    }
+
     private func cleanupAggregate() {
         if aggregateDeviceID != 0 {
-            AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
-            aggregateDeviceID = 0
+            let status = AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            if status == noErr || Self.allowedAlreadyDestroyedStatuses.contains(status) {
+                aggregateDeviceID = 0
+            } else {
+                NSLog("[AudioCaptureManager] AudioHardwareDestroyAggregateDevice failed: \(status)")
+            }
         }
     }
 
     private func cleanupTap() {
         guard tapObjectID != kAudioObjectUnknown else { return }
         if #available(macOS 14.2, *) {
-            AudioHardwareDestroyProcessTap(tapObjectID)
+            let status = AudioHardwareDestroyProcessTap(tapObjectID)
+            if status == noErr || Self.allowedAlreadyDestroyedStatuses.contains(status) {
+                tapObjectID = kAudioObjectUnknown
+            } else {
+                NSLog("[AudioCaptureManager] AudioHardwareDestroyProcessTap failed: \(status)")
+            }
+        } else {
+            tapObjectID = kAudioObjectUnknown
         }
-        tapObjectID = kAudioObjectUnknown
+    }
+
+    private func setCapturing(_ capturing: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.isCapturing != capturing else { return }
+            self.isCapturing = capturing
+        }
     }
 
     // MARK: - IO proc
@@ -448,9 +514,10 @@ final class AudioCaptureManager: ObservableObject {
         let mutableBL = UnsafeMutablePointer(mutating: bufferList)
         let abl = UnsafeMutableAudioBufferListPointer(mutableBL)
         guard let first = abl.first, let rawData = first.mData else { return }
-        // Tap is configured with monoMixdownOfProcesses, so we always receive one channel.
-        assert(first.mNumberChannels == 1)
-        let frameCount = Int(first.mDataByteSize) / MemoryLayout<Float>.size
+        let expectedBytesPerFrame = UInt32(MemoryLayout<Float>.size)
+        guard first.mNumberChannels == 1,
+              first.mDataByteSize % expectedBytesPerFrame == 0 else { return }
+        let frameCount = Int(first.mDataByteSize / expectedBytesPerFrame)
         guard frameCount > 0 else { return }
         let src = rawData.assumingMemoryBound(to: Float.self)
 
@@ -582,7 +649,7 @@ final class AudioCaptureManager: ObservableObject {
         for i in 0..<Self.barCount {
             lastPublishedBuf[i] = barsBuf[i]
         }
-        publishLevels(barsBuf)
+        publishLevels(barsBuf.map { $0 })
     }
 
     private func publishLevels(_ values: [Float]) {
@@ -631,6 +698,16 @@ final class AudioCaptureManager: ObservableObject {
         }
         bandRanges = ranges
         pinkCompensationDB = pinks
+    }
+
+    private func validateTapFormat(_ format: AudioStreamBasicDescription) -> Bool {
+        let floatPCMFlags = kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked
+        return format.mFormatID == kAudioFormatLinearPCM
+            && (format.mFormatFlags & floatPCMFlags) == floatPCMFlags
+            && (format.mFormatFlags & kAudioFormatFlagIsNonInterleaved) == 0
+            && format.mChannelsPerFrame == 1
+            && format.mBytesPerFrame == UInt32(MemoryLayout<Float>.size)
+            && format.mBitsPerChannel == UInt32(MemoryLayout<Float>.size * 8)
     }
 
     // MARK: - Core Audio helpers

--- a/boringNotch/managers/AudioCaptureManager.swift
+++ b/boringNotch/managers/AudioCaptureManager.swift
@@ -26,6 +26,7 @@ final class AudioCaptureManager: ObservableObject {
     private static let floorDB: Float = -50
     private static let ceilDB: Float = -25
     private static let referenceHz: Double = 1000
+    private static let fftQueueKey = DispatchSpecificKey<Void>()
 
     let levelsPublisher = PassthroughSubject<[Float], Never>()
     @Published private(set) var isCapturing: Bool = false
@@ -88,6 +89,7 @@ final class AudioCaptureManager: ObservableObject {
         // Seed with a sentinel so the first real frame always publishes.
         lastPublishedBuf = [Float](repeating: -1, count: Self.barCount)
 
+        fftQueue.setSpecific(key: Self.fftQueueKey, value: ())
         computeBandRanges(sampleRate: sampleRate)
         observeState()
     }
@@ -241,14 +243,16 @@ final class AudioCaptureManager: ObservableObject {
         stopFFTTimer()
         teardownCapture()
         currentPID = 0
-        ringLock.lock()
-        ringBuffer.update(repeating: 0, count: Self.ringCapacity)
-        ringWrite = 0
-        ringLock.unlock()
-        for i in 0..<Self.barCount {
-            smoothed[i] = 0
-            barsBuf[i] = 0
-            lastPublishedBuf[i] = -1
+        syncOnFFTQueue {
+            ringLock.lock()
+            ringBuffer.update(repeating: 0, count: Self.ringCapacity)
+            ringWrite = 0
+            ringLock.unlock()
+            for i in 0..<Self.barCount {
+                smoothed[i] = 0
+                barsBuf[i] = 0
+                lastPublishedBuf[i] = -1
+            }
         }
         let zeros = [Float](repeating: 0, count: Self.barCount)
         DispatchQueue.main.async { [weak self] in
@@ -324,6 +328,14 @@ final class AudioCaptureManager: ObservableObject {
     private func stopFFTTimer() {
         fftTimer?.cancel()
         fftTimer = nil
+    }
+
+    private func syncOnFFTQueue(_ work: () -> Void) {
+        if DispatchQueue.getSpecific(key: Self.fftQueueKey) != nil {
+            work()
+        } else {
+            fftQueue.sync(execute: work)
+        }
     }
 
     private func processFFT() {

--- a/boringNotch/managers/AudioCaptureManager.swift
+++ b/boringNotch/managers/AudioCaptureManager.swift
@@ -15,7 +15,6 @@ import CoreAudio
 import Darwin
 import Defaults
 import Foundation
-import os
 
 protocol AudioCaptureLevelsConsumer: AnyObject {
     func audioCaptureManager(_ manager: AudioCaptureManager, didProduceLevels values: [Float])
@@ -175,9 +174,7 @@ final class AudioCaptureManager: ObservableObject {
               enabled, isPlaying,
               let resolvedDisplayBundleID = displayBundleID,
               !resolvedDisplayBundleID.isEmpty else {
-            lifecycleQueue.async { [weak self] in
-                self?.stopCaptureOnLifecycleQueue()
-            }
+            stopCaptureAsync()
             return
         }
         let resolvedPIDs = resolvePIDs(
@@ -185,13 +182,17 @@ final class AudioCaptureManager: ObservableObject {
             captureBundleIDs: captureBundleIDs
         )
         guard !resolvedPIDs.isEmpty else {
-            lifecycleQueue.async { [weak self] in
-                self?.stopCaptureOnLifecycleQueue()
-            }
+            stopCaptureAsync()
             return
         }
         lifecycleQueue.async { [weak self] in
             self?.startCaptureOnLifecycleQueue(pids: resolvedPIDs)
+        }
+    }
+
+    private func stopCaptureAsync() {
+        lifecycleQueue.async { [weak self] in
+            self?.stopCaptureOnLifecycleQueue()
         }
     }
 
@@ -204,7 +205,7 @@ final class AudioCaptureManager: ObservableObject {
             Set(captureBundleIDs + [displayBundleID])
         ).sorted()
 
-        var pidsByBundleID: [(pid: pid_t, bundleID: String)] = []
+        var pids = Set<pid_t>()
         for bundleID in bundleIDs {
             let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
             let requireDisplayAppTie = bundleID != displayBundleID && runningApps.count > 1
@@ -215,19 +216,18 @@ final class AudioCaptureManager: ObservableObject {
                     displayNames: displayNames,
                     displayBundlePaths: displayBundlePaths
                 ) else { continue }
-                pidsByBundleID.append((pid: app.processIdentifier, bundleID: bundleID))
+                pids.insert(app.processIdentifier)
             }
         }
 
-        if pidsByBundleID.isEmpty {
+        if pids.isEmpty {
             return NSRunningApplication
                 .runningApplications(withBundleIdentifier: displayBundleID)
                 .map(\.processIdentifier)
                 .sorted()
         }
 
-        let deduped = Dictionary(uniqueKeysWithValues: pidsByBundleID.map { ($0.pid, $0.bundleID) })
-        return deduped.keys.sorted()
+        return pids.sorted()
     }
 
     private func shouldInclude(
@@ -440,19 +440,24 @@ final class AudioCaptureManager: ObservableObject {
         teardownCapture()
         currentPIDs.removeAll(keepingCapacity: true)
         syncOnFFTQueue {
-            ringLock.lock()
-            ringBuffer.update(repeating: 0, count: Self.ringCapacity)
-            ringWrite = 0
-            ringLock.unlock()
-            for i in 0..<Self.barCount {
-                smoothed[i] = 0
-                barsBuf[i] = 0
-                lastPublishedBuf[i] = -1
-            }
+            resetProcessingState()
         }
         let zeros = [Float](repeating: 0, count: Self.barCount)
         setCapturing(false)
         publishLevels(zeros)
+    }
+
+    private func resetProcessingState() {
+        ringLock.lock()
+        ringBuffer.update(repeating: 0, count: Self.ringCapacity)
+        ringWrite = 0
+        ringLock.unlock()
+
+        for i in 0..<Self.barCount {
+            smoothed[i] = 0
+            barsBuf[i] = 0
+            lastPublishedBuf[i] = -1
+        }
     }
 
     private func teardownCapture() {
@@ -522,12 +527,13 @@ final class AudioCaptureManager: ObservableObject {
         let src = rawData.assumingMemoryBound(to: Float.self)
 
         ringLock.lock()
+        defer { ringLock.unlock() }
+
         let cap = Self.ringCapacity
         if frameCount >= cap {
             let newestFrames = src.advanced(by: frameCount - cap)
             memcpy(ringBuffer, newestFrames, cap * MemoryLayout<Float>.size)
             ringWrite = 0
-            ringLock.unlock()
             return
         }
         let write = ringWrite
@@ -541,7 +547,6 @@ final class AudioCaptureManager: ObservableObject {
             )
         }
         ringWrite = (write + frameCount) % cap
-        ringLock.unlock()
     }
 
     // MARK: - FFT loop
@@ -573,26 +578,7 @@ final class AudioCaptureManager: ObservableObject {
 
     private func processFFT() {
         let n = Self.fftSize
-
-        ringLock.lock()
-        let cap = Self.ringCapacity
-        let end = ringWrite
-        let start = (end - n + cap) % cap
-        samplesBuf.withUnsafeMutableBufferPointer { dst in
-            guard let base = dst.baseAddress else { return }
-            if start + n <= cap {
-                memcpy(base, ringBuffer.advanced(by: start), n * MemoryLayout<Float>.size)
-            } else {
-                let firstCount = cap - start
-                memcpy(base, ringBuffer.advanced(by: start), firstCount * MemoryLayout<Float>.size)
-                memcpy(
-                    base.advanced(by: firstCount),
-                    ringBuffer,
-                    (n - firstCount) * MemoryLayout<Float>.size
-                )
-            }
-        }
-        ringLock.unlock()
+        copyLatestSamples(count: n)
 
         vDSP.multiply(samplesBuf, hannWindow, result: &windowedBuf)
 
@@ -650,6 +636,29 @@ final class AudioCaptureManager: ObservableObject {
             lastPublishedBuf[i] = barsBuf[i]
         }
         publishLevels(barsBuf.map { $0 })
+    }
+
+    private func copyLatestSamples(count: Int) {
+        ringLock.lock()
+        defer { ringLock.unlock() }
+
+        let cap = Self.ringCapacity
+        let end = ringWrite
+        let start = (end - count + cap) % cap
+        samplesBuf.withUnsafeMutableBufferPointer { dst in
+            guard let base = dst.baseAddress else { return }
+            if start + count <= cap {
+                memcpy(base, ringBuffer.advanced(by: start), count * MemoryLayout<Float>.size)
+            } else {
+                let firstCount = cap - start
+                memcpy(base, ringBuffer.advanced(by: start), firstCount * MemoryLayout<Float>.size)
+                memcpy(
+                    base.advanced(by: firstCount),
+                    ringBuffer,
+                    (count - firstCount) * MemoryLayout<Float>.size
+                )
+            }
+        }
     }
 
     private func publishLevels(_ values: [Float]) {

--- a/boringNotch/managers/AudioCaptureManager.swift
+++ b/boringNotch/managers/AudioCaptureManager.swift
@@ -1,0 +1,453 @@
+//
+//  AudioCaptureManager.swift
+//  boringNotch
+//
+//  Captures audio from the currently-playing music app via Core Audio
+//  Process Tap (macOS 14.2+), runs an FFT via Accelerate, and publishes
+//  6 log-spaced magnitude bands for the visualizer.
+//
+
+import Accelerate
+import AppKit
+import AudioToolbox
+import Combine
+import CoreAudio
+import Defaults
+import Foundation
+import os
+
+final class AudioCaptureManager: ObservableObject {
+    static let shared = AudioCaptureManager()
+
+    static let barCount = 6
+    private static let fftSize = 1024
+    private static let log2n: vDSP_Length = 10
+    private static let ringCapacity = 4096
+    private static let floorDB: Float = -50
+    private static let ceilDB: Float = -25
+    private static let referenceHz: Double = 1000
+
+    @Published private(set) var levels: [CGFloat] = Array(repeating: 0, count: AudioCaptureManager.barCount)
+    @Published private(set) var isCapturing: Bool = false
+
+    private var cancellables = Set<AnyCancellable>()
+
+    private var tapObjectID: AudioObjectID = kAudioObjectUnknown
+    private var aggregateDeviceID: AudioDeviceID = 0
+    private var ioProcID: AudioDeviceIOProcID?
+    private var currentPID: pid_t = 0
+    private var sampleRate: Double = 48_000
+
+    private let ringBuffer: UnsafeMutablePointer<Float>
+    private var ringWrite: Int = 0
+    private let ringLock = OSAllocatedUnfairLock()
+
+    private let fft: vDSP.FFT<DSPSplitComplex>
+    private let hannWindow: [Float]
+    private let windowPowerScalar: Float
+    private var samplesBuf: [Float]
+    private var windowedBuf: [Float]
+    private var realBuf: [Float]
+    private var imagBuf: [Float]
+    private var powBuf: [Float]
+    private var smoothed: [Float]
+    private var bandRanges: [Range<Int>] = []
+    private var pinkCompensationDB: [Float] = []
+
+    private let fftQueue = DispatchQueue(label: "com.boringnotch.audiocapture.fft", qos: .userInitiated)
+    private var fftTimer: DispatchSourceTimer?
+
+    private init() {
+        ringBuffer = UnsafeMutablePointer<Float>.allocate(capacity: Self.ringCapacity)
+        ringBuffer.initialize(repeating: 0, count: Self.ringCapacity)
+
+        guard let setup = vDSP.FFT(log2n: Self.log2n, radix: .radix2, ofType: DSPSplitComplex.self) else {
+            fatalError("Failed to create vDSP.FFT setup")
+        }
+        fft = setup
+        let window = vDSP.window(
+            ofType: Float.self,
+            usingSequence: .hanningDenormalized,
+            count: Self.fftSize,
+            isHalfWindow: false
+        )
+        hannWindow = window
+        // Parseval-style normalization so full-scale input lands near 0 dBFS.
+        // Factor of 2 folds the one-sided real FFT back to total power.
+        let windowPowerGain = vDSP.sum(vDSP.multiply(window, window))
+        windowPowerScalar = 2.0 / (Float(Self.fftSize) * windowPowerGain)
+        samplesBuf = [Float](repeating: 0, count: Self.fftSize)
+        windowedBuf = [Float](repeating: 0, count: Self.fftSize)
+        realBuf = [Float](repeating: 0, count: Self.fftSize / 2)
+        imagBuf = [Float](repeating: 0, count: Self.fftSize / 2)
+        powBuf = [Float](repeating: 0, count: Self.fftSize / 2)
+        smoothed = [Float](repeating: 0, count: Self.barCount)
+
+        computeBandRanges(sampleRate: sampleRate)
+        observeState()
+    }
+
+    deinit {
+        teardownCapture()
+        ringBuffer.deinitialize(count: Self.ringCapacity)
+        ringBuffer.deallocate()
+    }
+
+    // MARK: - State observation
+
+    private func observeState() {
+        let music = MusicManager.shared
+        let enabledPublisher = Defaults.publisher(.realtimeAudioWaveform)
+            .map(\.newValue)
+            .prepend(Defaults[.realtimeAudioWaveform])
+
+        Publishers.CombineLatest3(music.$isPlaying, music.$bundleIdentifier, enabledPublisher)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isPlaying, bundleID, enabled in
+                self?.evaluate(isPlaying: isPlaying, bundleID: bundleID, enabled: enabled)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func evaluate(isPlaying: Bool, bundleID: String?, enabled: Bool) {
+        guard #available(macOS 14.2, *),
+              enabled, isPlaying,
+              let bundleID, !bundleID.isEmpty,
+              let pid = resolvePID(forBundleID: bundleID) else {
+            if isCapturing { stopCapture() }
+            return
+        }
+        if isCapturing && pid == currentPID { return }
+        if isCapturing { stopCapture() }
+        startCapture(pid: pid)
+    }
+
+    private func resolvePID(forBundleID bundleID: String) -> pid_t? {
+        NSRunningApplication
+            .runningApplications(withBundleIdentifier: bundleID)
+            .first?
+            .processIdentifier
+    }
+
+    // MARK: - Capture lifecycle
+
+    @available(macOS 14.2, *)
+    private func startCapture(pid: pid_t) {
+        currentPID = pid
+
+        guard let processObjectID = translatePIDToAudioObject(pid: pid) else {
+            NSLog("[AudioCaptureManager] Failed to translate PID \(pid) to AudioObjectID")
+            return
+        }
+
+        let tapDescription = CATapDescription(monoMixdownOfProcesses: [processObjectID])
+        tapDescription.muteBehavior = .unmuted
+        tapDescription.isPrivate = true
+        tapDescription.isExclusive = false
+
+        var newTapID: AudioObjectID = kAudioObjectUnknown
+        let tapStatus = AudioHardwareCreateProcessTap(tapDescription, &newTapID)
+        guard tapStatus == noErr, newTapID != kAudioObjectUnknown else {
+            NSLog("[AudioCaptureManager] AudioHardwareCreateProcessTap failed: \(tapStatus)")
+            return
+        }
+        tapObjectID = newTapID
+
+        guard let tapUID = getAudioObjectStringProperty(
+            objectID: tapObjectID,
+            selector: kAudioTapPropertyUID
+        ) else {
+            NSLog("[AudioCaptureManager] Failed to read tap UID")
+            cleanupTap()
+            return
+        }
+
+        var streamFormat = AudioStreamBasicDescription()
+        var formatSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        var formatAddr = AudioObjectPropertyAddress(
+            mSelector: kAudioTapPropertyFormat,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let fmtStatus = AudioObjectGetPropertyData(
+            tapObjectID, &formatAddr, 0, nil, &formatSize, &streamFormat
+        )
+        if fmtStatus == noErr, streamFormat.mSampleRate > 0 {
+            sampleRate = streamFormat.mSampleRate
+            computeBandRanges(sampleRate: sampleRate)
+        }
+
+        let aggregateUID = "com.boringnotch.audiotap.\(UUID().uuidString)"
+        let aggregateDescription: [String: Any] = [
+            kAudioAggregateDeviceNameKey: "boringNotchTapAggregate",
+            kAudioAggregateDeviceUIDKey: aggregateUID,
+            kAudioAggregateDeviceMainSubDeviceKey: "",
+            kAudioAggregateDeviceIsPrivateKey: 1,
+            kAudioAggregateDeviceIsStackedKey: 0,
+            kAudioAggregateDeviceTapAutoStartKey: 1,
+            kAudioAggregateDeviceTapListKey: [
+                [
+                    kAudioSubTapUIDKey: tapUID,
+                    kAudioSubTapDriftCompensationKey: 0
+                ]
+            ]
+        ]
+
+        var newAggID: AudioDeviceID = 0
+        let aggStatus = AudioHardwareCreateAggregateDevice(
+            aggregateDescription as CFDictionary, &newAggID
+        )
+        guard aggStatus == noErr, newAggID != 0 else {
+            NSLog("[AudioCaptureManager] AudioHardwareCreateAggregateDevice failed: \(aggStatus)")
+            cleanupTap()
+            return
+        }
+        aggregateDeviceID = newAggID
+
+        var newIOProc: AudioDeviceIOProcID?
+        let ioStatus = AudioDeviceCreateIOProcIDWithBlock(
+            &newIOProc, aggregateDeviceID, fftQueue
+        ) { [weak self] _, inInputData, _, _, _ in
+            self?.handleInputBuffer(inInputData)
+        }
+        guard ioStatus == noErr, let ioProc = newIOProc else {
+            NSLog("[AudioCaptureManager] AudioDeviceCreateIOProcIDWithBlock failed: \(ioStatus)")
+            cleanupAggregate()
+            cleanupTap()
+            return
+        }
+        ioProcID = ioProc
+
+        let startStatus = AudioDeviceStart(aggregateDeviceID, ioProc)
+        guard startStatus == noErr else {
+            NSLog("[AudioCaptureManager] AudioDeviceStart failed: \(startStatus)")
+            AudioDeviceDestroyIOProcID(aggregateDeviceID, ioProc)
+            ioProcID = nil
+            cleanupAggregate()
+            cleanupTap()
+            return
+        }
+
+        startFFTTimer()
+        isCapturing = true
+    }
+
+    private func stopCapture() {
+        stopFFTTimer()
+        teardownCapture()
+        currentPID = 0
+        ringLock.lock()
+        ringBuffer.update(repeating: 0, count: Self.ringCapacity)
+        ringWrite = 0
+        ringLock.unlock()
+        smoothed = [Float](repeating: 0, count: Self.barCount)
+        let zeros = Array<CGFloat>(repeating: 0, count: Self.barCount)
+        DispatchQueue.main.async { [weak self] in
+            self?.levels = zeros
+            self?.isCapturing = false
+        }
+    }
+
+    private func teardownCapture() {
+        if aggregateDeviceID != 0, let proc = ioProcID {
+            AudioDeviceStop(aggregateDeviceID, proc)
+            AudioDeviceDestroyIOProcID(aggregateDeviceID, proc)
+        }
+        ioProcID = nil
+        cleanupAggregate()
+        cleanupTap()
+    }
+
+    private func cleanupAggregate() {
+        if aggregateDeviceID != 0 {
+            AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            aggregateDeviceID = 0
+        }
+    }
+
+    private func cleanupTap() {
+        guard tapObjectID != kAudioObjectUnknown else { return }
+        if #available(macOS 14.2, *) {
+            AudioHardwareDestroyProcessTap(tapObjectID)
+        }
+        tapObjectID = kAudioObjectUnknown
+    }
+
+    // MARK: - IO proc
+
+    private func handleInputBuffer(_ bufferList: UnsafePointer<AudioBufferList>) {
+        let mutableBL = UnsafeMutablePointer(mutating: bufferList)
+        let abl = UnsafeMutableAudioBufferListPointer(mutableBL)
+        guard let first = abl.first, let rawData = first.mData else { return }
+        // Tap is configured with monoMixdownOfProcesses, so we always receive one channel.
+        assert(first.mNumberChannels == 1)
+        let frameCount = Int(first.mDataByteSize) / MemoryLayout<Float>.size
+        guard frameCount > 0 else { return }
+        let src = rawData.assumingMemoryBound(to: Float.self)
+
+        ringLock.lock()
+        let cap = Self.ringCapacity
+        let write = ringWrite
+        let firstCount = min(frameCount, cap - write)
+        memcpy(ringBuffer.advanced(by: write), src, firstCount * MemoryLayout<Float>.size)
+        if firstCount < frameCount {
+            memcpy(
+                ringBuffer,
+                src.advanced(by: firstCount),
+                (frameCount - firstCount) * MemoryLayout<Float>.size
+            )
+        }
+        ringWrite = (write + frameCount) % cap
+        ringLock.unlock()
+    }
+
+    // MARK: - FFT loop
+
+    private func startFFTTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: fftQueue)
+        timer.schedule(deadline: .now(), repeating: .milliseconds(33))
+        timer.setEventHandler { [weak self] in self?.processFFT() }
+        fftTimer = timer
+        timer.resume()
+    }
+
+    private func stopFFTTimer() {
+        fftTimer?.cancel()
+        fftTimer = nil
+    }
+
+    private func processFFT() {
+        let n = Self.fftSize
+
+        ringLock.lock()
+        let cap = Self.ringCapacity
+        let end = ringWrite
+        let start = (end - n + cap) % cap
+        samplesBuf.withUnsafeMutableBufferPointer { dst in
+            guard let base = dst.baseAddress else { return }
+            if start + n <= cap {
+                memcpy(base, ringBuffer.advanced(by: start), n * MemoryLayout<Float>.size)
+            } else {
+                let firstCount = cap - start
+                memcpy(base, ringBuffer.advanced(by: start), firstCount * MemoryLayout<Float>.size)
+                memcpy(
+                    base.advanced(by: firstCount),
+                    ringBuffer,
+                    (n - firstCount) * MemoryLayout<Float>.size
+                )
+            }
+        }
+        ringLock.unlock()
+
+        vDSP.multiply(samplesBuf, hannWindow, result: &windowedBuf)
+
+        let halfN = n / 2
+        realBuf.withUnsafeMutableBufferPointer { rPtr in
+            imagBuf.withUnsafeMutableBufferPointer { iPtr in
+                var split = DSPSplitComplex(realp: rPtr.baseAddress!, imagp: iPtr.baseAddress!)
+                windowedBuf.withUnsafeBufferPointer { wPtr in
+                    wPtr.baseAddress!.withMemoryRebound(to: DSPComplex.self, capacity: halfN) { cPtr in
+                        vDSP_ctoz(cPtr, 2, &split, 1, vDSP_Length(halfN))
+                    }
+                }
+                fft.forward(input: split, output: &split)
+                // vDSP packs DC in realp[0] and Nyquist in imagp[0]; zero both
+                // so they can't pollute the sub-bass band.
+                rPtr[0] = 0
+                iPtr[0] = 0
+                vDSP.squareMagnitudes(split, result: &powBuf)
+            }
+        }
+        vDSP.multiply(windowPowerScalar, powBuf, result: &powBuf)
+
+        let floorDB = Self.floorDB
+        let ceilDB = Self.ceilDB
+        let dbRange = ceilDB - floorDB
+        var bars = [Float](repeating: 0, count: Self.barCount)
+        for (i, range) in bandRanges.enumerated() where !range.isEmpty {
+            let meanPow = vDSP.sum(powBuf[range]) / Float(range.count)
+            let db = 10 * log10f(max(meanPow, 1e-12)) + pinkCompensationDB[i]
+            let clamped = max(floorDB, min(ceilDB, db))
+            bars[i] = (clamped - floorDB) / dbRange
+        }
+
+        for i in 0..<Self.barCount {
+            let target = bars[i]
+            let decayed = smoothed[i] * 0.82
+            smoothed[i] = target > decayed ? (decayed + (target - decayed) * 0.6) : decayed
+        }
+
+        let cgLevels = smoothed.map { CGFloat(max(0, min(1, $0))) }
+        DispatchQueue.main.async { [weak self] in
+            self?.levels = cgLevels
+        }
+    }
+
+    private func computeBandRanges(sampleRate: Double) {
+        let halfN = Self.fftSize / 2
+        let nyquist = sampleRate / 2
+        let minHz: Double = 60
+        let maxHz: Double = min(16_000, nyquist - 1)
+        guard maxHz > minHz else {
+            bandRanges = Array(repeating: 0..<0, count: Self.barCount)
+            pinkCompensationDB = Array(repeating: 0, count: Self.barCount)
+            return
+        }
+        let logMin = log(minHz)
+        let logMax = log(maxHz)
+        var ranges: [Range<Int>] = []
+        var pinks: [Float] = []
+        for i in 0..<Self.barCount {
+            let startHz = exp(logMin + (logMax - logMin) * Double(i) / Double(Self.barCount))
+            let endHz = exp(logMin + (logMax - logMin) * Double(i + 1) / Double(Self.barCount))
+            let startBin = max(1, Int((startHz / nyquist) * Double(halfN)))
+            let endBin = max(startBin + 1, min(halfN, Int((endHz / nyquist) * Double(halfN))))
+            ranges.append(startBin..<endBin)
+            let centerHz = sqrt(startHz * endHz)
+            pinks.append(Float(3.0 * log2(centerHz / Self.referenceHz)))
+        }
+        bandRanges = ranges
+        pinkCompensationDB = pinks
+    }
+
+    // MARK: - Core Audio helpers
+
+    private func translatePIDToAudioObject(pid: pid_t) -> AudioObjectID? {
+        var pidVal = pid
+        var processObject: AudioObjectID = kAudioObjectUnknown
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyTranslatePIDToProcessObject,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &addr,
+            UInt32(MemoryLayout<pid_t>.size),
+            &pidVal,
+            &size,
+            &processObject
+        )
+        guard status == noErr, processObject != kAudioObjectUnknown else { return nil }
+        return processObject
+    }
+
+    private func getAudioObjectStringProperty(
+        objectID: AudioObjectID,
+        selector: AudioObjectPropertySelector
+    ) -> String? {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size = UInt32(MemoryLayout<CFString?>.size)
+        var cfStr: CFString?
+        let status = withUnsafeMutablePointer(to: &cfStr) { ptr in
+            AudioObjectGetPropertyData(objectID, &addr, 0, nil, &size, ptr)
+        }
+        guard status == noErr, let cfStr = cfStr else { return nil }
+        return cfStr as String
+    }
+}

--- a/boringNotch/managers/AudioCaptureManager.swift
+++ b/boringNotch/managers/AudioCaptureManager.swift
@@ -27,7 +27,7 @@ final class AudioCaptureManager: ObservableObject {
     private static let ceilDB: Float = -25
     private static let referenceHz: Double = 1000
 
-    @Published private(set) var levels: [CGFloat] = Array(repeating: 0, count: AudioCaptureManager.barCount)
+    let levelsPublisher = PassthroughSubject<[Float], Never>()
     @Published private(set) var isCapturing: Bool = false
 
     private var cancellables = Set<AnyCancellable>()
@@ -51,6 +51,8 @@ final class AudioCaptureManager: ObservableObject {
     private var imagBuf: [Float]
     private var powBuf: [Float]
     private var smoothed: [Float]
+    private var barsBuf: [Float]
+    private var lastPublishedBuf: [Float]
     private var bandRanges: [Range<Int>] = []
     private var pinkCompensationDB: [Float] = []
 
@@ -82,6 +84,9 @@ final class AudioCaptureManager: ObservableObject {
         imagBuf = [Float](repeating: 0, count: Self.fftSize / 2)
         powBuf = [Float](repeating: 0, count: Self.fftSize / 2)
         smoothed = [Float](repeating: 0, count: Self.barCount)
+        barsBuf = [Float](repeating: 0, count: Self.barCount)
+        // Seed with a sentinel so the first real frame always publishes.
+        lastPublishedBuf = [Float](repeating: -1, count: Self.barCount)
 
         computeBandRanges(sampleRate: sampleRate)
         observeState()
@@ -240,11 +245,16 @@ final class AudioCaptureManager: ObservableObject {
         ringBuffer.update(repeating: 0, count: Self.ringCapacity)
         ringWrite = 0
         ringLock.unlock()
-        smoothed = [Float](repeating: 0, count: Self.barCount)
-        let zeros = Array<CGFloat>(repeating: 0, count: Self.barCount)
+        for i in 0..<Self.barCount {
+            smoothed[i] = 0
+            barsBuf[i] = 0
+            lastPublishedBuf[i] = -1
+        }
+        let zeros = [Float](repeating: 0, count: Self.barCount)
         DispatchQueue.main.async { [weak self] in
-            self?.levels = zeros
-            self?.isCapturing = false
+            guard let self else { return }
+            self.levelsPublisher.send(zeros)
+            self.isCapturing = false
         }
     }
 
@@ -363,24 +373,40 @@ final class AudioCaptureManager: ObservableObject {
         let floorDB = Self.floorDB
         let ceilDB = Self.ceilDB
         let dbRange = ceilDB - floorDB
-        var bars = [Float](repeating: 0, count: Self.barCount)
-        for (i, range) in bandRanges.enumerated() where !range.isEmpty {
-            let meanPow = vDSP.sum(powBuf[range]) / Float(range.count)
-            let db = 10 * log10f(max(meanPow, 1e-12)) + pinkCompensationDB[i]
-            let clamped = max(floorDB, min(ceilDB, db))
-            bars[i] = (clamped - floorDB) / dbRange
+        powBuf.withUnsafeBufferPointer { pPtr in
+            guard let base = pPtr.baseAddress else { return }
+            for i in 0..<Self.barCount {
+                let range = bandRanges[i]
+                guard !range.isEmpty else { barsBuf[i] = 0; continue }
+                var sum: Float = 0
+                vDSP_sve(base.advanced(by: range.lowerBound), 1, &sum, vDSP_Length(range.count))
+                let meanPow = sum / Float(range.count)
+                let db = 10 * log10f(max(meanPow, 1e-12)) + pinkCompensationDB[i]
+                let clamped = max(floorDB, min(ceilDB, db))
+                barsBuf[i] = (clamped - floorDB) / dbRange
+            }
         }
 
+        var maxDelta: Float = 0
         for i in 0..<Self.barCount {
-            let target = bars[i]
+            let target = barsBuf[i]
             let decayed = smoothed[i] * 0.82
-            smoothed[i] = target > decayed ? (decayed + (target - decayed) * 0.6) : decayed
+            let next = target > decayed ? (decayed + (target - decayed) * 0.6) : decayed
+            smoothed[i] = next
+            let clipped = max(0, min(1, next))
+            barsBuf[i] = clipped
+            let delta = abs(clipped - lastPublishedBuf[i])
+            if delta > maxDelta { maxDelta = delta }
         }
 
-        let cgLevels = smoothed.map { CGFloat(max(0, min(1, $0))) }
-        DispatchQueue.main.async { [weak self] in
-            self?.levels = cgLevels
+        // Skip the hop to main + Combine fan-out when nothing perceptible changed.
+        // Stacks with the view-side threshold to collapse idle cost toward zero.
+        guard maxDelta > 1e-4 else { return }
+        for i in 0..<Self.barCount {
+            lastPublishedBuf[i] = barsBuf[i]
         }
+        let snapshot = barsBuf
+        levelsPublisher.send(snapshot)
     }
 
     private func computeBandRanges(sampleRate: Double) {

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -38,6 +38,7 @@ class MusicManager: ObservableObject {
     @Published var animations: BoringAnimations = .init()
     @Published var avgColor: NSColor = .white
     @Published var bundleIdentifier: String? = nil
+    @Published var audioCaptureBundleIdentifiers: [String] = []
     @Published var songDuration: TimeInterval = 0
     @Published var elapsedTime: TimeInterval = 0
     @Published var timestampDate: Date = .init()
@@ -278,6 +279,11 @@ class MusicManager: ObservableObject {
             self.bundleIdentifier = state.bundleIdentifier
             // Update volume control support from active controller
             self.volumeControlSupported = activeController?.supportsVolumeControl ?? false
+        }
+
+        let captureBundleIDs = state.effectiveAudioCaptureBundleIdentifiers
+        if captureBundleIDs != self.audioCaptureBundleIdentifiers {
+            self.audioCaptureBundleIdentifiers = captureBundleIDs
         }
 
         if repeatModeChanged {

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -191,6 +191,7 @@ extension Defaults.Keys {
     
     // MARK: Media playback
     static let coloredSpectrogram = Key<Bool>("coloredSpectrogram", default: true)
+    static let realtimeAudioWaveform = Key<Bool>("realtimeAudioWaveform", default: false)
     static let enableSneakPeek = Key<Bool>("enableSneakPeek", default: false)
     static let sneakPeekStyles = Key<SneakPeekStyle>("sneakPeekStyles", default: .standard)
     static let waitInterval = Key<Double>("waitInterval", default: 3)

--- a/boringNotch/models/PlaybackState.swift
+++ b/boringNotch/models/PlaybackState.swift
@@ -15,6 +15,7 @@ enum RepeatMode: Int, Codable {
 
 struct PlaybackState {
     var bundleIdentifier: String
+    var audioCaptureBundleIdentifiers: [String] = []
     var isPlaying: Bool = false
     var title: String = "I'm Handsome"
     var artist: String = "Me"
@@ -28,11 +29,22 @@ struct PlaybackState {
     var artwork: Data?
     var volume: Double = 0.5
     var isFavorite: Bool = false
+
+    var effectiveAudioCaptureBundleIdentifiers: [String] {
+        let raw = audioCaptureBundleIdentifiers.isEmpty ? [bundleIdentifier] : audioCaptureBundleIdentifiers
+        var seen = Set<String>()
+        return raw.filter { bundleID in
+            guard !bundleID.isEmpty, !seen.contains(bundleID) else { return false }
+            seen.insert(bundleID)
+            return true
+        }
+    }
 }
 
 extension PlaybackState: Equatable {
     static func == (lhs: PlaybackState, rhs: PlaybackState) -> Bool {
         return lhs.bundleIdentifier == rhs.bundleIdentifier
+            && lhs.effectiveAudioCaptureBundleIdentifiers == rhs.effectiveAudioCaptureBundleIdentifiers
             && lhs.isPlaying == rhs.isPlaying
             && lhs.title == rhs.title
             && lhs.artist == rhs.artist

--- a/boringNotch/models/PlaybackState.swift
+++ b/boringNotch/models/PlaybackState.swift
@@ -32,10 +32,16 @@ struct PlaybackState {
 
     var effectiveAudioCaptureBundleIdentifiers: [String] {
         let raw = audioCaptureBundleIdentifiers.isEmpty ? [bundleIdentifier] : audioCaptureBundleIdentifiers
+        return raw.normalizedBundleIdentifiers
+    }
+}
+
+extension Sequence where Element == String {
+    var normalizedBundleIdentifiers: [String] {
         var seen = Set<String>()
-        return raw.filter { bundleID in
-            guard !bundleID.isEmpty, !seen.contains(bundleID) else { return false }
-            seen.insert(bundleID)
+        return filter { value in
+            guard !value.isEmpty, !seen.contains(value) else { return false }
+            seen.insert(value)
             return true
         }
     }

--- a/boringNotch/sizing/matters.swift
+++ b/boringNotch/sizing/matters.swift
@@ -17,6 +17,11 @@ let openNotchSize: CGSize = .init(width: 640, height: 190)
 let windowSize: CGSize = .init(width: openNotchSize.width, height: openNotchSize.height + shadowPadding)
 let cornerRadiusInsets: (opened: (top: CGFloat, bottom: CGFloat), closed: (top: CGFloat, bottom: CGFloat)) = (opened: (top: 19, bottom: 24), closed: (top: 6, bottom: 14))
 
+// Horizontal gap between closed-state live-activity content (album art / waveform)
+// and the physical notch edge. Without this margin the hardware bezel clips the
+// adjacent content since the spacer rect used to be narrower than the physical notch.
+let liveActivityEdgeMargin: CGFloat = 8
+
 enum MusicPlayerImageSizes {
     static let cornerRadiusInset: (opened: CGFloat, closed: CGFloat) = (opened: 13.0, closed: 4.0)
     static let size = (opened: CGSize(width: 90, height: 90), closed: CGSize(width: 20, height: 20))


### PR DESCRIPTION
This PR implements a FFT backend for the waveform visualizer widget in the notch that models the actual audio values instead of synthetic (random) data as the visualizer currently does. This works in real time using Apple's Accelerate framework which works in-place and is hardware accelerated.