### PR TITLE
Add image conversion actions to Drop Shelf

### DIFF
--- a/boringNotch/components/Shelf/Services/ImageProcessingService.swift
+++ b/boringNotch/components/Shelf/Services/ImageProcessingService.swift
@@ -36,7 +36,7 @@ final class ImageProcessingService {
 
     private static let preferredFormats: [ImageConversionFormat] = [
         .init(displayName: "PNG", utType: .png, fileExtension: "png", supportsCompressionQuality: false),
-        .init(displayName: "JPEG", utType: .jpeg, fileExtension: "jpg", supportsCompressionQuality: true),
+        .init(displayName: "JPG", utType: .jpeg, fileExtension: "jpg", supportsCompressionQuality: true),
         .init(displayName: "WEBP", utType: UTType("org.webmproject.webp") ?? UTType(importedAs: "org.webmproject.webp"), fileExtension: "webp", supportsCompressionQuality: true),
         .init(displayName: "HEIC", utType: .heic, fileExtension: "heic", supportsCompressionQuality: true),
         .init(displayName: "TIFF", utType: .tiff, fileExtension: "tiff", supportsCompressionQuality: false),

--- a/boringNotch/components/Shelf/Services/ImageProcessingService.swift
+++ b/boringNotch/components/Shelf/Services/ImageProcessingService.swift
@@ -14,42 +14,34 @@ import PDFKit
 import UniformTypeIdentifiers
 import ImageIO
 
+struct ImageConversionFormat: Hashable {
+    let displayName: String
+    let utType: UTType
+    let fileExtension: String
+    let supportsCompressionQuality: Bool
+}
+
 /// Options for image conversion
 struct ImageConversionOptions {
-    enum ImageFormat {
-        case png, jpeg, heic, tiff, bmp
-        
-        var utType: UTType {
-            switch self {
-            case .png: return .png
-            case .jpeg: return .jpeg
-            case .heic: return .heic
-            case .tiff: return .tiff
-            case .bmp: return .bmp
-            }
-        }
-        
-        var fileExtension: String {
-            switch self {
-            case .png: return "png"
-            case .jpeg: return "jpg"
-            case .heic: return "heic"
-            case .tiff: return "tiff"
-            case .bmp: return "bmp"
-            }
-        }
-    }
-    
-    let format: ImageFormat
+    let format: ImageConversionFormat
     let compressionQuality: Double // 0.0 to 1.0, only applies to JPEG/HEIC
     let maxDimension: CGFloat? // Max width or height, nil for no scaling
-    let removeMetadata: Bool
+    let preserveMetadata: Bool
 }
 
 /// Service for processing images (background removal, conversion, PDF creation)
 @MainActor
 final class ImageProcessingService {
     static let shared = ImageProcessingService()
+
+    private static let preferredFormats: [ImageConversionFormat] = [
+        .init(displayName: "PNG", utType: .png, fileExtension: "png", supportsCompressionQuality: false),
+        .init(displayName: "JPEG", utType: .jpeg, fileExtension: "jpg", supportsCompressionQuality: true),
+        .init(displayName: "WEBP", utType: UTType("org.webmproject.webp") ?? UTType(importedAs: "org.webmproject.webp"), fileExtension: "webp", supportsCompressionQuality: true),
+        .init(displayName: "HEIC", utType: .heic, fileExtension: "heic", supportsCompressionQuality: true),
+        .init(displayName: "TIFF", utType: .tiff, fileExtension: "tiff", supportsCompressionQuality: false),
+        .init(displayName: "BMP", utType: .bmp, fileExtension: "bmp", supportsCompressionQuality: false),
+    ]
     
     private init() {}
     private let ciContext = CIContext(options: nil)
@@ -122,43 +114,52 @@ final class ImageProcessingService {
     }
     
     // MARK: - Convert Image
+
+    func availableConversionFormats(for url: URL? = nil) -> [ImageConversionFormat] {
+        let writableTypeIdentifiers = Set((CGImageDestinationCopyTypeIdentifiers() as? [String]) ?? [])
+        let sourceTypeIdentifier = url.flatMap {
+            try? $0.resourceValues(forKeys: [.contentTypeKey]).contentType?.identifier
+        }
+
+        return Self.preferredFormats.filter { format in
+            writableTypeIdentifiers.contains(format.utType.identifier) && format.utType.conforms(to: .image)
+        }.filter { format in
+            guard let sourceTypeIdentifier else { return true }
+            return format.utType.identifier != sourceTypeIdentifier
+        }
+    }
     
     /// Converts an image with specified options
     func convertImage(from url: URL, options: ImageConversionOptions) async throws -> URL? {
-        guard var inputImage = NSImage(contentsOf: url) else {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let sourceImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
             throw ImageProcessingError.invalidImage
         }
-        
+
+        var inputImage = NSImage(cgImage: sourceImage, size: .zero)
+
         // Scale image if needed
         if let maxDim = options.maxDimension {
             inputImage = scaleImage(inputImage, maxDimension: maxDim)
         }
-        
-        // Get image data based on format
-        let imageData: Data?
-        
-        if options.removeMetadata {
-            // Create new image without metadata
-            guard let cgImage = inputImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
-                throw ImageProcessingError.invalidImage
-            }
-            
-            let newImage = NSImage(cgImage: cgImage, size: inputImage.size)
-            imageData = try convertToFormat(newImage, format: options.format, quality: options.compressionQuality)
-        } else {
-            imageData = try convertToFormat(inputImage, format: options.format, quality: options.compressionQuality)
+
+        guard let outputImage = inputImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            throw ImageProcessingError.invalidImage
         }
-        
-        guard let data = imageData else {
-            throw ImageProcessingError.conversionFailed
-        }
-        
+
+        let imageData = try convertToFormat(
+            outputImage,
+            source: options.preserveMetadata ? source : nil,
+            format: options.format,
+            quality: options.compressionQuality
+        )
+
         // Create temporary file
         let originalName = url.deletingPathExtension().lastPathComponent
         let newName = "\(originalName)_converted.\(options.format.fileExtension)"
         
         guard let tempURL = await TemporaryFileStorageService.shared.createTempFile(
-            for: .data(data, suggestedName: newName)
+            for: .data(imageData, suggestedName: newName)
         ) else {
             throw ImageProcessingError.saveFailed
         }
@@ -166,40 +167,37 @@ final class ImageProcessingService {
         return tempURL
     }
     
-    private func convertToFormat(_ image: NSImage, format: ImageConversionOptions.ImageFormat, quality: Double) throws -> Data? {
-        guard let tiffData = image.tiffRepresentation,
-              let bitmap = NSBitmapImageRep(data: tiffData) else {
-            return nil
+    private func convertToFormat(
+        _ image: CGImage,
+        source: CGImageSource?,
+        format: ImageConversionFormat,
+        quality: Double
+    ) throws -> Data {
+        let outputData = NSMutableData()
+
+        guard let destination = CGImageDestinationCreateWithData(
+            outputData,
+            format.utType.identifier as CFString,
+            1,
+            nil
+        ) else {
+            throw ImageProcessingError.conversionFailed
         }
-        
-        switch format {
-        case .png:
-            return bitmap.representation(using: .png, properties: [:])
-        case .jpeg:
-            let properties: [NSBitmapImageRep.PropertyKey: Any] = [
-                .compressionFactor: quality
-            ]
-            return bitmap.representation(using: .jpeg, properties: properties)
-        case .tiff:
-            let properties: [NSBitmapImageRep.PropertyKey: Any] = [
-                .compressionMethod: NSNumber(value: NSBitmapImageRep.TIFFCompression.lzw.rawValue)
-            ]
-            return bitmap.representation(using: .tiff, properties: properties)
-        case .bmp:
-            return bitmap.representation(using: .bmp, properties: [:])
-        case .heic:
-            // HEIC requires using CIContext
-            guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
-                return nil
-            }
-            let ciImage = CIImage(cgImage: cgImage)
-            let context = CIContext()
-            let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
-            let options: [CIImageRepresentationOption: Any] = [
-                CIImageRepresentationOption(rawValue: kCGImageDestinationLossyCompressionQuality as String): quality
-            ]
-            return context.heifRepresentation(of: ciImage, format: .RGBA8, colorSpace: colorSpace, options: options)
+
+        var properties = (source.flatMap { CGImageSourceCopyPropertiesAtIndex($0, 0, nil) as? [String: Any] }) ?? [:]
+        if format.supportsCompressionQuality {
+            properties[kCGImageDestinationLossyCompressionQuality as String] = quality
+        } else {
+            properties.removeValue(forKey: kCGImageDestinationLossyCompressionQuality as String)
         }
+
+        CGImageDestinationAddImage(destination, image, properties as CFDictionary)
+
+        guard CGImageDestinationFinalize(destination) else {
+            throw ImageProcessingError.conversionFailed
+        }
+
+        return outputData as Data
     }
     
     private func scaleImage(_ image: NSImage, maxDimension: CGFloat) -> NSImage {

--- a/boringNotch/components/Shelf/ViewModels/ShelfItemViewModel.swift
+++ b/boringNotch/components/Shelf/ViewModels/ShelfItemViewModel.swift
@@ -36,7 +36,8 @@ final class ShelfItemViewModel: ObservableObject {
         static let remove = NSLocalizedString("Shelf.ContextMenu.Remove", comment: "Context menu item: Remove")
 
         static var convertImageMenu: String {
-            convertImage.replacingOccurrences(of: "…", with: "").replacingOccurrences(of: "...", with: "")
+            let resolved = convertImage == "Shelf.ContextMenu.ConvertImage" ? "Convert Image…" : convertImage
+            return resolved.replacingOccurrences(of: "…", with: "").replacingOccurrences(of: "...", with: "")
         }
     }
 

--- a/boringNotch/components/Shelf/ViewModels/ShelfItemViewModel.swift
+++ b/boringNotch/components/Shelf/ViewModels/ShelfItemViewModel.swift
@@ -366,7 +366,8 @@ final class ShelfItemViewModel: ObservableObject {
 
             let imageActions = NSMenuItem(title: "Image Actions", action: nil, keyEquivalent: "")
             let imageSubmenu = NSMenu()
-            let availableConversionFormats = imageURLs.count == 1
+            let hasSingleImageSelection = selectedItems.count == 1 && imageURLs.count == 1
+            let availableConversionFormats = hasSingleImageSelection
                 ? ImageProcessingService.shared.availableConversionFormats(for: imageURLs.first)
                 : []
 

--- a/boringNotch/components/Shelf/ViewModels/ShelfItemViewModel.swift
+++ b/boringNotch/components/Shelf/ViewModels/ShelfItemViewModel.swift
@@ -34,6 +34,10 @@ final class ShelfItemViewModel: ObservableObject {
         static let copy = NSLocalizedString("Shelf.ContextMenu.Copy", comment: "Context menu item: Copy")
         static let copyPath = NSLocalizedString("Shelf.ContextMenu.CopyPath", comment: "Context menu item: Copy Path")
         static let remove = NSLocalizedString("Shelf.ContextMenu.Remove", comment: "Context menu item: Remove")
+
+        static var convertImageMenu: String {
+            convertImage.replacingOccurrences(of: "…", with: "").replacingOccurrences(of: "...", with: "")
+        }
     }
 
     private enum ContextMenuAction: String {
@@ -257,7 +261,6 @@ final class ShelfItemViewModel: ObservableObject {
             if case .link(let url) = itm.kind { return url }
             return nil
         }
-        let selectedFolderURLs = selectedFileURLs.filter { isDirectory($0) }
         // URLs valid for Open/Open With (exclude folders)
         let selectedOpenableURLs = selectedItems.compactMap { itm -> URL? in
             if let u = itm.fileURL { return isDirectory(u) ? nil : u }
@@ -362,6 +365,9 @@ final class ShelfItemViewModel: ObservableObject {
 
             let imageActions = NSMenuItem(title: "Image Actions", action: nil, keyEquivalent: "")
             let imageSubmenu = NSMenu()
+            let availableConversionFormats = imageURLs.count == 1
+                ? ImageProcessingService.shared.availableConversionFormats(for: imageURLs.first)
+                : []
 
             // Remove Background - only for single images
             if imageURLs.count == 1 {
@@ -369,9 +375,18 @@ final class ShelfItemViewModel: ObservableObject {
                 imageSubmenu.addItem(removeBg)
             }
 
-            // Convert Image - only for single images
-            if imageURLs.count == 1 {
-                let convertItem = NSMenuItem(title: "Convert Image…", action: nil, keyEquivalent: "")
+            // Convert Image - only for single images and only for formats this macOS can write.
+            if !availableConversionFormats.isEmpty {
+                let convertItem = NSMenuItem(title: Strings.convertImageMenu, action: nil, keyEquivalent: "")
+                let convertSubmenu = NSMenu()
+
+                for format in availableConversionFormats {
+                    let formatItem = NSMenuItem(title: format.displayName, action: nil, keyEquivalent: "")
+                    formatItem.representedObject = "__CONVERT__:\(format.utType.identifier)"
+                    convertSubmenu.addItem(formatItem)
+                }
+
+                convertItem.submenu = convertSubmenu
                 imageSubmenu.addItem(convertItem)
             }
 
@@ -407,20 +422,19 @@ final class ShelfItemViewModel: ObservableObject {
 
         let actionTarget = MenuActionTarget(item: item, view: view, viewModel: self)
 
-        for menuItem in menu.items {
-            if menuItem.isSeparatorItem { continue }
-            menuItem.target = actionTarget
-            menuItem.action = #selector(MenuActionTarget.handle(_:))
+        func bindActions(in menu: NSMenu) {
+            for menuItem in menu.items {
+                if menuItem.isSeparatorItem { continue }
+                menuItem.target = actionTarget
+                menuItem.action = #selector(MenuActionTarget.handle(_:))
 
-            if let submenu = menuItem.submenu {
-                for subItem in submenu.items {
-                    if !subItem.isSeparatorItem {
-                        subItem.target = actionTarget
-                        subItem.action = #selector(MenuActionTarget.handle(_:))
-                    }
+                if let submenu = menuItem.submenu {
+                    bindActions(in: submenu)
                 }
             }
         }
+
+        bindActions(in: menu)
         
         menu.retainActionTarget(actionTarget)
         
@@ -452,6 +466,13 @@ final class ShelfItemViewModel: ObservableObject {
 
             if let marker = sender.representedObject as? String, marker == "__OTHER__" {
                 openWithPanel()
+                return
+            }
+
+            if let marker = sender.representedObject as? String,
+               marker.hasPrefix("__CONVERT__:") {
+                let typeIdentifier = String(marker.dropFirst("__CONVERT__:".count))
+                handleConvertImage(typeIdentifier: typeIdentifier)
                 return
             }
 
@@ -581,9 +602,6 @@ final class ShelfItemViewModel: ObservableObject {
                 
             case "Remove Background":
                 handleRemoveBackground()
-                
-            case "Convert Image…":
-                showConvertImageDialog()
                 
             case "Create PDF":
                 handleCreatePDF()
@@ -879,49 +897,49 @@ final class ShelfItemViewModel: ObservableObject {
         }
         
         @MainActor
-        private func showConvertImageDialog() {
+        private func handleConvertImage(typeIdentifier: String) {
             let selected = ShelfSelectionModel.shared.selectedItems(in: ShelfStateViewModel.shared.items)
             let imageURLs = selected.compactMap { $0.fileURL }.filter { ImageProcessingService.shared.isImageFile($0) }
-            
-            guard let imageURL = imageURLs.first else { return }
-            
+
+            guard let imageURL = imageURLs.first,
+                  let format = ImageProcessingService.shared.availableConversionFormats(for: imageURL)
+                    .first(where: { $0.utType.identifier == typeIdentifier }) else {
+                return
+            }
+
+            showConvertImageDialog(for: imageURL, format: format)
+        }
+
+        @MainActor
+        private func showConvertImageDialog(for imageURL: URL, format: ImageConversionFormat) {
+            let selected = ShelfSelectionModel.shared.selectedItems(in: ShelfStateViewModel.shared.items)
+            guard selected.count == 1 else { return }
+
             // Create and show conversion options dialog with better layout
             let alert = NSAlert()
-            alert.messageText = "Convert Image"
+            alert.messageText = "Convert to \(format.displayName)"
             alert.alertStyle = .informational
             alert.addButton(withTitle: "Convert")
             alert.addButton(withTitle: "Cancel")
             
             // Create accessory view with better spacing and organization
-            let accessoryView = NSView(frame: NSRect(x: 0, y: 0, width: 380, height: 180))
+            let accessoryView = NSView(frame: NSRect(x: 0, y: 0, width: 380, height: 145))
             accessoryView.wantsLayer = true
-            
-            // MARK: Format Row
-            let formatLabel = NSTextField(labelWithString: "Format:")
-            formatLabel.frame = NSRect(x: 0, y: 145, width: 100, height: 20)
-            formatLabel.font = .systemFont(ofSize: 12, weight: .medium)
-            accessoryView.addSubview(formatLabel)
-            
-            let formatPopup = NSPopUpButton(frame: NSRect(x: 120, y: 140, width: 250, height: 28))
-            formatPopup.addItems(withTitles: ["PNG", "JPEG", "HEIC", "TIFF", "BMP"])
-            formatPopup.selectItem(at: 0)
-            formatPopup.font = .systemFont(ofSize: 12)
-            accessoryView.addSubview(formatPopup)
             
             // MARK: Image Size Row
             let imageSizeLabel = NSTextField(labelWithString: "Image Size:")
-            imageSizeLabel.frame = NSRect(x: 0, y: 105, width: 100, height: 20)
+            imageSizeLabel.frame = NSRect(x: 0, y: 110, width: 100, height: 20)
             imageSizeLabel.font = .systemFont(ofSize: 12, weight: .medium)
             accessoryView.addSubview(imageSizeLabel)
             
-            let imageSizePopup = NSPopUpButton(frame: NSRect(x: 120, y: 100, width: 160, height: 28))
+            let imageSizePopup = NSPopUpButton(frame: NSRect(x: 120, y: 105, width: 160, height: 28))
             imageSizePopup.addItems(withTitles: ["Actual Size", "Large", "Medium", "Small", "Custom..."])
             imageSizePopup.selectItem(at: 0)
             imageSizePopup.font = .systemFont(ofSize: 12)
             accessoryView.addSubview(imageSizePopup)
             
             // Custom size field (initially hidden)
-            let customSizeField = NSTextField(frame: NSRect(x: 285, y: 103, width: 85, height: 22))
+            let customSizeField = NSTextField(frame: NSRect(x: 285, y: 108, width: 85, height: 22))
             customSizeField.placeholderString = "e.g., 1920"
             customSizeField.font = .systemFont(ofSize: 12)
             customSizeField.isHidden = true
@@ -929,25 +947,21 @@ final class ShelfItemViewModel: ObservableObject {
             
             // MARK: Preserve Metadata Checkbox
             let metadataCheckbox = NSButton(checkboxWithTitle: "Preserve Metadata", target: nil, action: nil)
-            metadataCheckbox.frame = NSRect(x: 120, y: 65, width: 200, height: 20)
+            metadataCheckbox.frame = NSRect(x: 120, y: 70, width: 200, height: 20)
             metadataCheckbox.font = .systemFont(ofSize: 12)
             metadataCheckbox.state = .on
             accessoryView.addSubview(metadataCheckbox)
             
             // MARK: Separator line
-            let separatorLine = NSView(frame: NSRect(x: 0, y: 50, width: 380, height: 1))
+            let separatorLine = NSView(frame: NSRect(x: 0, y: 55, width: 380, height: 1))
             separatorLine.wantsLayer = true
             separatorLine.layer?.backgroundColor = NSColor.separatorColor.cgColor
             accessoryView.addSubview(separatorLine)
             
-            // MARK: Format-specific options (shown/hidden based on format selection)
-            let qualityRow = NSView(frame: NSRect(x: 0, y: 15, width: 380, height: 30))
-            qualityRow.wantsLayer = true
-            
             let qualityLabel = NSTextField(labelWithString: "Compression:")
             qualityLabel.frame = NSRect(x: 0, y: 7, width: 100, height: 20)
             qualityLabel.font = .systemFont(ofSize: 12, weight: .medium)
-            qualityRow.addSubview(qualityLabel)
+            accessoryView.addSubview(qualityLabel)
             
             let qualitySlider = NSSlider(frame: NSRect(x: 120, y: 12, width: 200, height: 20))
             qualitySlider.minValue = 0.0
@@ -968,8 +982,7 @@ final class ShelfItemViewModel: ObservableObject {
             }
             
             let updateCompressionVisibility = {
-                let formatIndex = formatPopup.indexOfSelectedItem
-                let showCompression = formatIndex == 1 || formatIndex == 2 // JPEG or HEIC
+                let showCompression = format.supportsCompressionQuality
                 qualitySlider.isHidden = !showCompression
                 qualityValueLabel.isHidden = !showCompression
                 qualityLabel.isHidden = !showCompression
@@ -983,32 +996,24 @@ final class ShelfItemViewModel: ObservableObject {
             // Create a target object to handle slider value changes
             class SliderHandler: NSObject {
                 let updateLabel: () -> Void
-                let updateVisibility: () -> Void
                 let updateCustomSize: () -> Void
-                init(updateLabel: @escaping () -> Void, updateVisibility: @escaping () -> Void, updateCustomSize: @escaping () -> Void) {
+                init(updateLabel: @escaping () -> Void, updateCustomSize: @escaping () -> Void) {
                     self.updateLabel = updateLabel
-                    self.updateVisibility = updateVisibility
                     self.updateCustomSize = updateCustomSize
                 }
                 @objc func sliderChanged(_ sender: NSSlider) {
                     updateLabel()
-                }
-                @objc func formatChanged(_ sender: NSPopUpButton) {
-                    updateVisibility()
                 }
                 @objc func sizeChanged(_ sender: NSPopUpButton) {
                     updateCustomSize()
                 }
             }
             
-            let handler = SliderHandler(updateLabel: updateQualityLabel, updateVisibility: updateCompressionVisibility, updateCustomSize: updateCustomSizeVisibility)
+            let handler = SliderHandler(updateLabel: updateQualityLabel, updateCustomSize: updateCustomSizeVisibility)
             qualitySlider.target = handler
             qualitySlider.action = #selector(SliderHandler.sliderChanged(_:))
             qualitySlider.isContinuous = true
-            
-            formatPopup.target = handler
-            formatPopup.action = #selector(SliderHandler.formatChanged(_:))
-            
+
             imageSizePopup.target = handler
             imageSizePopup.action = #selector(SliderHandler.sizeChanged(_:))
             
@@ -1024,18 +1029,6 @@ final class ShelfItemViewModel: ObservableObject {
             let response = alert.runModal()
             
             if response == .alertFirstButtonReturn {
-                // Get selected options
-                let formatIndex = formatPopup.indexOfSelectedItem
-                let format: ImageConversionOptions.ImageFormat
-                switch formatIndex {
-                case 0: format = .png
-                case 1: format = .jpeg
-                case 2: format = .heic
-                case 3: format = .tiff
-                case 4: format = .bmp
-                default: format = .png
-                }
-                
                 let quality = qualitySlider.doubleValue
                 
                 // Get max dimension based on image size selection
@@ -1060,7 +1053,7 @@ final class ShelfItemViewModel: ObservableObject {
                     format: format,
                     compressionQuality: quality,
                     maxDimension: maxDimension,
-                    removeMetadata: removeMetadata
+                    preserveMetadata: !removeMetadata
                 )
                 
                 Task {


### PR DESCRIPTION
Fixes #1291.

## What changed

This adds image conversion actions to the Drop Shelf context menu.

When a supported image is in the Shelf, the user can now choose:

Image Actions → Convert Image → [Format]

The available output formats are detected at runtime using native macOS Image I/O write support, so unsupported formats are not shown. The image’s current format is also excluded from the conversion list.

## Scope

This PR keeps the feature focused on image conversion only.

Supported target formats:
- PNG
- JPG/JPEG
- HEIC
- WEBP

This does not add video conversion, batch conversion, compression controls, or a separate converter interface.

## Notes

The conversion is handled through the existing Shelf image-processing flow and keeps the UI small by exposing conversion as a contextual file action instead of adding a new panel or tab.

Converted files are written as new files rather than overwriting the original.

## Testing

Tested:
- Added image files to the Drop Shelf
- Opened the Shelf context menu for supported image files
- Verified `Image Actions → Convert Image` appears
- Verified the current source format is excluded from the output choices
- Verified unsupported output formats are hidden when not writable on the current macOS runtime
- Converted PNG → JPG
- Converted JPG → PNG
- Confirmed the original file is not overwritten