### PR TITLE
Detect shelf drags via NSDraggingDestination instead of global event monitor

### DIFF
--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -223,27 +223,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func setupDragDetectorForScreen(_ screen: NSScreen) {
         guard let uuid = screen.displayUUID else { return }
-        
-        let screenFrame = screen.frame
-        let notchHeight = openNotchSize.height
-        let notchWidth = openNotchSize.width
-        
-        // Create notch region at the top-center of the screen where an open notch would occupy
-        let notchRegion = CGRect(
-            x: screenFrame.midX - notchWidth / 2,
-            y: screenFrame.maxY - notchHeight,
-            width: notchWidth,
-            height: notchHeight
-        )
-        
-        let detector = DragDetector(notchRegion: notchRegion)
-        
+
+        let detector = DragDetector(screen: screen)
+
         detector.onDragEntersNotchRegion = { [weak self] in
             Task { @MainActor in
                 self?.handleDragEntersNotchRegion(onScreen: screen)
             }
         }
-        
+
         dragDetectors[uuid] = detector
         detector.startMonitoring()
     }

--- a/boringNotch/observers/DragDetector.swift
+++ b/boringNotch/observers/DragDetector.swift
@@ -5,119 +5,133 @@
 //  Created by Alexander on 2025-11-20.
 //
 
-import Cocoa
-import UniformTypeIdentifiers
+import AppKit
 
 final class DragDetector {
 
-    // MARK: - Callbacks
-
     typealias VoidCallback = () -> Void
-    typealias PositionCallback = (_ globalPoint: CGPoint) -> Void
 
     var onDragEntersNotchRegion: VoidCallback?
     var onDragExitsNotchRegion: VoidCallback?
-    var onDragMove: PositionCallback?
 
+    private let panel: HitPanel
+    private let hitView: HitView
 
-    private var mouseDownMonitor: Any?
-    private var mouseDraggedMonitor: Any?
-    private var mouseUpMonitor: Any?
+    init(screen: NSScreen) {
+        let view = HitView()
+        hitView = view
 
-    private var pasteboardChangeCount: Int = -1
-    private var isDragging: Bool = false
-    private var isContentDragging: Bool = false
-    private var hasEnteredNotchRegion: Bool = false
-
-    private let notchRegion: CGRect
-    private let dragPasteboard = NSPasteboard(name: .drag)
-
-    init(notchRegion: CGRect) {
-        self.notchRegion = notchRegion
-    }
-
-    // MARK: - Private Helpers
-    
-    /// Checks if the drag pasteboard contains valid content types that can be dropped on the shelf
-    private func hasValidDragContent() -> Bool {
-        let validTypes: [NSPasteboard.PasteboardType] = [
-            .fileURL,
-            NSPasteboard.PasteboardType(UTType.url.identifier),
-            .string
+        panel = HitPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isFloatingPanel = true
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.isMovable = false
+        panel.isReleasedWhenClosed = false
+        panel.level = .mainMenu + 4
+        panel.collectionBehavior = [
+            .canJoinAllSpaces,
+            .stationary,
+            .fullScreenAuxiliary,
+            .ignoresCycle,
         ]
-        let isValid = dragPasteboard.pasteboardItems?.allSatisfy { item in
-            item.types.allSatisfy { validTypes.contains($0) }
-        }
-        return isValid ?? false
+        panel.contentView = view
+
+        view.onDragEntered = { [weak self] in self?.onDragEntersNotchRegion?() }
+        view.onDragExited = { [weak self] in self?.onDragExitsNotchRegion?() }
+
+        updateFrame(for: screen)
     }
 
     func startMonitoring() {
-        stopMonitoring()
-
-        // Track pasteboard to detect content drag
-        mouseDownMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown]) { [weak self] _ in
-            guard let self = self else { return }
-            self.pasteboardChangeCount = self.dragPasteboard.changeCount
-            self.isDragging = true
-            self.isContentDragging = false
-            self.hasEnteredNotchRegion = false
-        }
-
-        // Track drag movement and notch region intersection
-        mouseDraggedMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDragged]) { [weak self] event in
-            guard let self = self else { return }
-            guard self.isDragging else { return }
-
-            let newContent = self.dragPasteboard.changeCount != self.pasteboardChangeCount
-            
-            // Detect if actual content is being dragged AND it's valid content
-            if newContent && !self.isContentDragging && self.hasValidDragContent() {
-                self.isContentDragging = true
-            }
-
-            // Only process position when content is being dragged
-            if self.isContentDragging {
-                let mouseLocation = NSEvent.mouseLocation
-                self.onDragMove?(mouseLocation)
-                
-                // Track notch region entry/exit
-                let containsMouse = self.notchRegion.contains(mouseLocation)
-                if containsMouse && !self.hasEnteredNotchRegion {
-                    self.hasEnteredNotchRegion = true
-                    self.onDragEntersNotchRegion?()
-                } else if !containsMouse && self.hasEnteredNotchRegion {
-                    self.hasEnteredNotchRegion = false
-                    self.onDragExitsNotchRegion?()
-                }
-            }
-        }
-
-        mouseUpMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseUp]) { [weak self] _ in
-            guard let self = self else { return }
-            guard self.isDragging else { return }
-            
-            self.isDragging = false
-            self.isContentDragging = false
-            self.hasEnteredNotchRegion = false
-            self.pasteboardChangeCount = -1
-        }
+        // Join the notch CGSSpace so the dragging session enumerates this panel
+        // alongside BoringNotchSkyLightWindow rather than below it. Without this
+        // the notch panel (which sits in the max-level space but has no
+        // registered drag types) shadows the hit panel, so draggingEntered: is
+        // never delivered.
+        NotchSpaceManager.shared.notchSpace.windows.insert(panel)
+        panel.orderFrontRegardless()
     }
 
     func stopMonitoring() {
-        [mouseDownMonitor, mouseDraggedMonitor, mouseUpMonitor].forEach { monitor in
-            if let monitor = monitor {
-                NSEvent.removeMonitor(monitor)
-            }
-        }
-        mouseDownMonitor = nil
-        mouseDraggedMonitor = nil
-        mouseUpMonitor = nil
-        isDragging = false
-        isContentDragging = false
-        hasEnteredNotchRegion = false
+        NotchSpaceManager.shared.notchSpace.windows.remove(panel)
+        panel.orderOut(nil)
+        panel.close()
     }
 
     deinit {
         stopMonitoring()
+    }
+
+    private func updateFrame(for screen: NSScreen) {
+        let frame = screen.frame
+        let rect = NSRect(
+            x: frame.midX - openNotchSize.width / 2,
+            y: frame.maxY - openNotchSize.height,
+            width: openNotchSize.width,
+            height: openNotchSize.height
+        )
+        panel.setFrame(rect, display: false)
+        hitView.frame = NSRect(origin: .zero, size: rect.size)
+    }
+}
+
+private final class HitPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+private final class HitView: NSView {
+
+    var onDragEntered: (() -> Void)?
+    var onDragExited: (() -> Void)?
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        registerForDraggedTypes([
+            .fileURL,
+            .URL,
+            .string,
+            .tiff,
+            .png,
+            .pdf,
+            .rtf,
+            .html,
+            NSPasteboard.PasteboardType("public.file-url"),
+            NSPasteboard.PasteboardType("public.url"),
+            NSPasteboard.PasteboardType("com.apple.pasteboard.promised-file-url"),
+            NSPasteboard.PasteboardType("com.apple.pasteboard.promised-file-content-type"),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // Pass clicks through when no drag is in progress so the menu bar / windows
+    // beneath this transparent overlay stay clickable. The dragging session
+    // populates the .drag pasteboard before evaluating destinations, so a
+    // non-empty type list is a reliable signal that a drag is active.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard NSPasteboard(name: .drag).types?.isEmpty == false else { return nil }
+        return super.hitTest(point)
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        onDragEntered?()
+        return .copy
+    }
+
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        onDragExited?()
+    }
+
+    override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        false
     }
 }


