### PR TITLE
feat: add custom calendar support via plist

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		B141C2412CA5F53F00AC8CC8 /* SparkleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B141C2402CA5F53E00AC8CC8 /* SparkleView.swift */; };
 		B1628B922CC260C0003D8DF3 /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = B1628B912CC260C0003D8DF3 /* SwiftUIIntrospect */; };
 		B17266DF2C64DFA00031BA0D /* BundleInfos.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17266DE2C64DFA00031BA0D /* BundleInfos.swift */; };
+		442F87339A9A4131BE8A09B6 /* CalendarAppURLSchemes.plist in Resources */ = {isa = PBXBuildFile; fileRef = D94887D6942243249BCD46EC /* CalendarAppURLSchemes.plist */; };
 		B17266E12C6532560031BA0D /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B17266E02C6532560031BA0D /* Localizable.xcstrings */; };
 		B172AAC02C95DA0B001623F1 /* InlineOSD.swift in Sources */ = {isa = PBXBuildFile; fileRef = B172AABF2C95DA0B001623F1 /* InlineOSD.swift */; };
 		B18654392C6F4990000B926A /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = B18654382C6F4990000B926A /* KeyboardShortcuts */; };
@@ -322,6 +323,7 @@
 		B141C2402CA5F53E00AC8CC8 /* SparkleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleView.swift; sourceTree = "<group>"; };
 		B17266DE2C64DFA00031BA0D /* BundleInfos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleInfos.swift; sourceTree = "<group>"; };
 		B17266E02C6532560031BA0D /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		D94887D6942243249BCD46EC /* CalendarAppURLSchemes.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = CalendarAppURLSchemes.plist; sourceTree = "<group>"; };
 		B172AABF2C95DA0B001623F1 /* InlineOSD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineOSD.swift; sourceTree = "<group>"; };
 		B186543B2C6F49AE000B926A /* ShortcutConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutConstants.swift; sourceTree = "<group>"; };
 		B19016232CC15B4D00E3F12E /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -673,6 +675,7 @@
 				14CEF4152C5CAED300855D72 /* boringNotchApp.swift */,
 				14CEF4172C5CAED300855D72 /* ContentView.swift */,
 				B17266E02C6532560031BA0D /* Localizable.xcstrings */,
+				D94887D6942243249BCD46EC /* CalendarAppURLSchemes.plist */,
 				14CEF4192C5CAED400855D72 /* Assets.xcassets */,
 				14A7E5962C65FD31008C1BE9 /* boring.m4a */,
 				1443E7F42C609E650027C1FC /* Info.plist */,
@@ -972,6 +975,7 @@
 				112B0EB82E30DD0F00562D6C /* MediaRemoteAdapterTestClient in Resources */,
 				112B0EB92E30DD0F00562D6C /* mediaremote-adapter.pl in Resources */,
 				B17266E12C6532560031BA0D /* Localizable.xcstrings in Resources */,
