### PR TITLE
Stop notch clicks from leaking through to the menu bar

### DIFF
--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -276,7 +276,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             window.disableSkyLight()
         }
 
-        window.contentView = NSHostingView(
+        window.contentView = FirstMouseHostingView(
             rootView: ContentView()
                 .environmentObject(viewModel)
         )

--- a/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
@@ -9,6 +9,11 @@ import Cocoa
 import SkyLightWindow
 import Defaults
 import Combine
+import SwiftUI
+
+final class FirstMouseHostingView<Content: View>: NSHostingView<Content> {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+}
 
 extension SkyLightOperator {
     func undelegateWindow(_ window: NSWindow) {


### PR DESCRIPTION
The notch window is a non-activating panel with canBecomeKey = false and a stock NSHostingView. NSView.acceptsFirstMouse(for:) defaults to false, so clicks on SwiftUI buttons inside the panel were not treated as a real first-mouse event and continued propagating through the WindowServer chain. Apps monitoring the menu bar (e.g. Ice) saw the click as a menu-bar click.

Wrap the contentView in a FirstMouseHostingView that overrides acceptsFirstMouse to true, so the click is fully owned by our window.