### PR TITLE
Add notch animation speed setting

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -38,7 +38,13 @@ struct ContentView: View {
     @Default(.showNotHumanFace) var showNotHumanFace
 
     // Shared interactive spring for movement/resizing to avoid conflicting animations
-    private let animationSpring = Animation.interactiveSpring(response: 0.38, dampingFraction: 0.8, blendDuration: 0)
+    private var animationSpring: Animation {
+        Animation.interactiveSpring(
+            response: scaledAnimationDuration(0.38),
+            dampingFraction: 0.8,
+            blendDuration: 0
+        )
+    }
 
     private let extendedHoverPadding: CGFloat = 30
     private let zeroHeightHoverPadding: CGFloat = 10
@@ -120,12 +126,20 @@ struct ContentView: View {
                 mainLayout
                     .frame(height: vm.notchState == .open ? vm.notchSize.height : nil)
                     .conditionalModifier(true) { view in
-                        let openAnimation = Animation.spring(response: 0.42, dampingFraction: 0.8, blendDuration: 0)
-                        let closeAnimation = Animation.spring(response: 0.45, dampingFraction: 1.0, blendDuration: 0)
+                        let openAnimation = Animation.spring(
+                            response: scaledAnimationDuration(0.42),
+                            dampingFraction: 0.8,
+                            blendDuration: 0
+                        )
+                        let closeAnimation = Animation.spring(
+                            response: scaledAnimationDuration(0.45),
+                            dampingFraction: 1.0,
+                            blendDuration: 0
+                        )
                         
                         return view
                             .animation(vm.notchState == .open ? openAnimation : closeAnimation, value: vm.notchState)
-                            .animation(.smooth, value: gestureProgress)
+                            .animation(.smooth(duration: scaledAnimationDuration(0.35)), value: gestureProgress)
                     }
                     .contentShape(Rectangle())
                     .onHover { hovering in
@@ -210,7 +224,7 @@ struct ContentView: View {
             y: gestureScale,
             anchor: .top
         )
-        .animation(.smooth, value: gestureProgress)
+        .animation(.smooth(duration: scaledAnimationDuration(0.35)), value: gestureProgress)
         .background(dragDetector)
         .preferredColorScheme(.dark)
         .environmentObject(vm)

--- a/boringNotch/animations/drop.swift
+++ b/boringNotch/animations/drop.swift
@@ -18,9 +18,9 @@ public class BoringAnimations {
     
     var animation: Animation {
         if #available(macOS 14.0, *), notchStyle == .notch {
-            Animation.spring(.bouncy(duration: 0.4))
+            Animation.spring(.bouncy(duration: scaledAnimationDuration(0.4)))
         } else {
-            Animation.timingCurve(0.16, 1, 0.3, 1, duration: 0.7)
+            Animation.timingCurve(0.16, 1, 0.3, 1, duration: scaledAnimationDuration(0.7))
         }
     }
     

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -139,6 +139,7 @@ struct GeneralSettings: View {
     @Default(.showEmojis) var showEmojis
     @Default(.gestureSensitivity) var gestureSensitivity
     @Default(.minimumHoverDuration) var minimumHoverDuration
+    @Default(.animationSpeedMultiplier) var animationSpeedMultiplier
     @Default(.nonNotchHeight) var nonNotchHeight
     @Default(.nonNotchHeightMode) var nonNotchHeightMode
     @Default(.notchHeight) var notchHeight
@@ -342,8 +343,21 @@ struct GeneralSettings: View {
                         name: Notification.Name.notchHeightChanged, object: nil)
                 }
             }
+            Slider(value: $animationSpeedMultiplier, in: 0.5...3.0, step: 0.25) {
+                HStack {
+                    Text("Animation speed")
+                    Spacer()
+                    Text("\(animationSpeedMultiplier, specifier: "%.2g")x")
+                        .foregroundStyle(.secondary)
+                }
+            }
         } header: {
             Text("Notch behavior")
+        } footer: {
+            Text("Adjusts the notch opening, closing, and gesture spring animations.")
+                .multilineTextAlignment(.trailing)
+                .foregroundStyle(.secondary)
+                .font(.caption)
         }
     }
 }

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -14,7 +14,9 @@ class BoringViewModel: NSObject, ObservableObject {
     @ObservedObject var detector = FullscreenMediaDetector.shared
 
     let animationLibrary: BoringAnimations = .init()
-    let animation: Animation?
+    var animation: Animation {
+        animationLibrary.animation
+    }
 
     @Published var contentType: ContentType = .normal
     @Published private(set) var notchState: NotchState = .closed
@@ -51,8 +53,6 @@ class BoringViewModel: NSObject, ObservableObject {
     }
 
     init(screenUUID: String? = nil) {
-        animation = animationLibrary.animation
-
         super.init()
         
         self.screenUUID = screenUUID

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -77,6 +77,7 @@ extension Defaults.Keys {
     
     // MARK: Behavior
     static let minimumHoverDuration = Key<TimeInterval>("minimumHoverDuration", default: 0.3)
+    static let animationSpeedMultiplier = Key<Double>("animationSpeedMultiplier", default: 1.0)
     static let enableHaptics = Key<Bool>("enableHaptics", default: true)
     static let openNotchOnHover = Key<Bool>("openNotchOnHover", default: true)
     static let extendHoverArea = Key<Bool>("extendHoverArea", default: false)
@@ -199,4 +200,9 @@ extension Defaults.Keys {
     }
 
     static let didClearLegacyURLCacheV1 = Key<Bool>("didClearLegacyURLCache_v1", default: false)
+}
+
+func scaledAnimationDuration(_ duration: Double) -> Double {
+    let speed = min(max(Defaults[.animationSpeedMultiplier], 0.5), 3.0)
+    return duration / speed
 }


### PR DESCRIPTION
## Summary
- add an Animation speed slider under Notch behavior
- persist the speed multiplier with Defaults, defaulting to 1.0x
- apply the multiplier to notch open/close, gesture, and shared boring animations

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project boringNotch.xcodeproj -scheme boringNotch -configuration Debug -destination 'platform=macOS' build`