### PR TITLE
Fix email attachment drops on the file shelf by fulfilling file promises

### DIFF
--- a/boringNotch/components/Shelf/Services/ShelfDropService.swift
+++ b/boringNotch/components/Shelf/Services/ShelfDropService.swift
@@ -54,7 +54,16 @@ struct ShelfDropService {
         if let text = await provider.extractText() {
             return await ShelfItem(kind: .text(string: text), isTemporary: false)
         }
-        
+
+        // File promises (e.g. attachments dragged out of Mail, Spark, Outlook, Messages)
+        // vend no real file URL, so fulfill the promise and shelf the copied temp file.
+        if let promisedURL = await provider.extractPromisedFile() {
+            if let bookmark = createBookmark(for: promisedURL) {
+                return await ShelfItem(kind: .file(bookmark: bookmark), isTemporary: true)
+            }
+            return nil
+        }
+
         if let data = await provider.loadData() {
             if let tempDataURL = await TemporaryFileStorageService.shared.createTempFile(for: .data(data, suggestedName: provider.suggestedName)),
                let bookmark = createBookmark(for: tempDataURL) {

--- a/boringNotch/extensions/NSItemProvider+LoadHelpers.swift
+++ b/boringNotch/extensions/NSItemProvider+LoadHelpers.swift
@@ -74,6 +74,74 @@ extension NSItemProvider {
         }
     }
 
+    /// Fulfills a file promise (e.g. an attachment dragged out of Mail, Spark, Outlook,
+    /// or Messages) by asking the provider to write its bytes to disk via
+    /// `loadFileRepresentation(forTypeIdentifier:)`, then copies the result into the
+    /// app's own temp area before the system reclaims the original temp file.
+    func extractPromisedFile() async -> URL? {
+        guard let typeIdentifier = bestPromisedTypeIdentifier() else { return nil }
+
+        return await withCheckedContinuation { (cont: CheckedContinuation<URL?, Never>) in
+            self.loadFileRepresentation(forTypeIdentifier: typeIdentifier) { url, error in
+                if let error = error {
+                    print("❌ Error fulfilling file promise for type \(typeIdentifier): \(error.localizedDescription)")
+                    cont.resume(returning: nil)
+                    return
+                }
+                guard let url = url else {
+                    cont.resume(returning: nil)
+                    return
+                }
+
+                // The provided URL points at a system-owned temp file that is deleted the
+                // instant this handler returns, so copy it synchronously into our own temp area.
+                let filename = self.suggestedName ?? url.lastPathComponent
+                let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+                let dirURL = tempDir.appendingPathComponent(UUID().uuidString, isDirectory: true)
+                let destURL = dirURL.appendingPathComponent(filename)
+
+                do {
+                    try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+                    try FileManager.default.copyItem(at: url, to: destURL)
+                    cont.resume(returning: destURL)
+                } catch {
+                    print("❌ Error copying fulfilled file promise: \(error.localizedDescription)")
+                    cont.resume(returning: nil)
+                }
+            }
+        }
+    }
+
+    /// Selects the most specific concrete content type to fulfill a file promise with,
+    /// excluding transport/abstract identifiers. Falls back to `public.data` if the
+    /// provider only advertises the generic type.
+    private func bestPromisedTypeIdentifier() -> String? {
+        let excluded: Set<String> = [
+            UTType.url.identifier,
+            UTType.fileURL.identifier,
+            UTType.plainText.identifier,
+            UTType.utf8PlainText.identifier,
+            "com.apple.pasteboard.promised-file-url",
+        ]
+
+        let candidates = registeredTypeIdentifiers.filter { !excluded.contains($0) }
+
+        // Prefer a concrete type that conforms to data/content/item.
+        if let concrete = candidates.first(where: { identifier in
+            guard let type = UTType(identifier) else { return false }
+            return type.conforms(to: .data) || type.conforms(to: .content) || type.conforms(to: .item)
+        }) {
+            return concrete
+        }
+
+        // Fall back to the generic data type if the provider advertises nothing more specific.
+        if hasItemConformingToTypeIdentifier(UTType.data.identifier) {
+            return UTType.data.identifier
+        }
+
+        return nil
+    }
+
     /// Attempts to extract a URL (web link) from the provider
     func extractURL() async -> URL? {
         if self.hasItemConformingToTypeIdentifier(UTType.url.identifier) {


### PR DESCRIPTION
Fixes #1299.

Heads-up: I'm not a programmer by trade — I used Claude Code to implement this. It compiles and works on my machine, but please review carefully.

Problem: Dragging an attachment straight out of Apple Mail or Spark onto the shelf did nothing. These apps vend attachments as file promises rather than real file URLs, and the drop pipeline only fulfilled promises routed through SwiftUI's own temp path (the com.apple.SwiftUI.filePromises check in loadData()), so AppKit mail clients fell through silently.

Fix: Added NSItemProvider.extractPromisedFile(), which fulfills the promise via loadFileRepresentation(forTypeIdentifier:) and copies the materialized file into temp storage before the system reclaims it. ShelfDropService.processProvider now tries this after the existing file/link/text checks and before the loadData() fallback, so existing drops are unchanged.

Testing: Dragged PDF and JPEG attachments from Apple Mail and Spark directly onto the shelf — all now land with their original filenames. Finder drags, links, dragged text, and browser-image drops still work.
