### PR TITLE
Hide notch overlay on displays without a physical notch

### DIFF
--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -208,6 +208,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         if Defaults[.showOnAllDisplays] {
             for screen in NSScreen.screens {
+                if Defaults[.onlyShowOnNotchDisplays] && !screen.hasNotch { continue }
                 setupDragDetectorForScreen(screen)
             }
         } else {
@@ -215,7 +216,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 ?? NSScreen.screen(withUUID: coordinator.selectedScreenUUID)
                 ?? NSScreen.main
 
-            if let screen = preferredScreen {
+            if let screen = preferredScreen,
+               !(Defaults[.onlyShowOnNotchDisplays] && !screen.hasNotch) {
                 setupDragDetectorForScreen(screen)
             }
         }
@@ -353,6 +355,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor in
                 guard let self = self else { return }
                 self.cleanupWindows(shouldInvert: true)
+                self.adjustWindowPosition(changeAlpha: true)
+                self.setupDragDetectors()
+            }
+        })
+
+        observers.append(NotificationCenter.default.addObserver(
+            forName: Notification.Name.onlyShowOnNotchDisplaysChanged, object: nil, queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor in
+                guard let self = self else { return }
+                self.cleanupWindows()
                 self.adjustWindowPosition(changeAlpha: true)
                 self.setupDragDetectors()
             }
@@ -541,7 +554,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // Create or update windows for all screens
             for screen in NSScreen.screens {
                 guard let uuid = screen.displayUUID else { continue }
-                
+
+                if Defaults[.onlyShowOnNotchDisplays] && !screen.hasNotch {
+                    if let window = windows[uuid] {
+                        window.close()
+                        NotchSpaceManager.shared.notchSpace.windows.remove(window)
+                        windows.removeValue(forKey: uuid)
+                        viewModels.removeValue(forKey: uuid)
+                    }
+                    continue
+                }
+
                 if windows[uuid] == nil {
                     let viewModel = BoringViewModel(screenUUID: uuid)
                     let window = createBoringNotchWindow(for: screen, with: viewModel)
@@ -569,6 +592,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 coordinator.selectedScreenUUID = mainUUID
                 selectedScreen = mainScreen
             } else {
+                if let window = window {
+                    window.alphaValue = 0
+                }
+                return
+            }
+
+            if Defaults[.onlyShowOnNotchDisplays] && !selectedScreen.hasNotch {
                 if let window = window {
                     window.alphaValue = 0
                 }

--- a/boringNotch/components/Settings/Views/GeneralSettingsView.swift
+++ b/boringNotch/components/Settings/Views/GeneralSettingsView.swift
@@ -27,6 +27,7 @@ struct GeneralSettings: View {
     @Default(.notchHeight) var notchHeight
     @Default(.notchHeightMode) var notchHeightMode
     @Default(.showOnAllDisplays) var showOnAllDisplays
+    @Default(.onlyShowOnNotchDisplays) var onlyShowOnNotchDisplays
     @Default(.automaticallySwitchDisplay) var automaticallySwitchDisplay
     @Default(.enableGestures) var enableGestures
     @Default(.openNotchOnHover) var openNotchOnHover
@@ -61,6 +62,13 @@ struct GeneralSettings: View {
                 .onChange(of: showOnAllDisplays) {
                     NotificationCenter.default.post(
                         name: Notification.Name.showOnAllDisplaysChanged, object: nil)
+                }
+                Defaults.Toggle(key: .onlyShowOnNotchDisplays) {
+                    Text("Only show on displays with a notch")
+                }
+                .onChange(of: onlyShowOnNotchDisplays) {
+                    NotificationCenter.default.post(
+                        name: Notification.Name.onlyShowOnNotchDisplaysChanged, object: nil)
                 }
                 Picker("Preferred display", selection: $coordinator.preferredScreenUUID) {
                     ForEach(screens, id: \.uuid) { screen in

--- a/boringNotch/extensions/NSScreen+UUID.swift
+++ b/boringNotch/extensions/NSScreen+UUID.swift
@@ -9,6 +9,10 @@ import AppKit
 import CoreGraphics
 
 extension NSScreen {
+    var hasNotch: Bool {
+        safeAreaInsets.top > 0
+    }
+
     /// Returns a persistent UUID for this display
     var displayUUID: String? {
         guard let number = deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -109,6 +109,7 @@ extension Notification.Name {
     static let selectedScreenChanged = Notification.Name("SelectedScreenChanged")
     static let notchHeightChanged = Notification.Name("NotchHeightChanged")
     static let showOnAllDisplaysChanged = Notification.Name("showOnAllDisplaysChanged")
+    static let onlyShowOnNotchDisplaysChanged = Notification.Name("onlyShowOnNotchDisplaysChanged")
     static let automaticallySwitchDisplayChanged = Notification.Name("automaticallySwitchDisplayChanged")
     
     // MARK: - Shelf
@@ -209,6 +210,7 @@ extension Defaults.Keys {
     static let appLanguage = Key<AppLanguage>("appLanguage", default: .system)
     static let menubarIcon = Key<Bool>("menubarIcon", default: true)
     static let showOnAllDisplays = Key<Bool>("showOnAllDisplays", default: false)
+    static let onlyShowOnNotchDisplays = Key<Bool>("onlyShowOnNotchDisplays", default: true)
     static let automaticallySwitchDisplay = Key<Bool>("automaticallySwitchDisplay", default: true)
     static let releaseName = Key<String>("releaseName", default: "Flying Rabbit 🐇🪽")
     


### PR DESCRIPTION
Closes #1281

## Summary
- Adds a new **"Only show on displays with a notch"** setting (default: **on**) under Settings > General
- When enabled, the notch overlay is not created on screens where `safeAreaInsets.top == 0` (no physical notch)
- Fixes the issue where closing the MacBook lid in clamshell/docked mode still renders the notch on external displays that don't have one
- Also skips drag detector setup on non-notch screens when the setting is enabled
- Users who want the notch on all displays can toggle the setting off

## Related issues
- #786 — Disable on clamshell mode
- #829 — Auto-hide Notch UI When Built-in Display is Not Present
- #247 — Add "Disable for external displays" option
- #562 — Macbook clamshell mode support

## Changes
- `NSScreen+UUID.swift` — Added `hasNotch` computed property
- `Constants.swift` — Added `onlyShowOnNotchDisplays` Defaults key and notification name
- `boringNotchApp.swift` — Filter non-notch screens in `adjustWindowPosition()` (both multi-display and single-display paths), `setupDragDetectors()`, and added notification observer for the new setting
- `GeneralSettingsView.swift` — Added toggle in General settings

## Test plan
- [ ] Enable "Show on all displays" with a MacBook connected to an external monitor — notch should only appear on the built-in display
- [ ] Close MacBook lid (clamshell mode) — notch should not appear on external display
- [ ] Toggle "Only show on displays with a notch" off — notch should appear on all displays again
- [ ] With setting on, disconnect/reconnect displays — windows should correctly appear/disappear