### PR TITLE
Add Language Selector

### DIFF
--- a/boringNotch/Info.plist
+++ b/boringNotch/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -2449,6 +2449,16 @@
         }
       }
     },
+    "Changing the app language requires restarting Boring Notch." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changing the app language requires restarting Boring Notch."
+          }
+        }
+      }
+    },
     "Change media with horizontal gestures" : {
       "localizations" : {
         "de" : {
@@ -6873,6 +6883,16 @@
         }
       }
     },
+    "Language" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Language"
+          }
+        }
+      }
+    },
     "Launch at login" : {
       "localizations" : {
         "fr" : {
@@ -6891,6 +6911,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oturum açıldığında başlat"
+          }
+        }
+      }
+    },
+    "Later" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Later"
           }
         }
       }
@@ -10599,6 +10629,26 @@
         }
       }
     },
+    "Restart Now" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restart Now"
+          }
+        }
+      }
+    },
+    "Restart to apply language" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restart to apply language"
+          }
+        }
+      }
+    },
     "Running" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -12701,6 +12751,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sistem"
+          }
+        }
+      }
+    },
+    "System default" : {
+      "comment" : "Language picker option: follow the system app language",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System default"
           }
         }
       }

--- a/boringNotch/components/Settings/Views/GeneralSettingsView.swift
+++ b/boringNotch/components/Settings/Views/GeneralSettingsView.swift
@@ -14,9 +14,11 @@ struct GeneralSettings: View {
         guard let uuid = screen.displayUUID else { return nil }
         return (uuid, screen.localizedName)
     }
+    @State private var showLanguageRestartAlert = false
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var coordinator = BoringViewCoordinator.shared
 
+    @Default(.appLanguage) var appLanguage
     @Default(.mirrorShape) var mirrorShape
     @Default(.gestureSensitivity) var gestureSensitivity
     @Default(.minimumHoverDuration) var minimumHoverDuration
