### PR TITLE
Add album art display options to music live activity

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -34,9 +34,13 @@ struct ContentView: View {
 
     @State private var haptics: Bool = false
 
+    @State private var albumArtOpacity: Double = 1.0
+    @State private var albumArtFadeTask: Task<Void, Never>?
+
     @Namespace var albumArtNamespace
 
     @Default(.showNotHumanFace) var showNotHumanFace
+    @Default(.albumArtDisplayMode) var albumArtDisplayMode
 
     // Use standardized animations from StandardAnimations enum
     private let animationSpring = StandardAnimations.interactive
@@ -451,7 +455,7 @@ struct ContentView: View {
                 return base
             }()
 
-            Image(nsImage: musicManager.albumArt)
+            currentAlbumArtImage
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .clipShape(
@@ -463,6 +467,7 @@ struct ContentView: View {
                     width: scaledArtSize,
                     height: scaledArtSize
                 )
+                .opacity(albumArtDisplayMode == .fade ? albumArtOpacity : 1.0)
 
             Rectangle()
                 .fill(.black)
@@ -536,6 +541,68 @@ struct ContentView: View {
             height: displayClosedNotchHeight,
             alignment: .center
         )
+        .onAppear {
+            refreshAlbumArtFade()
+        }
+        .onChange(of: musicManager.songTitle) { _, _ in
+            refreshAlbumArtFade()
+        }
+        .onChange(of: vm.notchState) { _, _ in
+            refreshAlbumArtFade()
+        }
+        .onChange(of: isHovering) { _, _ in
+            refreshAlbumArtFade()
+        }
+        .onChange(of: albumArtDisplayMode) { _, _ in
+            refreshAlbumArtFade()
+        }
+    }
+
+    private var currentAlbumArtImage: Image {
+        if albumArtDisplayMode == .appIcon,
+           let bundleID = musicManager.bundleIdentifier,
+           !bundleID.isEmpty {
+            return AppIcon(for: bundleID)
+        }
+        return Image(nsImage: musicManager.albumArt)
+    }
+
+    private func refreshAlbumArtFade() {
+        guard albumArtDisplayMode == .fade else {
+            albumArtFadeTask?.cancel()
+            albumArtFadeTask = nil
+            if albumArtOpacity != 1.0 {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    albumArtOpacity = 1.0
+                }
+            }
+            return
+        }
+
+        if vm.notchState != .closed || isHovering {
+            albumArtFadeTask?.cancel()
+            albumArtFadeTask = nil
+            withAnimation(.easeInOut(duration: 0.3)) {
+                albumArtOpacity = 1.0
+            }
+            return
+        }
+
+        scheduleAlbumArtFade()
+    }
+
+    private func scheduleAlbumArtFade() {
+        albumArtFadeTask?.cancel()
+        withAnimation(.easeInOut(duration: 0.3)) {
+            albumArtOpacity = 1.0
+        }
+        albumArtFadeTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(3))
+            if Task.isCancelled { return }
+            withAnimation(.easeInOut(duration: 1.0)) {
+                albumArtOpacity = 0.0
+            }
+        }
     }
 
     @ViewBuilder

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -873,6 +873,49 @@
         }
       }
     },
+    "Album art display" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album art display"
+          }
+        }
+      }
+    },
+    "album_art_always" : {
+      "comment" : "Album art display: Always show",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Always show"
+          }
+        }
+      }
+    },
+    "album_art_app_icon" : {
+      "comment" : "Album art display: Show app icon",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show app icon"
+          }
+        }
+      }
+    },
+    "album_art_fade" : {
+      "comment" : "Album art display: Fade after 3 seconds",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fade after 3 seconds"
+          }
+        }
+      }
+    },
     "All-day" : {
       "localizations" : {
         "cs" : {
@@ -2449,16 +2492,6 @@
         }
       }
     },
-    "Changing the app language requires restarting Boring Notch." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changing the app language requires restarting Boring Notch."
-          }
-        }
-      }
-    },
     "Change media with horizontal gestures" : {
       "localizations" : {
         "de" : {
@@ -2501,6 +2534,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Перемикання медіа горизонтальними жестами"
+          }
+        }
+      }
+    },
+    "Changing the app language requires restarting Boring Notch." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changing the app language requires restarting Boring Notch."
           }
         }
       }
@@ -6893,6 +6936,16 @@
         }
       }
     },
+    "Later" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Later"
+          }
+        }
+      }
+    },
     "Launch at login" : {
       "localizations" : {
         "fr" : {
@@ -6911,16 +6964,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oturum açıldığında başlat"
-          }
-        }
-      }
-    },
-    "Later" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Later"
           }
         }
       }
@@ -9559,6 +9602,7 @@
       }
     },
     "OSD" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -10056,9 +10100,6 @@
     "Real-time audio waveform" : {
 
     },
