### PR TITLE
fix(media): localize music control button labels (#1090)

### DIFF
--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -14150,6 +14150,116 @@
           }
         }
       }
+    },
+    "music_control_empty_slot" : {
+      "comment" : "Music control button label: Empty slot placeholder",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empty slot"
+          }
+        }
+      }
+    },
+    "music_control_favorite" : {
+      "comment" : "Music control button label: Favorite (heart) current track",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favorite"
+          }
+        }
+      }
+    },
+    "music_control_go_backward_15" : {
+      "comment" : "Music control button label: Seek backward 15 seconds",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backward 15s"
+          }
+        }
+      }
+    },
+    "music_control_go_forward_15" : {
+      "comment" : "Music control button label: Seek forward 15 seconds",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forward 15s"
+          }
+        }
+      }
+    },
+    "music_control_next" : {
+      "comment" : "Music control button label: Next track",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
+          }
+        }
+      }
+    },
+    "music_control_play_pause" : {
+      "comment" : "Music control button label: Play/Pause",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play/Pause"
+          }
+        }
+      }
+    },
+    "music_control_previous" : {
+      "comment" : "Music control button label: Previous track",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous"
+          }
+        }
+      }
+    },
+    "music_control_repeat" : {
+      "comment" : "Music control button label: Repeat mode",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repeat"
+          }
+        }
+      }
+    },
+    "music_control_shuffle" : {
+      "comment" : "Music control button label: Shuffle",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuffle"
+          }
+        }
+      }
+    },
+    "music_control_volume" : {
+      "comment" : "Music control button label: Volume",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volume"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/boringNotch/components/Settings/MusicSlotConfigurationView.swift
+++ b/boringNotch/components/Settings/MusicSlotConfigurationView.swift
@@ -149,7 +149,7 @@ struct MusicSlotConfigurationView: View {
                                     }
                                 }
 
-                                Text(control.label)
+                                Text(control.localizedString)
                                     .font(.caption2)
                                     .foregroundStyle(.secondary)
                                     .frame(width: 60)

--- a/boringNotch/models/MusicControlButton.swift
+++ b/boringNotch/models/MusicControlButton.swift
@@ -6,6 +6,7 @@
 //
 
 import Defaults
+import Foundation
 
 enum MusicControlButton: String, CaseIterable, Identifiable, Codable, Defaults.Serializable {
     case shuffle
@@ -44,28 +45,52 @@ enum MusicControlButton: String, CaseIterable, Identifiable, Codable, Defaults.S
         .goForward
     ]
 
-    var label: String {
+    /// Localised display name for the slot palette in
+    /// ``MusicSlotConfigurationView``.  Uses ``NSLocalizedString`` so the
+    /// label round-trips through ``Localizable.xcstrings`` (and therefore
+    /// Crowdin) instead of being emitted as raw English. (#1090)
+    var localizedString: String {
         switch self {
         case .shuffle:
-            return "Shuffle"
+            return NSLocalizedString(
+                "music_control_shuffle",
+                comment: "Music control button label: Shuffle")
         case .previous:
-            return "Previous"
+            return NSLocalizedString(
+                "music_control_previous",
+                comment: "Music control button label: Previous track")
         case .playPause:
-            return "Play/Pause"
+            return NSLocalizedString(
+                "music_control_play_pause",
+                comment: "Music control button label: Play/Pause")
         case .next:
-            return "Next"
+            return NSLocalizedString(
+                "music_control_next",
+                comment: "Music control button label: Next track")
         case .repeatMode:
-            return "Repeat"
+            return NSLocalizedString(
+                "music_control_repeat",
+                comment: "Music control button label: Repeat mode")
         case .volume:
-            return "Volume"
+            return NSLocalizedString(
+                "music_control_volume",
+                comment: "Music control button label: Volume")
         case .favorite:
-            return "Favorite"
+            return NSLocalizedString(
+                "music_control_favorite",
+                comment: "Music control button label: Favorite (heart) current track")
         case .goBackward:
-            return "Backward 15s"
+            return NSLocalizedString(
+                "music_control_go_backward_15",
+                comment: "Music control button label: Seek backward 15 seconds")
         case .goForward:
-            return "Forward 15s"
+            return NSLocalizedString(
+                "music_control_go_forward_15",
+                comment: "Music control button label: Seek forward 15 seconds")
         case .none:
-            return "Empty slot"
+            return NSLocalizedString(
+                "music_control_empty_slot",
+                comment: "Music control button label: Empty slot placeholder")
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #1090 — the slot-palette labels in **Settings → Media → Media controls** (Shuffle / Previous / Play-Pause / Next / Repeat / Volume / Favorite / Backward 15s / Forward 15s / Empty slot) shipped as hardcoded English regardless of system locale.

## Root cause

`MusicControlButton.label` in `boringNotch/models/MusicControlButton.swift` is typed `String` and returns plain literals. The one call site renders it as `Text(control.label)` in `MusicSlotConfigurationView`. SwiftUI's `Text` initialiser only auto-localises **string literals** (typed `LocalizedStringKey` at the source site) — when given a `String`-typed value, it bypasses localisation entirely. So even when other parts of the Media settings (Picker title, Section header, etc.) were translated, the slot palette stayed in English.

## Fix

Mirror the existing pattern used by `MediaControllerType.localizedString`, `SneakPeekStyle.localizedString`, and `OptionKeyBehavior.localizedString` in `models/Constants.swift`:

1. **`boringNotch/models/MusicControlButton.swift`** — rename `label` → `localizedString`, route each case through `NSLocalizedString(key, comment:)` with stable `music_control_*` keys (matches the `sneak_peek_*` / `option_key_*` naming convention already in `Constants.swift`).
2. **`boringNotch/components/Settings/MusicSlotConfigurationView.swift`** — update the single call site `Text(control.label)` → `Text(control.localizedString)`.
3. **`boringNotch/Localizable.xcstrings`** — append the 10 new keys as English-only source entries so Crowdin picks them up on the next sync per [CONTRIBUTING.md](https://github.com/TheBoredTeam/boring.notch/blob/dev/.github/CONTRIBUTING.md).

Diff: **3 files, +147 / -12.** No behaviour change for English locales; localised locales will now see translated labels once Crowdin returns them.

## Verification I did

- Confirmed `control.label` had exactly one call site (`MusicSlotConfigurationView.swift:152`) via `grep -rn "\\.label" boringNotch/` — safe to rename.
- Confirmed the `Localizable.xcstrings` JSON still parses cleanly (`python3 -m json.tool`) and 300 total entries (290 → 300).
- Diff in the catalog is appended-only (no reordering of existing entries) so existing translations are untouched.

## Verification I could not do

I do not have Xcode available in this session, so I have **not built or run the app**. The change is pure code (`String` → `NSLocalizedString` redirect + one identifier rename + 10 catalog appends) so the runtime risk is small, but please confirm a clean build before merging.

## Targeting `dev` branch per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)