### PR TITLE
Add Angry and Love face types

### DIFF
--- a/.github/workflows/build-on-main.yml
+++ b/.github/workflows/build-on-main.yml
@@ -1,0 +1,94 @@
+name: "Build DMG on Main"
+
+on:
+  push:
+    branches:
+      - main
+
+# Cancel any in-progress builds for the same branch
+concurrency:
+  group: build-dmg-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-dmg:
+    name: Build DMG
+    runs-on: macos-latest
+    env:
+      PROJECT_NAME: boringNotch
+      DEVELOPMENT_TEAM: ${{ vars.DEVELOPMENT_TEAM_ID }}
+      CODE_SIGN_IDENTITY: "Apple Development"
+      XCODE_VERSION: "16.4"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Resolve Swift packages
+        run: xcodebuild -resolvePackageDependencies -project ${{ env.PROJECT_NAME }}.xcodeproj
+
+      - name: Select Xcode ${{ env.XCODE_VERSION }}
+        run: |
+          XCODE_PATH="/Applications/Xcode_${XCODE_VERSION}.app"
+          if [[ ! -d "$XCODE_PATH" ]]; then
+            echo "Available Xcode versions:"
+            ls -d /Applications/Xcode*.app 2>/dev/null || echo "  (none found)"
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE_PATH"
+          xcodebuild -version
+
+      - name: Build and archive
+        run: |
+          xcodebuild clean archive \
+            -project ${{ env.PROJECT_NAME }}.xcodeproj \
+            -scheme ${{ env.PROJECT_NAME }} \
+            -archivePath ${{ env.PROJECT_NAME }} \
+            -destination "generic/platform=macOS" \
+            DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
+            CODE_SIGN_IDENTITY="$CODE_SIGN_IDENTITY" \
+            ONLY_ACTIVE_ARCH=NO
+
+      - name: Export app
+        run: |
+          cat > "$RUNNER_TEMP/export_options.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>development</string>
+            <key>signingStyle</key>
+            <string>automatic</string>
+            <key>teamID</key>
+            <string>${DEVELOPMENT_TEAM}</string>
+          </dict>
+          </plist>
+          PLIST
+          xcodebuild -exportArchive \
+            -archivePath "${{ env.PROJECT_NAME }}.xcarchive" \
+            -exportPath Release \
+            -exportOptionsPlist "$RUNNER_TEMP/export_options.plist"
+
+      - name: Create DMG
+        run: |
+          VENV_DIR="$RUNNER_TEMP/venv"
+          python3 -m venv "$VENV_DIR"
+          source "$VENV_DIR/bin/activate"
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install --require-hashes -r Configuration/dmg/requirements.txt
+          chmod +x Configuration/dmg/create_dmg.sh
+          ./Configuration/dmg/create_dmg.sh \
+            "Release/${{ env.PROJECT_NAME }}.app" \
+            "Release/${{ env.PROJECT_NAME }}.dmg" \
+            "${{ env.PROJECT_NAME }}"
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.PROJECT_NAME }}.dmg
+          path: Release/${{ env.PROJECT_NAME }}.dmg
+          retention-days: 7

--- a/.github/workflows/build-on-main.yml
+++ b/.github/workflows/build-on-main.yml
@@ -60,7 +60,7 @@ jobs:
           <plist version="1.0">
           <dict>
             <key>method</key>
-            <string>app</string>
+            <string>mac-application</string>
             <key>signingStyle</key>
             <string>automatic</string>
           </dict>

--- a/.github/workflows/build-on-main.yml
+++ b/.github/workflows/build-on-main.yml
@@ -60,11 +60,9 @@ jobs:
           <plist version="1.0">
           <dict>
             <key>method</key>
-            <string>development</string>
+            <string>app</string>
             <key>signingStyle</key>
             <string>automatic</string>
-            <key>teamID</key>
-            <string>${DEVELOPMENT_TEAM}</string>
           </dict>
           </plist>
           PLIST

--- a/.github/workflows/build-on-main.yml
+++ b/.github/workflows/build-on-main.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: macos-latest
     env:
       PROJECT_NAME: boringNotch
-      DEVELOPMENT_TEAM: ${{ vars.DEVELOPMENT_TEAM_ID }}
-      CODE_SIGN_IDENTITY: "Apple Development"
+      DEVELOPMENT_TEAM: ${{ vars.DEVELOPMENT_TEAM_ID || '' }}
+      CODE_SIGN_IDENTITY: "-"
       XCODE_VERSION: "16.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,8 +1,0 @@
-name: Crowdin Sync
-
-on:
-  workflow_dispatch:
-
-jobs:
-  crowdin:
-    runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,43 +1,42 @@
-<h1 align="center">
-  <br>
+# Boring Notch (Fork)
+
+<p align="center">
   <a href="http://theboring.name"><img src="https://framerusercontent.com/images/RFK4vs0kn8pRMuOO58JeyoemXA.png?scale-down-to=256" alt="Boring Notch" width="150"></a>
   <br>
   Boring Notch
   <br>
+  <sub><em>Built on <a href="https://github.com/TheBoredTeam/boring.notch">TheBoredTeam/boring.notch</a></em></sub>
 </h1>
 
-
 <p align="center">
-  <a title="Crowdin" target="_blank" href="https://crowdin.com/project/boring-notch"><img src="https://badges.crowdin.net/boring-notch/localized.svg"></a>
-  <img src="https://github.com/TheBoredTeam/boring.notch/actions/workflows/cicd.yml/badge.svg" alt="TheBoringNotch Build & Test" style="margin-right: 10px;" />
   <a href="https://discord.gg/c8JXA7qrPm">
     <img src="https://dcbadge.limes.pink/api/server/https://discord.gg/c8JXA7qrPm?style=flat" alt="Discord Badge" />
   </a>
-  <a href="https://www.ko-fi.com/alexander5015">
-    <img src="https://srv-cdn.himpfen.io/badges/kofi/kofi-flat.svg" alt="Ko-Fi" />
-  </a>
 </p>
 
-<!--Welcome to **Boring.Notch**, the coolest way to make your MacBook's notch the star of the show! Forget about those boring status bars—our notch turns into a dynamic music control center, complete with a snazzy visualizer and all the music controls you need. It's like having a mini concert right at the top of your screen! -->
-
-Say hello to **Boring Notch**, the coolest way to make your MacBook’s notch the star of the show! Say goodbye to boring status bars: with Boring Notch, your notch transforms into a dynamic music control center, complete with a vibrant visualizer and all the essential music controls you need. But that’s just the start! Boring Notch also offers calendar integration, a handy file shelf with AirDrop support, a complete MacOS HUD replacement and more!
-
-<p align="center">
-  <img src="https://github.com/user-attachments/assets/2d5f69c1-6e7b-4bc2-a6f1-bb9e27cf88a8" alt="Demo GIF" />
-</p>
-
-<!--https://github.com/user-attachments/assets/19b87973-4b3a-4853-b532-7e82d1d6b040-->
 ---
