### PR TITLE
Click-to-add and pointer cursor for the Shelf

### DIFF
--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -2449,16 +2449,6 @@
         }
       }
     },
-    "Changing the app language requires restarting Boring Notch." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changing the app language requires restarting Boring Notch."
-          }
-        }
-      }
-    },
     "Change media with horizontal gestures" : {
       "localizations" : {
         "de" : {
@@ -2501,6 +2491,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Перемикання медіа горизонтальними жестами"
+          }
+        }
+      }
+    },
+    "Changing the app language requires restarting Boring Notch." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changing the app language requires restarting Boring Notch."
           }
         }
       }
@@ -6893,6 +6893,16 @@
         }
       }
     },
+    "Later" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Later"
+          }
+        }
+      }
+    },
     "Launch at login" : {
       "localizations" : {
         "fr" : {
@@ -6911,16 +6921,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oturum açıldığında başlat"
-          }
-        }
-      }
-    },
-    "Later" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Later"
           }
         }
       }
@@ -9559,6 +9559,7 @@
       }
     },
     "OSD" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -10056,9 +10057,6 @@
     "Real-time audio waveform" : {
 
     },
-    "Requires macOS 14.2 or later. Update macOS to enable real-time audio waveform." : {
-
-    },
     "Release name" : {
       "localizations" : {
         "cs" : {
@@ -10441,6 +10439,9 @@
           }
         }
       }
+    },
+    "Requires macOS 14.2 or later. Update macOS to enable real-time audio waveform." : {
+
     },
     "Reset to Defaults" : {
       "localizations" : {

--- a/boringNotch/components/Shelf/Views/FileShareView.swift
+++ b/boringNotch/components/Shelf/Views/FileShareView.swift
@@ -32,6 +32,13 @@ struct FileShareView: View {
                 Task { await handleDrop(providers) }
                 return true
             }
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.pointingHand.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
             .onTapGesture {
                 Task {
                     await handleClick()

--- a/boringNotch/components/Shelf/Views/ShelfView.swift
+++ b/boringNotch/components/Shelf/Views/ShelfView.swift
@@ -38,7 +38,22 @@ struct ShelfView: View {
         ShelfStateViewModel.shared.load(providers)
         return true
     }
-    
+
+    private func presentFilePicker() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = true
+        panel.title = "Add to Shelf"
+        panel.message = "Choose files or folders to add to the shelf"
+
+        guard panel.runModal() == .OK, !panel.urls.isEmpty else { return }
+
+        let providers = panel.urls.map { NSItemProvider(contentsOf: $0) ?? NSItemProvider() }
+        vm.dropEvent = true
+        ShelfStateViewModel.shared.load(providers)
+    }
+
     private func updateQuickLookSelection() {
         guard quickLookService.isQuickLookOpen && !selection.selectedIDs.isEmpty else { return }
         
@@ -86,11 +101,23 @@ struct ShelfView: View {
                         .symbolRenderingMode(.hierarchical)
                         .foregroundStyle(.white, .gray)
                         .imageScale(.large)
-                    
+
                     Text("Drop files here")
                         .foregroundStyle(.gray)
                         .font(.system(.title3, design: .rounded))
                         .fontWeight(.medium)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .contentShape(Rectangle())
+                .onHover { hovering in
+                    if hovering {
+                        NSCursor.pointingHand.push()
+                    } else {
+                        NSCursor.pop()
+                    }
+                }
+                .onTapGesture {
+                    presentFilePicker()
                 }
             } else {
                 ScrollView(.horizontal) {


### PR DESCRIPTION
## Summary

- Clicking the empty Shelf area now opens a native file picker to add files/folders, mirroring the existing AirDrop/QuickShare tile behavior
- Hovering the Shelf drop zone and the AirDrop/QuickShare tile now shows the pointing-hand cursor so it's discoverable that they're clickable

## Changes

**Click-to-add on the empty Shelf**
- Added `presentFilePicker()` in `ShelfView`, which runs an `NSOpenPanel` (multi-select, files + folders) and feeds the chosen URLs through `ShelfStateViewModel.shared.load(...)` — the same path used by drag-and-drop
- Attached `.contentShape(Rectangle())` + `.onTapGesture` to the "Drop files here" placeholder and expanded its hit area to fill the shelf so the entire empty region is clickable

**Pointing-hand cursor on hover**
- Added `.onHover` to the AirDrop/QuickShare tile (`FileShareView`) and the empty-shelf drop zone, pushing `NSCursor.pointingHand` on enter and popping on exit

## Testing

Tested locally in Xcode:
- Clicking the empty shelf opens the file picker; selecting one or multiple files/folders adds them to the shelf
- Cancelling the picker leaves the shelf untouched
- Cursor switches to the pointing hand over both the QuickShare tile and the empty shelf, and reverts on exit
- Drag-and-drop still works as before

## Notes

The `Localizable.xcstrings` diff is just Xcode reordering existing entries — no new strings were added or removed by this change. The file picker's title/message strings are currently hardcoded; happy to wire them through `xcstrings` if preferred.