### PR TITLE
feat: add background app icon strip in expanded notch header

### DIFF
--- a/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AppKit
 import ApplicationServices
 import IOKit
 import CoreGraphics
@@ -187,5 +188,19 @@ class BoringNotchXPCHelper: NSObject, BoringNotchXPCHelperProtocol {
             }
             return nil
         }()
+    }
+
+    // MARK: - Application Management
+    
+    @objc func quitApp(pid: pid_t, force: Bool, with reply: @escaping (Bool) -> Void) {
+        if let app = NSRunningApplication(processIdentifier: pid) {
+            let success = force ? app.forceTerminate() : app.terminate()
+            reply(success)
+        } else {
+            // Fallback to POSIX kill if NSRunningApplication fails to find it
+            let signal = force ? SIGKILL : SIGTERM
+            let result = kill(pid, signal)
+            reply(result == 0)
+        }
     }
 }

--- a/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
@@ -20,6 +20,8 @@ import Foundation
     func isScreenBrightnessAvailable(with reply: @escaping (Bool) -> Void)
     func currentScreenBrightness(with reply: @escaping (NSNumber?) -> Void)
     func setScreenBrightness(_ value: Float, with reply: @escaping (Bool) -> Void)
+    // Application management (performed by the helper)
+    func quitApp(pid: pid_t, force: Bool, with reply: @escaping (Bool) -> Void)
 }
 
 /*

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -110,11 +110,13 @@
 		5917FD112E57891600E87F1C /* MediaKeyInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5917FD102E57891600E87F1C /* MediaKeyInterceptor.swift */; };
 		5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */; };
 		59D8C23C2E589FAA00147B33 /* VolumeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D8C23B2E589FAA00147B33 /* VolumeManager.swift */; };
+		982D80D2F666C1DC220A599F /* BackgroundAppsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3AC76086FF7A3E46EC3B4B /* BackgroundAppsManager.swift */; };
 		9A0887322C7A693000C160EA /* TabButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0887312C7A693000C160EA /* TabButton.swift */; };
 		9A0887352C7AFF8E00C160EA /* TabSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0887342C7AFF8E00C160EA /* TabSelectionView.swift */; };
 		9A987A0D2C73CA66005CA465 /* ShelfView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A987A032C73CA66005CA465 /* ShelfView.swift */; };
 		9A987A102C73CA8D005CA465 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 9A987A0F2C73CA8D005CA465 /* Collections */; };
 		9AB0C6BD2C73C9CB00F7CD30 /* NotchHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */; };
+		A253D94175074E015499112A /* BackgroundAppStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8624EB117961A8CA065D8524 /* BackgroundAppStrip.swift */; };
 		B10348D92C74E56000475897 /* ConditionalModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10348D82C74E56000475897 /* ConditionalModifier.swift */; };
 		B10F84A32C6C9596009F3026 /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10F84A22C6C9596009F3026 /* TestView.swift */; };
 		B141C2412CA5F53F00AC8CC8 /* SparkleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B141C2402CA5F53E00AC8CC8 /* SparkleView.swift */; };