-    "Requires macOS 14.2 or later. Update macOS to enable real-time audio waveform." : {
-
-    },
     "Release name" : {
       "localizations" : {
         "cs" : {
@@ -10441,6 +10482,9 @@
           }
         }
       }
+    },
+    "Requires macOS 14.2 or later. Update macOS to enable real-time audio waveform." : {
+
     },
     "Reset to Defaults" : {
       "localizations" : {

--- a/boringNotch/components/Settings/Views/MediaSettingsView.swift
+++ b/boringNotch/components/Settings/Views/MediaSettingsView.swift
@@ -15,6 +15,7 @@ struct Media: View {
     @Default(.hideNotchOption) var hideNotchOption
     @Default(.enableSneakPeek) private var enableSneakPeek
     @Default(.sneakPeekStyles) var sneakPeekStyles
+    @Default(.albumArtDisplayMode) var albumArtDisplayMode
 
     @Default(.enableLyrics) var enableLyrics
 
@@ -75,6 +76,11 @@ struct Media: View {
                             Text("\(Defaults[.waitInterval], specifier: "%.0f") seconds")
                                 .foregroundStyle(.secondary)
                         }
+                    }
+                }
+                Picker("Album art display", selection: $albumArtDisplayMode) {
+                    ForEach(AlbumArtDisplayMode.allCases) { mode in
+                        Text(mode.localizedString).tag(mode)
                     }
                 }
                 Picker(

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -164,6 +164,26 @@ enum SneakPeekStyle: String, CaseIterable, Identifiable, Defaults.Serializable {
     }
 }
 
+// Album art display options for the closed-notch music live activity
+enum AlbumArtDisplayMode: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case always
+    case fade
+    case appIcon
+
+    var id: String { self.rawValue }
+
+    var localizedString: String {
+        switch self {
+        case .always:
+            return NSLocalizedString("album_art_always", comment: "Album art display: Always show")
+        case .fade:
+            return NSLocalizedString("album_art_fade", comment: "Album art display: Fade after 3 seconds")
+        case .appIcon:
+            return NSLocalizedString("album_art_app_icon", comment: "Album art display: Show app icon")
+        }
+    }
+}
+
 // Action to perform when Option (⌥) is held while pressing media keys
 enum OptionKeyAction: String, CaseIterable, Identifiable, Defaults.Serializable {
     case openSettings
@@ -276,7 +296,11 @@ extension Defaults.Keys {
         "musicControlSlotLimit",
         default: MusicControlButton.defaultLayout.count
     )
-    
+    static let albumArtDisplayMode = Key<AlbumArtDisplayMode>(
+        "albumArtDisplayMode",
+        default: .always
+    )
+
     // MARK: Battery
     static let showPowerStatusNotifications = Key<Bool>("showPowerStatusNotifications", default: true)
     static let showBatteryIndicator = Key<Bool>("showBatteryIndicator", default: true)


### PR DESCRIPTION
## Summary

Adds a new "Album art display" picker in Media settings with three options:

- **Always show** (default) — current behavior, no change for existing users
- **Fade after 3 seconds** — album art appears briefly then gradually fades out for a more minimal look; re-appears on song change, hover, or when the notch reopens
- **Show app icon** — replaces the album art with the icon of the currently-playing app (Spotify, Apple Music, etc.)

Implements two Discord feature requests:
https://discord.com/channels/1269588937320566815/1493582011678330962

## Changes

- **`Constants`** — new `AlbumArtDisplayMode` enum (`.always`, `.fade`, `.appIcon`) + `albumArtDisplayMode` Defaults key, default `.always`
- **`MediaSettingsView`** — new *Album art display* picker, placed under *Media inactivity timeout*
- **`ContentView`** — `MusicLiveActivity()` now switches image source and applies a cancellable fade timer based on the selected mode, reacting to song changes, notch state, and hover via `.onAppear` + `.onChange`
- **`Localizable.xcstrings`** — new English keys for the picker label and three options

## Testing Done in Xcode

- **Always show** — verified album art renders identically to before; no regression
- **Fade after 3s**:
  - Art fades out ~3s after notch settles closed
  - Song change resets the fade; art reappears at full opacity then fades again
  - Hovering cancels the fade and snaps to full opacity; moving away restarts the countdown
  - Opening the notch cancels the fade; closing it restarts the countdown
- **Show app icon** — app icon correctly replaces album art; falls back to album art if no bundle ID is available yet

## Screenshots/Screen Recordings


https://github.com/user-attachments/assets/a20d0c33-f918-4190-b601-eb92476a8b15

<img width="305" height="35" alt="Screenshot 2026-05-11 at 12 56 18 PM" src="https://github.com/user-attachments/assets/8496dca5-d908-4ad0-b50d-bca8853b77af" />