@@ -43,6 +45,15 @@ struct GeneralSettings: View {
                 .tint(.effectiveAccent)
                 LaunchAtLogin.Toggle() {
                     Text("Launch at login")
+                }
+                Picker("Language", selection: $appLanguage) {
+                    ForEach(AppLanguage.allCases) { language in
+                        Text(language.displayName).tag(language)
+                    }
+                }
+                .onChange(of: appLanguage) {
+                    appLanguage.applyAppleLanguagesOverride()
+                    showLanguageRestartAlert = true
                 }
                 Defaults.Toggle(key: .showOnAllDisplays) {
                     Text("Show on all displays")
@@ -167,6 +178,14 @@ struct GeneralSettings: View {
             if !openNotchOnHover {
                 enableGestures = true
             }
+        }
+        .alert("Restart to apply language", isPresented: $showLanguageRestartAlert) {
+            Button("Later", role: .cancel) {}
+            Button("Restart Now") {
+                ApplicationRelauncher.restart()
+            }
+        } message: {
+            Text("Changing the app language requires restarting Boring Notch.")
         }
     }
 

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -30,49 +30,64 @@ enum HideNotchOption: String, Defaults.Serializable {
     case never
 }
 
-enum AppLanguage: String, CaseIterable, Identifiable, Defaults.Serializable {
-    case system
-    case arabic = "ar"
-    case czech = "cs"
-    case german = "de"
-    case english = "en"
-    case britishEnglish = "en-GB"
-    case spanish = "es"
-    case french = "fr"
-    case italian = "it"
-    case korean = "ko"
-    case polish = "pl"
-    case brazilianPortuguese = "pt-BR"
-    case russian = "ru"
-    case turkish = "tr"
-    case ukrainian = "uk"
-    case simplifiedChinese = "zh-Hans"
+struct AppLanguage: RawRepresentable, Hashable, Identifiable, Defaults.Serializable {
+    static let system = AppLanguage(rawValue: "system")
 
     var id: String { rawValue }
+    let rawValue: String
+
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    static var allCases: [AppLanguage] {
+        let languages = Bundle.main.localizations
+            .filter(isSelectableLocalization)
+            .map(AppLanguage.init(rawValue:))
+            .sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
+
+        return [.system] + languages
+    }
 
     var displayName: String {
-        switch self {
-        case .system:
-            NSLocalizedString(
+        if self == .system {
+            return NSLocalizedString(
                 "System default",
                 comment: "Language picker option: follow the system app language"
             )
-        case .arabic: "Arabic"
-        case .czech: "Czech"
-        case .german: "German"
-        case .english: "English"
-        case .britishEnglish: "English (UK)"
-        case .spanish: "Spanish"
-        case .french: "French"
-        case .italian: "Italian"
-        case .korean: "Korean"
-        case .polish: "Polish"
-        case .brazilianPortuguese: "Portuguese (Brazil)"
-        case .russian: "Russian"
-        case .turkish: "Turkish"
-        case .ukrainian: "Ukrainian"
-        case .simplifiedChinese: "Chinese (Simplified)"
         }
+
+        let displayName = nativeLocale.localizedString(forIdentifier: rawValue) ?? rawValue
+        return displayName.capitalized(with: nativeLocale)
+    }
+
+    private var nativeLocale: Locale {
+        Locale(identifier: rawValue)
+    }
+
+    private static func isSelectableLocalization(_ identifier: String) -> Bool {
+        guard identifier != "Base" else { return false }
+        guard let url = Bundle.main.url(
+            forResource: "Localizable",
+            withExtension: "strings",
+            subdirectory: nil,
+            localization: identifier
+        ) else {
+            return false
+        }
+
+        guard
+            let data = try? Data(contentsOf: url),
+            let strings = try? PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: nil
+            ) as? [String: String]
+        else {
+            return false
+        }
+
+        return strings.values.contains { !$0.isEmpty }
     }
 
     func applyAppleLanguagesOverride() {

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -30,6 +30,61 @@ enum HideNotchOption: String, Defaults.Serializable {
     case never
 }
 
+enum AppLanguage: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case system
+    case arabic = "ar"
+    case czech = "cs"
+    case german = "de"
+    case english = "en"
+    case britishEnglish = "en-GB"
+    case spanish = "es"
+    case french = "fr"
+    case italian = "it"
+    case korean = "ko"
+    case polish = "pl"
+    case brazilianPortuguese = "pt-BR"
+    case russian = "ru"
+    case turkish = "tr"
+    case ukrainian = "uk"
+    case simplifiedChinese = "zh-Hans"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .system:
+            NSLocalizedString(
+                "System default",
+                comment: "Language picker option: follow the system app language"
+            )
+        case .arabic: "Arabic"
+        case .czech: "Czech"
+        case .german: "German"
+        case .english: "English"
+        case .britishEnglish: "English (UK)"
+        case .spanish: "Spanish"
+        case .french: "French"
+        case .italian: "Italian"
+        case .korean: "Korean"
+        case .polish: "Polish"
+        case .brazilianPortuguese: "Portuguese (Brazil)"
+        case .russian: "Russian"
+        case .turkish: "Turkish"
+        case .ukrainian: "Ukrainian"
+        case .simplifiedChinese: "Chinese (Simplified)"
+        }
+    }
+
+    func applyAppleLanguagesOverride() {
+        if self == .system {
+            UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+        } else {
+            UserDefaults.standard.set([rawValue], forKey: "AppleLanguages")
+        }
+        UserDefaults.standard.synchronize()
+    }
+}
+
 // Define notification names at file scope
 extension Notification.Name {
     // MARK: - Media
@@ -136,6 +191,7 @@ enum OSDControlSource: String, CaseIterable, Identifiable, Defaults.Serializable
 
 extension Defaults.Keys {
     // MARK: General
+    static let appLanguage = Key<AppLanguage>("appLanguage", default: .system)
     static let menubarIcon = Key<Bool>("menubarIcon", default: true)
     static let showOnAllDisplays = Key<Bool>("showOnAllDisplays", default: false)
     static let automaticallySwitchDisplay = Key<Bool>("automaticallySwitchDisplay", default: true)


### PR DESCRIPTION
This pull request adds support for explicitly selecting the app language within the app's general settings. Users can now choose their preferred language, and the app will prompt them to restart for the change to take effect.