@@ -276,10 +278,12 @@
 		14E9FEA92C70BF610062E83F /* DownloadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadView.swift; sourceTree = "<group>"; };
 		14E9FEAD2C7325770062E83F /* Button+Bouncing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Button+Bouncing.swift"; sourceTree = "<group>"; };
 		14FC6E4F2C7DED5600C7BEA5 /* DataTypes+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataTypes+Extensions.swift"; sourceTree = "<group>"; };
+		2B3AC76086FF7A3E46EC3B4B /* BackgroundAppsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BackgroundAppsManager.swift; path = BackgroundAppsManager.swift; sourceTree = "<group>"; };
 		507266DA2C908E2E00A2D00D /* HoverButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverButton.swift; sourceTree = "<group>"; };
 		5917FD102E57891600E87F1C /* MediaKeyInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaKeyInterceptor.swift; sourceTree = "<group>"; };
 		5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationRelauncher.swift; sourceTree = "<group>"; };
 		59D8C23B2E589FAA00147B33 /* VolumeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeManager.swift; sourceTree = "<group>"; };
+		8624EB117961A8CA065D8524 /* BackgroundAppStrip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BackgroundAppStrip.swift; path = BackgroundAppStrip.swift; sourceTree = "<group>"; };
 		9A0887312C7A693000C160EA /* TabButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabButton.swift; sourceTree = "<group>"; };
 		9A0887342C7AFF8E00C160EA /* TabSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSelectionView.swift; sourceTree = "<group>"; };
 		9A987A032C73CA66005CA465 /* ShelfView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShelfView.swift; sourceTree = "<group>"; };
@@ -312,7 +316,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		11F7485C2EC9AABA00F841DB /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		11F7485C2EC9AABA00F841DB /* Exceptions for "BoringNotchXPCHelper" folder in "BoringNotchXPCHelper" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -322,8 +326,29 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		112FB72F2CCF12CC0015238C /* private */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = private; sourceTree = "<group>"; };
-		11F748502EC9AABA00F841DB /* BoringNotchXPCHelper */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (11F7485C2EC9AABA00F841DB /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = BoringNotchXPCHelper; sourceTree = "<group>"; };
+		112FB72F2CCF12CC0015238C /* private */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = private;
+			sourceTree = "<group>";
+		};
+		11F748502EC9AABA00F841DB /* BoringNotchXPCHelper */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				11F7485C2EC9AABA00F841DB /* Exceptions for "BoringNotchXPCHelper" folder in "BoringNotchXPCHelper" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = BoringNotchXPCHelper;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -518,6 +543,7 @@
 				14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */,
 				B1F0A0012E60000100000001 /* BrightnessManager.swift */,
 				59D8C23B2E589FAA00147B33 /* VolumeManager.swift */,
+				2B3AC76086FF7A3E46EC3B4B /* BackgroundAppsManager.swift */,
 			);
 			path = managers;
 			sourceTree = "<group>";
@@ -710,6 +736,7 @@
 				14D570C52C5F38210011E668 /* BoringHeader.swift */,
 				14D570D12C5F6C6A0011E668 /* BoringExtrasMenu.swift */,
 				1471A8582C6281BD0058408D /* BoringNotchWindow.swift */,
+				8624EB117961A8CA065D8524 /* BackgroundAppStrip.swift */,
 			);
 			path = Notch;
 			sourceTree = "<group>";
@@ -776,8 +803,6 @@
 				11F748502EC9AABA00F841DB /* BoringNotchXPCHelper */,
 			);
 			name = BoringNotchXPCHelper;
-			packageProductDependencies = (
-			);
 			productName = BoringNotchXPCHelper;
 			productReference = 11F7484F2EC9AABA00F841DB /* BoringNotchXPCHelper.xpc */;
 			productType = "com.apple.product-type.xpc-service";
@@ -1020,6 +1045,8 @@
 				1100290C2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift in Sources */,
 				11CFC6632E09918400748C80 /* MusicControllerSelectionView.swift in Sources */,
 				B1F0A0022E60000100000001 /* BrightnessManager.swift in Sources */,