### PR DESCRIPTION
Drags toward the notch no longer expand the shelf on macOS Tahoe 26.x — the file falls onto whatever window sits below the closed notch. closes #1175.

The current `DragDetector` infers "the user is dragging content" by combining global mouse-event monitors with `NSPasteboard(name: .drag).changeCount` deltas between mouseDown and mouseDragged. On macOS 14+, and consistently on Tahoe, Finder / browsers / Mail use lazy / promised pasteboards that don't bump `changeCount` during the drag, so `isContentDragging` never flips and `onDragEntersNotchRegion` never fires.

This replaces the implementation with a transparent always-on-top `NSPanel` sized to the notch hit-rect that registers as `NSDraggingDestination`. AppKit delivers `draggingEntered:` regardless of pasteboard semantics, so the same `handleDragEntersNotchRegion` callback fires reliably.

The external API on `DragDetector` (`startMonitoring`, `stopMonitoring`, `onDragEntersNotchRegion`, `onDragExitsNotchRegion`) is preserved; only the initializer signature changes from `notchRegion: CGRect` to `screen: NSScreen`, since the panel computes its own hit-rect from `openNotchSize` and the screen frame.

Tested on Mac mini + external display, macOS Tahoe 26.4.1 — drags from Finder, Safari, Chrome (URL + image) and Mail all expand the shelf and the dropped item lands in it. Repro for the original failure follows the path described in #1175. Happy to attach a screen recording if it would help review.