+				442F87339A9A4131BE8A09B6 /* CalendarAppURLSchemes.plist in Resources */,
 				14A7E5972C65FD31008C1BE9 /* boring.m4a in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/boringNotch/CalendarAppURLSchemes.plist
+++ b/boringNotch/CalendarAppURLSchemes.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+    Maps a calendar app's bundle ID to a URL template for opening a specific event.
+
+    Placeholders:
+      {id}   – percent-encoded EKEvent.calendarItemIdentifier
+      {date} – ISO-8601 recurrence date prefix used by Apple Calendar ("/yyyy-MM-dd'T'HH:mm:ssZ"),
+               empty string for non-recurring events; safe to omit from templates that don't need it
+
+    To add support for another calendar app:
+      1. Find its bundle ID (e.g. via: mdls -name kMDItemCFBundleIdentifier /Applications/YourApp.app)
+      2. Find its URL scheme (check the app's documentation or Info.plist CFBundleURLSchemes)
+      3. Add a new key/string pair below
+-->
+<dict>
+    <!-- Apple Calendar -->
+    <key>com.apple.iCal</key>
+    <string>ical://ekevent{date}/{id}?method=show&amp;options=more</string>
+
+    <!-- Fantastical (bundle ID unchanged across versions 2 and 3) -->
+    <key>com.flexibits.fantastical2.mac</key>
+    <string>x-fantastical2://show?eventIdentifier={id}</string>
+
+    <!-- BusyCal -->
+    <key>com.busymac.busycal3</key>
+    <string>busycal://open?calendarItemIdentifier={id}</string>
+</dict>
+</plist>

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -2449,16 +2449,6 @@
         }
       }
     },
-    "Changing the app language requires restarting Boring Notch." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changing the app language requires restarting Boring Notch."
-          }
-        }
-      }
-    },
     "Change media with horizontal gestures" : {
       "localizations" : {
         "de" : {
@@ -2501,6 +2491,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Перемикання медіа горизонтальними жестами"
+          }
+        }
+      }
+    },
+    "Changing the app language requires restarting Boring Notch." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changing the app language requires restarting Boring Notch."
           }
         }
       }
@@ -6893,6 +6893,16 @@
         }
       }
     },
+    "Later" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Later"
+          }
+        }
+      }
+    },
     "Launch at login" : {
       "localizations" : {
         "fr" : {
@@ -6911,16 +6921,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oturum açıldığında başlat"
-          }
-        }
-      }
-    },
-    "Later" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Later"
           }
         }
       }
@@ -9559,6 +9559,7 @@
       }
     },
     "OSD" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -10056,9 +10057,6 @@
     "Real-time audio waveform" : {
 
     },
-    "Requires macOS 14.2 or later. Update macOS to enable real-time audio waveform." : {
-
-    },
     "Release name" : {
       "localizations" : {
         "cs" : {
@@ -10441,6 +10439,9 @@
           }
         }
       }
+    },
+    "Requires macOS 14.2 or later. Update macOS to enable real-time audio waveform." : {
+
     },
     "Reset to Defaults" : {
       "localizations" : {

--- a/boringNotch/models/EventModel.swift
+++ b/boringNotch/models/EventModel.swift
@@ -7,6 +7,7 @@
 //  Modified by Alexander on 2025-05-18.
 //
 
+import AppKit
 import Foundation
 
 struct EventModel: Equatable, Identifiable {
@@ -83,31 +84,53 @@ extension EventModel {
     var isMeeting: Bool { !participants.isEmpty }
 
     func calendarAppURL() -> URL? {
-
-        guard let id = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
+        guard let encodedId = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
             return nil
         }
 
         guard !type.isReminder else {
-            return URL(string: "x-apple-reminderkit://remcdreminder/\(id)")
+            return URL(string: "x-apple-reminderkit://remcdreminder/\(encodedId)")
         }
 
-        let date: String
+        // Recurrence date fragment — only used by the Apple Calendar ical:// template.
+        // Other app templates omit {date} so this replacement is a harmless no-op for them.
+        let dateFragment: String
         if hasRecurrenceRules {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
             if !isAllDay {
                 formatter.timeZone = .init(secondsFromGMT: 0)
             }
-            if let formattedDate = formatter.string(for: start) {
-                date = "/\(formattedDate)"
-            } else {
-                return nil
-            }
+            guard let formattedDate = formatter.string(for: start) else { return nil }
+            dateFragment = "/\(formattedDate)"
         } else {
-            date =  ""
+            dateFragment = ""
         }
-        return URL(string: "ical://ekevent\(date)/\(id)?method=show&options=more")
+
+        if let template = Self.urlTemplate(forDefaultCalendarApp: ()) {
+            let urlString = template
+                .replacingOccurrences(of: "{id}", with: encodedId)
+                .replacingOccurrences(of: "{date}", with: dateFragment)
+            return URL(string: urlString)
+        }
+
+        // Fallback when the plist is missing or the default app has no entry.
+        return URL(string: "ical://ekevent\(dateFragment)/\(encodedId)?method=show&options=more")
+    }
+
+    // Reads CalendarAppURLSchemes.plist and returns the URL template for the current
+    // default calendar app (identified by which app handles webcal:// links).
+    private static func urlTemplate(forDefaultCalendarApp _: ()) -> String? {
+        guard
+            let webcalURL = URL(string: "webcal://x"),
+            let appURL = NSWorkspace.shared.urlForApplication(toOpen: webcalURL),
+            let bundleId = Bundle(url: appURL)?.bundleIdentifier,
+            let plistURL = Bundle.main.url(forResource: "CalendarAppURLSchemes", withExtension: "plist"),
+            let data = try? Data(contentsOf: plistURL),
+            let mapping = try? PropertyListDecoder().decode([String: String].self, from: data)
+        else { return nil }
+
+        return mapping[bundleId]
     }
 }
 


### PR DESCRIPTION
## Problem

  Clicking a calendar event in the Notch always opened **Apple Calendar**, ignoring the macOS *Default Calendar App* system setting (https://github.com/TheBoredTeam/boring.notch/issues/1286).

This is alternative implementation to (#1288)

  **Root cause:** `EventModel.calendarAppURL()` hardcoded the `ical://ekevent/…` URL scheme. This scheme is Apple Calendar's proprietary internal protocol — macOS never routes it to any third-party app, regardless of the system preference. The *Default Calendar App* setting only affects `.ics` file opens and `webcal://` subscription URLs, not `ical://`.

  ## Solution

  ### Detection

  The default calendar app is resolved at runtime by querying which application handles `webcal://` links — the same signal macOS uses for the system
  preference:

  ```swift
  NSWorkspace.shared.urlForApplication(toOpen: URL(string: "webcal://x"))
  ```

  ### Data-driven URL routing

  A new bundled resource — `CalendarAppURLSchemes.plist` — maps each calendar app's bundle ID to a URL template. Two placeholders are supported:

  | Placeholder | Value |
  |-------------|-------|
  | `{id}` | percent-encoded `EKEvent.calendarItemIdentifier` |
  | `{date}` | ISO-8601 recurrence date prefix for Apple Calendar (`/yyyy-MM-dd'T'HH:mm:ssZ`), empty string for non-recurring events |

  Initial entries:

  | App | Bundle ID | Template |
  |-----|-----------|----------|
  | Apple Calendar | `com.apple.iCal` | `ical://ekevent{date}/{id}?method=show&options=more` |
  | Fantastical | `com.flexibits.fantastical2.mac` | `x-fantastical2://show?eventIdentifier={id}` |
  | BusyCal | `com.busymac.busycal3` | `busycal://open?calendarItemIdentifier={id}` |

  If the plist has no entry for the current default app, the code falls back to the original `ical://` URL (Apple Calendar behaviour).

  ### Adding support for a new calendar app

  No Swift changes needed — just a one-line addition to the plist:

  ```bash
  # 1. Find the bundle ID
  mdls -name kMDItemCFBundleIdentifier /Applications/YourCalendar.app

  # 2. Add to CalendarAppURLSchemes.plist:
  # <key>com.example.yourcalendar</key>
  # <string>yourcal://open?id={id}</string>
  ```

  ## Known limitation

  **Microsoft Outlook for Mac** is not supported: it does not register as a `webcal://` handler (so it cannot be detected) and has no documented URL
  scheme for opening an existing calendar event by identifier.