+				A253D94175074E015499112A /* BackgroundAppStrip.swift in Sources */,
+				982D80D2F666C1DC220A599F /* BackgroundAppsManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
+++ b/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
@@ -20,5 +20,7 @@ import Foundation
     func isScreenBrightnessAvailable(with reply: @escaping (Bool) -> Void)
     func currentScreenBrightness(with reply: @escaping (NSNumber?) -> Void)
     func setScreenBrightness(_ value: Float, with reply: @escaping (Bool) -> Void)
+    // Application management (performed by the helper)
+    func quitApp(pid: pid_t, force: Bool, with reply: @escaping (Bool) -> Void)
 }
 

--- a/boringNotch/XPCHelperClient/XPCHelperClient.swift
+++ b/boringNotch/XPCHelperClient/XPCHelperClient.swift
@@ -241,6 +241,21 @@ final class XPCHelperClient: NSObject {
             return false
         }
     }
+
+    nonisolated func quitApp(pid: pid_t, force: Bool) async -> Bool {
+        do {
+            let service = await MainActor.run {
+                ensureRemoteService()
+            }
+            return try await service.withContinuation { service, continuation in
+                service.quitApp(pid: pid, force: force) { success in
+                    continuation.resume(returning: success)
+                }
+            }
+        } catch {
+            return false
+        }
+    }
 }
 
 extension Notification.Name {

--- a/boringNotch/boringNotch.entitlements
+++ b/boringNotch/boringNotch.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
 	<key>com.apple.security.device.camera</key>

--- a/boringNotch/components/Notch/BackgroundAppStrip.swift
+++ b/boringNotch/components/Notch/BackgroundAppStrip.swift
@@ -1,0 +1,175 @@
+//
+//  BackgroundAppStrip.swift
+//  boringNotch
+//
+//  Horizontal strip of background app icons shown in the expanded notch header
+//
+
+import Defaults
+import SwiftUI
+
+struct BackgroundAppStrip: View {
+    @ObservedObject var appsManager = BackgroundAppsManager.shared
+    @State private var hasAppeared = false
+    @State private var haptics: Bool = false
+
+    var body: some View {
+        Group {
+            if appsManager.runningApps.isEmpty {
+                EmptyView()
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(Array(appsManager.runningApps.enumerated()), id: \.element.id) { index, app in
+                            AppIconNSView(app: app, onTap: {
+                                if Defaults[.enableHaptics] { haptics.toggle() }
+                            })
+                            .frame(width: 22, height: 22)
+                            .opacity(hasAppeared ? 1 : 0)
+                            .scaleEffect(hasAppeared ? 1 : 0.5)
+                            .animation(
+                                .spring(response: 0.35, dampingFraction: 0.7)
+                                    .delay(Double(index) * 0.03),
+                                value: hasAppeared
+                            )
+                        }
+                    }
+                    .padding(.horizontal, 4)
+                }
+                .sensoryFeedback(.alignment, trigger: haptics)
+                .onAppear {
+                    hasAppeared = false
+                    withAnimation {
+                        hasAppeared = true
+                    }
+                }
+                .onChange(of: appsManager.runningApps.count) { _, newCount in
+                    if newCount > 0 {
+                        hasAppeared = false
+                        withAnimation {
+                            hasAppeared = true
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Native AppKit view with right-click menu
+
+struct AppIconNSView: NSViewRepresentable {
+    let app: AppInfo
+    var onTap: (() -> Void)?
+
+    func makeNSView(context: Context) -> AppIconView {
+        let view = AppIconView(app: app, onTap: onTap)
+        view.toolTip = app.localizedName
+        return view
+    }
+
+    func updateNSView(_ nsView: AppIconView, context: Context) {
+        nsView.updateIcon(app.icon)
+        nsView.onTap = onTap
+        nsView.toolTip = app.localizedName
+    }
+}
+
+final class AppIconView: NSView {
+    private let app: AppInfo
+    private let imageView: NSImageView
+    private var trackingArea: NSTrackingArea?
+    var onTap: (() -> Void)?
+
+    init(app: AppInfo, onTap: (() -> Void)? = nil) {
+        self.app = app
+        self.onTap = onTap
+        self.imageView = NSImageView(frame: NSRect(x: 0, y: 0, width: 22, height: 22))
+        super.init(frame: NSRect(x: 0, y: 0, width: 22, height: 22))
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        updateIcon(app.icon)
+        addSubview(imageView)
+        self.updateTrackingAreas()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func updateIcon(_ icon: NSImage) {
+        let sized = icon.copy() as! NSImage
+        sized.size = NSSize(width: 22, height: 22)
+        imageView.image = sized
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let existing = trackingArea {
+            removeTrackingArea(existing)
+        }
+        trackingArea = NSTrackingArea(rect: bounds, options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect], owner: self, userInfo: nil)
+        if let ta = trackingArea { addTrackingArea(ta) }
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        imageView.frame = NSRect(x: -2, y: -2, width: 26, height: 26)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        imageView.frame = NSRect(x: 0, y: 0, width: 22, height: 22)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        BackgroundAppsManager.shared.activateApp(app)
+        onTap?()
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        let menu = NSMenu()
+
+        // Title item: app name
+        let titleItem = NSMenuItem(title: app.localizedName, action: nil, keyEquivalent: "")
+        titleItem.isEnabled = false
+        titleItem.image = app.icon
+        titleItem.image?.size = NSSize(width: 16, height: 16)
+        menu.addItem(titleItem)
+        menu.addItem(.separator())
+
+        // Show
+        let showItem = NSMenuItem(title: "Show", action: #selector(menuShow), keyEquivalent: "")
+        showItem.target = self
+        menu.addItem(showItem)
+        menu.addItem(.separator())
+
+        // Quit
+        let quitItem = NSMenuItem(title: "Quit", action: #selector(menuQuit), keyEquivalent: "q")
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        // Force Quit
+        let forceItem = NSMenuItem(title: "Force Quit", action: #selector(menuForceQuit), keyEquivalent: "")
+        forceItem.keyEquivalentModifierMask = [.command, .option]
+        forceItem.target = self
+        menu.addItem(forceItem)
+
+        NSMenu.popUpContextMenu(menu, with: event, for: self)
+    }
+
+    // MARK: - Menu actions
+
+    @objc private func menuShow() {
+        if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: app.bundleID) {
+            let config = NSWorkspace.OpenConfiguration()
+            config.activates = true
+            NSWorkspace.shared.openApplication(at: url, configuration: config) { _, _ in }
+        }
+    }
+
+    @objc private func menuQuit() {
+        let apps = NSRunningApplication.runningApplications(withBundleIdentifier: app.bundleID)
+        apps.first?.terminate()
+    }
+
+    @objc private func menuForceQuit() {
+        let apps = NSRunningApplication.runningApplications(withBundleIdentifier: app.bundleID)
+        apps.first?.forceTerminate()
+    }
+}

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -15,11 +15,12 @@ struct BoringHeader: View {
     @StateObject var tvm = ShelfStateViewModel.shared
     var body: some View {
         HStack(spacing: 0) {
+            // Left: tabs (when shelf has content)
             HStack {
-                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
+                if !tvm.isEmpty && Defaults[.boringShelf] {
                     TabSelectionView()
-                } else if vm.notchState == .open {
-                    EmptyView()
+                } else if coordinator.alwaysShowTabs && Defaults[.boringShelf] {
+                    TabSelectionView()
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -36,6 +37,7 @@ struct BoringHeader: View {
                     }
             }
 
+            // Right: camera, settings, then background app icons (blending with system status bar)
             HStack(spacing: 4) {
                 if vm.notchState == .open {
                     if isHUDType(coordinator.sneakPeek.type) && coordinator.sneakPeek.show && Defaults[.showOpenNotchHUD] {
@@ -63,7 +65,7 @@ struct BoringHeader: View {
                                 DispatchQueue.main.async {
                                     SettingsWindowController.shared.showWindow()
                                 }
-                                
+
                             }) {
                                 Capsule()
                                     .fill(.black)
@@ -77,22 +79,12 @@ struct BoringHeader: View {
                             }
                             .buttonStyle(PlainButtonStyle())
                         }
-                        if Defaults[.showBatteryIndicator] {
-                            BoringBatteryView(
-                                batteryWidth: 30,
-                                isCharging: batteryModel.isCharging,
-                                isInLowPowerMode: batteryModel.isInLowPowerMode,
-                                isPluggedIn: batteryModel.isPluggedIn,
-                                levelBattery: batteryModel.levelBattery,
-                                maxCapacity: batteryModel.maxCapacity,
-                                timeToFullCharge: batteryModel.timeToFullCharge,
-                                isForNotification: false
-                            )
+                        if Defaults[.showBackgroundAppIcons] {
+                            BackgroundAppStrip()
                         }
                     }
                 }
             }
-            .font(.system(.headline, design: .rounded))
             .frame(maxWidth: .infinity, alignment: .trailing)
             .opacity(vm.notchState == .closed ? 0 : 1)
             .blur(radius: vm.notchState == .closed ? 20 : 0)

--- a/boringNotch/managers/BackgroundAppsManager.swift
+++ b/boringNotch/managers/BackgroundAppsManager.swift
@@ -1,0 +1,208 @@
+//
+//  BackgroundAppsManager.swift
+//  boringNotch
+//
+//  Tracks menu bar apps whose icons may be hidden by the notch
+//
+
+import AppKit
+import Combine
+import SwiftUI
+
+struct AppInfo: Identifiable, Equatable {
+    let id: String          // bundleIdentifier
+    let bundleID: String
+    let localizedName: String
+    let icon: NSImage
+    let pid: pid_t
+
+    static func == (lhs: AppInfo, rhs: AppInfo) -> Bool {
+        lhs.bundleID == rhs.bundleID
+    }
+}
+
+@MainActor
+class BackgroundAppsManager: ObservableObject {
+    static let shared = BackgroundAppsManager()
+
+    @Published var runningApps: [AppInfo] = []
+
+    private var cancellables = Set<AnyCancellable>()
+
+    private init() {
+        refreshAppsImpl()
+        observeNotifications()
+    }
+
+    deinit {
+        cancellables.forEach { $0.cancel() }
+    }
+
+    // MARK: - Public
+
+    func refreshApps() {
+        refreshAppsImpl()
+    }
+
+    func activateApp(_ app: AppInfo) {
+        if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: app.bundleID) {
+            let config = NSWorkspace.OpenConfiguration()
+            NSWorkspace.shared.openApplication(at: url, configuration: config) { _, _ in }
+        }
+    }
+
+    func showApp(_ app: AppInfo) {
+        let apps = NSRunningApplication.runningApplications(withBundleIdentifier: app.bundleID)
+        guard let runningApp = apps.first else { return }
+        runningApp.unhide()
+        runningApp.activate(options: .activateIgnoringOtherApps)
+    }
+
+    func quitApp(_ app: AppInfo) {
+        let pid = app.pid
+        Task {
+            await XPCHelperClient.shared.quitApp(pid: pid, force: false)
+        }
+    }
+
+    func forceQuitApp(_ app: AppInfo) {
+        let pid = app.pid
+        Task {
+            await XPCHelperClient.shared.quitApp(pid: pid, force: true)
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func findRunningApp(_ bundleID: String) -> NSRunningApplication? {
+        NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).first
+    }
+
+    // MARK: - Private
+
+    private func refreshAppsImpl() {
+        let workspace = NSWorkspace.shared
+        let ourBundleID = Bundle.main.bundleIdentifier ?? ""
+
+        let apps = workspace.runningApplications
+            .filter { app in
+                guard let bundleID = app.bundleIdentifier,
+                      let name = app.localizedName, !name.isEmpty
+                else { return false }
+
+                // Show all regular and accessory GUI apps
+                guard app.activationPolicy == .regular || app.activationPolicy == .accessory else { return false }
+
+                // Exclude ourselves
+                guard bundleID != ourBundleID else { return false }
+
+                // Exclude Apple system daemons
+                guard !bundleID.hasPrefix("com.apple.") else { return false }
+
+                // Exclude WebKit helper / renderer subprocesses
+                guard bundleID.range(of: "\\.WebKit\\.", options: .regularExpression) == nil else { return false }
+                guard !bundleID.contains(".helper") else { return false }
+                guard !bundleID.contains(".renderer") else { return false }
+
+                // Exclude virtualization guest VMs
+                guard bundleID != "com.apple.Virtualization.VirtualMachine" else { return false }
+
+                return true
+            }
+            .compactMap { app -> AppInfo? in
+                guard
+                    let bundleID = app.bundleIdentifier,
+                    let name = app.localizedName
+                else { return nil }
+
+                let icon: NSImage
+                if let appURL = workspace.urlForApplication(withBundleIdentifier: bundleID) {
+                    icon = workspace.icon(forFile: appURL.path)
+                    icon.size = NSSize(width: 22, height: 22)
+                } else {
+                    let runningIcon = app.icon ?? workspace.icon(for: .applicationBundle)
+                    runningIcon.size = NSSize(width: 22, height: 22)
+                    icon = runningIcon
+                }
+
+                return AppInfo(
+                    id: bundleID,
+                    bundleID: bundleID,
+                    localizedName: name,
+                    icon: icon,
+                    pid: app.processIdentifier
+                )
+            }
+
+        // Deduplicate by "clean name" — merge sub-processes into their parent app
+        var seen = [String: AppInfo]()
+        for appInfo in apps {
+            let key = Self.groupKey(for: appInfo)
+            if let existing = seen[key] {
+                // Keep the one with the shorter bundle ID (more likely the main app)
+                if appInfo.bundleID.count < existing.bundleID.count {
+                    seen[key] = appInfo
+                }
+            } else {
+                seen[key] = appInfo
+            }
+        }
+        runningApps = Array(seen.values)
+    }
+
+    /// Derive a group key from an app's name so sub-processes map to the same parent
+    private static func groupKey(for app: AppInfo) -> String {
+        var name = app.localizedName
+        let suffixes = [
+            " Helper (Renderer)", " Helper (Plugin)", " Helper",
+            " Graphics and Media", " Networking", " Web Content",
+            " Agent", " Launcher", " Health Monitor", " Menu",
+        ]
+        for suffix in suffixes {
+            if name.hasSuffix(suffix) {
+                name = String(name.dropLast(suffix.count))
+                break
+            }
+        }
+        return name.trimmingCharacters(in: .whitespaces).lowercased()
+    }
+
+    private func observeNotifications() {
+        let center = NSWorkspace.shared.notificationCenter
+
+        center.publisher(for: NSWorkspace.didLaunchApplicationNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.refreshAppsImpl() }
+            .store(in: &cancellables)
+
+        center.publisher(for: NSWorkspace.didTerminateApplicationNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.refreshAppsImpl() }
+            .store(in: &cancellables)
+
+        center.publisher(for: NSWorkspace.didActivateApplicationNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.refreshAppsImpl() }
+            .store(in: &cancellables)
+    }
+
+    /// Convert icon to grayscale for menu-bar-like appearance
+    private static func desaturatedIcon(_ icon: NSImage) -> NSImage {
+        guard let tiff = icon.tiffRepresentation,
+              let ciImage = CIImage(data: tiff)
+        else { return icon }
+
+        let filter = CIFilter(name: "CIColorControls")
+        filter?.setValue(ciImage, forKey: kCIInputImageKey)
+        filter?.setValue(0.0, forKey: kCIInputSaturationKey)
+        filter?.setValue(0.05, forKey: kCIInputBrightnessKey)
+        filter?.setValue(1.1, forKey: kCIInputContrastKey)
+
+        guard let output = filter?.outputImage else { return icon }
+
+        let rep = NSCIImageRep(ciImage: output)
+        let result = NSImage(size: NSSize(width: 22, height: 22))
+        result.addRepresentation(rep)
+        return result
+    }
+}

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -95,6 +95,7 @@ extension Defaults.Keys {
     static let hideFromScreenRecording = Key<Bool>("hideFromScreenRecording", default: false)
     
     // MARK: Appearance
+    static let showBackgroundAppIcons = Key<Bool>("showBackgroundAppIcons", default: true)
     static let showEmojis = Key<Bool>("showEmojis", default: false)
     //static let alwaysShowTabs = Key<Bool>("alwaysShowTabs", default: true)
     static let showMirror = Key<Bool>("showMirror", default: false)


### PR DESCRIPTION
- Show all running GUI apps (regular + accessory) in BoringHeader right side
- Right-click context menu: Show / Quit / Force Quit
- Deduplication: merge sub-processes to parent app
- Haptic feedback on icon click
- Settings toggle: showBackgroundAppIcons (default: true)
- Disable app sandbox to enable quit functionality
- Remove battery indicator from notch header（Because everyone's battery indicator is all in his screen corner）
- Add AppKit import to XPC helper