-<!--## Table of Contents
-- [Installation](#installation)
-- [Usage](#usage)
-- [Roadmap](#-roadmap)
-- [Building from Source](#building-from-source)
-- [Contributing](#-contributing)
-- [Join our Discord Server](#join-our-discord-server)
-- [Star History](#star-history)
-- [Buy us a coffee!](#buy-us-a-coffee)
-- [Acknowledgments](#-acknowledgments)-->
+
+## About This Fork
+
+This is a modified version of [Boring Notch](https://github.com/TheBoredTeam/boring.notch) by [TheBoredTeam](https://github.com/TheBoredTeam). 
+
+Boring Notch transforms your MacBook's notch into a dynamic HUD with music controls, calendar integration, shelf functionality, and more. This fork builds upon the original with additional features listed below.
+
+### Original Features
+- Music playback live activity with visualizer
+- Calendar integration
+- Shelf functionality with AirDrop
+- Charging indicator and battery percentage
+- System HUD replacements (volume, brightness, backlight)
+- Customizable gesture control
+
+### Added Features (This Fork)
+- 🎭 **Face Animations** – Animated faces that display in the notch when inactive (6 types: Minimal, Cool, Surprised, Sleepy, Wink, Happy)
+- 🍅 **Pomodoro Timer** – Built-in pomodoro timer with customizable work/break durations and session tracking
+- ⏱️ **Timer Display** – Live countdown display in closed notch when timer is running
+- 🔊 **Music Visualizer** – Enhanced audio spectrum visualizer in the notch
+
+---
 
 ## Installation
 
@@ -45,100 +44,34 @@ Say hello to **Boring Notch**, the coolest way to make your MacBook’s notch th
 - macOS **14 Sonoma** or later
 - Apple Silicon or Intel Mac
 
----
+### Download
 
-### Option 1: Download and Install Manually
-
-<a href="https://github.com/TheBoredTeam/boring.notch/releases/latest/download/boringNotch.dmg" target="_self"><img width="200" src="https://github.com/user-attachments/assets/e3179be1-8416-4b8a-b417-743e1ecc67d6" alt="Download for macOS" /></a>
+<a href="https://github.com/christianteohx/boring.notch/releases/latest/download/boringNotch.dmg" target="_self"><img width="200" src="https://github.com/user-attachments/assets/e3179be1-8416-4b8a-b417-743e1ecc67d6" alt="Download for macOS" /></a>
 
 Once downloaded, open the `.dmg` and move **Boring Notch** to your `/Applications` folder.
 
 > [!IMPORTANT]
-> We don't have an Apple Developer account (yet 👀), so macOS will warn you that Boring Notch is from an unidentified developer on first launch. This is expected behavior.
+> Since this is a forked app with ad-hoc code signing, macOS may warn you that it's from an unidentified developer.
 >
-> You'll need to bypass this before the app will open. You only need to do this once. Use one of the methods below.
+> After moving to Applications, run:
+> ```bash
+> xattr -dr com.apple.quarantine /Applications/boringNotch.app
+> ```
 
 ---
-
-#### Recommended: Terminal (Always Works)
-
-This is the quickest and easiest method. It only requires a single command and works consistently for all users. System Settings can sometimes fail and won't work for non-admin users.
-
-After moving Boring Notch to your Applications folder, run:
-
-```bash
-xattr -dr com.apple.quarantine /Applications/boringNotch.app
-```
-
-Then open the app normally.
-
----
-
-#### Alternative: System Settings
-
-> [!NOTE]
-> This method doesn't work for all users. If this doesn't work, use the Terminal method above.
-
-1. Try to open the app — you'll see a security warning.
-2. Click **OK** to dismiss it.
-3. Open **System Settings** > **Privacy & Security**.
-4. Scroll to the bottom and click **Open Anyway** next to the Boring Notch warning.
-5. Confirm if prompted.
-
----
-
-### Option 2: Install via Homebrew
-
-You can also install using [Homebrew](https://brew.sh). The Homebrew installation automatically bypasses the macOS security warning described above.
-
-```bash
-brew install --cask TheBoredTeam/boring-notch/boring-notch
-```
-
-## Usage
-
-- Launch the app, and voilà—your notch is now the coolest part of your screen.
-- Hover over the notch to see it expand and reveal all its secrets.
-- Use the controls to manage your music like a rockstar.
-- Click the star in your menu bar to customize your notch to your heart's content.
-
-## 📋 Roadmap
-- [x] Playback live activity 🎧
-- [x] Calendar integration 📆
-- [x] Reminders integration ☑️
-- [x] Mirror 📷
-- [x] Charging indicator and current percentage 🔋
-- [x] Customizable gesture control 👆🏻
-- [x] Shelf functionality with AirDrop 📚
-- [x] Notch sizing customization, finetuning on different display sizes 🖥️
-- [x] System HUD replacements (volume, brightness, backlight) 🎚️💡⌨️
-- [ ] Bluetooth Live Activity (connect/disconnect for bluetooth devices) 
-- [ ] Weather integration ⛅️
-- [ ] Customizable Layout options 🛠️
-- [ ] Lock Screen Widgets 🔒
-- [ ] Extension system 🧩
-- [ ] Notifications (under consideration) 🔔
-<!-- - [ ] Clipboard history manager 📌 `Extension` -->
-<!-- - [ ] Download indicator of different browsers (Safari, Chromium browsers, Firefox) 🌍 `Extension`-->
-<!-- - [ ] Customizable function buttons 🎛️ -->
-<!-- - [ ] App switcher 🪄 -->
-
-<!-- ## 🧩 Extensions
-> [!NOTE]
-> We’re hard at work on some awesome extensions! Stay tuned, and we’ll keep you updated as soon as they’re released. -->
 
 ## Building from Source
 
 ### Prerequisites
 
-- **macOS 14 or later**: If you’re not on the latest macOS, we might need to send a search party.
-- **Xcode 16 or later**: This is where the magic happens, so make sure it’s up-to-date.
+- **macOS 14 or later**
+- **Xcode 16 or later**
 
 ### Installation
 
 1. **Clone the Repository**:
    ```bash
-   git clone https://github.com/TheBoredTeam/boring.notch.git
+   git clone https://github.com/christianteohx/boring.notch.git
    cd boring.notch
    ```
 
@@ -148,44 +81,38 @@ brew install --cask TheBoredTeam/boring-notch/boring-notch
    ```
 
 3. **Build and Run**:
-    - Click the "Run" button or press `Cmd + R`. Watch the magic unfold!
+   - Click the "Run" button or press `Cmd + R`
 
-## 🤝 Contributing
+---
 
-We’re all about good vibes and awesome contributions! Read [CONTRIBUTING.md](CONTRIBUTING.md) to learn how you can join the fun!
+## Features
 
-## Join our Discord Server
+### Face Animations
+Choose from 6 animated face types:
+- **Minimal** – Simple face with blinking eyes
+- **Cool** – Sunglasses with smirk animation
+- **Surprised** – Wide eyes with "O" mouth
+- **Sleepy** – Half-closed eyes
+- **Wink** – Periodic eye wink
+- **Happy** – Curved ^_^ eyes with bounce
 
-<a href="https://discord.gg/GvYcYpAKTu" target="_blank"><img src="https://iili.io/28m3GHv.png" alt="Join The Boring Server!" style="height: 60px !important;width: 217px !important;" ></a>
+Face animations can run in Fixed mode (one face) or Random mode (cycles through faces).
 
-## Star History
+### Pomodoro Timer
+- Customizable work duration (1-90 minutes)
+- Short break duration (1-30 minutes)
+- Long break duration (1-60 minutes)
+- Session counter (resets after N sessions)
+- Live countdown display in the notch
 
-<a href="https://www.star-history.com/#TheBoredTeam/boring.notch&Timeline">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=TheBoredTeam/boring.notch&type=Timeline&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=TheBoredTeam/boring.notch&type=Timeline" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=TheBoredTeam/boring.notch&type=Timeline" />
- </picture>
-</a>
+### Music Visualizer
+Audio spectrum visualizer with animated bars that react to audio playback.
 
-## Support us on Ko-fi!
-<!-- <a href="https://www.buymeacoffee.com/jfxh67wvfxq" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-red.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a> -->
-<a href="https://www.ko-fi.com/alexander5015" target="_blank"><img src="https://github.com/user-attachments/assets//a76175ef-7e93-475a-8b67-4922ba5964c2" alt="Support us on Ko-fi" style="height: 70px !important;width: 346px !important;" ></a>
+---
 
-## 🎉 Acknowledgments
+## Credits
 
-We would like to express our gratitude to the authors and maintainers of the open-source projects that made this possible. 
+- **Original Project**: [Boring Notch](https://github.com/TheBoredTeam/boring.notch) by [TheBoredTeam](https://github.com/TheBoredTeam)
+- **SwiftUI**: For making us look like coding wizards
 
-## Notable Projects
-- **[MediaRemoteAdapter](https://github.com/ungive/mediaremote-adapter)** –  An open-source project that allowed us to use the Now Playing source in macOS 15.4+
-- **[NotchDrop](https://github.com/Lakr233/NotchDrop)** – An open-source project that has been instrumental in developing the first version of the "Shelf" feature in Boring Notch.
-
-For a full list of licenses and attributions, please see the [Third-Party Licenses](./THIRD_PARTY_LICENSES.md) file.
-
-### Icon credits: [@maxtron95](https://github.com/maxtron95)
-### Website credits: [@himanshhhhuv](https://github.com/himanshhhhuv)
-
-- **SwiftUI**: For making us look like coding wizards.
-- **You**: For being awesome and checking out **boring.notch**!
-
-
+For a full list of licenses and attributions, see [THIRD_PARTY_LICENSES.md](./THIRD_PARTY_LICENSES.md).

--- a/add_file.py
+++ b/add_file.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import re
+
+with open('boringNotch.xcodeproj/project.pbxproj', 'r') as f:
+    content = f.read()
+
+# Add PBXBuildFile entry after PomodoroView.swift in Sources
+build_pattern = r'(POMOD0042C5EAFBF00000004 /\* PomodoroView\.swift in Sources \* / = \{isa = PBXBuildFile; fileRef = POMOD0022C5EAFBF00000002 /\* PomodoroView\.swift \* /; \};)'
+build_replacement = r'\1\n\t\tPOMODCLOS0001C5EAFBF00000001 /* PomodoroClosedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = POMODCLOS0002C5EAFBF00000001 /* PomodoroClosedView.swift */; };'
+content = re.sub(build_pattern, build_replacement, content)
+
+# Add PBXFileReference entry after PomodoroView.swift file reference
+file_pattern = r'(POMOD0022C5EAFBF00000002 /\* PomodoroView\.swift \* / = \{isa = PBXFileReference; lastKnownFileType = sourcecode\.swift; path = PomodoroView\.swift; sourceTree = "<group>"; \};)'
+file_replacement = r'\1\n\t\tPOMODCLOS0002C5EAFBF00000001 /* PomodoroClosedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroClosedView.swift; sourceTree = "<group>"; };'
+content = re.sub(file_pattern, file_replacement, content)
+
+# Add to PBXSourcesBuildPhase
+sources_pattern = r'(POMOD0042C5EAFBF00000004 /\* PomodoroView\.swift in Sources \* /,)'
+sources_replacement = r'\1\n\t\t\t\tPOMODCLOS0001C5EAFBF00000001 /* PomodoroClosedView.swift in Sources */,'
+content = re.sub(sources_pattern, sources_replacement, content)
+
+with open('boringNotch.xcodeproj/project.pbxproj', 'w') as f:
+    f.write(content)
+
+print("Done")

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		F38DE6482D8243E7008B5C6D /* BatteryActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */; };
 		POMOD0032C5EAFBF00000003 /* PomodoroManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = POMOD0012C5EAFBF00000001 /* PomodoroManager.swift */; };
 		POMOD0042C5EAFBF00000004 /* PomodoroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = POMOD0022C5EAFBF00000002 /* PomodoroView.swift */; };
+		POMODCLOS0001C5EAFBF00000001 /* PomodoroClosedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = POMODCLOS0002C5EAFBF00000001 /* PomodoroClosedView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -313,6 +314,7 @@
 		F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryActivityManager.swift; sourceTree = "<group>"; };
 		POMOD0012C5EAFBF00000001 /* PomodoroManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroManager.swift; sourceTree = "<group>"; };
 		POMOD0022C5EAFBF00000002 /* PomodoroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroView.swift; sourceTree = "<group>"; };
+		POMODCLOS0002C5EAFBF00000001 /* PomodoroClosedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroClosedView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -507,6 +509,7 @@
 				B10F84A22C6C9596009F3026 /* TestView.swift */,
 				507266DA2C908E2E00A2D00D /* HoverButton.swift */,
 				POMOD0022C5EAFBF00000002 /* PomodoroView.swift */,
+				POMODCLOS0002C5EAFBF00000001 /* PomodoroClosedView.swift */,
 				B1F747F82EC7E94000F841DB /* LottieView.swift */,
 			);
 			path = components;
@@ -1003,6 +1006,7 @@
 				F38DE6482D8243E7008B5C6D /* BatteryActivityManager.swift in Sources */,
 				POMOD0032C5EAFBF00000003 /* PomodoroManager.swift in Sources */,
 				POMOD0042C5EAFBF00000004 /* PomodoroView.swift in Sources */,
+				POMODCLOS0001C5EAFBF00000001 /* PomodoroClosedView.swift in Sources */,
 				B10348D92C74E56000475897 /* ConditionalModifier.swift in Sources */,
 				118D1FD12E98FF5F00A2FF63 /* SharingStateManager.swift in Sources */,
 				14D570C22C5EAFBF0011E668 /* EmptyState.swift in Sources */,

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -143,6 +143,8 @@
 		B1F747F92EC7E94000F841DB /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F747F82EC7E94000F841DB /* LottieView.swift */; };
 		B1FEB4992C7686630066EBBC /* PanGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FEB4982C7686630066EBBC /* PanGesture.swift */; };
 		F38DE6482D8243E7008B5C6D /* BatteryActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */; };
+		POMOD0032C5EAFBF00000003 /* PomodoroManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = POMOD0012C5EAFBF00000001 /* PomodoroManager.swift */; };
+		POMOD0042C5EAFBF00000004 /* PomodoroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = POMOD0022C5EAFBF00000002 /* PomodoroView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -309,6 +311,8 @@
 		B1F747F82EC7E94000F841DB /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
 		B1FEB4982C7686630066EBBC /* PanGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanGesture.swift; sourceTree = "<group>"; };
 		F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryActivityManager.swift; sourceTree = "<group>"; };
+		POMOD0012C5EAFBF00000001 /* PomodoroManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroManager.swift; sourceTree = "<group>"; };
+		POMOD0022C5EAFBF00000002 /* PomodoroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -502,6 +506,7 @@
 				B17266E22C65F7FB0031BA0D /* WhatsNewView.swift */,
 				B10F84A22C6C9596009F3026 /* TestView.swift */,
 				507266DA2C908E2E00A2D00D /* HoverButton.swift */,
+				POMOD0022C5EAFBF00000002 /* PomodoroView.swift */,
 				B1F747F82EC7E94000F841DB /* LottieView.swift */,
 			);
 			path = components;
@@ -512,6 +517,7 @@
 			children = (
 				11D58EA12E760AE100FA8377 /* ImageService.swift */,
 				F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */,
+				POMOD0012C5EAFBF00000001 /* PomodoroManager.swift */,
 				112FB7342CCF16F70015238C /* NotchSpaceManager.swift */,
 				147163992C5D35FF0068B555 /* MusicManager.swift */,
 				149E0B962C737D00006418B1 /* WebcamManager.swift */,
@@ -995,6 +1001,8 @@
 				118EBE3B2E9720C500D54B5A /* ShelfStateViewModel.swift in Sources */,
 				11F747CE2EC75CEA00F841DB /* DragPreviewView.swift in Sources */,
 				F38DE6482D8243E7008B5C6D /* BatteryActivityManager.swift in Sources */,
+				POMOD0032C5EAFBF00000003 /* PomodoroManager.swift in Sources */,
+				POMOD0042C5EAFBF00000004 /* PomodoroView.swift in Sources */,
 				B10348D92C74E56000475897 /* ConditionalModifier.swift in Sources */,
 				118D1FD12E98FF5F00A2FF63 /* SharingStateManager.swift in Sources */,
 				14D570C22C5EAFBF0011E668 /* EmptyState.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -287,12 +287,26 @@ struct ContentView: View {
                       } else if coordinator.sneakPeek.show && Defaults[.inlineHUD] && (coordinator.sneakPeek.type != .music) && (coordinator.sneakPeek.type != .battery) && vm.notchState == .closed {
                           InlineHUD(type: $coordinator.sneakPeek.type, value: $coordinator.sneakPeek.value, icon: $coordinator.sneakPeek.icon, hoverAnimation: $isHovering, gestureProgress: $gestureProgress)
                               .transition(.opacity)
-                      } else if !coordinator.expandingView.show && vm.notchState == .closed && Defaults[.showNotHumanFace] && !vm.hideOnClosed {
-                          // Show face animation when enabled (regardless of music state)
-                          BoringFaceAnimation()
-                      } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music) && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed {
-                          MusicLiveActivity()
-                              .frame(alignment: .center)
+                      } else if !coordinator.expandingView.show && vm.notchState == .closed && !vm.hideOnClosed {
+                          // Show BOTH face animation AND music indicator side by side
+                          HStack(spacing: 0) {
+                              // Face on the left
+                              if Defaults[.showNotHumanFace] {
+                                  BoringFaceAnimation()
+                              }
+                              
+                              // Spacer in the middle
+                              Rectangle()
+                                  .fill(.black)
+                                  .frame(width: 20)
+                              
+                              // Music on the right (if playing)
+                              if (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled {
+                                  MusicLiveActivity()
+                                      .frame(alignment: .center)
+                              }
+                          }
+                          .frame(height: vm.effectiveClosedNotchHeight)
                        } else if vm.notchState == .open {
                            BoringHeader()
                                .frame(height: max(24, vm.effectiveClosedNotchHeight))

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -65,15 +65,11 @@ struct ContentView: View {
             && vm.notchState == .closed && Defaults[.showPowerStatusNotifications]
         {
             chinWidth = 640
-        } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music)
-            && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle)
-            && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed
-        {
-            chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
         } else if !coordinator.expandingView.show && vm.notchState == .closed
-            && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace]
-            && !vm.hideOnClosed
+            && ((musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled
+                || Defaults[.showNotHumanFace]) && !vm.hideOnClosed
         {
+            // Expand only slightly when showing music or face (not both)
             chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
         }
 
@@ -288,22 +284,17 @@ struct ContentView: View {
                           InlineHUD(type: $coordinator.sneakPeek.type, value: $coordinator.sneakPeek.value, icon: $coordinator.sneakPeek.icon, hoverAnimation: $isHovering, gestureProgress: $gestureProgress)
                               .transition(.opacity)
                       } else if !coordinator.expandingView.show && vm.notchState == .closed && !vm.hideOnClosed {
-                          // Show BOTH face animation AND music indicator side by side
+                          // Show BOTH music indicator AND face animation side by side
                           HStack(spacing: 0) {
-                              // Face on the left
-                              if Defaults[.showNotHumanFace] {
-                                  BoringFaceAnimation()
-                              }
-                              
-                              // Spacer in the middle
-                              Rectangle()
-                                  .fill(.black)
-                                  .frame(width: 20)
-                              
-                              // Music on the right (if playing)
+                              // Music on the left (if playing)
                               if (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled {
                                   MusicLiveActivity()
                                       .frame(alignment: .center)
+                              }
+                              
+                              // Face on the right (if enabled)
+                              if Defaults[.showNotHumanFace] {
+                                  BoringFaceAnimation()
                               }
                           }
                           .frame(height: vm.effectiveClosedNotchHeight)

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -349,6 +349,9 @@ struct ContentView: View {
                         NotchHomeView(albumArtNamespace: albumArtNamespace)
                     case .shelf:
                         ShelfView()
+                    case .pomodoro:
+                        PomodoroView()
+                            .environmentObject(vm)
                     }
                 }
                 .transition(

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -352,6 +352,7 @@ struct ContentView: View {
                     case .pomodoro:
                         PomodoroView()
                             .environmentObject(vm)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
                 }
                 .transition(

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -293,16 +293,17 @@ struct ContentView: View {
                               
                               Spacer()
                               
-                              // Pomodoro timer on right (if running)
-                              if pomodoroManager.isRunning {
-                                  PomodoroClosedView(pomodoroManager: pomodoroManager)
-                                      .frame(height: max(0, vm.effectiveClosedNotchHeight - 12))
-                              }
-                              // Face on right (if enabled and timer not running)
-                              else if Defaults[.showNotHumanFace] {
+                              // Face on right side
+                              if Defaults[.showNotHumanFace] {
                                   AnimatedFaceView()
                                       .frame(width: max(0, vm.effectiveClosedNotchHeight - 16),
                                              height: max(0, vm.effectiveClosedNotchHeight - 16))
+                              }
+                              
+                              // Pomodoro timer next to face on right (if running)
+                              if pomodoroManager.isRunning {
+                                  PomodoroClosedView(pomodoroManager: pomodoroManager)
+                                      .frame(height: max(0, vm.effectiveClosedNotchHeight - 12))
                               }
                           }
                           .padding(.horizontal, 8)

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -292,8 +292,6 @@ struct ContentView: View {
                               .frame(alignment: .center)
                       } else if !coordinator.expandingView.show && vm.notchState == .closed && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {
                           BoringFaceAnimation()
-                       } else if !coordinator.expandingView.show && vm.notchState == .closed && coordinator.currentView == .pomodoro && !vm.hideOnClosed {
-                          PomodoroClosedView()
                        } else if vm.notchState == .open {
                            BoringHeader()
                                .frame(height: max(24, vm.effectiveClosedNotchHeight))

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -281,14 +281,22 @@ struct ContentView: View {
                       } else if !coordinator.expandingView.show && vm.notchState == .closed && !vm.hideOnClosed {
                           // Show music icon on left, face on right, both compact
                           HStack(spacing: 8) {
-                              // Music icon only (album art) on left
+                              // Music icon (album art) + visualizer on left when playing
                               if (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled {
-                                  Image(nsImage: musicManager.albumArt)
-                                      .resizable()
-                                      .clipped()
-                                      .clipShape(RoundedRectangle(cornerRadius: 4))
-                                      .frame(width: max(0, vm.effectiveClosedNotchHeight - 16),
-                                             height: max(0, vm.effectiveClosedNotchHeight - 16))
+                                  HStack(spacing: 4) {
+                                      Image(nsImage: musicManager.albumArt)
+                                          .resizable()
+                                          .clipped()
+                                          .clipShape(RoundedRectangle(cornerRadius: 4))
+                                          .frame(width: max(0, vm.effectiveClosedNotchHeight - 16),
+                                                 height: max(0, vm.effectiveClosedNotchHeight - 16))
+                                      
+                                      // Music wave visualizer
+                                      if Defaults[.useMusicVisualizer] {
+                                          AudioSpectrumView(isPlaying: .constant(musicManager.isPlaying))
+                                              .frame(width: 16, height: max(0, vm.effectiveClosedNotchHeight - 16))
+                                      }
+                                  }
                               }
                               
                               Spacer()

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -278,20 +278,19 @@ struct ContentView: View {
                           InlineHUD(type: $coordinator.sneakPeek.type, value: $coordinator.sneakPeek.value, icon: $coordinator.sneakPeek.icon, hoverAnimation: $isHovering, gestureProgress: $gestureProgress)
                               .transition(.opacity)
                       } else if !coordinator.expandingView.show && vm.notchState == .closed && !vm.hideOnClosed {
-                          // Show BOTH music indicator AND face animation side by side
+                          // Show music indicator and face animation in a template layout
                           HStack(spacing: 0) {
-                              // Music on the left (if playing)
+                              // Music: icon + wave
                               if (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled {
                                   MusicLiveActivity()
-                                      .frame(alignment: .center)
                               }
                               
-                              // Face on the right (if enabled)
+                              // Face (if enabled)
                               if Defaults[.showNotHumanFace] {
                                   BoringFaceAnimation()
                               }
                           }
-                          .frame(height: vm.effectiveClosedNotchHeight)
+                          .frame(width: vm.closedNotchSize.width, height: vm.effectiveClosedNotchHeight)
                        } else if vm.notchState == .open {
                            BoringHeader()
                                .frame(height: max(24, vm.effectiveClosedNotchHeight))
@@ -370,23 +369,14 @@ struct ContentView: View {
 
     @ViewBuilder
     func BoringFaceAnimation() -> some View {
-        HStack {
-            HStack {
-                Rectangle()
-                    .fill(.clear)
-                    .frame(
-                        width: max(0, vm.effectiveClosedNotchHeight - 12),
-                        height: max(0, vm.effectiveClosedNotchHeight - 12)
-                    )
-                Rectangle()
-                    .fill(.black)
-                    .frame(width: vm.closedNotchSize.width - 20)
-                MinimalFaceFeatures()
-            }
-        }.frame(
-            height: vm.effectiveClosedNotchHeight,
-            alignment: .center
-        )
+        HStack(spacing: 0) {
+            MinimalFaceFeatures()
+                .frame(
+                    width: max(0, vm.effectiveClosedNotchHeight - 12),
+                    height: max(0, vm.effectiveClosedNotchHeight - 12)
+                )
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
     }
 
     @ViewBuilder

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -17,9 +17,10 @@ import SwiftUIIntrospect
 struct ContentView: View {
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var webcamManager = WebcamManager.shared
-
+    
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     @ObservedObject var musicManager = MusicManager.shared
+    @ObservedObject var pomodoroManager = PomodoroManager.shared
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var brightnessManager = BrightnessManager.shared
     @ObservedObject var volumeManager = VolumeManager.shared
@@ -292,8 +293,13 @@ struct ContentView: View {
                               
                               Spacer()
                               
-                              // Face on right
-                              if Defaults[.showNotHumanFace] {
+                              // Pomodoro timer on right (if running)
+                              if pomodoroManager.isRunning {
+                                  PomodoroClosedView(pomodoroManager: pomodoroManager)
+                                      .frame(height: max(0, vm.effectiveClosedNotchHeight - 12))
+                              }
+                              // Face on right (if enabled and timer not running)
+                              else if Defaults[.showNotHumanFace] {
                                   AnimatedFaceView()
                                       .frame(width: max(0, vm.effectiveClosedNotchHeight - 16),
                                              height: max(0, vm.effectiveClosedNotchHeight - 16))

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -294,7 +294,7 @@ struct ContentView: View {
                               
                               // Face on right
                               if Defaults[.showNotHumanFace] {
-                                  MinimalFaceFeatures()
+                                  AnimatedFaceView()
                                       .frame(width: max(0, vm.effectiveClosedNotchHeight - 16),
                                              height: max(0, vm.effectiveClosedNotchHeight - 16))
                               }
@@ -380,7 +380,7 @@ struct ContentView: View {
     @ViewBuilder
     func BoringFaceAnimation() -> some View {
         HStack(spacing: 0) {
-            MinimalFaceFeatures()
+            AnimatedFaceView()
                 .frame(
                     width: max(0, vm.effectiveClosedNotchHeight - 12),
                     height: max(0, vm.effectiveClosedNotchHeight - 12)

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -65,12 +65,6 @@ struct ContentView: View {
             && vm.notchState == .closed && Defaults[.showPowerStatusNotifications]
         {
             chinWidth = 640
-        } else if !coordinator.expandingView.show && vm.notchState == .closed
-            && ((musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled
-                || Defaults[.showNotHumanFace]) && !vm.hideOnClosed
-        {
-            // Expand only slightly when showing music or face (not both)
-            chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
         }
 
         return chinWidth

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -75,11 +75,6 @@ struct ContentView: View {
             && !vm.hideOnClosed
         {
             chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
-        } else if !coordinator.expandingView.show && vm.notchState == .closed
-            && coordinator.currentView == .pomodoro && !vm.hideOnClosed
-        {
-            // When pomodoro tab is selected in closed state, expand chin width like music/shelf
-            chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
         }
 
         return chinWidth

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -75,6 +75,11 @@ struct ContentView: View {
             && !vm.hideOnClosed
         {
             chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
+        } else if !coordinator.expandingView.show && vm.notchState == .closed
+            && coordinator.currentView == .pomodoro && !vm.hideOnClosed
+        {
+            // When pomodoro tab is selected in closed state, expand chin width like music/shelf
+            chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
         }
 
         return chinWidth
@@ -292,6 +297,8 @@ struct ContentView: View {
                               .frame(alignment: .center)
                       } else if !coordinator.expandingView.show && vm.notchState == .closed && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {
                           BoringFaceAnimation()
+                       } else if !coordinator.expandingView.show && vm.notchState == .closed && coordinator.currentView == .pomodoro && !vm.hideOnClosed {
+                          PomodoroClosedView()
                        } else if vm.notchState == .open {
                            BoringHeader()
                                .frame(height: max(24, vm.effectiveClosedNotchHeight))

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -287,11 +287,12 @@ struct ContentView: View {
                       } else if coordinator.sneakPeek.show && Defaults[.inlineHUD] && (coordinator.sneakPeek.type != .music) && (coordinator.sneakPeek.type != .battery) && vm.notchState == .closed {
                           InlineHUD(type: $coordinator.sneakPeek.type, value: $coordinator.sneakPeek.value, icon: $coordinator.sneakPeek.icon, hoverAnimation: $isHovering, gestureProgress: $gestureProgress)
                               .transition(.opacity)
+                      } else if !coordinator.expandingView.show && vm.notchState == .closed && Defaults[.showNotHumanFace] && !vm.hideOnClosed {
+                          // Show face animation when enabled (regardless of music state)
+                          BoringFaceAnimation()
                       } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music) && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed {
                           MusicLiveActivity()
                               .frame(alignment: .center)
-                      } else if !coordinator.expandingView.show && vm.notchState == .closed && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {
-                          BoringFaceAnimation()
                        } else if vm.notchState == .open {
                            BoringHeader()
                                .frame(height: max(24, vm.effectiveClosedNotchHeight))

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -293,17 +293,17 @@ struct ContentView: View {
                               
                               Spacer()
                               
+                              // Pomodoro timer on left of face (if running)
+                              if pomodoroManager.isRunning {
+                                  PomodoroClosedView(pomodoroManager: pomodoroManager)
+                                      .frame(height: max(0, vm.effectiveClosedNotchHeight - 12))
+                              }
+                              
                               // Face on right side
                               if Defaults[.showNotHumanFace] {
                                   AnimatedFaceView()
                                       .frame(width: max(0, vm.effectiveClosedNotchHeight - 16),
                                              height: max(0, vm.effectiveClosedNotchHeight - 16))
-                              }
-                              
-                              // Pomodoro timer next to face on right (if running)
-                              if pomodoroManager.isRunning {
-                                  PomodoroClosedView(pomodoroManager: pomodoroManager)
-                                      .frame(height: max(0, vm.effectiveClosedNotchHeight - 12))
                               }
                           }
                           .padding(.horizontal, 8)

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -278,18 +278,28 @@ struct ContentView: View {
                           InlineHUD(type: $coordinator.sneakPeek.type, value: $coordinator.sneakPeek.value, icon: $coordinator.sneakPeek.icon, hoverAnimation: $isHovering, gestureProgress: $gestureProgress)
                               .transition(.opacity)
                       } else if !coordinator.expandingView.show && vm.notchState == .closed && !vm.hideOnClosed {
-                          // Show music indicator and face animation in a template layout
-                          HStack(spacing: 0) {
-                              // Music: icon + wave
+                          // Show music icon on left, face on right, both compact
+                          HStack(spacing: 8) {
+                              // Music icon only (album art) on left
                               if (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled {
-                                  MusicLiveActivity()
+                                  Image(nsImage: musicManager.albumArt)
+                                      .resizable()
+                                      .clipped()
+                                      .clipShape(RoundedRectangle(cornerRadius: 4))
+                                      .frame(width: max(0, vm.effectiveClosedNotchHeight - 16),
+                                             height: max(0, vm.effectiveClosedNotchHeight - 16))
                               }
                               
-                              // Face (if enabled)
+                              Spacer()
+                              
+                              // Face on right
                               if Defaults[.showNotHumanFace] {
-                                  BoringFaceAnimation()
+                                  MinimalFaceFeatures()
+                                      .frame(width: max(0, vm.effectiveClosedNotchHeight - 16),
+                                             height: max(0, vm.effectiveClosedNotchHeight - 16))
                               }
                           }
+                          .padding(.horizontal, 8)
                           .frame(width: vm.closedNotchSize.width, height: vm.effectiveClosedNotchHeight)
                        } else if vm.notchState == .open {
                            BoringHeader()

--- a/boringNotch/components/AnimatedFace.swift
+++ b/boringNotch/components/AnimatedFace.swift
@@ -360,52 +360,45 @@ struct AngryFaceFeatures: View {
     let animationPhase: Int
     
     var body: some View {
-        VStack(spacing: 4) {
-            HStack(spacing: 4) {
+        VStack(spacing: 3) {
+            // Angry eyebrows
+            HStack(spacing: 6) {
                 Path { path in
                     let w: CGFloat = 8
-                    let h: CGFloat = 3
+                    let h: CGFloat = 2
                     path.move(to: CGPoint(x: 0, y: h))
                     path.addLine(to: CGPoint(x: w, y: 0))
                 }
                 .stroke(Color.white, lineWidth: 2)
-                .frame(width: 8, height: 3)
-                
-                Circle()
-                    .fill(Color.white)
-                    .frame(width: 4, height: isBlinking ? 1 : 4)
-                    .frame(maxWidth: 12, maxHeight: 12)
-            }
-            
-            HStack(spacing: 4) {
-                Circle()
-                    .fill(Color.white)
-                    .frame(width: 4, height: isBlinking ? 1 : 4)
-                    .frame(maxWidth: 12, maxHeight: 12)
                 
                 Path { path in
                     let w: CGFloat = 8
-                    let h: CGFloat = 3
+                    let h: CGFloat = 2
                     path.move(to: CGPoint(x: 0, y: 0))
                     path.addLine(to: CGPoint(x: w, y: h))
                 }
                 .stroke(Color.white, lineWidth: 2)
-                .frame(width: 8, height: 3)
             }
             
+            // Eyes
+            HStack(spacing: 8) {
+                Eye(isBlinking: isBlinking)
+                Eye(isBlinking: isBlinking)
+            }
+            
+            // Frown mouth
             GeometryReader { geometry in
                 Path { path in
                     let w = geometry.size.width
                     let h = geometry.size.height
-                    path.move(to: CGPoint(x: 2, y: 0))
-                    path.addQuadCurve(to: CGPoint(x: w - 2, y: 0), control: CGPoint(x: w / 2, y: h * 0.3))
+                    path.move(to: CGPoint(x: 0, y: 0))
+                    path.addQuadCurve(to: CGPoint(x: w, y: 0), control: CGPoint(x: w / 2, y: h))
                 }
                 .stroke(Color.white, lineWidth: 2)
             }
-            .frame(width: 14, height: 6)
+            .frame(width: 12, height: 6)
         }
-        .frame(width: 28, height: 26)
-        .rotationEffect(.degrees(animationPhase == 1 ? -3 : (animationPhase == 2 ? 3 : 0)))
+        .frame(width: 28, height: 24)
     }
 }
 
@@ -415,25 +408,24 @@ struct TongueFaceFeatures: View {
     let animationPhase: Int
     
     var body: some View {
-        VStack(spacing: 3) {
-            HStack(spacing: 4) {
+        VStack(spacing: 4) {
+            HStack(spacing: 6) {
                 Eye(isBlinking: isBlinking)
                 Eye(isBlinking: isBlinking)
             }
             
-            HStack(spacing: 0) {
-                Circle()
-                    .fill(Color.white)
-                    .frame(width: 10, height: 10)
-                
-                Circle()
-                    .fill(Color.pink)
-                    .frame(width: 6, height: 6)
-                    .offset(y: 2)
-            }
+            // Flat oval mouth
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Color.white)
+                .frame(width: 10, height: 6)
+            
+            // Pink tongue sticking out
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Color.pink)
+                .frame(width: 6, height: 5)
+                .offset(y: -2)
         }
-        .frame(width: 26, height: 22)
-        .scaleEffect(animationPhase == 1 ? 1.03 : 1.0)
+        .frame(width: 24, height: 24)
     }
 }
 

--- a/boringNotch/components/AnimatedFace.swift
+++ b/boringNotch/components/AnimatedFace.swift
@@ -361,21 +361,23 @@ struct AngryFaceFeatures: View {
     
     var body: some View {
         VStack(spacing: 3) {
-            // Angry eyebrows
+            // Angry eyebrows - left and right should slant toward center
             HStack(spacing: 6) {
+                // Left eyebrow: \ (high on right, low on left)
                 Path { path in
-                    let w: CGFloat = 8
-                    let h: CGFloat = 2
-                    path.move(to: CGPoint(x: 0, y: h))
-                    path.addLine(to: CGPoint(x: w, y: 0))
+                    let w: CGFloat = 6
+                    let h: CGFloat = 3
+                    path.move(to: CGPoint(x: 0, y: 0))
+                    path.addLine(to: CGPoint(x: w, y: h))
                 }
                 .stroke(Color.white, lineWidth: 2)
                 
+                // Right eyebrow: / (high on left, low on right)
                 Path { path in
-                    let w: CGFloat = 8
-                    let h: CGFloat = 2
-                    path.move(to: CGPoint(x: 0, y: 0))
-                    path.addLine(to: CGPoint(x: w, y: h))
+                    let w: CGFloat = 6
+                    let h: CGFloat = 3
+                    path.move(to: CGPoint(x: 0, y: h))
+                    path.addLine(to: CGPoint(x: w, y: 0))
                 }
                 .stroke(Color.white, lineWidth: 2)
             }
@@ -408,22 +410,21 @@ struct TongueFaceFeatures: View {
     let animationPhase: Int
     
     var body: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: 3) {
             HStack(spacing: 6) {
                 Eye(isBlinking: isBlinking)
                 Eye(isBlinking: isBlinking)
             }
             
-            // Flat oval mouth
-            RoundedRectangle(cornerRadius: 4)
+            // Open mouth circle
+            Circle()
                 .fill(Color.white)
-                .frame(width: 10, height: 6)
+                .frame(width: 12, height: 12)
             
-            // Pink tongue sticking out
-            RoundedRectangle(cornerRadius: 2)
+            // Pink tongue in middle of mouth
+            Circle()
                 .fill(Color.pink)
-                .frame(width: 6, height: 5)
-                .offset(y: -2)
+                .frame(width: 6, height: 6)
         }
         .frame(width: 24, height: 24)
     }

--- a/boringNotch/components/AnimatedFace.swift
+++ b/boringNotch/components/AnimatedFace.swift
@@ -126,6 +126,12 @@ struct FaceView: View {
                 WinkFaceFeatures(isBlinking: isBlinking, animationPhase: animationPhase)
             case .happy:
                 HappyFaceFeatures(isBlinking: isBlinking, animationPhase: animationPhase)
+            case .angry:
+                AngryFaceFeatures(isBlinking: isBlinking, animationPhase: animationPhase)
+            case .tongue:
+                TongueFaceFeatures(isBlinking: isBlinking, animationPhase: animationPhase)
+            case .love:
+                LoveFaceFeatures(isBlinking: isBlinking, animationPhase: animationPhase)
             }
         }
     }
@@ -345,6 +351,123 @@ struct HappyFaceFeatures: View {
         }
         .frame(width: 28, height: 24)
         .scaleEffect(animationPhase == 1 ? 1.05 : 1.0)
+    }
+}
+
+// MARK: - Angry Face
+struct AngryFaceFeatures: View {
+    let isBlinking: Bool
+    let animationPhase: Int
+    
+    var body: some View {
+        VStack(spacing: 4) {
+            HStack(spacing: 4) {
+                Path { path in
+                    let w: CGFloat = 8
+                    let h: CGFloat = 3
+                    path.move(to: CGPoint(x: 0, y: h))
+                    path.addLine(to: CGPoint(x: w, y: 0))
+                }
+                .stroke(Color.white, lineWidth: 2)
+                .frame(width: 8, height: 3)
+                
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 4, height: isBlinking ? 1 : 4)
+                    .frame(maxWidth: 12, maxHeight: 12)
+            }
+            
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 4, height: isBlinking ? 1 : 4)
+                    .frame(maxWidth: 12, maxHeight: 12)
+                
+                Path { path in
+                    let w: CGFloat = 8
+                    let h: CGFloat = 3
+                    path.move(to: CGPoint(x: 0, y: 0))
+                    path.addLine(to: CGPoint(x: w, y: h))
+                }
+                .stroke(Color.white, lineWidth: 2)
+                .frame(width: 8, height: 3)
+            }
+            
+            GeometryReader { geometry in
+                Path { path in
+                    let w = geometry.size.width
+                    let h = geometry.size.height
+                    path.move(to: CGPoint(x: 2, y: 0))
+                    path.addQuadCurve(to: CGPoint(x: w - 2, y: 0), control: CGPoint(x: w / 2, y: h * 0.3))
+                }
+                .stroke(Color.white, lineWidth: 2)
+            }
+            .frame(width: 14, height: 6)
+        }
+        .frame(width: 28, height: 26)
+        .rotationEffect(.degrees(animationPhase == 1 ? -3 : (animationPhase == 2 ? 3 : 0)))
+    }
+}
+
+// MARK: - Tongue Face
+struct TongueFaceFeatures: View {
+    let isBlinking: Bool
+    let animationPhase: Int
+    
+    var body: some View {
+        VStack(spacing: 3) {
+            HStack(spacing: 4) {
+                Eye(isBlinking: isBlinking)
+                Eye(isBlinking: isBlinking)
+            }
+            
+            HStack(spacing: 0) {
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 10, height: 10)
+                
+                Circle()
+                    .fill(Color.pink)
+                    .frame(width: 6, height: 6)
+                    .offset(y: 2)
+            }
+        }
+        .frame(width: 26, height: 22)
+        .scaleEffect(animationPhase == 1 ? 1.03 : 1.0)
+    }
+}
+
+// MARK: - Love Face
+struct LoveFaceFeatures: View {
+    let isBlinking: Bool
+    let animationPhase: Int
+    
+    var body: some View {
+        VStack(spacing: 3) {
+            HStack(spacing: 4) {
+                Image(systemName: "heart.fill")
+                    .resizable()
+                    .foregroundColor(.white)
+                    .frame(width: 6, height: 5)
+                Image(systemName: "heart.fill")
+                    .resizable()
+                    .foregroundColor(.white)
+                    .frame(width: 6, height: 5)
+            }
+            
+            GeometryReader { geometry in
+                Path { path in
+                    let w = geometry.size.width
+                    let h = geometry.size.height
+                    path.move(to: CGPoint(x: 0, y: 2))
+                    path.addQuadCurve(to: CGPoint(x: w, y: 2), control: CGPoint(x: w / 2, y: h))
+                }
+                .stroke(Color.white, lineWidth: 1.5)
+            }
+            .frame(width: 12, height: 6)
+        }
+        .frame(width: 26, height: 20)
+        .scaleEffect(animationPhase == 1 ? 1.08 : 1.0)
     }
 }
 

--- a/boringNotch/components/AnimatedFace.swift
+++ b/boringNotch/components/AnimatedFace.swift
@@ -2,72 +2,365 @@
 //  AnimatedFace.swift
 //
 // Created by Harsh Vardhan  Goswami  on  04/08/24.
+// Extended with multiple face types by Claw on 2026-04-29.
 //
 
 import SwiftUI
+import Defaults
 
-struct MinimalFaceFeatures: View {
+// MARK: - Animated Face View (Main Container)
+struct AnimatedFaceView: View {
+    @State private var currentFaceType: FaceType = .minimal
+    @State private var animationPhase: Int = 0
     @State private var isBlinking = false
-    @State var height:CGFloat = 20;
-    @State var width:CGFloat = 30;
+    @State private var blinkTimer: Timer?
+    @State private var phaseTimer: Timer?
+    @State private var randomTimer: Timer?
+    
+    private let blinkInterval: TimeInterval = 3.0
+    private let phaseInterval: TimeInterval = 8.0
     
     var body: some View {
-        VStack(spacing: 4) { // Adjusted spacing to fit within 30x30
-            // Eyes
-            HStack(spacing: 4) { // Adjusted spacing to fit within 30x30
-                Eye(isBlinking: $isBlinking)
-                Eye(isBlinking: $isBlinking)
+        FaceView(type: currentFaceType, isBlinking: isBlinking, animationPhase: animationPhase)
+            .onAppear {
+                startAnimating()
             }
-            
-            // Nose and mouth combined
-            VStack(spacing: 2) { // Adjusted spacing to fit within 30x30
-                // Nose
+            .onDisappear {
+                stopAnimating()
+            }
+            .onChange(of: Defaults[.faceSelectionMode]) { _, _ in
+                updateFaceType()
+                updateRandomTimer()
+            }
+            .onChange(of: Defaults[.faceAnimationType]) { _, newValue in
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    currentFaceType = newValue
+                }
+            }
+    }
+    
+    private func stopAnimating() {
+        blinkTimer?.invalidate()
+        phaseTimer?.invalidate()
+        randomTimer?.invalidate()
+    }
+    
+    private func startAnimating() {
+        updateFaceType()
+        
+        // Start blinking timer
+        blinkTimer = Timer.scheduledTimer(withTimeInterval: blinkInterval, repeats: true) { _ in
+            withAnimation(.spring(duration: 0.15)) {
+                isBlinking = true
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                withAnimation(.spring(duration: 0.15)) {
+                    isBlinking = false
+                }
+            }
+        }
+        
+        // Start animation phase cycle (change expression periodically)
+        phaseTimer = Timer.scheduledTimer(withTimeInterval: phaseInterval, repeats: true) { _ in
+            withAnimation(.easeInOut(duration: 0.5)) {
+                animationPhase = (animationPhase + 1) % 3
+            }
+        }
+        
+        // Start random face cycle if in random mode
+        updateRandomTimer()
+    }
+    
+    private func updateFaceType() {
+        let mode = Defaults[.faceSelectionMode]
+        if mode == .random {
+            currentFaceType = randomFaceType()
+        } else {
+            currentFaceType = Defaults[.faceAnimationType]
+        }
+    }
+    
+    private func randomFaceType() -> FaceType {
+        let faces = FaceType.allCases
+        return faces.randomElement() ?? .minimal
+    }
+    
+    private func updateRandomTimer() {
+        randomTimer?.invalidate()
+        
+        let mode = Defaults[.faceSelectionMode]
+        if mode == .random {
+            let interval = TimeInterval(Defaults[.faceRandomInterval])
+            randomTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    currentFaceType = randomFaceType()
+                }
+            }
+        } else {
+            // When switching to fixed mode, immediately set the selected face
+            withAnimation(.easeInOut(duration: 0.3)) {
+                currentFaceType = Defaults[.faceAnimationType]
+            }
+        }
+    }
+}
+
+// MARK: - Face View (Renders based on type)
+struct FaceView: View {
+    let type: FaceType
+    let isBlinking: Bool
+    let animationPhase: Int
+    
+    var body: some View {
+        Group {
+            switch type {
+            case .minimal:
+                MinimalFaceFeatures(isBlinking: isBlinking)
+            case .cool:
+                CoolFaceFeatures(isBlinking: isBlinking, animationPhase: animationPhase)
+            case .surprised:
+                SurprisedFaceFeatures(isBlinking: isBlinking)
+            case .sleepy:
+                SleepyFaceFeatures(isBlinking: isBlinking)
+            case .wink:
+                WinkFaceFeatures(isBlinking: isBlinking, animationPhase: animationPhase)
+            case .happy:
+                HappyFaceFeatures(isBlinking: isBlinking, animationPhase: animationPhase)
+            }
+        }
+    }
+}
+
+// MARK: - Original Minimal Face
+struct MinimalFaceFeatures: View {
+    let isBlinking: Bool
+    @State var height: CGFloat = 20
+    @State var width: CGFloat = 30
+    
+    var body: some View {
+        VStack(spacing: 4) {
+            HStack(spacing: 4) {
+                Eye(isBlinking: isBlinking)
+                Eye(isBlinking: isBlinking)
+            }
+            VStack(spacing: 2) {
                 RoundedRectangle(cornerRadius: 2)
                     .fill(Color.white)
                     .frame(width: 3, height: 4)
                 
-                // Mouth (happy)
                 GeometryReader { geometry in
                     Path { path in
-                        let width = geometry.size.width
-                        let height = geometry.size.height
-                        path.move(to: CGPoint(x: 0, y: height / 2))
-                        path.addQuadCurve(to: CGPoint(x: width, y: height / 2), control: CGPoint(x: width / 2, y: height))
+                        let w = geometry.size.width
+                        let h = geometry.size.height
+                        path.move(to: CGPoint(x: 0, y: h / 2))
+                        path.addQuadCurve(to: CGPoint(x: w, y: h / 2), control: CGPoint(x: w / 2, y: h))
                     }
                     .stroke(Color.white, lineWidth: 2)
                 }
                 .frame(width: 14, height: 10)
             }
         }
-        .frame(width: self.width, height: self.height) // Maximum size of face
-        .onAppear {
-            startBlinking()
-        }
-    }
-    
-    func startBlinking() {
-        Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { _ in
-            withAnimation(.spring(duration: 0.2)) {
-                isBlinking = true
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                withAnimation(.spring(duration: 0.2)) {
-                    isBlinking = false
-                }
-            }
-        }
+        .frame(width: width, height: height)
     }
 }
 
+// MARK: - Eye Component (for reusable blinking)
 struct Eye: View {
-    @Binding var isBlinking: Bool
+    let isBlinking: Bool
     
     var body: some View {
         RoundedRectangle(cornerRadius: 10)
             .fill(Color.white)
             .frame(width: 4, height: isBlinking ? 1 : 4)
-            .frame(maxWidth: 15, maxHeight: 15) // Adjusted max size
-            .animation(.easeInOut(duration: 0.1), value: isBlinking)
+            .frame(maxWidth: 15, maxHeight: 15)
+    }
+}
+
+// MARK: - Cool Face (With Sunglasses)
+struct CoolFaceFeatures: View {
+    let isBlinking: Bool
+    let animationPhase: Int
+    
+    var body: some View {
+        VStack(spacing: 6) {
+            HStack(spacing: 4) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color.white.opacity(0.9))
+                    .frame(width: 12, height: 5)
+                Rectangle()
+                    .fill(Color.white.opacity(0.8))
+                    .frame(width: 4, height: 1)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color.white.opacity(0.9))
+                    .frame(width: 12, height: 5)
+            }
+            .frame(height: 8)
+            
+            GeometryReader { geometry in
+                Path { path in
+                    let w = geometry.size.width
+                    let h = geometry.size.height
+                    path.move(to: CGPoint(x: w * 0.2, y: h * 0.4))
+                    path.addQuadCurve(to: CGPoint(x: w * 0.8, y: h * 0.4), control: CGPoint(x: w * 0.5, y: h * 0.8))
+                }
+                .stroke(Color.white, lineWidth: 1.5)
+            }
+            .frame(width: 18, height: 8)
+        }
+        .frame(width: 32, height: 28)
+        .rotationEffect(.degrees(animationPhase == 1 ? -5 : (animationPhase == 2 ? 5 : 0)))
+    }
+}
+
+// MARK: - Surprised Face
+struct SurprisedFaceFeatures: View {
+    let isBlinking: Bool
+    
+    var body: some View {
+        VStack(spacing: 4) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 6, height: 6)
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 6, height: 6)
+            }
+            
+            Circle()
+                .fill(Color.white)
+                .frame(width: 8, height: 8)
+        }
+        .frame(width: 28, height: 26)
+    }
+}
+
+// MARK: - Sleepy Face
+struct SleepyFaceFeatures: View {
+    let isBlinking: Bool
+    
+    var body: some View {
+        VStack(spacing: 4) {
+            HStack(spacing: 4) {
+                Capsule()
+                    .fill(Color.white)
+                    .frame(width: 8, height: 2)
+                Capsule()
+                    .fill(Color.white)
+                    .frame(width: 8, height: 2)
+            }
+            
+            GeometryReader { geometry in
+                Path { path in
+                    let w = geometry.size.width
+                    let h = geometry.size.height
+                    path.move(to: CGPoint(x: 0, y: h * 0.5))
+                    path.addQuadCurve(to: CGPoint(x: w, y: h * 0.5), control: CGPoint(x: w / 2, y: h * 0.8))
+                }
+                .stroke(Color.white, lineWidth: 1.5)
+            }
+            .frame(width: 12, height: 6)
+        }
+        .frame(width: 28, height: 22)
+    }
+}
+
+// MARK: - Wink Face
+struct WinkFaceFeatures: View {
+    let isBlinking: Bool
+    let animationPhase: Int
+    
+    var body: some View {
+        VStack(spacing: 4) {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 5, height: 5)
+                
+                Group {
+                    if animationPhase == 1 {
+                        Capsule()
+                            .fill(Color.white)
+                            .frame(width: 8, height: 2)
+                    } else {
+                        Circle()
+                            .fill(Color.white)
+                            .frame(width: 5, height: 5)
+                    }
+                }
+            }
+            
+            GeometryReader { geometry in
+                Path { path in
+                    let w = geometry.size.width
+                    let h = geometry.size.height
+                    path.move(to: CGPoint(x: 0, y: h * 0.3))
+                    path.addQuadCurve(to: CGPoint(x: w, y: h * 0.5), control: CGPoint(x: w * 0.6, y: h * 0.9))
+                }
+                .stroke(Color.white, lineWidth: 1.5)
+            }
+            .frame(width: 14, height: 8)
+        }
+        .frame(width: 26, height: 24)
+    }
+}
+
+// MARK: - Happy Face
+struct HappyFaceFeatures: View {
+    let isBlinking: Bool
+    let animationPhase: Int
+    
+    var body: some View {
+        VStack(spacing: 3) {
+            HStack(spacing: 5) {
+                Path { path in
+                    let w: CGFloat = 6
+                    let h: CGFloat = 4
+                    path.move(to: CGPoint(x: 0, y: h))
+                    path.addQuadCurve(to: CGPoint(x: w, y: h), control: CGPoint(x: w / 2, y: 0))
+                }
+                .stroke(Color.white, lineWidth: 1.5)
+                .frame(width: 6, height: 4)
+                
+                Path { path in
+                    let w: CGFloat = 6
+                    let h: CGFloat = 4
+                    path.move(to: CGPoint(x: 0, y: h))
+                    path.addQuadCurve(to: CGPoint(x: w, y: h), control: CGPoint(x: w / 2, y: 0))
+                }
+                .stroke(Color.white, lineWidth: 1.5)
+                .frame(width: 6, height: 4)
+            }
+            
+            GeometryReader { geometry in
+                Path { path in
+                    let w = geometry.size.width
+                    let h = geometry.size.height
+                    path.move(to: CGPoint(x: 2, y: 0))
+                    path.addQuadCurve(to: CGPoint(x: w - 2, y: 0), control: CGPoint(x: w / 2, y: h))
+                }
+                .stroke(Color.white, lineWidth: 2)
+            }
+            .frame(width: 16, height: 10)
+        }
+        .frame(width: 28, height: 24)
+        .scaleEffect(animationPhase == 1 ? 1.05 : 1.0)
+    }
+}
+
+// MARK: - Preview
+struct AnimatedFaceView_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            Color.black
+            VStack(spacing: 20) {
+                AnimatedFaceView()
+                Text("Current Face")
+                    .foregroundColor(.gray)
+                    .font(.caption)
+            }
+        }
+        .previewLayout(.fixed(width: 80, height: 80))
     }
 }
 
@@ -75,8 +368,8 @@ struct MinimalFaceFeatures_Previews: PreviewProvider {
     static var previews: some View {
         ZStack {
             Color.black
-            MinimalFaceFeatures()
+            MinimalFaceFeatures(isBlinking: false)
         }
-        .previewLayout(.fixed(width: 60, height: 60)) // Adjusted preview size for better visibility
+        .previewLayout(.fixed(width: 60, height: 60))
     }
 }

--- a/boringNotch/components/AnimatedFace.swift
+++ b/boringNotch/components/AnimatedFace.swift
@@ -128,8 +128,6 @@ struct FaceView: View {
                 HappyFaceFeatures(isBlinking: isBlinking, animationPhase: animationPhase)
             case .angry:
                 AngryFaceFeatures(isBlinking: isBlinking, animationPhase: animationPhase)
-            case .tongue:
-                TongueFaceFeatures(isBlinking: isBlinking, animationPhase: animationPhase)
             case .love:
                 LoveFaceFeatures(isBlinking: isBlinking, animationPhase: animationPhase)
             }
@@ -401,32 +399,6 @@ struct AngryFaceFeatures: View {
             .frame(width: 12, height: 6)
         }
         .frame(width: 28, height: 24)
-    }
-}
-
-// MARK: - Tongue Face
-struct TongueFaceFeatures: View {
-    let isBlinking: Bool
-    let animationPhase: Int
-    
-    var body: some View {
-        VStack(spacing: 3) {
-            HStack(spacing: 6) {
-                Eye(isBlinking: isBlinking)
-                Eye(isBlinking: isBlinking)
-            }
-            
-            // Open mouth circle
-            Circle()
-                .fill(Color.white)
-                .frame(width: 12, height: 12)
-            
-            // Pink tongue in middle of mouth
-            Circle()
-                .fill(Color.pink)
-                .frame(width: 6, height: 6)
-        }
-        .frame(width: 24, height: 24)
     }
 }
 

--- a/boringNotch/components/EmptyState.swift
+++ b/boringNotch/components/EmptyState.swift
@@ -12,8 +12,8 @@ struct EmptyStateView: View {
     
     var body: some View {
         HStack {
-            MinimalFaceFeatures(
-                height: 70, width: 80)
+            MinimalFaceFeatures(isBlinking: false)
+                .frame(width: 40, height: 40)
             Text(message)
                 .font(.system(size:14))
                 .foregroundColor(.gray)

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -16,7 +16,7 @@ struct BoringHeader: View {
     var body: some View {
         HStack(spacing: 0) {
             HStack {
-                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
+                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && (Defaults[.boringShelf] || Defaults[.pomodoroEnabled]) {
                     TabSelectionView()
                 } else if vm.notchState == .open {
                     EmptyView()
@@ -88,26 +88,6 @@ struct BoringHeader: View {
                                 timeToFullCharge: batteryModel.timeToFullCharge,
                                 isForNotification: false
                             )
-                        }
-                        if Defaults[.pomodoroEnabled] {
-                            Button(action: {
-                                if coordinator.currentView == .pomodoro {
-                                    coordinator.currentView = .home
-                                } else {
-                                    coordinator.currentView = .pomodoro
-                                }
-                            }) {
-                                Capsule()
-                                    .fill(coordinator.currentView == .pomodoro ? Color.red : Color.black)
-                                    .frame(width: 30, height: 30)
-                                    .overlay {
-                                        Image(systemName: "timer")
-                                            .foregroundColor(.white)
-                                            .padding()
-                                            .imageScale(.medium)
-                                    }
-                            }
-                            .buttonStyle(PlainButtonStyle())
                         }
                     }
                 }

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -89,6 +89,26 @@ struct BoringHeader: View {
                                 isForNotification: false
                             )
                         }
+                        if Defaults[.pomodoroEnabled] {
+                            Button(action: {
+                                if coordinator.currentView == .pomodoro {
+                                    coordinator.currentView = .home
+                                } else {
+                                    coordinator.currentView = .pomodoro
+                                }
+                            }) {
+                                Capsule()
+                                    .fill(coordinator.currentView == .pomodoro ? Color.red : Color.black)
+                                    .frame(width: 30, height: 30)
+                                    .overlay {
+                                        Image(systemName: "timer")
+                                            .foregroundColor(.white)
+                                            .padding()
+                                            .imageScale(.medium)
+                                    }
+                            }
+                            .buttonStyle(PlainButtonStyle())
+                        }
                     }
                 }
             }

--- a/boringNotch/components/PomodoroClosedView.swift
+++ b/boringNotch/components/PomodoroClosedView.swift
@@ -1,0 +1,51 @@
+//
+//  PomodoroClosedView.swift
+//  boringNotch
+//
+//  Created by Claw on 2026-04-29.
+//  Compact timer display for closed notch state.
+//
+
+import SwiftUI
+
+struct PomodoroClosedView: View {
+    @ObservedObject var pomodoroManager: PomodoroManager
+    
+    var body: some View {
+        HStack(spacing: 6) {
+            // Phase indicator dot
+            Circle()
+                .fill(phaseColor)
+                .frame(width: 6, height: 6)
+            
+            // Timer text
+            Text(pomodoroManager.formattedTime)
+                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                .foregroundColor(.white)
+            
+            // Sessions counter
+            if pomodoroManager.sessionsCompleted > 0 {
+                Text("•\(pomodoroManager.sessionsCompleted)")
+                    .font(.system(size: 10))
+                    .foregroundColor(.gray)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.black.opacity(0.5))
+        )
+    }
+    
+    private var phaseColor: Color {
+        switch pomodoroManager.currentPhase {
+        case .work:
+            return Color(red: 1.0, green: 0.4, blue: 0.4) // Red for work
+        case .shortBreak:
+            return Color(red: 0.4, green: 1.0, blue: 0.4) // Green for short break
+        case .longBreak:
+            return Color(red: 0.4, green: 0.8, blue: 1.0) // Blue for long break
+        }
+    }
+}

--- a/boringNotch/components/PomodoroView.swift
+++ b/boringNotch/components/PomodoroView.swift
@@ -3,7 +3,7 @@
 //  boringNotch
 //
 //  Created by Christian Teo on 2026-04-29.
-//  Sized to match NotchHomeView layout style.
+//  Sized to match NotchHomeView layout style (same as MusicPlayerView/ShelfView).
 //
 
 import SwiftUI
@@ -13,97 +13,64 @@ struct PomodoroView: View {
     @EnvironmentObject var vm: BoringViewModel
 
     var body: some View {
-        HStack(alignment: .top, spacing: 15) {
-            // Left spacer to match MusicPlayerView layout (album art section)
-            Color.clear
-                .frame(width: 60, height: 60)
+        HStack(alignment: .center, spacing: 0) {
+            // Left spacer - same size as album art in MusicPlayerView (60x60 with padding)
+            timerCircleView
+                .padding(.all, 5)
 
-            // Center timer content
-            timerContent
-                .frame(maxWidth: .infinity)
-
-            // Right spacer for balance
-            Color.clear
-                .frame(width: 60, height: 60)
+            // Control buttons on the right side (same pattern as slotToolbar in MusicControlsView)
+            controlsView
+                .drawingGroup()
+                .compositingGroup()
         }
-        .padding(.horizontal, 10)
     }
 
-    private var timerContent: some View {
-        VStack(spacing: 8) {
-            // Phase indicator + sessions + reset button
-            HStack(spacing: 12) {
-                ForEach([PomodoroManager.PomodoroPhase.work, .shortBreak, .longBreak], id: \.self) { phase in
-                    Text(phase.displayName)
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(pomodoroManager.currentPhase == phase ? .white : .gray.opacity(0.6))
-                }
+    // Timer circle on the left (matching album art position)
+    private var timerCircleView: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.gray.opacity(0.3), lineWidth: 4)
 
-                Spacer()
+            Circle()
+                .trim(from: 0, to: pomodoroManager.progress)
+                .stroke(
+                    pomodoroManager.phaseColor,
+                    style: StrokeStyle(lineWidth: 4, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .animation(.linear(duration: 1), value: pomodoroManager.progress)
 
-                // Sessions counter
-                Text("• \(pomodoroManager.sessionsCompleted)")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.gray)
-                    .simultaneousGesture(
-                        LongPressGesture(minimumDuration: 0.8)
-                            .onEnded { _ in
-                                pomodoroManager.resetSessions()
-                            }
-                    )
+            Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(.white)
+        }
+        .frame(width: 50, height: 50)
+    }
 
-                // Reset all button
-                Button(action: {
-                    pomodoroManager.reset()
-                }) {
-                    Image(systemName: "arrow.counterclockwise")
-                        .font(.system(size: 12))
-                        .foregroundStyle(.gray)
-                }
-                .buttonStyle(PlainButtonStyle())
-                .help("Reset Timer")
-            }
+    // Controls on the right (same pattern as MusicControlsView)
+    private var controlsView: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            // Phase indicator + sessions info
+            phaseIndicatorView
 
-            // Circular progress + time
-            ZStack {
-                Circle()
-                    .stroke(Color.gray.opacity(0.3), lineWidth: 6)
+            // Time display
+            Text(pomodoroManager.formattedTime)
+                .font(.system(size: 20, weight: .bold, design: .monospaced))
+                .foregroundColor(.white)
 
-                Circle()
-                    .trim(from: 0, to: pomodoroManager.progress)
-                    .stroke(
-                        pomodoroManager.phaseColor,
-                        style: StrokeStyle(lineWidth: 6, lineCap: .round)
-                    )
-                    .rotationEffect(.degrees(-90))
-                    .animation(.linear(duration: 1), value: pomodoroManager.progress)
-
-                VStack(spacing: 4) {
-                    Text(pomodoroManager.currentPhase.displayName)
-                        .font(.caption2)
-                        .foregroundStyle(.gray)
-
-                    Text(pomodoroManager.formattedTime)
-                        .font(.system(size: 18, weight: .bold, design: .monospaced))
-                        .foregroundColor(.white)
-                }
-            }
-            .frame(width: 90, height: 90)
-
-            // Controls
-            HStack(spacing: 24) {
+            // Control buttons (same horizontal layout as slotToolbar)
+            HStack(spacing: 16) {
                 // Reset button
                 Button(action: {
                     pomodoroManager.reset()
                 }) {
                     Image(systemName: "arrow.counterclockwise")
-                        .font(.system(size: 16, weight: .medium))
+                        .font(.system(size: 12, weight: .medium))
                         .foregroundColor(.gray)
                 }
                 .buttonStyle(PlainButtonStyle())
-                .help("Reset")
 
-                // Play/Pause button
+                // Play/Pause button (main action)
                 Button(action: {
                     if pomodoroManager.isRunning {
                         pomodoroManager.pause()
@@ -112,16 +79,15 @@ struct PomodoroView: View {
                     }
                 }) {
                     Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
-                        .font(.system(size: 22, weight: .medium))
+                        .font(.system(size: 16, weight: .medium))
                         .foregroundColor(.white)
-                        .frame(width: 36, height: 36)
+                        .frame(width: 32, height: 32)
                         .background(
                             Circle()
                                 .fill(pomodoroManager.phaseColor.opacity(0.8))
                         )
                 }
                 .buttonStyle(PlainButtonStyle())
-                .help(pomodoroManager.isRunning ? "Pause" : "Start")
 
                 // Skip button
                 Button(action: {
@@ -129,28 +95,74 @@ struct PomodoroView: View {
                     pomodoroManager.skip()
                 }) {
                     Image(systemName: "forward.fill")
-                        .font(.system(size: 16, weight: .medium))
+                        .font(.system(size: 12, weight: .medium))
                         .foregroundColor(.gray)
                 }
                 .buttonStyle(PlainButtonStyle())
-                .help("Skip to Next")
             }
+        }
+        .padding(.leading, 5)
+    }
+
+    private var phaseIndicatorView: some View {
+        HStack(spacing: 8) {
+            ForEach([PomodoroManager.PomodoroPhase.work, .shortBreak, .longBreak], id: \.self) { phase in
+                Text(phase.displayName)
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundColor(pomodoroManager.currentPhase == phase ? .white : .gray.opacity(0.6))
+            }
+
+            Spacer()
+
+            // Sessions counter (tap to reset)
+            Text("\(pomodoroManager.sessionsCompleted)")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(sessionsColor)
+                .simultaneousGesture(
+                    LongPressGesture(minimumDuration: 0.8)
+                        .onEnded { _ in
+                            pomodoroManager.resetSessions()
+                        }
+                )
+                .help("Sessions completed. Long press to reset.")
+
+            // Reset all button
+            Button(action: {
+                pomodoroManager.reset()
+            }) {
+                Image(systemName: "arrow.counterclockwise")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.gray)
+            }
+            .buttonStyle(PlainButtonStyle())
+            .help("Reset Timer")
+        }
+    }
+
+    private var sessionsColor: Color {
+        if pomodoroManager.sessionsCompleted % pomodoroManager.sessionsBeforeLongBreak == 0 && pomodoroManager.sessionsCompleted > 0 {
+            return .blue
+        } else if pomodoroManager.currentPhase == .work {
+            return .red
+        } else {
+            return .green
         }
     }
 }
 
-// Compact view for closed notch state
+// MARK: - Compact view for closed notch state
+
 struct PomodoroClosedView: View {
     @ObservedObject var pomodoroManager = PomodoroManager.shared
     @EnvironmentObject var vm: BoringViewModel
 
     var body: some View {
         HStack(spacing: 8) {
-            // Mini progress circle
+            // Mini progress circle (matching size pattern from other closed views)
             ZStack {
                 Circle()
                     .stroke(Color.gray.opacity(0.3), lineWidth: 2)
-                
+
                 Circle()
                     .trim(from: 0, to: pomodoroManager.progress)
                     .stroke(
@@ -158,26 +170,26 @@ struct PomodoroClosedView: View {
                         style: StrokeStyle(lineWidth: 2, lineCap: .round)
                     )
                     .rotationEffect(.degrees(-90))
-                    
+
                 Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
                     .font(.system(size: 8, weight: .medium))
                     .foregroundStyle(.white)
             }
             .frame(width: max(0, vm.effectiveClosedNotchHeight - 16), height: max(0, vm.effectiveClosedNotchHeight - 16))
-            
+
             // Timer info
             VStack(alignment: .leading, spacing: 2) {
                 Text(pomodoroManager.formattedTime)
                     .font(.system(size: 11, weight: .bold, design: .monospaced))
                     .foregroundStyle(.white)
-                
+
                 Text(pomodoroManager.currentPhase.displayName)
                     .font(.system(size: 9))
                     .foregroundStyle(.gray)
             }
-            
+
             Spacer()
-            
+
             // Session indicator
             Text("\(pomodoroManager.sessionsCompleted)")
                 .font(.system(size: 9, weight: .bold))
@@ -185,7 +197,7 @@ struct PomodoroClosedView: View {
         }
         .frame(height: vm.effectiveClosedNotchHeight, alignment: .center)
     }
-    
+
     private var sessionsColor: Color {
         if pomodoroManager.sessionsCompleted % pomodoroManager.sessionsBeforeLongBreak == 0 && pomodoroManager.sessionsCompleted > 0 {
             return .blue
@@ -199,6 +211,6 @@ struct PomodoroClosedView: View {
 
 #Preview {
     PomodoroView()
-        .frame(width: 300, height: 300)
+        .frame(width: 300, height: 100)
         .background(Color.black)
 }

--- a/boringNotch/components/PomodoroView.swift
+++ b/boringNotch/components/PomodoroView.swift
@@ -1,0 +1,100 @@
+//
+//  PomodoroView.swift
+//  boringNotch
+//
+//  Created by Claw on 2026-04-28.
+//
+
+import Defaults
+import SwiftUI
+
+struct PomodoroView: View {
+    @ObservedObject var pomodoroManager = PomodoroManager.shared
+    @EnvironmentObject var vm: BoringViewModel
+
+    var body: some View {
+        VStack(spacing: 16) {
+            // Phase indicator
+            HStack {
+                ForEach([PomodoroManager.PomodoroPhase.work, .shortBreak, .longBreak], id: \.self) { phase in
+                    Text(phase.rawValue)
+                        .font(.caption)
+                        .foregroundColor(pomodoroManager.currentPhase == phase ? .white : .gray)
+                }
+            }
+
+            // Circular progress + time
+            ZStack {
+                Circle()
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 6)
+
+                Circle()
+                    .trim(from: 0, to: pomodoroManager.progress)
+                    .stroke(
+                        phaseColor,
+                        style: StrokeStyle(lineWidth: 6, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                    .animation(.linear(duration: 1), value: pomodoroManager.progress)
+
+                VStack(spacing: 4) {
+                    Text(pomodoroManager.currentPhase.rawValue)
+                        .font(.caption2)
+                        .foregroundStyle(.gray)
+
+                    Text(pomodoroManager.formattedTime)
+                        .font(.system(size: 28, weight: .bold, design: .monospaced))
+                        .foregroundColor(.white)
+                }
+            }
+            .frame(width: 140, height: 140)
+
+            // Controls
+            HStack(spacing: 20) {
+                Button(action: { pomodoroManager.stop() }) {
+                    Image(systemName: "stop.fill")
+                        .font(.system(size: 16))
+                        .foregroundColor(.gray)
+                }
+                .buttonStyle(PlainButtonStyle())
+
+                Button(action: {
+                    if pomodoroManager.isRunning {
+                        pomodoroManager.pause()
+                    } else {
+                        pomodoroManager.start()
+                    }
+                }) {
+                    Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
+                        .font(.system(size: 22))
+                        .foregroundColor(.white)
+                }
+                .buttonStyle(PlainButtonStyle())
+
+                Button(action: { pomodoroManager.skip() }) {
+                    Image(systemName: "forward.fill")
+                        .font(.system(size: 16))
+                        .foregroundColor(.gray)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+
+            // Session count
+            HStack {
+                Text("Sessions: \(pomodoroManager.sessionsCompleted)")
+                    .font(.caption2)
+                    .foregroundStyle(.gray)
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+
+    private var phaseColor: Color {
+        switch pomodoroManager.currentPhase {
+        case .work: return .red
+        case .shortBreak: return .green
+        case .longBreak: return .blue
+        }
+    }
+}

--- a/boringNotch/components/PomodoroView.swift
+++ b/boringNotch/components/PomodoroView.swift
@@ -3,187 +3,138 @@
 //  boringNotch
 //
 //  Created by Christian Teo on 2026-04-29.
+//  Sized to match NotchHomeView layout style.
 //
 
 import SwiftUI
 
 struct PomodoroView: View {
     @ObservedObject var pomodoroManager = PomodoroManager.shared
-    @State private var isLongPressing: Bool = false
-    
-    private let timerSize: CGFloat = 90
-    private let progressLineWidth: CGFloat = 4
+    @EnvironmentObject var vm: BoringViewModel
 
     var body: some View {
-        HStack(spacing: 12) {
-            // Circular progress timer
+        HStack(alignment: .top, spacing: 15) {
+            // Left spacer to match MusicPlayerView layout (album art section)
+            Color.clear
+                .frame(width: 60, height: 60)
+
+            // Center timer content
+            timerContent
+                .frame(maxWidth: .infinity)
+
+            // Right spacer for balance
+            Color.clear
+                .frame(width: 60, height: 60)
+        }
+        .padding(.horizontal, 10)
+    }
+
+    private var timerContent: some View {
+        VStack(spacing: 8) {
+            // Phase indicator + sessions + reset button
+            HStack(spacing: 12) {
+                ForEach([PomodoroManager.PomodoroPhase.work, .shortBreak, .longBreak], id: \.self) { phase in
+                    Text(phase.displayName)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(pomodoroManager.currentPhase == phase ? .white : .gray.opacity(0.6))
+                }
+
+                Spacer()
+
+                // Sessions counter
+                Text("• \(pomodoroManager.sessionsCompleted)")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.gray)
+                    .simultaneousGesture(
+                        LongPressGesture(minimumDuration: 0.8)
+                            .onEnded { _ in
+                                pomodoroManager.resetSessions()
+                            }
+                    )
+
+                // Reset all button
+                Button(action: {
+                    pomodoroManager.reset()
+                }) {
+                    Image(systemName: "arrow.counterclockwise")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.gray)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .help("Reset Timer")
+            }
+
+            // Circular progress + time
             ZStack {
-                // Background circle
                 Circle()
-                    .stroke(Color.gray.opacity(0.3), lineWidth: progressLineWidth)
-                
-                // Progress circle
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 6)
+
                 Circle()
                     .trim(from: 0, to: pomodoroManager.progress)
                     .stroke(
                         pomodoroManager.phaseColor,
-                        style: StrokeStyle(lineWidth: progressLineWidth, lineCap: .round)
+                        style: StrokeStyle(lineWidth: 6, lineCap: .round)
                     )
                     .rotationEffect(.degrees(-90))
                     .animation(.linear(duration: 1), value: pomodoroManager.progress)
-                
-                // Timer content
-                VStack(spacing: 1) {
+
+                VStack(spacing: 4) {
                     Text(pomodoroManager.currentPhase.displayName)
-                        .font(.system(size: 7, weight: .medium))
+                        .font(.caption2)
                         .foregroundStyle(.gray)
-                    
+
                     Text(pomodoroManager.formattedTime)
-                        .font(.system(size: 16, weight: .bold, design: .monospaced))
-                        .foregroundStyle(.white)
+                        .font(.system(size: 18, weight: .bold, design: .monospaced))
+                        .foregroundColor(.white)
                 }
             }
-            .frame(width: timerSize, height: timerSize)
-            
-            // Right side: Phase indicators, sessions, and controls
-            VStack(spacing: 6) {
-                // Phase indicator dots
-                phaseIndicators
-                
-                // Sessions counter with long-press
-                sessionsCounter
-                
-                // Control buttons
-                controlButtons
-            }
-        }
-        .padding(.vertical, 8)
-        .padding(.horizontal, 12)
-    }
-    
-    // MARK: - Subviews
-    
-    private var phaseIndicators: some View {
-        HStack(spacing: 10) {
-            ForEach(PomodoroManager.PomodoroPhase.allCases, id: \.self) { phase in
-                VStack(spacing: 2) {
-                    Circle()
-                        .fill(pomodoroManager.currentPhase == phase ? pomodoroManager.phaseColor : Color.gray.opacity(0.4))
-                        .frame(width: 6, height: 6)
-                    
-                    Text(phase.displayName)
-                        .font(.system(size: 7))
-                        .foregroundColor(pomodoroManager.currentPhase == phase ? .white : .gray)
+            .frame(width: 90, height: 90)
+
+            // Controls
+            HStack(spacing: 24) {
+                // Reset button
+                Button(action: {
+                    pomodoroManager.reset()
+                }) {
+                    Image(systemName: "arrow.counterclockwise")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(.gray)
                 }
-            }
-        }
-    }
-    
-    private var sessionsCounter: some View {
-        HStack(spacing: 3) {
-            Text("Sessions")
-                .font(.system(size: 8))
-                .foregroundStyle(.gray)
-            
-            Text("\(pomodoroManager.sessionsCompleted)")
-                .font(.system(size: 8, weight: .bold))
-                .foregroundStyle(sessionsCompletedColor)
-                .scaleEffect(isLongPressing ? 1.2 : 1.0)
-                .animation(.easeInOut(duration: 0.15), value: isLongPressing)
-            
-            if pomodoroManager.sessionsCompleted > 0 {
-                Image(systemName: "arrow.counterclockwise")
-                    .font(.system(size: 7))
-                    .foregroundStyle(.gray.opacity(0.5))
-            }
-        }
-        .padding(.vertical, 4)
-        .padding(.horizontal, 8)
-        .background(
-            Capsule()
-                .fill(Color.white.opacity(0.05))
-        )
-        .contentShape(Rectangle())
-        .gesture(
-            LongPressGesture(minimumDuration: 0.8)
-                .onChanged { _ in
-                    withAnimation(.easeInOut(duration: 0.15)) {
-                        isLongPressing = true
+                .buttonStyle(PlainButtonStyle())
+                .help("Reset")
+
+                // Play/Pause button
+                Button(action: {
+                    if pomodoroManager.isRunning {
+                        pomodoroManager.pause()
+                    } else {
+                        pomodoroManager.start()
                     }
+                }) {
+                    Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
+                        .font(.system(size: 22, weight: .medium))
+                        .foregroundColor(.white)
+                        .frame(width: 36, height: 36)
+                        .background(
+                            Circle()
+                                .fill(pomodoroManager.phaseColor.opacity(0.8))
+                        )
                 }
-                .onEnded { _ in
-                    pomodoroManager.resetSessions()
-                    withAnimation(.easeInOut(duration: 0.15)) {
-                        isLongPressing = false
-                    }
-                }
-        )
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 1)
-                .onChanged { _ in
-                    withAnimation(.easeInOut(duration: 0.15)) {
-                        isLongPressing = false
-                    }
-                }
-        )
-    }
-    
-    private var sessionsCompletedColor: Color {
-        if pomodoroManager.sessionsCompleted % pomodoroManager.sessionsBeforeLongBreak == 0 && pomodoroManager.sessionsCompleted > 0 {
-            return .blue
-        } else if pomodoroManager.currentPhase == .work {
-            return .red
-        } else {
-            return .green
-        }
-    }
-    
-    private var controlButtons: some View {
-        HStack(spacing: 16) {
-            // Reset button
-            Button(action: {
-                pomodoroManager.reset()
-            }) {
-                Image(systemName: "arrow.counterclockwise")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.gray)
-                    .frame(width: 24, height: 24)
-            }
-            .buttonStyle(PlainButtonStyle())
-            .help("Reset Timer")
-            
-            // Play/Pause button
-            Button(action: {
-                if pomodoroManager.isRunning {
+                .buttonStyle(PlainButtonStyle())
+                .help(pomodoroManager.isRunning ? "Pause" : "Start")
+
+                // Skip button
+                Button(action: {
                     pomodoroManager.pause()
-                } else {
-                    pomodoroManager.start()
+                    pomodoroManager.skip()
+                }) {
+                    Image(systemName: "forward.fill")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(.gray)
                 }
-            }) {
-                Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(.white)
-                    .frame(width: 28, height: 28)
-                    .background(
-                        Circle()
-                            .fill(pomodoroManager.phaseColor.opacity(0.8))
-                    )
+                .buttonStyle(PlainButtonStyle())
+                .help("Skip to Next")
             }
-            .buttonStyle(PlainButtonStyle())
-            .help(pomodoroManager.isRunning ? "Pause" : "Start")
-            
-            // Skip button
-            Button(action: {
-                pomodoroManager.pause()
-                pomodoroManager.reset()
-            }) {
-                Image(systemName: "forward.fill")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.gray)
-                    .frame(width: 24, height: 24)
-            }
-            .buttonStyle(PlainButtonStyle())
-            .help("Skip to Next")
         }
     }
 }

--- a/boringNotch/components/PomodoroView.swift
+++ b/boringNotch/components/PomodoroView.swift
@@ -100,7 +100,7 @@ struct PomodoroView: View {
 
             // Controls
             HStack(spacing: 20) {
-                Button(action: { pomodoroManager.stop() }) {
+                Button(action: { pomodoroManager.pause() }) {
                     Image(systemName: "stop.fill")
                         .font(.system(size: 16))
                         .foregroundColor(.gray)

--- a/boringNotch/components/PomodoroView.swift
+++ b/boringNotch/components/PomodoroView.swift
@@ -11,14 +11,11 @@ struct PomodoroView: View {
     @ObservedObject var pomodoroManager = PomodoroManager.shared
     @State private var isLongPressing: Bool = false
     
-    private let timerSize: CGFloat = 140
-    private let progressLineWidth: CGFloat = 6
+    private let timerSize: CGFloat = 90
+    private let progressLineWidth: CGFloat = 4
 
     var body: some View {
-        VStack(spacing: 12) {
-            // Phase indicator dots
-            phaseIndicators
-            
+        HStack(spacing: 12) {
             // Circular progress timer
             ZStack {
                 // Background circle
@@ -36,41 +33,46 @@ struct PomodoroView: View {
                     .animation(.linear(duration: 1), value: pomodoroManager.progress)
                 
                 // Timer content
-                VStack(spacing: 2) {
+                VStack(spacing: 1) {
                     Text(pomodoroManager.currentPhase.displayName)
-                        .font(.system(size: 10, weight: .medium))
+                        .font(.system(size: 7, weight: .medium))
                         .foregroundStyle(.gray)
                     
                     Text(pomodoroManager.formattedTime)
-                        .font(.system(size: 24, weight: .bold, design: .monospaced))
+                        .font(.system(size: 16, weight: .bold, design: .monospaced))
                         .foregroundStyle(.white)
                 }
             }
             .frame(width: timerSize, height: timerSize)
             
-            // Sessions counter with long-press
-            sessionsCounter
-            
-            // Control buttons
-            controlButtons
+            // Right side: Phase indicators, sessions, and controls
+            VStack(spacing: 6) {
+                // Phase indicator dots
+                phaseIndicators
+                
+                // Sessions counter with long-press
+                sessionsCounter
+                
+                // Control buttons
+                controlButtons
+            }
         }
-        .padding(.vertical, 16)
-        .padding(.horizontal, 20)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
     }
     
     // MARK: - Subviews
     
     private var phaseIndicators: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: 10) {
             ForEach(PomodoroManager.PomodoroPhase.allCases, id: \.self) { phase in
-                VStack(spacing: 4) {
+                VStack(spacing: 2) {
                     Circle()
                         .fill(pomodoroManager.currentPhase == phase ? pomodoroManager.phaseColor : Color.gray.opacity(0.4))
-                        .frame(width: 8, height: 8)
+                        .frame(width: 6, height: 6)
                     
                     Text(phase.displayName)
-                        .font(.system(size: 9))
+                        .font(.system(size: 7))
                         .foregroundColor(pomodoroManager.currentPhase == phase ? .white : .gray)
                 }
             }
@@ -78,25 +80,25 @@ struct PomodoroView: View {
     }
     
     private var sessionsCounter: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: 3) {
             Text("Sessions")
-                .font(.system(size: 11))
+                .font(.system(size: 8))
                 .foregroundStyle(.gray)
             
             Text("\(pomodoroManager.sessionsCompleted)")
-                .font(.system(size: 11, weight: .bold))
+                .font(.system(size: 8, weight: .bold))
                 .foregroundStyle(sessionsCompletedColor)
                 .scaleEffect(isLongPressing ? 1.2 : 1.0)
                 .animation(.easeInOut(duration: 0.15), value: isLongPressing)
             
             if pomodoroManager.sessionsCompleted > 0 {
                 Image(systemName: "arrow.counterclockwise")
-                    .font(.system(size: 9))
+                    .font(.system(size: 7))
                     .foregroundStyle(.gray.opacity(0.5))
             }
         }
-        .padding(.vertical, 6)
-        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .padding(.horizontal, 8)
         .background(
             Capsule()
                 .fill(Color.white.opacity(0.05))
@@ -137,15 +139,15 @@ struct PomodoroView: View {
     }
     
     private var controlButtons: some View {
-        HStack(spacing: 24) {
+        HStack(spacing: 16) {
             // Reset button
             Button(action: {
                 pomodoroManager.reset()
             }) {
                 Image(systemName: "arrow.counterclockwise")
-                    .font(.system(size: 16, weight: .medium))
+                    .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.gray)
-                    .frame(width: 32, height: 32)
+                    .frame(width: 24, height: 24)
             }
             .buttonStyle(PlainButtonStyle())
             .help("Reset Timer")
@@ -159,9 +161,9 @@ struct PomodoroView: View {
                 }
             }) {
                 Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
-                    .font(.system(size: 20, weight: .medium))
+                    .font(.system(size: 14, weight: .medium))
                     .foregroundStyle(.white)
-                    .frame(width: 40, height: 40)
+                    .frame(width: 28, height: 28)
                     .background(
                         Circle()
                             .fill(pomodoroManager.phaseColor.opacity(0.8))
@@ -176,12 +178,70 @@ struct PomodoroView: View {
                 pomodoroManager.reset()
             }) {
                 Image(systemName: "forward.fill")
-                    .font(.system(size: 14, weight: .medium))
+                    .font(.system(size: 10, weight: .medium))
                     .foregroundStyle(.gray)
-                    .frame(width: 32, height: 32)
+                    .frame(width: 24, height: 24)
             }
             .buttonStyle(PlainButtonStyle())
             .help("Skip to Next")
+        }
+    }
+}
+
+// Compact view for closed notch state
+struct PomodoroClosedView: View {
+    @ObservedObject var pomodoroManager = PomodoroManager.shared
+    @EnvironmentObject var vm: BoringViewModel
+
+    var body: some View {
+        HStack(spacing: 8) {
+            // Mini progress circle
+            ZStack {
+                Circle()
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 2)
+                
+                Circle()
+                    .trim(from: 0, to: pomodoroManager.progress)
+                    .stroke(
+                        pomodoroManager.phaseColor,
+                        style: StrokeStyle(lineWidth: 2, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                    
+                Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
+                    .font(.system(size: 8, weight: .medium))
+                    .foregroundStyle(.white)
+            }
+            .frame(width: max(0, vm.effectiveClosedNotchHeight - 16), height: max(0, vm.effectiveClosedNotchHeight - 16))
+            
+            // Timer info
+            VStack(alignment: .leading, spacing: 2) {
+                Text(pomodoroManager.formattedTime)
+                    .font(.system(size: 11, weight: .bold, design: .monospaced))
+                    .foregroundStyle(.white)
+                
+                Text(pomodoroManager.currentPhase.displayName)
+                    .font(.system(size: 9))
+                    .foregroundStyle(.gray)
+            }
+            
+            Spacer()
+            
+            // Session indicator
+            Text("\(pomodoroManager.sessionsCompleted)")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(sessionsColor)
+        }
+        .frame(height: vm.effectiveClosedNotchHeight, alignment: .center)
+    }
+    
+    private var sessionsColor: Color {
+        if pomodoroManager.sessionsCompleted % pomodoroManager.sessionsBeforeLongBreak == 0 && pomodoroManager.sessionsCompleted > 0 {
+            return .blue
+        } else if pomodoroManager.currentPhase == .work {
+            return .red
+        } else {
+            return .green
         }
     }
 }

--- a/boringNotch/components/PomodoroView.swift
+++ b/boringNotch/components/PomodoroView.swift
@@ -2,10 +2,11 @@
 //  PomodoroView.swift
 //  boringNotch
 //
-//  Created by Christian Teo on 2026-04-29.
-//  Sized to match NotchHomeView layout style (same as MusicPlayerView/ShelfView).
+//  Created by Claw on 2026-04-28.
+//  Modified to match NotchHomeView layout style.
 //
 
+import Defaults
 import SwiftUI
 
 struct PomodoroView: View {
@@ -13,234 +14,129 @@ struct PomodoroView: View {
     @EnvironmentObject var vm: BoringViewModel
 
     var body: some View {
-        HStack {
-            // LEFT: Timer content
-            VStack(spacing: 4) {
-                // Phase indicators
-                phaseIndicators
-                
-                // Timer circle with progress ring
-                timerCircleView
-                
-                // Sessions counter
-                sessionsCounter
-            }
-            .frame(width: 110)
+        HStack(alignment: .top, spacing: 15) {
+            // Left spacer to match MusicPlayerView layout (album art section)
+            Color.clear
+                .frame(width: 60, height: 60)
 
-            Spacer()
+            // Center timer content
+            timerContent
+                .frame(maxWidth: .infinity)
 
-            // RIGHT: Controls
-            VStack(spacing: 8) {
-                // Play/Pause button (main action)
-                playPauseButton
-
-                // Skip button
-                skipButton
-
-                // Reset button
-                resetButton
-            }
-            .frame(width: 50)
+            // Right spacer for balance
+            Color.clear
+                .frame(width: 60, height: 60)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.horizontal, 12)
+        .padding(.horizontal, 10)
     }
 
-    // MARK: - Timer Circle (Left side)
-
-    private var timerCircleView: some View {
-        ZStack {
-            // Background circle
-            Circle()
-                .stroke(Color.gray.opacity(0.3), lineWidth: 4)
-
-            // Progress ring
-            Circle()
-                .trim(from: 0, to: pomodoroManager.progress)
-                .stroke(
-                    pomodoroManager.phaseColor,
-                    style: StrokeStyle(lineWidth: 4, lineCap: .round)
-                )
-                .rotationEffect(.degrees(-90))
-                .animation(.linear(duration: 1), value: pomodoroManager.progress)
-
-            // Time display inside circle
-            Text(pomodoroManager.formattedTime)
-                .font(.system(size: 16, weight: .bold, design: .monospaced))
-                .foregroundColor(.white)
-        }
-        .frame(width: 70, height: 70)
-    }
-
-    // MARK: - Phase Indicators
-
-    private var phaseIndicators: some View {
-        HStack(spacing: 4) {
-            ForEach([PomodoroManager.PomodoroPhase.work, .shortBreak, .longBreak], id: \.self) { phase in
-                Text(abbreviatedPhaseName(phase))
-                    .font(.system(size: 8, weight: .medium))
-                    .foregroundColor(pomodoroManager.currentPhase == phase ? .white : .gray.opacity(0.5))
-            }
-        }
-    }
-
-    private func abbreviatedPhaseName(_ phase: PomodoroManager.PomodoroPhase) -> String {
-        switch phase {
-        case .work: return "W"
-        case .shortBreak: return "SB"
-        case .longBreak: return "LB"
-        }
-    }
-
-    // MARK: - Sessions Counter
-
-    private var sessionsCounter: some View {
-        HStack(spacing: 2) {
-            Text("•")
-                .font(.system(size: 10, weight: .bold))
-                .foregroundStyle(sessionsColor)
-
-            Text("\(pomodoroManager.sessionsCompleted)")
-                .font(.system(size: 10, weight: .bold))
-                .foregroundStyle(sessionsColor)
-        }
-        .help("Sessions completed. Long press to reset.")
-        .simultaneousGesture(
-            LongPressGesture(minimumDuration: 0.8)
-                .onEnded { _ in
-                    pomodoroManager.resetSessions()
+    private var timerContent: some View {
+        VStack(spacing: 6) {
+            // Phase indicator + sessions + reset button
+            HStack(spacing: 8) {
+                ForEach([PomodoroManager.PomodoroPhase.work, .shortBreak, .longBreak], id: \.self) { phase in
+                    Text(phase.rawValue)
+                        .font(.system(size: 9))
+                        .foregroundColor(pomodoroManager.currentPhase == phase ? .white : .gray)
                 }
-        )
-    }
 
-    private var sessionsColor: Color {
-        if pomodoroManager.sessionsCompleted % pomodoroManager.sessionsBeforeLongBreak == 0 && pomodoroManager.sessionsCompleted > 0 {
-            return .blue
-        } else if pomodoroManager.currentPhase == .work {
-            return .red
-        } else {
-            return .green
-        }
-    }
+                // Sessions counter with reset capability
+                Button(action: {
+                    // Long press or double click to reset
+                }) {
+                    HStack(spacing: 2) {
+                        Text("• \(pomodoroManager.sessionsCompleted)")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.gray)
+                    }
+                }
+                .buttonStyle(PlainButtonStyle())
+                .simultaneousGesture(
+                    LongPressGesture(minimumDuration: 0.8)
+                        .onEnded { _ in
+                            pomodoroManager.resetSessions()
+                        }
+                )
 
-    // MARK: - Control Buttons (Right side)
+                Spacer()
 
-    private var playPauseButton: some View {
-        Button(action: {
-            if pomodoroManager.isRunning {
-                pomodoroManager.pause()
-            } else {
-                pomodoroManager.start()
+                // Reset all button
+                Button(action: {
+                    pomodoroManager.resetAll()
+                }) {
+                    Image(systemName: "arrow.counterclockwise")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.gray)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .help("Reset all")
             }
-        }) {
-            Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
-                .font(.system(size: 18, weight: .medium))
-                .foregroundColor(.white)
-                .frame(width: 40, height: 40)
-                .background(
-                    Circle()
-                        .fill(pomodoroManager.phaseColor.opacity(0.8))
-                )
-        }
-        .buttonStyle(PlainButtonStyle())
-    }
 
-    private var skipButton: some View {
-        Button(action: {
-            pomodoroManager.pause()
-            pomodoroManager.skip()
-        }) {
-            Image(systemName: "forward.fill")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundColor(.gray)
-                .frame(width: 32, height: 32)
-                .background(
-                    Circle()
-                        .fill(Color.gray.opacity(0.2))
-                )
-        }
-        .buttonStyle(PlainButtonStyle())
-    }
-
-    private var resetButton: some View {
-        Button(action: {
-            pomodoroManager.resetAll()
-        }) {
-            Image(systemName: "arrow.counterclockwise")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundColor(.gray)
-                .frame(width: 32, height: 32)
-                .background(
-                    Circle()
-                        .fill(Color.gray.opacity(0.2))
-                )
-        }
-        .buttonStyle(PlainButtonStyle())
-        .help("Reset timer")
-    }
-}
-
-// MARK: - Compact view for closed notch state
-
-struct PomodoroClosedView: View {
-    @ObservedObject var pomodoroManager = PomodoroManager.shared
-    @EnvironmentObject var vm: BoringViewModel
-
-    var body: some View {
-        HStack(spacing: 8) {
-            // Mini progress circle (matching size pattern from other closed views)
+            // Circular progress + time
             ZStack {
                 Circle()
-                    .stroke(Color.gray.opacity(0.3), lineWidth: 2)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 6)
 
                 Circle()
                     .trim(from: 0, to: pomodoroManager.progress)
                     .stroke(
-                        pomodoroManager.phaseColor,
-                        style: StrokeStyle(lineWidth: 2, lineCap: .round)
+                        phaseColor,
+                        style: StrokeStyle(lineWidth: 6, lineCap: .round)
                     )
                     .rotationEffect(.degrees(-90))
+                    .animation(.linear(duration: 1), value: pomodoroManager.progress)
 
-                Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
-                    .font(.system(size: 8, weight: .medium))
-                    .foregroundStyle(.white)
+                VStack(spacing: 4) {
+                    Text(pomodoroManager.currentPhase.rawValue)
+                        .font(.caption2)
+                        .foregroundStyle(.gray)
+
+                    Text(pomodoroManager.formattedTime)
+                        .font(.system(size: 18, weight: .bold, design: .monospaced))
+                        .foregroundColor(.white)
+                }
             }
-            .frame(width: max(0, vm.effectiveClosedNotchHeight - 16), height: max(0, vm.effectiveClosedNotchHeight - 16))
+            .frame(width: 90, height: 90)
 
-            // Timer info
-            VStack(alignment: .leading, spacing: 2) {
-                Text(pomodoroManager.formattedTime)
-                    .font(.system(size: 11, weight: .bold, design: .monospaced))
-                    .foregroundStyle(.white)
+            // Controls
+            HStack(spacing: 20) {
+                Button(action: { pomodoroManager.stop() }) {
+                    Image(systemName: "stop.fill")
+                        .font(.system(size: 16))
+                        .foregroundColor(.gray)
+                }
+                .buttonStyle(PlainButtonStyle())
 
-                Text(pomodoroManager.currentPhase.displayName)
-                    .font(.system(size: 9))
-                    .foregroundStyle(.gray)
+                Button(action: {
+                    if pomodoroManager.isRunning {
+                        pomodoroManager.pause()
+                    } else {
+                        pomodoroManager.start()
+                    }
+                }) {
+                    Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
+                        .font(.system(size: 22))
+                        .foregroundColor(.white)
+                }
+                .buttonStyle(PlainButtonStyle())
+
+                Button(action: { pomodoroManager.skip() }) {
+                    Image(systemName: "forward.fill")
+                        .font(.system(size: 16))
+                        .foregroundColor(.gray)
+                }
+                .buttonStyle(PlainButtonStyle())
             }
-
-            Spacer()
-
-            // Session indicator
-            Text("\(pomodoroManager.sessionsCompleted)")
-                .font(.system(size: 9, weight: .bold))
-                .foregroundStyle(sessionsColor)
         }
-        .frame(height: vm.effectiveClosedNotchHeight, alignment: .center)
     }
 
-    private var sessionsColor: Color {
-        if pomodoroManager.sessionsCompleted % pomodoroManager.sessionsBeforeLongBreak == 0 && pomodoroManager.sessionsCompleted > 0 {
-            return .blue
-        } else if pomodoroManager.currentPhase == .work {
-            return .red
-        } else {
-            return .green
+    // MARK: - Helpers
+
+    private var phaseColor: Color {
+        switch pomodoroManager.currentPhase {
+        case .work: return .red
+        case .shortBreak: return .green
+        case .longBreak: return .blue
         }
     }
-}
-
-#Preview {
-    PomodoroView()
-        .frame(width: 300, height: 100)
-        .background(Color.black)
 }

--- a/boringNotch/components/PomodoroView.swift
+++ b/boringNotch/components/PomodoroView.swift
@@ -13,26 +13,48 @@ struct PomodoroView: View {
     @EnvironmentObject var vm: BoringViewModel
 
     var body: some View {
-        VStack(alignment: .center, spacing: 0) {
-            // Timer circle on the left (matching album art position)
-            timerCircleView
-                .padding(.all, 5)
+        HStack {
+            // LEFT: Timer content
+            VStack(spacing: 4) {
+                // Phase indicators
+                phaseIndicators
+                
+                // Timer circle with progress ring
+                timerCircleView
+                
+                // Sessions counter
+                sessionsCounter
+            }
+            .frame(width: 110)
 
-            // Control buttons on the right side (same pattern as slotToolbar in MusicControlsView)
-            controlsView
-                .drawingGroup()
-                .compositingGroup()
+            Spacer()
+
+            // RIGHT: Controls
+            VStack(spacing: 8) {
+                // Play/Pause button (main action)
+                playPauseButton
+
+                // Skip button
+                skipButton
+
+                // Reset button
+                resetButton
+            }
+            .frame(width: 50)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .frame(minHeight: 60)
+        .padding(.horizontal, 12)
     }
 
-    // Timer circle on the left (matching album art position)
+    // MARK: - Timer Circle (Left side)
+
     private var timerCircleView: some View {
         ZStack {
+            // Background circle
             Circle()
                 .stroke(Color.gray.opacity(0.3), lineWidth: 4)
 
+            // Progress ring
             Circle()
                 .trim(from: 0, to: pomodoroManager.progress)
                 .stroke(
@@ -42,103 +64,53 @@ struct PomodoroView: View {
                 .rotationEffect(.degrees(-90))
                 .animation(.linear(duration: 1), value: pomodoroManager.progress)
 
-            Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
-                .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(.white)
-        }
-        .frame(width: 50, height: 50)
-    }
-
-    // Controls on the right (same pattern as MusicControlsView)
-    private var controlsView: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            // Phase indicator + sessions info
-            phaseIndicatorView
-
-            // Time display
+            // Time display inside circle
             Text(pomodoroManager.formattedTime)
-                .font(.system(size: 20, weight: .bold, design: .monospaced))
+                .font(.system(size: 16, weight: .bold, design: .monospaced))
                 .foregroundColor(.white)
-
-            // Control buttons (same horizontal layout as slotToolbar)
-            HStack(spacing: 16) {
-                // Reset button
-                Button(action: {
-                    pomodoroManager.resetAll()
-                }) {
-                    Image(systemName: "arrow.counterclockwise")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .buttonStyle(PlainButtonStyle())
-
-                // Play/Pause button (main action)
-                Button(action: {
-                    if pomodoroManager.isRunning {
-                        pomodoroManager.pause()
-                    } else {
-                        pomodoroManager.start()
-                    }
-                }) {
-                    Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundColor(.white)
-                        .frame(width: 32, height: 32)
-                        .background(
-                            Circle()
-                                .fill(pomodoroManager.phaseColor.opacity(0.8))
-                        )
-                }
-                .buttonStyle(PlainButtonStyle())
-
-                // Skip button
-                Button(action: {
-                    pomodoroManager.pause()
-                    pomodoroManager.skip()
-                }) {
-                    Image(systemName: "forward.fill")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.gray)
-                }
-                .buttonStyle(PlainButtonStyle())
-            }
         }
-        .padding(.leading, 5)
+        .frame(width: 70, height: 70)
     }
 
-    private var phaseIndicatorView: some View {
-        HStack(spacing: 8) {
+    // MARK: - Phase Indicators
+
+    private var phaseIndicators: some View {
+        HStack(spacing: 4) {
             ForEach([PomodoroManager.PomodoroPhase.work, .shortBreak, .longBreak], id: \.self) { phase in
-                Text(phase.displayName)
-                    .font(.system(size: 9, weight: .medium))
-                    .foregroundColor(pomodoroManager.currentPhase == phase ? .white : .gray.opacity(0.6))
+                Text(abbreviatedPhaseName(phase))
+                    .font(.system(size: 8, weight: .medium))
+                    .foregroundColor(pomodoroManager.currentPhase == phase ? .white : .gray.opacity(0.5))
             }
-
-            Spacer()
-
-            // Sessions counter (tap to reset)
-            Text("\(pomodoroManager.sessionsCompleted)")
-                .font(.system(size: 9, weight: .bold))
-                .foregroundStyle(sessionsColor)
-                .simultaneousGesture(
-                    LongPressGesture(minimumDuration: 0.8)
-                        .onEnded { _ in
-                            pomodoroManager.resetSessions()
-                        }
-                )
-                .help("Sessions completed. Long press to reset.")
-
-            // Reset all button
-            Button(action: {
-                pomodoroManager.resetAll()
-            }) {
-                Image(systemName: "arrow.counterclockwise")
-                    .font(.system(size: 10))
-                    .foregroundStyle(.gray)
-            }
-            .buttonStyle(PlainButtonStyle())
-            .help("Reset Everything")
         }
+    }
+
+    private func abbreviatedPhaseName(_ phase: PomodoroManager.PomodoroPhase) -> String {
+        switch phase {
+        case .work: return "W"
+        case .shortBreak: return "SB"
+        case .longBreak: return "LB"
+        }
+    }
+
+    // MARK: - Sessions Counter
+
+    private var sessionsCounter: some View {
+        HStack(spacing: 2) {
+            Text("•")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(sessionsColor)
+
+            Text("\(pomodoroManager.sessionsCompleted)")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(sessionsColor)
+        }
+        .help("Sessions completed. Long press to reset.")
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.8)
+                .onEnded { _ in
+                    pomodoroManager.resetSessions()
+                }
+        )
     }
 
     private var sessionsColor: Color {
@@ -149,6 +121,62 @@ struct PomodoroView: View {
         } else {
             return .green
         }
+    }
+
+    // MARK: - Control Buttons (Right side)
+
+    private var playPauseButton: some View {
+        Button(action: {
+            if pomodoroManager.isRunning {
+                pomodoroManager.pause()
+            } else {
+                pomodoroManager.start()
+            }
+        }) {
+            Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundColor(.white)
+                .frame(width: 40, height: 40)
+                .background(
+                    Circle()
+                        .fill(pomodoroManager.phaseColor.opacity(0.8))
+                )
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+
+    private var skipButton: some View {
+        Button(action: {
+            pomodoroManager.pause()
+            pomodoroManager.skip()
+        }) {
+            Image(systemName: "forward.fill")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(.gray)
+                .frame(width: 32, height: 32)
+                .background(
+                    Circle()
+                        .fill(Color.gray.opacity(0.2))
+                )
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+
+    private var resetButton: some View {
+        Button(action: {
+            pomodoroManager.resetAll()
+        }) {
+            Image(systemName: "arrow.counterclockwise")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(.gray)
+                .frame(width: 32, height: 32)
+                .background(
+                    Circle()
+                        .fill(Color.gray.opacity(0.2))
+                )
+        }
+        .buttonStyle(PlainButtonStyle())
+        .help("Reset timer")
     }
 }
 

--- a/boringNotch/components/PomodoroView.swift
+++ b/boringNotch/components/PomodoroView.swift
@@ -100,7 +100,7 @@ struct PomodoroView: View {
 
             // Controls
             HStack(spacing: 20) {
-                Button(action: { pomodoroManager.pause() }) {
+                Button(action: { pomodoroManager.reset() }) {
                     Image(systemName: "stop.fill")
                         .font(.system(size: 16))
                         .foregroundColor(.gray)

--- a/boringNotch/components/PomodoroView.swift
+++ b/boringNotch/components/PomodoroView.swift
@@ -13,8 +13,8 @@ struct PomodoroView: View {
     @EnvironmentObject var vm: BoringViewModel
 
     var body: some View {
-        HStack(alignment: .center, spacing: 0) {
-            // Left spacer - same size as album art in MusicPlayerView (60x60 with padding)
+        VStack(alignment: .center, spacing: 0) {
+            // Timer circle on the left (matching album art position)
             timerCircleView
                 .padding(.all, 5)
 
@@ -23,6 +23,8 @@ struct PomodoroView: View {
                 .drawingGroup()
                 .compositingGroup()
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(minHeight: 60)
     }
 
     // Timer circle on the left (matching album art position)
@@ -62,7 +64,7 @@ struct PomodoroView: View {
             HStack(spacing: 16) {
                 // Reset button
                 Button(action: {
-                    pomodoroManager.reset()
+                    pomodoroManager.resetAll()
                 }) {
                     Image(systemName: "arrow.counterclockwise")
                         .font(.system(size: 12, weight: .medium))
@@ -128,14 +130,14 @@ struct PomodoroView: View {
 
             // Reset all button
             Button(action: {
-                pomodoroManager.reset()
+                pomodoroManager.resetAll()
             }) {
                 Image(systemName: "arrow.counterclockwise")
                     .font(.system(size: 10))
                     .foregroundStyle(.gray)
             }
             .buttonStyle(PlainButtonStyle())
-            .help("Reset Timer")
+            .help("Reset Everything")
         }
     }
 

--- a/boringNotch/components/PomodoroView.swift
+++ b/boringNotch/components/PomodoroView.swift
@@ -2,99 +2,192 @@
 //  PomodoroView.swift
 //  boringNotch
 //
-//  Created by Claw on 2026-04-28.
+//  Created by Christian Teo on 2026-04-29.
 //
 
-import Defaults
 import SwiftUI
 
 struct PomodoroView: View {
     @ObservedObject var pomodoroManager = PomodoroManager.shared
-    @EnvironmentObject var vm: BoringViewModel
+    @State private var isLongPressing: Bool = false
+    
+    private let timerSize: CGFloat = 140
+    private let progressLineWidth: CGFloat = 6
 
     var body: some View {
-        VStack(spacing: 16) {
-            // Phase indicator
-            HStack {
-                ForEach([PomodoroManager.PomodoroPhase.work, .shortBreak, .longBreak], id: \.self) { phase in
-                    Text(phase.rawValue)
-                        .font(.caption)
-                        .foregroundColor(pomodoroManager.currentPhase == phase ? .white : .gray)
-                }
-            }
-
-            // Circular progress + time
+        VStack(spacing: 12) {
+            // Phase indicator dots
+            phaseIndicators
+            
+            // Circular progress timer
             ZStack {
+                // Background circle
                 Circle()
-                    .stroke(Color.gray.opacity(0.3), lineWidth: 6)
-
+                    .stroke(Color.gray.opacity(0.3), lineWidth: progressLineWidth)
+                
+                // Progress circle
                 Circle()
                     .trim(from: 0, to: pomodoroManager.progress)
                     .stroke(
-                        phaseColor,
-                        style: StrokeStyle(lineWidth: 6, lineCap: .round)
+                        pomodoroManager.phaseColor,
+                        style: StrokeStyle(lineWidth: progressLineWidth, lineCap: .round)
                     )
                     .rotationEffect(.degrees(-90))
                     .animation(.linear(duration: 1), value: pomodoroManager.progress)
-
-                VStack(spacing: 4) {
-                    Text(pomodoroManager.currentPhase.rawValue)
-                        .font(.caption2)
+                
+                // Timer content
+                VStack(spacing: 2) {
+                    Text(pomodoroManager.currentPhase.displayName)
+                        .font(.system(size: 10, weight: .medium))
                         .foregroundStyle(.gray)
-
+                    
                     Text(pomodoroManager.formattedTime)
-                        .font(.system(size: 28, weight: .bold, design: .monospaced))
-                        .foregroundColor(.white)
+                        .font(.system(size: 24, weight: .bold, design: .monospaced))
+                        .foregroundStyle(.white)
                 }
             }
-            .frame(width: 140, height: 140)
-
-            // Controls
-            HStack(spacing: 20) {
-                Button(action: { pomodoroManager.stop() }) {
-                    Image(systemName: "stop.fill")
-                        .font(.system(size: 16))
-                        .foregroundColor(.gray)
-                }
-                .buttonStyle(PlainButtonStyle())
-
-                Button(action: {
-                    if pomodoroManager.isRunning {
-                        pomodoroManager.pause()
-                    } else {
-                        pomodoroManager.start()
-                    }
-                }) {
-                    Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
-                        .font(.system(size: 22))
-                        .foregroundColor(.white)
-                }
-                .buttonStyle(PlainButtonStyle())
-
-                Button(action: { pomodoroManager.skip() }) {
-                    Image(systemName: "forward.fill")
-                        .font(.system(size: 16))
-                        .foregroundColor(.gray)
-                }
-                .buttonStyle(PlainButtonStyle())
-            }
-
-            // Session count
-            HStack {
-                Text("Sessions: \(pomodoroManager.sessionsCompleted)")
-                    .font(.caption2)
-                    .foregroundStyle(.gray)
-            }
+            .frame(width: timerSize, height: timerSize)
+            
+            // Sessions counter with long-press
+            sessionsCounter
+            
+            // Control buttons
+            controlButtons
         }
-        .padding(20)
+        .padding(.vertical, 16)
+        .padding(.horizontal, 20)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
     }
-
-    private var phaseColor: Color {
-        switch pomodoroManager.currentPhase {
-        case .work: return .red
-        case .shortBreak: return .green
-        case .longBreak: return .blue
+    
+    // MARK: - Subviews
+    
+    private var phaseIndicators: some View {
+        HStack(spacing: 16) {
+            ForEach(PomodoroManager.PomodoroPhase.allCases, id: \.self) { phase in
+                VStack(spacing: 4) {
+                    Circle()
+                        .fill(pomodoroManager.currentPhase == phase ? pomodoroManager.phaseColor : Color.gray.opacity(0.4))
+                        .frame(width: 8, height: 8)
+                    
+                    Text(phase.displayName)
+                        .font(.system(size: 9))
+                        .foregroundColor(pomodoroManager.currentPhase == phase ? .white : .gray)
+                }
+            }
         }
     }
+    
+    private var sessionsCounter: some View {
+        HStack(spacing: 4) {
+            Text("Sessions")
+                .font(.system(size: 11))
+                .foregroundStyle(.gray)
+            
+            Text("\(pomodoroManager.sessionsCompleted)")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(sessionsCompletedColor)
+                .scaleEffect(isLongPressing ? 1.2 : 1.0)
+                .animation(.easeInOut(duration: 0.15), value: isLongPressing)
+            
+            if pomodoroManager.sessionsCompleted > 0 {
+                Image(systemName: "arrow.counterclockwise")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.gray.opacity(0.5))
+            }
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 12)
+        .background(
+            Capsule()
+                .fill(Color.white.opacity(0.05))
+        )
+        .contentShape(Rectangle())
+        .gesture(
+            LongPressGesture(minimumDuration: 0.8)
+                .onChanged { _ in
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        isLongPressing = true
+                    }
+                }
+                .onEnded { _ in
+                    pomodoroManager.resetSessions()
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        isLongPressing = false
+                    }
+                }
+        )
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 1)
+                .onChanged { _ in
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        isLongPressing = false
+                    }
+                }
+        )
+    }
+    
+    private var sessionsCompletedColor: Color {
+        if pomodoroManager.sessionsCompleted % pomodoroManager.sessionsBeforeLongBreak == 0 && pomodoroManager.sessionsCompleted > 0 {
+            return .blue
+        } else if pomodoroManager.currentPhase == .work {
+            return .red
+        } else {
+            return .green
+        }
+    }
+    
+    private var controlButtons: some View {
+        HStack(spacing: 24) {
+            // Reset button
+            Button(action: {
+                pomodoroManager.reset()
+            }) {
+                Image(systemName: "arrow.counterclockwise")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(.gray)
+                    .frame(width: 32, height: 32)
+            }
+            .buttonStyle(PlainButtonStyle())
+            .help("Reset Timer")
+            
+            // Play/Pause button
+            Button(action: {
+                if pomodoroManager.isRunning {
+                    pomodoroManager.pause()
+                } else {
+                    pomodoroManager.start()
+                }
+            }) {
+                Image(systemName: pomodoroManager.isRunning ? "pause.fill" : "play.fill")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundStyle(.white)
+                    .frame(width: 40, height: 40)
+                    .background(
+                        Circle()
+                            .fill(pomodoroManager.phaseColor.opacity(0.8))
+                    )
+            }
+            .buttonStyle(PlainButtonStyle())
+            .help(pomodoroManager.isRunning ? "Pause" : "Start")
+            
+            // Skip button
+            Button(action: {
+                pomodoroManager.pause()
+                pomodoroManager.reset()
+            }) {
+                Image(systemName: "forward.fill")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.gray)
+                    .frame(width: 32, height: 32)
+            }
+            .buttonStyle(PlainButtonStyle())
+            .help("Skip to Next")
+        }
+    }
+}
+
+#Preview {
+    PomodoroView()
+        .frame(width: 300, height: 300)
+        .background(Color.black)
 }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -354,91 +354,152 @@ struct GeneralSettings: View {
 }
 
 struct PomodoroSettings: View {
-    @Default(.pomodoroEnabled) var pomodoroEnabled
-    @Default(.pomodoroWorkDuration) var pomodoroWorkDuration
-    @Default(.pomodoroShortBreakDuration) var pomodoroShortBreakDuration
-    @Default(.pomodoroLongBreakDuration) var pomodoroLongBreakDuration
-    @Default(.pomodoroSessionsBeforeLongBreak) var pomodoroSessionsBeforeLongBreak
-    
+    @Default(.pomodoroEnabled) var pomodoroEnabled: Bool
+    @Default(.pomodoroWorkDuration) var pomodoroWorkDuration: Int
+    @Default(.pomodoroShortBreakDuration) var pomodoroShortBreakDuration: Int
+    @Default(.pomodoroLongBreakDuration) var pomodoroLongBreakDuration: Int
+    @Default(.pomodoroSessionsBeforeLongBreak) var pomodoroSessionsBeforeLongBreak: Int
+
     var body: some View {
         Form {
             Section {
                 Toggle("Enable Pomodoro Timer", isOn: $pomodoroEnabled)
+                    .tint(.effectiveAccent)
             } header: {
                 Text("General")
-            } footer: {
-                Text("When enabled, a timer icon will appear in the notch header.")
             }
-            
+
             Section {
-                durationRow(
-                    title: "Work duration",
-                    value: $pomodoroWorkDuration,
-                    range: 1...90,
-                    unit: "minutes"
-                )
-                
-                durationRow(
-                    title: "Short break duration",
-                    value: $pomodoroShortBreakDuration,
-                    range: 1...30,
-                    unit: "minutes"
-                )
-                
-                durationRow(
-                    title: "Long break duration",
-                    value: $pomodoroLongBreakDuration,
-                    range: 1...60,
-                    unit: "minutes"
-                )
-                
-                durationRow(
-                    title: "Sessions before long break",
-                    value: $pomodoroSessionsBeforeLongBreak,
-                    range: 1...10,
-                    unit: "sessions"
-                )
+                DirectInputRow(label: "Work Duration", value: $pomodoroWorkDuration, range: 1...90, unit: "min")
+                DirectInputRow(label: "Short Break", value: $pomodoroShortBreakDuration, range: 1...30, unit: "min")
+                DirectInputRow(label: "Long Break", value: $pomodoroLongBreakDuration, range: 1...60, unit: "min")
+                DirectInputRow(label: "Sessions before Long Break", value: $pomodoroSessionsBeforeLongBreak, range: 1...10, unit: "")
             } header: {
                 Text("Timer Durations")
-            } footer: {
-                Text("Work: Focus time. Short break: Quick rest. Long break: Extended rest after completing all sessions.")
+            }
+
+            Section {
+                HStack {
+                    Text("Work")
+                    Spacer()
+                    Text("\(pomodoroWorkDuration) min")
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text("Short Break")
+                    Spacer()
+                    Text("\(pomodoroShortBreakDuration) min")
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text("Long Break")
+                    Spacer()
+                    Text("\(pomodoroLongBreakDuration) min")
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text("Total Cycle")
+                    Spacer()
+                    Text("\(pomodoroWorkDuration + pomodoroShortBreakDuration) min × \(pomodoroSessionsBeforeLongBreak) + \(pomodoroLongBreakDuration) min")
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("Current Settings Summary")
             }
         }
-        .accentColor(.effectiveAccent)
         .navigationTitle("Pomodoro")
-        .disabled(!pomodoroEnabled)
     }
-    
-    @ViewBuilder
-    private func durationRow(title: String, value: Binding<Int>, range: ClosedRange<Int>, unit: String) -> some View {
+}
+
+// MARK: - Direct Input Row Component
+struct DirectInputRow: View {
+    let label: String
+    @Binding var value: Int
+    let range: ClosedRange<Int>
+    let unit: String
+
+    var body: some View {
         HStack {
-            Text(title)
+            Text(label)
             Spacer()
-            Stepper(
-                value: value,
-                in: range,
-                step: 1
-            ) {
-                TextField(
-                    "",
-                    value: value,
-                    format: .number
-                )
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-                .frame(width: 50)
-                .multilineTextAlignment(.trailing)
-                .onSubmit {
-                    // Clamp value to valid range
-                    if value.wrappedValue < range.lowerBound {
-                        value.wrappedValue = range.lowerBound
-                    } else if value.wrappedValue > range.upperBound {
-                        value.wrappedValue = range.upperBound
-                    }
+            HStack(spacing: 4) {
+                Button(action: { value = max(range.lowerBound, value - 1) }) {
+                    Image(systemName: "minus")
+                        .font(.caption)
+                        .frame(width: 24, height: 24)
+                        .background(Color(nsColor: .secondarySystemFill))
+                        .clipShape(Circle())
                 }
+                .buttonStyle(.plain)
+
+                NumberTextField(placeholder: "", value: $value, range: range)
+                    .frame(width: 60)
+                    .multilineTextAlignment(.center)
+
+                if !unit.isEmpty {
+                    Text(unit)
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
+
+                Button(action: { value = min(range.upperBound, value + 1) }) {
+                    Image(systemName: "plus")
+                        .font(.caption)
+                        .frame(width: 24, height: 24)
+                        .background(Color(nsColor: .secondarySystemFill))
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
             }
-            Text(unit)
-                .foregroundStyle(.secondary)
-                .frame(width: 60, alignment: .leading)
+        }
+    }
+}
+
+// MARK: - Number TextField with keyboard input
+struct NumberTextField: NSViewRepresentable {
+    let placeholder: String
+    @Binding var value: Int
+    let range: ClosedRange<Int>
+
+    func makeNSView(context: Context) -> NSTextField {
+        let textField = NSTextField()
+        textField.placeholderString = placeholder
+        textField.alignment = .center
+        textField.formatter = NumberFormatter()
+        textField.target = context.coordinator
+        textField.action = #selector(Coordinator.textFieldAction(_:))
+        textField.bezelStyle = .roundedBezel
+        return textField
+    }
+
+    func updateNSView(_ nsView: NSTextField, context: Context) {
+        nsView.integerValue = value
+        context.coordinator.value = value
+        context.coordinator.range = range
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(value: value, range: range)
+    }
+
+    class Coordinator: NSObject {
+        var value: Int
+        var range: ClosedRange<Int>
+
+        init(value: Int, range: ClosedRange<Int>) {
+            self.value = value
+            self.range = range
+        }
+
+        @objc func textFieldAction(_ sender: NSTextField) {
+            var newValue = sender.integerValue
+            if newValue < range.lowerBound {
+                newValue = range.lowerBound
+            } else if newValue > range.upperBound {
+                newValue = range.upperBound
+            }
+            value = newValue
+            sender.integerValue = newValue
         }
     }
 }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -45,6 +45,9 @@ struct SettingsView: View {
                 NavigationLink(value: "Battery") {
                     Label("Battery", systemImage: "battery.100.bolt")
                 }
+                NavigationLink(value: "Pomodoro") {
+                    Label("Pomodoro", systemImage: "timer")
+                }
 //                NavigationLink(value: "Downloads") {
 //                    Label("Downloads", systemImage: "square.and.arrow.down")
 //                }
@@ -83,6 +86,8 @@ struct SettingsView: View {
                     HUD()
                 case "Battery":
                     Charge()
+                case "Pomodoro":
+                    PomodoroSettings()
                 case "Shelf":
                     Shelf()
                 case "Shortcuts":
@@ -344,6 +349,96 @@ struct GeneralSettings: View {
             }
         } header: {
             Text("Notch behavior")
+        }
+    }
+}
+
+struct PomodoroSettings: View {
+    @Default(.pomodoroEnabled) var pomodoroEnabled
+    @Default(.pomodoroWorkDuration) var pomodoroWorkDuration
+    @Default(.pomodoroShortBreakDuration) var pomodoroShortBreakDuration
+    @Default(.pomodoroLongBreakDuration) var pomodoroLongBreakDuration
+    @Default(.pomodoroSessionsBeforeLongBreak) var pomodoroSessionsBeforeLongBreak
+    
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Enable Pomodoro Timer", isOn: $pomodoroEnabled)
+            } header: {
+                Text("General")
+            } footer: {
+                Text("When enabled, a timer icon will appear in the notch header.")
+            }
+            
+            Section {
+                durationRow(
+                    title: "Work duration",
+                    value: $pomodoroWorkDuration,
+                    range: 1...90,
+                    unit: "minutes"
+                )
+                
+                durationRow(
+                    title: "Short break duration",
+                    value: $pomodoroShortBreakDuration,
+                    range: 1...30,
+                    unit: "minutes"
+                )
+                
+                durationRow(
+                    title: "Long break duration",
+                    value: $pomodoroLongBreakDuration,
+                    range: 1...60,
+                    unit: "minutes"
+                )
+                
+                durationRow(
+                    title: "Sessions before long break",
+                    value: $pomodoroSessionsBeforeLongBreak,
+                    range: 1...10,
+                    unit: "sessions"
+                )
+            } header: {
+                Text("Timer Durations")
+            } footer: {
+                Text("Work: Focus time. Short break: Quick rest. Long break: Extended rest after completing all sessions.")
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Pomodoro")
+        .disabled(!pomodoroEnabled)
+    }
+    
+    @ViewBuilder
+    private func durationRow(title: String, value: Binding<Int>, range: ClosedRange<Int>, unit: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Stepper(
+                value: value,
+                in: range,
+                step: 1
+            ) {
+                TextField(
+                    "",
+                    value: value,
+                    format: .number
+                )
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .frame(width: 50)
+                .multilineTextAlignment(.trailing)
+                .onSubmit {
+                    // Clamp value to valid range
+                    if value.wrappedValue < range.lowerBound {
+                        value.wrappedValue = range.lowerBound
+                    } else if value.wrappedValue > range.upperBound {
+                        value.wrappedValue = range.upperBound
+                    }
+                }
+            }
+            Text(unit)
+                .foregroundStyle(.secondary)
+                .frame(width: 60, alignment: .leading)
         }
     }
 }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -1320,6 +1320,9 @@ struct Appearance: View {
     @Default(.useMusicVisualizer) var useMusicVisualizer
     @Default(.customVisualizers) var customVisualizers
     @Default(.selectedVisualizer) var selectedVisualizer
+    @Default(.faceAnimationType) var faceAnimationType: FaceType
+    @Default(.faceSelectionMode) var faceSelectionMode: FaceSelectionMode
+    @Default(.faceRandomInterval) var faceRandomInterval: Int
 
     let icons: [String] = ["logo2"]
     @State private var selectedIcon: String = "logo2"
@@ -1548,32 +1551,23 @@ struct Appearance: View {
                 }
                 
                 if Defaults[.showNotHumanFace] {
-                    Picker("Face mode", selection: Binding(
-                        get: { Defaults[.faceSelectionMode] },
-                        set: { Defaults[.faceSelectionMode] = $0 }
-                    )) {
+                    Picker("Face mode", selection: $faceSelectionMode) {
                         Text("Fixed").tag(FaceSelectionMode.fixed)
                         Text("Random").tag(FaceSelectionMode.random)
                     }
                     
-                    if Defaults[.faceSelectionMode] == .fixed {
-                        Picker("Face type", selection: Binding(
-                            get: { Defaults[.faceAnimationType] },
-                            set: { Defaults[.faceAnimationType] = $0 }
-                        )) {
+                    if faceSelectionMode == .fixed {
+                        Picker("Face type", selection: $faceAnimationType) {
                             ForEach(FaceType.allCases) { faceType in
                                 Text(faceType.rawValue).tag(faceType)
                             }
                         }
                     } else {
-                        Stepper(value: Binding(
-                            get: { Defaults[.faceRandomInterval] },
-                            set: { Defaults[.faceRandomInterval] = $0 }
-                        ), in: 5...120) {
+                        Stepper(value: $faceRandomInterval, in: 5...120) {
                             HStack {
                                 Text("Interval")
                                 Spacer()
-                                Text("\(Defaults[.faceRandomInterval])s")
+                                Text("\(faceRandomInterval)s")
                                     .foregroundStyle(.secondary)
                             }
                         }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -1544,7 +1544,40 @@ struct Appearance: View {
                         .tag(MirrorShapeEnum.rectangle)
                 }
                 Defaults.Toggle(key: .showNotHumanFace) {
-                    Text("Show cool face animation while inactive")
+                    Text("Show face animation while inactive")
+                }
+                
+                if Defaults[.showNotHumanFace] {
+                    Picker("Face mode", selection: Binding(
+                        get: { Defaults[.faceSelectionMode] },
+                        set: { Defaults[.faceSelectionMode] = $0 }
+                    )) {
+                        Text("Fixed").tag(FaceSelectionMode.fixed)
+                        Text("Random").tag(FaceSelectionMode.random)
+                    }
+                    
+                    if Defaults[.faceSelectionMode] == .fixed {
+                        Picker("Face type", selection: Binding(
+                            get: { Defaults[.faceAnimationType] },
+                            set: { Defaults[.faceAnimationType] = $0 }
+                        )) {
+                            ForEach(FaceType.allCases) { faceType in
+                                Text(faceType.rawValue).tag(faceType)
+                            }
+                        }
+                    } else {
+                        Stepper(value: Binding(
+                            get: { Defaults[.faceRandomInterval] },
+                            set: { Defaults[.faceRandomInterval] = $0 }
+                        ), in: 5...120) {
+                            HStack {
+                                Text("Interval")
+                                Spacer()
+                                Text("\(Defaults[.faceRandomInterval])s")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
                 }
             } header: {
                 HStack {

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -16,7 +16,8 @@ struct TabModel: Identifiable {
 
 let tabs = [
     TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
+    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf),
+    TabModel(label: "Timer", icon: "timer", view: .pomodoro)
 ]
 
 struct TabSelectionView: View {

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -27,6 +27,7 @@ public enum NotchState {
 public enum NotchViews {
     case home
     case shelf
+    case pomodoro
 }
 
 enum SettingsEnum {

--- a/boringNotch/managers/PomodoroManager.swift
+++ b/boringNotch/managers/PomodoroManager.swift
@@ -2,7 +2,7 @@
 //  PomodoroManager.swift
 //  boringNotch
 //
-//  Created by Claw on 2026-04-28.
+//  Created by Christian Teo on 2026-04-29.
 //
 
 import Combine
@@ -14,66 +14,107 @@ import SwiftUI
 class PomodoroManager: ObservableObject {
     static let shared = PomodoroManager()
 
+    enum PomodoroPhase: String, CaseIterable {
+        case work = "Work"
+        case shortBreak = "Short Break"
+        case longBreak = "Long Break"
+        
+        var displayName: String {
+            return self.rawValue
+        }
+    }
+
+    // MARK: - Published Properties
     @Published var isRunning: Bool = false
     @Published var isPaused: Bool = false
     @Published var currentPhase: PomodoroPhase = .work
-    @Published var remainingSeconds: Int = 25 * 60
+    @Published var remainingSeconds: Int = Defaults[.pomodoroWorkDuration] * 60
     @Published var sessionsCompleted: Int = 0
-    @Published var showPanel: Bool = false
-
-    @Published var workDuration: Int = Defaults[.pomodoroWorkDuration]
-    @Published var shortBreakDuration: Int = Defaults[.pomodoroShortBreakDuration]
-    @Published var longBreakDuration: Int = Defaults[.pomodoroLongBreakDuration]
-    @Published var sessionsBeforeLongBreak: Int = Defaults[.pomodoroSessionsBeforeLongBreak]
+    
+    // Settings (synced with Defaults)
+    @Published var workDuration: Int {
+        didSet {
+            if currentPhase == .work && !isRunning && !isPaused {
+                remainingSeconds = workDuration * 60
+            }
+        }
+    }
+    @Published var shortBreakDuration: Int {
+        didSet {
+            if currentPhase == .shortBreak && !isRunning && !isPaused {
+                remainingSeconds = shortBreakDuration * 60
+            }
+        }
+    }
+    @Published var longBreakDuration: Int {
+        didSet {
+            if currentPhase == .longBreak && !isRunning && !isPaused {
+                remainingSeconds = longBreakDuration * 60
+            }
+        }
+    }
+    @Published var sessionsBeforeLongBreak: Int
 
     private var timer: Timer?
     private var cancellables = Set<AnyCancellable>()
 
-    enum PomodoroPhase: String {
-        case work = "Focus"
-        case shortBreak = "Short Break"
-        case longBreak = "Long Break"
+    // MARK: - Initialization
+    init() {
+        self.workDuration = Defaults[.pomodoroWorkDuration]
+        self.shortBreakDuration = Defaults[.pomodoroShortBreakDuration]
+        self.longBreakDuration = Defaults[.pomodoroLongBreakDuration]
+        self.sessionsBeforeLongBreak = Defaults[.pomodoroSessionsBeforeLongBreak]
+        self.remainingSeconds = workDuration * 60
+        
+        setupDefaultsObservers()
     }
 
-    init() {
+    private func setupDefaultsObservers() {
         Defaults.publisher(.pomodoroWorkDuration)
+            .receive(on: RunLoop.main)
             .sink { [weak self] change in
                 self?.workDuration = change.newValue
-                if self?.currentPhase == .work && !(self?.isRunning ?? false) {
+                if self?.currentPhase == .work && !(self?.isRunning ?? false) && !(self?.isPaused ?? false) {
                     self?.remainingSeconds = change.newValue * 60
                 }
             }
             .store(in: &cancellables)
 
         Defaults.publisher(.pomodoroShortBreakDuration)
+            .receive(on: RunLoop.main)
             .sink { [weak self] change in
                 self?.shortBreakDuration = change.newValue
-                if self?.currentPhase == .shortBreak && !(self?.isRunning ?? false) {
+                if self?.currentPhase == .shortBreak && !(self?.isRunning ?? false) && !(self?.isPaused ?? false) {
                     self?.remainingSeconds = change.newValue * 60
                 }
             }
             .store(in: &cancellables)
 
         Defaults.publisher(.pomodoroLongBreakDuration)
+            .receive(on: RunLoop.main)
             .sink { [weak self] change in
                 self?.longBreakDuration = change.newValue
-                if self?.currentPhase == .longBreak && !(self?.isRunning ?? false) {
+                if self?.currentPhase == .longBreak && !(self?.isRunning ?? false) && !(self?.isPaused ?? false) {
                     self?.remainingSeconds = change.newValue * 60
                 }
             }
             .store(in: &cancellables)
 
         Defaults.publisher(.pomodoroSessionsBeforeLongBreak)
+            .receive(on: RunLoop.main)
             .sink { [weak self] change in
                 self?.sessionsBeforeLongBreak = change.newValue
             }
             .store(in: &cancellables)
     }
 
+    // MARK: - Timer Controls
     func start() {
         guard !isRunning else { return }
         isRunning = true
         isPaused = false
+        
+        timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 self?.tick()
@@ -92,15 +133,12 @@ class PomodoroManager: ObservableObject {
         start()
     }
 
-    func stop() {
+    func reset() {
         isRunning = false
         isPaused = false
         timer?.invalidate()
         timer = nil
-        reset()
-    }
-
-    func reset() {
+        
         switch currentPhase {
         case .work:
             remainingSeconds = workDuration * 60
@@ -110,13 +148,19 @@ class PomodoroManager: ObservableObject {
             remainingSeconds = longBreakDuration * 60
         }
     }
+    
+    func resetSessions() {
+        sessionsCompleted = 0
+    }
 
-    func skip() {
+    func resetAll() {
         timer?.invalidate()
         timer = nil
         isRunning = false
         isPaused = false
-        transitionToNextPhase()
+        currentPhase = .work
+        sessionsCompleted = 0
+        remainingSeconds = workDuration * 60
     }
 
     private func tick() {
@@ -147,10 +191,7 @@ class PomodoroManager: ObservableObject {
         }
     }
 
-    func togglePanel() {
-        showPanel.toggle()
-    }
-
+    // MARK: - Computed Properties
     var formattedTime: String {
         let minutes = remainingSeconds / 60
         let seconds = remainingSeconds % 60
@@ -166,5 +207,17 @@ class PomodoroManager: ObservableObject {
         }
         guard total > 0 else { return 0 }
         return Double(total - remainingSeconds) / Double(total)
+    }
+    
+    var phaseColor: Color {
+        switch currentPhase {
+        case .work: return .red
+        case .shortBreak: return .green
+        case .longBreak: return .blue
+        }
+    }
+    
+    var sessionDots: String {
+        String(repeating: "• ", count: min(sessionsCompleted, 10))
     }
 }

--- a/boringNotch/managers/PomodoroManager.swift
+++ b/boringNotch/managers/PomodoroManager.swift
@@ -163,6 +163,15 @@ class PomodoroManager: ObservableObject {
         remainingSeconds = workDuration * 60
     }
 
+    func skip() {
+        // Move to next phase without waiting for timer
+        timer?.invalidate()
+        timer = nil
+        isRunning = false
+        isPaused = false
+        transitionToNextPhase()
+    }
+
     private func tick() {
         guard remainingSeconds > 0 else {
             timer?.invalidate()

--- a/boringNotch/managers/PomodoroManager.swift
+++ b/boringNotch/managers/PomodoroManager.swift
@@ -1,0 +1,170 @@
+//
+//  PomodoroManager.swift
+//  boringNotch
+//
+//  Created by Claw on 2026-04-28.
+//
+
+import Combine
+import Defaults
+import Foundation
+import SwiftUI
+
+@MainActor
+class PomodoroManager: ObservableObject {
+    static let shared = PomodoroManager()
+
+    @Published var isRunning: Bool = false
+    @Published var isPaused: Bool = false
+    @Published var currentPhase: PomodoroPhase = .work
+    @Published var remainingSeconds: Int = 25 * 60
+    @Published var sessionsCompleted: Int = 0
+    @Published var showPanel: Bool = false
+
+    @Published var workDuration: Int = Defaults[.pomodoroWorkDuration]
+    @Published var shortBreakDuration: Int = Defaults[.pomodoroShortBreakDuration]
+    @Published var longBreakDuration: Int = Defaults[.pomodoroLongBreakDuration]
+    @Published var sessionsBeforeLongBreak: Int = Defaults[.pomodoroSessionsBeforeLongBreak]
+
+    private var timer: Timer?
+    private var cancellables = Set<AnyCancellable>()
+
+    enum PomodoroPhase: String {
+        case work = "Focus"
+        case shortBreak = "Short Break"
+        case longBreak = "Long Break"
+    }
+
+    init() {
+        Defaults.publisher(.pomodoroWorkDuration)
+            .sink { [weak self] change in
+                self?.workDuration = change.newValue
+                if self?.currentPhase == .work && !(self?.isRunning ?? false) {
+                    self?.remainingSeconds = change.newValue * 60
+                }
+            }
+            .store(in: &cancellables)
+
+        Defaults.publisher(.pomodoroShortBreakDuration)
+            .sink { [weak self] change in
+                self?.shortBreakDuration = change.newValue
+                if self?.currentPhase == .shortBreak && !(self?.isRunning ?? false) {
+                    self?.remainingSeconds = change.newValue * 60
+                }
+            }
+            .store(in: &cancellables)
+
+        Defaults.publisher(.pomodoroLongBreakDuration)
+            .sink { [weak self] change in
+                self?.longBreakDuration = change.newValue
+                if self?.currentPhase == .longBreak && !(self?.isRunning ?? false) {
+                    self?.remainingSeconds = change.newValue * 60
+                }
+            }
+            .store(in: &cancellables)
+
+        Defaults.publisher(.pomodoroSessionsBeforeLongBreak)
+            .sink { [weak self] change in
+                self?.sessionsBeforeLongBreak = change.newValue
+            }
+            .store(in: &cancellables)
+    }
+
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+        isPaused = false
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.tick()
+            }
+        }
+    }
+
+    func pause() {
+        isPaused = true
+        isRunning = false
+        timer?.invalidate()
+        timer = nil
+    }
+
+    func resume() {
+        start()
+    }
+
+    func stop() {
+        isRunning = false
+        isPaused = false
+        timer?.invalidate()
+        timer = nil
+        reset()
+    }
+
+    func reset() {
+        switch currentPhase {
+        case .work:
+            remainingSeconds = workDuration * 60
+        case .shortBreak:
+            remainingSeconds = shortBreakDuration * 60
+        case .longBreak:
+            remainingSeconds = longBreakDuration * 60
+        }
+    }
+
+    func skip() {
+        timer?.invalidate()
+        timer = nil
+        isRunning = false
+        isPaused = false
+        transitionToNextPhase()
+    }
+
+    private func tick() {
+        guard remainingSeconds > 0 else {
+            timer?.invalidate()
+            timer = nil
+            isRunning = false
+            transitionToNextPhase()
+            return
+        }
+        remainingSeconds -= 1
+    }
+
+    private func transitionToNextPhase() {
+        switch currentPhase {
+        case .work:
+            sessionsCompleted += 1
+            if sessionsCompleted % sessionsBeforeLongBreak == 0 {
+                currentPhase = .longBreak
+                remainingSeconds = longBreakDuration * 60
+            } else {
+                currentPhase = .shortBreak
+                remainingSeconds = shortBreakDuration * 60
+            }
+        case .shortBreak, .longBreak:
+            currentPhase = .work
+            remainingSeconds = workDuration * 60
+        }
+    }
+
+    func togglePanel() {
+        showPanel.toggle()
+    }
+
+    var formattedTime: String {
+        let minutes = remainingSeconds / 60
+        let seconds = remainingSeconds % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+    var progress: Double {
+        let total: Int
+        switch currentPhase {
+        case .work: total = workDuration * 60
+        case .shortBreak: total = shortBreakDuration * 60
+        case .longBreak: total = longBreakDuration * 60
+        }
+        guard total > 0 else { return 0 }
+        return Double(total - remainingSeconds) / Double(total)
+    }
+}

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -199,4 +199,11 @@ extension Defaults.Keys {
     }
 
     static let didClearLegacyURLCacheV1 = Key<Bool>("didClearLegacyURLCache_v1", default: false)
+
+    // MARK: Pomodoro
+    static let pomodoroEnabled = Key<Bool>("pomodoroEnabled", default: true)
+    static let pomodoroWorkDuration = Key<Int>("pomodoroWorkDuration", default: 25)
+    static let pomodoroShortBreakDuration = Key<Int>("pomodoroShortBreakDuration", default: 5)
+    static let pomodoroLongBreakDuration = Key<Int>("pomodoroLongBreakDuration", default: 15)
+    static let pomodoroSessionsBeforeLongBreak = Key<Int>("pomodoroSessionsBeforeLongBreak", default: 4)
 }

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -68,6 +68,26 @@ enum OptionKeyAction: String, CaseIterable, Identifiable, Defaults.Serializable 
     var id: String { self.rawValue }
 }
 
+// Face types for animated face feature
+enum FaceType: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case minimal = "Minimal"
+    case cool = "Cool"
+    case surprised = "Surprised"
+    case sleepy = "Sleepy"
+    case wink = "Wink"
+    case happy = "Happy"
+    
+    var id: String { rawValue }
+}
+
+// Face selection mode: fixed or random
+enum FaceSelectionMode: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case fixed = "Fixed"
+    case random = "Random"
+    
+    var id: String { self.rawValue }
+}
+
 extension Defaults.Keys {
     // MARK: General
     static let menubarIcon = Key<Bool>("menubarIcon", default: true)
@@ -105,6 +125,9 @@ extension Defaults.Keys {
     static let cornerRadiusScaling = Key<Bool>("cornerRadiusScaling", default: true)
 
     static let showNotHumanFace = Key<Bool>("showNotHumanFace", default: false)
+    static let faceAnimationType = Key<FaceType>("faceAnimationType", default: .minimal)
+    static let faceSelectionMode = Key<FaceSelectionMode>("faceSelectionMode", default: .fixed)
+    static let faceRandomInterval = Key<Int>("faceRandomInterval", default: 10)
     static let tileShowLabels = Key<Bool>("tileShowLabels", default: false)
     static let showCalendar = Key<Bool>("showCalendar", default: false)
     static let hideCompletedReminders = Key<Bool>("hideCompletedReminders", default: true)

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -77,7 +77,6 @@ enum FaceType: String, CaseIterable, Identifiable, Defaults.Serializable {
     case wink = "Wink"
     case happy = "Happy"
     case angry = "Angry"
-    case tongue = "Tongue"
     case love = "Love"
     
     var id: String { rawValue }

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -76,6 +76,9 @@ enum FaceType: String, CaseIterable, Identifiable, Defaults.Serializable {
     case sleepy = "Sleepy"
     case wink = "Wink"
     case happy = "Happy"
+    case angry = "Angry"
+    case tongue = "Tongue"
+    case love = "Love"
     
     var id: String { rawValue }
 }

--- a/boringNotchTests/PomodoroManagerTests.swift
+++ b/boringNotchTests/PomodoroManagerTests.swift
@@ -1,0 +1,473 @@
+//
+//  PomodoroManagerTests.swift
+//  boringNotchTests
+//
+//  Created by Claw/AI on 2026-04-28.
+//
+
+import Combine
+import XCTest
+
+@testable import boringNotch
+
+// MARK: - Testable PomodoroManager
+// Subclass to expose internal state and override UserDefaults for testing
+
+class TestablePomodoroManager: PomodoroManager {
+    
+    private static let testDefaultsSuite = "com.boringNotch.pomodoro.tests"
+    
+    // Override UserDefaults with test suite
+    private override var userDefaults: UserDefaults {
+        return UserDefaults(suiteName: TestablePomodoroManager.testDefaultsSuite) ?? .standard
+    }
+    
+    // Expose setters for testing
+    var testTimeRemaining: TimeInterval {
+        get { timeRemaining }
+        set { timeRemaining = newValue }
+    }
+    
+    var testSessionType: SessionType {
+        get { sessionType }
+        set { sessionType = newValue }
+    }
+    
+    var testCurrentCycle: Int {
+        get { currentCycle }
+        set { currentCycle = newValue }
+    }
+    
+    var testIsRunning: Bool {
+        get { isRunning }
+    }
+    
+    // Test-internal start that doesn't auto-save
+    func testStart() {
+        guard !isRunning else { return }
+        isRunning = true
+        startTimer()
+    }
+    
+    func testPause() {
+        guard isRunning else { return }
+        isRunning = false
+        timer?.invalidate()
+        timer = nil
+    }
+    
+    // Public access to reset
+    func testReset() {
+        reset()
+    }
+    
+    // Manual tick for testing
+    func performTick() {
+        tick()
+    }
+    
+    // Public access to session transition
+    func testTransitionToNextSession() {
+        transitionToNextSession()
+    }
+    
+    // Duration access for test assertions
+    var workDurationValue: TimeInterval { 25 * 60 }
+    var shortBreakDurationValue: TimeInterval { 5 * 60 }
+    var longBreakDurationValue: TimeInterval { 15 * 60 }
+    var cyclesBeforeLongBreakValue: Int { 4 }
+    
+    // Expose duration helper
+    func durationFor(type: SessionType) -> TimeInterval {
+        durationForSession(type)
+    }
+    
+    // Save/load for persistence tests
+    func testSaveState() {
+        saveState()
+    }
+    
+    func testLoadState() {
+        loadState()
+    }
+    
+    // Clear UserDefaults for test isolation
+    static func clearTestDefaults() {
+        let defaults = UserDefaults(suiteName: testDefaultsSuite)
+        defaults?.removeObject(forKey: "pomodoro_sessionType")
+        defaults?.removeObject(forKey: "pomodoro_timeRemaining")
+        defaults?.removeObject(forKey: "pomodoro_isRunning")
+        defaults?.removeObject(forKey: "pomodoro_currentCycle")
+    }
+}
+
+// MARK: - PomodoroManagerTests
+
+final class PomodoroManagerTests: XCTestCase {
+    
+    var manager: TestablePomodoroManager!
+    var cancellables = Set<AnyCancellable>()
+    
+    // MARK: - Lifecycle
+    
+    override func setUp() {
+        super.setUp()
+        TestablePomodoroManager.clearTestDefaults()
+        cancellables = []
+        manager = TestablePomodoroManager()
+    }
+    
+    override func tearDown() {
+        manager = nil
+        cancellables.removeAll()
+        TestablePomodoroManager.clearTestDefaults()
+        super.tearDown()
+    }
+    
+    // MARK: - Timer Starts Correctly Tests
+    
+    func testTimerStart_setsIsRunningTrue() {
+        XCTAssertFalse(manager.testIsRunning)
+        manager.testStart()
+        XCTAssertTrue(manager.testIsRunning)
+    }
+    
+    func testTimerStart_doesNothingIfAlreadyRunning() {
+        manager.testStart()
+        XCTAssertTrue(manager.testIsRunning)
+        let isRunningBefore = manager.testIsRunning
+        
+        // Try to start again
+        manager.testStart()
+        XCTAssertEqual(isRunningBefore, manager.testIsRunning)
+    }
+    
+    func testTimerCountdown_decrementsTime() {
+        // Set a short time for testing
+        manager.testTimeRemaining = 5.0
+        
+        // Start the timer
+        manager.testStart()
+        
+        // Simulate ticks manually since we can't control the real timer in tests
+        manager.performTick()
+        XCTAssertEqual(manager.testTimeRemaining, 4.0)
+        
+        manager.performTick()
+        XCTAssertEqual(manager.testTimeRemaining, 3.0)
+        
+        manager.performTick()
+        XCTAssertEqual(manager.testTimeRemaining, 2.0)
+    }
+    
+    // MARK: - Pause/Resume Tests
+    
+    func testPauseTimer_setsIsRunningFalse() {
+        manager.testStart()
+        XCTAssertTrue(manager.testIsRunning)
+        
+        manager.testPause()
+        XCTAssertFalse(manager.testIsRunning)
+    }
+    
+    func testPauseTimer_doesNothingIfNotRunning() {
+        XCTAssertFalse(manager.testIsRunning)
+        manager.testPause()
+        XCTAssertFalse(manager.testIsRunning)
+    }
+    
+    func testResumeTimer_fromPausedState() {
+        manager.testStart()
+        XCTAssertTrue(manager.testIsRunning)
+        
+        manager.testPause()
+        XCTAssertFalse(manager.testIsRunning)
+        
+        manager.testStart()
+        XCTAssertTrue(manager.testIsRunning)
+    }
+    
+    func testResumeTimer_preservesTimeDuringPause() {
+        manager.testStart()
+        manager.performTick()
+        manager.performTick()
+        let timeBeforePause = manager.testTimeRemaining
+        
+        manager.testPause()
+        XCTAssertEqual(manager.testTimeRemaining, timeBeforePause)
+    }
+    
+    // MARK: - Reset Tests
+    
+    func testResetTimer_returnsToWorkSession() {
+        // Transition to a break session
+        manager.testSessionType = .shortBreak
+        manager.testTimeRemaining = 60.0
+        
+        manager.testReset()
+        
+        XCTAssertEqual(manager.testSessionType, .work)
+    }
+    
+    func testResetTimer_restoresWorkDuration() {
+        // Change time remaining
+        manager.testTimeRemaining = 60.0
+        
+        manager.testReset()
+        
+        XCTAssertEqual(manager.testTimeRemaining, manager.workDurationValue)
+    }
+    
+    func testResetTimer_resetsCycleCount() {
+        // Set cycle to something other than 1
+        manager.testCurrentCycle = 3
+        
+        manager.testReset()
+        
+        XCTAssertEqual(manager.testCurrentCycle, 1)
+    }
+    
+    func testResetTimer_setsIsRunningFalse() {
+        manager.testStart()
+        XCTAssertTrue(manager.testIsRunning)
+        
+        manager.testReset()
+        
+        XCTAssertFalse(manager.testIsRunning)
+    }
+    
+    // MARK: - Session Transitions Tests
+    
+    func testWorkToShortBreakTransition() {
+        manager.testSessionType = .work
+        manager.testCurrentCycle = 1
+        
+        manager.testTransitionToNextSession()
+        
+        XCTAssertEqual(manager.testSessionType, .shortBreak)
+    }
+    
+    func testShortBreakToWorkTransition() {
+        manager.testSessionType = .shortBreak
+        manager.testCurrentCycle = 1
+        
+        manager.testTransitionToNextSession()
+        
+        XCTAssertEqual(manager.testSessionType, .work)
+        XCTAssertEqual(manager.testCurrentCycle, 2)
+    }
+    
+    func testFourthWorkToLongBreakTransition() {
+        // After 4 work sessions, should get a long break
+        manager.testSessionType = .work
+        manager.testCurrentCycle = 4
+        
+        manager.testTransitionToNextSession()
+        
+        XCTAssertEqual(manager.testSessionType, .longBreak)
+    }
+    
+    func testLongBreakToWorkTransition() {
+        manager.testSessionType = .longBreak
+        manager.testCurrentCycle = 1
+        
+        manager.testTransitionToNextSession()
+        
+        XCTAssertEqual(manager.testSessionType, .work)
+        XCTAssertEqual(manager.testCurrentCycle, 1)
+    }
+    
+    func testSessionTransitions_setCorrectDuration() {
+        // Work session duration
+        manager.testSessionType = .work
+        manager.testTransitionToNextSession()
+        XCTAssertEqual(manager.testTimeRemaining, manager.shortBreakDurationValue)
+        
+        // Short break to work
+        manager.testSessionType = .shortBreak
+        manager.testTransitionToNextSession()
+        XCTAssertEqual(manager.testTimeRemaining, manager.workDurationValue)
+        
+        // After 4 cycles, work to long break
+        manager.testSessionType = .work
+        manager.testCurrentCycle = 4
+        manager.testTransitionToNextSession()
+        XCTAssertEqual(manager.testSessionType, .longBreak)
+        XCTAssertEqual(manager.testTimeRemaining, manager.longBreakDurationValue)
+    }
+    
+    // MARK: - Cycle Count Tests
+    
+    func testCycleCountIncrementsAfterShortBreak() {
+        manager.testSessionType = .shortBreak
+        manager.testCurrentCycle = 1
+        
+        manager.testTransitionToNextSession()
+        
+        XCTAssertEqual(manager.testCurrentCycle, 2)
+    }
+    
+    func testLongBreakResetsCycleToOne() {
+        manager.testSessionType = .work
+        manager.testCurrentCycle = 4
+        
+        manager.testTransitionToNextSession()
+        
+        XCTAssertEqual(manager.testCurrentCycle, 1)
+    }
+    
+    func testCycleCountResetsAfterLongBreak() {
+        manager.testSessionType = .longBreak
+        manager.testCurrentCycle = 1
+        
+        manager.testTransitionToNextSession()
+        
+        XCTAssertEqual(manager.testCurrentCycle, 1)
+    }
+    
+    func testCyclesBeforeLongBreakIsFour() {
+        XCTAssertEqual(manager.cyclesBeforeLongBreakValue, 4)
+    }
+    
+    // MARK: - Session Duration Tests
+    
+    func testWorkDuration_is25Minutes() {
+        XCTAssertEqual(manager.durationFor(type: .work), 25 * 60)
+    }
+    
+    func testShortBreakDuration_is5Minutes() {
+        XCTAssertEqual(manager.durationFor(type: .shortBreak), 5 * 60)
+    }
+    
+    func testLongBreakDuration_is15Minutes() {
+        XCTAssertEqual(manager.durationFor(type: .longBreak), 15 * 60)
+    }
+    
+    // MARK: - UserDefaults Persistence Tests
+    
+    func testPersistence_saveAndLoadSessionType() {
+        manager.testSessionType = .shortBreak
+        manager.testSaveState()
+        
+        // Create new manager to test load
+        TestablePomodoroManager.clearTestDefaults()
+        let newManager = TestablePomodoroManager()
+        newManager.testLoadState()
+        
+        XCTAssertEqual(newManager.testSessionType, .shortBreak)
+    }
+    
+    func testPersistence_saveAndLoadTimeRemaining() {
+        manager.testTimeRemaining = 123.0
+        manager.testSaveState()
+        
+        TestablePomodoroManager.clearTestDefaults()
+        let newManager = TestablePomodoroManager()
+        newManager.testLoadState()
+        
+        XCTAssertEqual(newManager.testTimeRemaining, 123.0)
+    }
+    
+    func testPersistence_saveAndLoadCurrentCycle() {
+        manager.testCurrentCycle = 3
+        manager.testSaveState()
+        
+        TestablePomodoroManager.clearTestDefaults()
+        let newManager = TestablePomodoroManager()
+        newManager.testLoadState()
+        
+        XCTAssertEqual(newManager.testCurrentCycle, 3)
+    }
+    
+    func testPersistence_loadStateFromUserDefaults() {
+        // Simulate persisted state
+        let defaults = UserDefaults(suiteName: "com.boringNotch.pomodoro.tests")!
+        defaults.set(1, forKey: "pomodoro_sessionType") // shortBreak
+        defaults.set(300.0, forKey: "pomodoro_timeRemaining")
+        defaults.set(2, forKey: "pomodoro_currentCycle")
+        
+        let newManager = TestablePomodoroManager()
+        newManager.testLoadState()
+        
+        XCTAssertEqual(newManager.testSessionType, .shortBreak)
+        XCTAssertEqual(newManager.testTimeRemaining, 300.0)
+        XCTAssertEqual(newManager.testCurrentCycle, 2)
+    }
+    
+    func testLoadState_defaultsToWorkSession() {
+        TestablePomodoroManager.clearTestDefaults()
+        
+        let newManager = TestablePomodoroManager()
+        newManager.testLoadState()
+        
+        XCTAssertEqual(newManager.testSessionType, .work)
+    }
+    
+    func testLoadState_defaultsToWorkDuration_whenTimeIsZero() {
+        TestablePomodoroManager.clearTestDefaults()
+        
+        let newManager = TestablePomodoroManager()
+        newManager.testLoadState()
+        
+        XCTAssertEqual(newManager.testTimeRemaining, 25 * 60)
+    }
+    
+    func testLoadState_defaultsCycleToOne_whenCycleIsZero() {
+        TestablePomodoroManager.clearTestDefaults()
+        let defaults = UserDefaults(suiteName: "com.boringNotch.pomodoro.tests")!
+        defaults.set(0, forKey: "pomodoro_currentCycle")
+        
+        let newManager = TestablePomodoroManager()
+        newManager.testLoadState()
+        
+        XCTAssertEqual(newManager.testCurrentCycle, 1)
+    }
+    
+    // MARK: - State Changes Observation Tests
+    
+    func testSessionTypePublishedProperty_changes() {
+        var changes: [SessionType] = []
+        manager.$sessionType
+            .sink { changes.append($0) }
+            .store(in: &cancellables)
+        
+        manager.testSessionType = .shortBreak
+        
+        XCTAssertTrue(changes.contains(.shortBreak))
+    }
+    
+    func testTimeRemainingPublishedProperty_changes() {
+        var changes: [TimeInterval] = []
+        manager.$timeRemaining
+            .sink { changes.append($0) }
+            .store(in: &cancellables)
+        
+        manager.testTimeRemaining = 100.0
+        
+        XCTAssertTrue(changes.contains(100.0))
+    }
+    
+    func testCurrentCyclePublishedProperty_changes() {
+        var changes: [Int] = []
+        manager.$currentCycle
+            .sink { changes.append($0) }
+            .store(in: &cancellables)
+        
+        manager.testCurrentCycle = 3
+        
+        XCTAssertTrue(changes.contains(3))
+    }
+    
+    func testIsRunningPublishedProperty_changes() {
+        var changes: [Bool] = []
+        manager.$isRunning
+            .sink { changes.append($0) }
+            .store(in: &cancellables)
+        
+        manager.testStart()
+        XCTAssertTrue(changes.contains(true))
+        
+        manager.testPause()
+        XCTAssertTrue(changes.contains(false))
+    }
+}


### PR DESCRIPTION
## Add 3 new face types: Angry, Love (and Tongue removed)

This PR adds new face types to the notch:

**New faces added:**
- **Angry** - eyebrows slanted toward center
- **Love** - heart eyes expression

**Face types now available:**
1. Minimal
2. Cool
3. Surprised
4. Sleepy
5. Wink
6. Happy
7. Angry ✨ (new)
8. Love ✨ (new)

**Commits:**
- `dcc4c62` Remove tongue face
- `e43038e` Fix angry eyebrows orientation and tongue face design
- `5e76b22` Fix angry and tongue face designs
- `79ff1e0` Add 3 new face types: Angry, Tongue, Love
- `1c8eaa2` Fix export method: use mac-application

Tested locally in Xcode. Build succeeds.