### PR TITLE
Add Yandex Music integration

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		1153BD982D9881F900979FB0 /* AppleScriptHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BD972D9881F900979FB0 /* AppleScriptHelper.swift */; };
 		1153BD9A2D98824300979FB0 /* SpotifyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BD992D98824300979FB0 /* SpotifyController.swift */; };
 		1153BD9C2D98853B00979FB0 /* NowPlayingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BD9B2D98853B00979FB0 /* NowPlayingController.swift */; };
+		A1B2C3D42F00000100AA0001 /* YandexMusicController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D32F00000100AA0001 /* YandexMusicController.swift */; };
 		1153BDA72D99B22200979FB0 /* YouTubeMusicController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BDA62D99B22200979FB0 /* YouTubeMusicController.swift */; };
 		115C12EC2ED3D003009754CA /* OpenNotchHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115C12EB2ED3D003009754CA /* OpenNotchHUD.swift */; };
 		1160F8D82DD98230006FBB94 /* NotchShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1160F8D72DD98230006FBB94 /* NotchShape.swift */; };
@@ -208,6 +209,7 @@
 		1153BD972D9881F900979FB0 /* AppleScriptHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptHelper.swift; sourceTree = "<group>"; };
 		1153BD992D98824300979FB0 /* SpotifyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyController.swift; sourceTree = "<group>"; };
 		1153BD9B2D98853B00979FB0 /* NowPlayingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingController.swift; sourceTree = "<group>"; };
+		A1B2C3D32F00000100AA0001 /* YandexMusicController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YandexMusicController.swift; sourceTree = "<group>"; };
 		1153BDA62D99B22200979FB0 /* YouTubeMusicController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeMusicController.swift; sourceTree = "<group>"; };
 		115C12EB2ED3D003009754CA /* OpenNotchHUD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenNotchHUD.swift; sourceTree = "<group>"; };
 		1160F8D72DD98230006FBB94 /* NotchShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchShape.swift; sourceTree = "<group>"; };
@@ -430,6 +432,7 @@
 				1153BD8D2D986B1F00979FB0 /* MediaControllerProtocol.swift */,
 				1153BD922D986E4300979FB0 /* AppleMusicController.swift */,
 				1153BD992D98824300979FB0 /* SpotifyController.swift */,
+				A1B2C3D32F00000100AA0001 /* YandexMusicController.swift */,
 				1153BD9B2D98853B00979FB0 /* NowPlayingController.swift */,
 			);
 			path = MediaControllers;
@@ -951,6 +954,7 @@
 				1160F8D82DD98230006FBB94 /* NotchShape.swift in Sources */,
 				5917FD112E57891600E87F1C /* MediaKeyInterceptor.swift in Sources */,
 				14C08BC12C8E03AD000F8AA0 /* NSImage+Extensions.swift in Sources */,
+				A1B2C3D42F00000100AA0001 /* YandexMusicController.swift in Sources */,
 				149E0B9A2C737D40006418B1 /* WebcamView.swift in Sources */,
 				1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */,
 				B1B112932C6A577E00093D8F /* MouseTracker.swift in Sources */,

--- a/boringNotch/MediaControllers/YandexMusicController.swift
+++ b/boringNotch/MediaControllers/YandexMusicController.swift
@@ -1,0 +1,86 @@
+//
+//  YandexMusicController.swift
+//  boringNotch
+//
+//  Created by Anatoly on 2026-04-27.
+//
+
+import AppKit
+import Combine
+import Foundation
+
+class YandexMusicController: MediaControllerProtocol {
+    private enum Constants {
+        static let bundleIdentifier = "ru.yandex.desktop.music"
+    }
+
+    @Published private var playbackState: PlaybackState = PlaybackState(
+        bundleIdentifier: Constants.bundleIdentifier
+    )
+
+    var playbackStatePublisher: AnyPublisher<PlaybackState, Never> {
+        $playbackState.eraseToAnyPublisher()
+    }
+
+    var supportsVolumeControl: Bool { false }
+    var supportsFavorite: Bool { false }
+
+    private var cancellables = Set<AnyCancellable>()
+    private let nowPlayingController: NowPlayingController?
+
+    init() {
+        self.nowPlayingController = NowPlayingController()
+        bindNowPlaying()
+    }
+
+    private func bindNowPlaying() {
+        nowPlayingController?.playbackStatePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self = self else { return }
+                guard state.bundleIdentifier == Constants.bundleIdentifier else { return }
+                self.playbackState = state
+            }
+            .store(in: &cancellables)
+    }
+
+    func setFavorite(_ favorite: Bool) async {}
+
+    func play() async {
+        await nowPlayingController?.play()
+    }
+
+    func pause() async {
+        await nowPlayingController?.pause()
+    }
+
+    func seek(to time: Double) async {
+        await nowPlayingController?.seek(to: time)
+    }
+
+    func nextTrack() async {
+        await nowPlayingController?.nextTrack()
+    }
+
+    func previousTrack() async {
+        await nowPlayingController?.previousTrack()
+    }
+
+    func togglePlay() async {
+        await nowPlayingController?.togglePlay()
+    }
+
+    func toggleShuffle() async {}
+    func toggleRepeat() async {}
+    func setVolume(_ level: Double) async {}
+
+    func isActive() -> Bool {
+        NSWorkspace.shared.runningApplications.contains {
+            $0.bundleIdentifier == Constants.bundleIdentifier
+        }
+    }
+
+    func updatePlaybackInfo() async {
+        await nowPlayingController?.updatePlaybackInfo()
+    }
+}

--- a/boringNotch/boringNotch.entitlements
+++ b/boringNotch/boringNotch.entitlements
@@ -24,6 +24,7 @@
 	<array>
 		<string>com.spotify.client</string>
 		<string>com.apple.Music</string>
+		<string>ru.yandex.desktop.music</string>
 	</array>
 	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
 	<array>

--- a/boringNotch/components/Onboarding/MusicControllerSelectionView.swift
+++ b/boringNotch/components/Onboarding/MusicControllerSelectionView.swift
@@ -130,6 +130,8 @@ extension MediaControllerType {
             return "Connects directly to the Apple Music app."
         case .youtubeMusic:
             return "Requires a third-party client with API plugin enabled."
+        case .yandexMusic:
+            return "Connects directly to the Yandex Music app."
         }
     }
 }

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -131,6 +131,8 @@ class MusicManager: ObservableObject {
             newController = SpotifyController()
         case .youtubeMusic:
             newController = YouTubeMusicController()
+        case .yandexMusic:
+            newController = YandexMusicController()
         }
 
         // Set up state observation for the new controller

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -47,6 +47,7 @@ enum MediaControllerType: String, CaseIterable, Identifiable, Defaults.Serializa
     case appleMusic = "Apple Music"
     case spotify = "Spotify"
     case youtubeMusic = "YouTube Music"
+    case yandexMusic = "Yandex Music"
     
     var id: String { self.rawValue }
 }


### PR DESCRIPTION
Added [Yandex Music](https://music.yandex.ru/download/) as a media source. Relied on the existing Apple Script integrations for examples.

Could not get shuffle, loop, volume and favorites to work, prodded at the Yandex Music app and it did not respond to anything of the above.