### PR TITLE
fix: typo in the about view

### DIFF
--- a/boringNotch/components/Settings/Views/AboutView.swift
+++ b/boringNotch/components/Settings/Views/AboutView.swift
@@ -66,7 +66,7 @@ struct About: View {
             }
             VStack(spacing: 0) {
                 Divider()
-                Text("Made with 🫶🏻 by not so boring not.people")
+                Text("Made with 🫶🏻 by not so boring.notch people")
                     .foregroundStyle(.secondary)
                     .padding(.top, 5)
                     .padding(.bottom, 7)


### PR DESCRIPTION
## Description
Fixes a typo in the About tab of the Settings menu.

**Before:** "Made with 🫶🏻 by not so boring not.people"
**After:** "Made with 🫶🏻 by not so boring.notch people"

## Changes
- Fixed typo in `components/Settings/Views/AboutView.swift` (line 69)