### PR TITLE
feat: add AI Quota tab showing Claude & Codex usage

### DIFF
--- a/AI_QUOTA_FEATURE_PLAN.md
+++ b/AI_QUOTA_FEATURE_PLAN.md
@@ -1,0 +1,360 @@
+# Boring.Notch — AI 额度显示功能计划
+
+> **v2** — 整合 Codex 审核反馈，修正 sandbox / 布局 / 生命周期 / 设置入口问题
+
+## 功能概述
+
+在 boring.notch 的 notch 展开视图中新增一个 **AI Quota** 面板，实时显示 Claude (Anthropic) 和 Codex (OpenAI/ChatGPT) 账号的使用率（已用百分比）。
+
+参考项目：[cc-switch](https://github.com/farion1231/cc-switch)
+
+---
+
+## 核心原理（来自 cc-switch 的逆向分析）
+
+### Claude 额度查询
+
+- **凭据来源**：优先从 macOS Keychain（service: `"Claude Code-credentials"`）读取，回退到 `~/.claude/.credentials.json`
+- **JSON 格式**：
+  ```json
+  {"claudeAiOauth": {"accessToken": "...", "expiresAt": ...}}
+  // 或
+  {"claude.ai_oauth": {"accessToken": "...", "expiresAt": ...}}
+  ```
+- **API 端点**：`GET https://api.anthropic.com/api/oauth/usage`
+- **请求头**：
+  - `Authorization: Bearer {token}`
+  - `anthropic-beta: oauth-2025-04-20`
+  - `Accept: application/json`
+- **返回数据**：按窗口维度的 `utilization`（0-100%），已知窗口类型包括：
+  - `five_hour` — 5 小时滑动窗口
+  - `seven_day` — 7 天窗口
+  - `seven_day_opus` — 7 天 Opus 模型窗口
+  - `seven_day_sonnet` — 7 天 Sonnet 模型窗口
+  - `extra_usage` — 超额使用信息（is_enabled, monthly_limit, used_credits, utilization, currency）
+  - API 可能返回未知窗口类型，需要兼容解析
+
+### Codex 额度查询
+
+- **凭据来源**：优先从 macOS Keychain（service: `"Codex Auth"`）读取，回退到 `~/.codex/auth.json`
+- **JSON 格式**：
+  ```json
+  {"auth_mode": "chatgpt", "tokens": {"access_token": "...", "account_id": "..."}, "last_refresh": "..."}
+  ```
+- **前提条件**：仅在 `auth_mode == "chatgpt"` (OAuth 模式) 时有效，API key 模式不支持用量查询
+- **API 端点**：`GET https://chatgpt.com/backend-api/wham/usage`
+- **请求头**：
+  - `Authorization: Bearer {token}`
+  - `User-Agent: codex-cli`
+  - `ChatGPT-Account-Id: {account_id}`（可选）
+  - `Accept: application/json`
+- **返回数据**：`rate_limit` 对象中包含 `primary_window` 和 `secondary_window`：
+  - `used_percent` — 使用百分比
+  - `limit_window_seconds` — 窗口秒数（18000 = 5h, 604800 = 7d，其他值动态映射）
+  - `reset_at` — Unix 时间戳（重置时间）
+
+---
+
+## 架构约束（审核修正）
+
+### 约束 1：App Sandbox
+
+主 app `boringNotch` 是 sandboxed（`com.apple.security.app-sandbox: true`），**无法**直接：
+- 调用 `security find-generic-password` 访问其他 app 写入的 Keychain 条目
+- 读取 `~/.claude/`、`~/.codex/` 等任意文件系统路径
+
+项目已有一个 **unsandboxed XPC Helper**（`BoringNotchXPCHelper`，`app-sandbox: false`），
+目前提供 accessibility、keyboard brightness、screen brightness 服务。
+
+**方案**：凭据读取必须通过 XPC Helper 完成，扩展 `BoringNotchXPCHelperProtocol`。
+
+### 约束 2：Notch 布局空间
+
+展开 notch 固定尺寸为 **640×190**（`matters.swift:16`）。当前 `NotchHomeView` 已在 HStack 中横排：
+- MusicPlayer（~250pt）
+- Calendar（170-215pt）
+- Camera（可变）
+
+再横向加 180pt 面板会溢出。
+
+**方案**：AI Quota 作为独立的 `NotchViews` tab（与 `.home` / `.shelf` 并列），通过 header 中的 tab 切换进入，拥有 640pt 全宽空间，不挤压现有布局。
+
+### 约束 3：刷新生命周期
+
+功能默认关闭（`showAIQuota` default: false），不应常驻刷新。
+
+**方案**：
+- 仅当 `Defaults[.showAIQuota] == true` 时启动定时刷新
+- 关闭设置时取消 timer
+- 切换到 AI Quota tab 时立即刷新一次
+- 提供手动刷新按钮
+- 使用 `Task` + cancellable 管理后台任务
+
+---
+
+## 实现步骤
+
+### 第 1 步：新增数据模型 — `AIQuotaModels.swift`
+
+**文件位置**：`boringNotch/models/AIQuotaModels.swift`
+
+定义以下类型：
+
+- `AIProvider` 枚举（`.claude`, `.codex`）
+- `CredentialStatus` 枚举（`.valid`, `.expired`, `.notFound`, `.parseError`）
+- `QuotaTier` 结构体
+  - `name: String` — 窗口标识（five_hour, seven_day 等，保留未知窗口兼容）
+  - `utilization: Double` — 已用百分比 0-100
+  - `resetsAt: Date?` — 重置时间
+- `ExtraUsage` 结构体（需声明 `CodingKeys` 映射 snake_case）
+  - `isEnabled: Bool`
+  - `monthlyLimit: Double?`
+  - `usedCredits: Double?`
+  - `utilization: Double?`
+  - `currency: String?`
+- `AIQuotaResult` 结构体
+  - `provider: AIProvider`
+  - `credentialStatus: CredentialStatus`
+  - `success: Bool`
+  - `tiers: [QuotaTier]`
+  - `extraUsage: ExtraUsage?`
+  - `error: String?`
+  - `queriedAt: Date?`
+
+**解析兼容逻辑**：
+- Claude：解析已知窗口（five_hour, seven_day, seven_day_opus, seven_day_sonnet），同时遍历响应 JSON 所有顶层 key，将未知的、包含 `utilization` 字段的 object 也作为 tier 保留
+- Codex：`limit_window_seconds` 动态映射 tier name（18000→five_hour, 604800→seven_day, 其他→`{n}_hour` 或 `{n}_day`）
+- Token 过期检测兼容秒/毫秒时间戳和 ISO 8601 格式
+
+### 第 2 步：扩展 XPC Helper — 凭据读取
+
+**关键变更**：凭据读取逻辑放在 XPC Helper 中，而非主 app。
+
+#### 2a. 扩展 XPC Protocol
+
+**修改文件**：`BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift`（及主 app 中的副本 `boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift`）
+
+新增方法：
+
+```swift
+func readClaudeCredentials(with reply: @escaping (String?, String?, String?) -> Void)
+// 返回: (accessToken?, credentialStatus, errorMessage?)
+
+func readCodexCredentials(with reply: @escaping (String?, String?, String?, String?) -> Void)
+// 返回: (accessToken?, accountId?, credentialStatus, errorMessage?)
+```
+
+#### 2b. 在 XPC Helper 中实现凭据读取
+
+**新建文件**：`BoringNotchXPCHelper/AICredentialReader.swift`
+
+在 unsandboxed 环境中：
+1. Claude：先 `security find-generic-password -s "Claude Code-credentials" -w`，失败则读 `~/.claude/.credentials.json`，解析 `claudeAiOauth` / `claude.ai_oauth` 下的 accessToken 和 expiresAt
+2. Codex：先 `security find-generic-password -s "Codex Auth" -w`，失败则读 `~/.codex/auth.json`，验证 `auth_mode == "chatgpt"`，解析 tokens
+
+**修改文件**：`BoringNotchXPCHelper/BoringNotchXPCHelper.swift` — 实现新 protocol 方法，委托给 `AICredentialReader`
+
+#### 2c. 扩展 XPC Client
+
+**修改文件**：`boringNotch/XPCHelperClient/XPCHelperClient.swift`
+
+新增：
+
+```swift
+nonisolated func readClaudeCredentials() async -> (accessToken: String?, status: String, message: String?)
+nonisolated func readCodexCredentials() async -> (accessToken: String?, accountId: String?, status: String, message: String?)
+```
+
+遵循现有模式（`ensureRemoteService()` → `withContinuation`）。
+
+### 第 3 步：额度查询管理器 — `AIQuotaManager.swift`
+
+**文件位置**：`boringNotch/managers/AIQuotaManager.swift`
+
+作为 `ObservableObject` 单例：
+
+- `@Published var claudeQuota: AIQuotaResult?`
+- `@Published var codexQuota: AIQuotaResult?`
+- `@Published var isLoading: Bool`
+- `static let shared = AIQuotaManager()`
+
+**生命周期管理**：
+
+```swift
+private var refreshTask: Task<Void, Never>?
+
+func startAutoRefresh() {
+    // 仅当 showAIQuota == true 时调用
+    refreshTask?.cancel()
+    refreshTask = Task { ... 每 300 秒循环 fetchAll ... }
+}
+
+func stopAutoRefresh() {
+    refreshTask?.cancel()
+    refreshTask = nil
+}
+```
+
+- 监听 `Defaults.observe(.showAIQuota)` 的变化，开/关时自动 start/stop
+- **不在 app 启动时无条件初始化**
+
+**核心方法**：
+
+- `fetchAll()` — 使用 `async let` 并发请求两个 API
+- `fetchClaudeQuota()` — 通过 XPCHelperClient 读凭据 → URLSession 调 Anthropic API → 解析所有 tier 窗口（含未知窗口）和 extra_usage
+- `fetchCodexQuota()` — 通过 XPCHelperClient 读凭据 → URLSession 调 ChatGPT API → 解析 rate_limit 窗口（动态映射 window_seconds → tier name）
+- 网络请求使用 `URLSession`，10 秒超时
+- 主 app 已有 `com.apple.security.network.client` 权限，网络请求可在主 app 中发起
+
+### 第 4 步：UI 视图
+
+#### 布局方案：独立 Tab
+
+AI Quota 作为 `NotchViews.quota` 独立 tab，拥有完整 640×190 展开空间。
+
+#### `AIQuotaView.swift`
+
+**文件位置**：`boringNotch/components/AIQuota/AIQuotaView.swift`
+
+主面板视图，水平排列 Claude 和 Codex 的额度卡片，右上角手动刷新按钮：
+
+```
+┌─────────────────────────────────────────────────────┐
+│  ☁ Claude                    ◎ Codex           ↻   │
+│  ┌────────────────────┐      ┌────────────────────┐ │
+│  │ 5h  ●━━━━━━○  23%  │      │ 5h  ●━━━━━━━○ 45% │ │
+│  │ 7d  ●━━━━━━━━○ 67% │      │ 7d  ●━○       12% │ │
+│  │ Opus ●━━○     35%  │      │                    │ │
+│  └────────────────────┘      └────────────────────┘ │
+│  Resets in 3h 12m            Resets in 1h 05m       │
+└─────────────────────────────────────────────────────┘
+```
+
+**UI 文案**：API 返回的是 `utilization` / `used_percent`（已用百分比），UI 显示为 **"已用 X%"**，进度条表示已用量。
+
+#### `QuotaCardView.swift`
+
+**文件位置**：`boringNotch/components/AIQuota/QuotaCardView.swift`
+
+单个 provider 的额度卡片，显示：
+
+- Provider 图标和名称
+- 各窗口使用率（水平进度条 + 百分比文字）
+  - `five_hour` → "5h"
+  - `seven_day` → "7d"
+  - `seven_day_opus` → "Opus"
+  - `seven_day_sonnet` → "Sonnet"
+  - 未知窗口 → 原始 name
+- 最近的重置倒计时
+- 状态提示：
+  - 凭据未找到 → "Run `claude`/`codex` CLI to login"
+  - 凭据过期 → "Token expired, re-login required"
+  - 查询失败 → 显示错误信息
+  - 加载中 → ProgressView
+
+#### `QuotaProgressBar.swift`
+
+**文件位置**：`boringNotch/components/AIQuota/QuotaProgressBar.swift`
+
+水平进度条（类似现有 MusicSlider 风格）：
+
+- 颜色随使用率变化：0-50% 绿色 → 50-80% 黄色 → 80-100% 红色
+- 高度 6pt，圆角
+
+视觉风格与现有 UI 保持一致（深色背景、圆角、紧凑布局）。
+
+### 第 5 步：集成到 Notch 导航
+
+#### 5a. 扩展 NotchViews 枚举
+
+**修改文件**：`boringNotch/enums/generic.swift`
+
+```swift
+public enum NotchViews {
+    case home
+    case shelf
+    case quota  // 新增
+}
+```
+
+#### 5b. 在 ContentView 中路由
+
+**修改文件**：`boringNotch/ContentView.swift`
+
+在 `NotchLayout` 的 `switch coordinator.currentView` 中添加：
+
+```swift
+case .quota:
+    AIQuotaView()
+```
+
+#### 5c. 在 Tab 栏中添加入口
+
+**修改文件**：`boringNotch/components/Tabs/TabSelectionView.swift` 或 `BoringHeader.swift`
+
+当 `Defaults[.showAIQuota]` 为 true 时，在 header tab 区域添加 quota tab 按钮。切换到 quota tab 时触发立即刷新。
+
+### 第 6 步：设置项
+
+**修改文件**：`boringNotch/models/Constants.swift`
+
+```swift
+extension Defaults.Keys {
+    static let showAIQuota = Key<Bool>("showAIQuota", default: false)
+}
+```
+
+**修改文件**：`boringNotch/components/Settings/SettingsView.swift`
+
+在 Appearance 页面的 **"Additional features"** section（与 `showMirror`、`showNotHumanFace` 同区）添加：
+
+```swift
+Defaults.Toggle(key: .showAIQuota) {
+    Text("Show AI quota (Claude & Codex)")
+}
+```
+
+### 第 7 步：生命周期连接
+
+**修改文件**：`boringNotch/boringNotchApp.swift`
+
+监听 `Defaults[.showAIQuota]` 变化：
+- 变为 true → `AIQuotaManager.shared.startAutoRefresh()`
+- 变为 false → `AIQuotaManager.shared.stopAutoRefresh()`
+- 启动时检查一次初始值
+
+---
+
+## 文件变更清单
+
+| 操作 | 文件路径 | 说明 |
+|------|----------|------|
+| **新建** | `boringNotch/models/AIQuotaModels.swift` | 数据模型（含 CodingKeys） |
+| **新建** | `BoringNotchXPCHelper/AICredentialReader.swift` | XPC Helper 端凭据读取（Keychain + 文件） |
+| **新建** | `boringNotch/managers/AIQuotaManager.swift` | 网络请求 + 状态管理 + 生命周期控制 |
+| **新建** | `boringNotch/components/AIQuota/AIQuotaView.swift` | UI 主视图 |
+| **新建** | `boringNotch/components/AIQuota/QuotaCardView.swift` | 单 provider 额度卡片 |
+| **新建** | `boringNotch/components/AIQuota/QuotaProgressBar.swift` | 水平进度条组件 |
+| **修改** | `BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift` | 新增凭据读取 protocol 方法 |
+| **修改** | `boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift` | 同步 protocol 副本 |
+| **修改** | `BoringNotchXPCHelper/BoringNotchXPCHelper.swift` | 实现新 protocol 方法 |
+| **修改** | `boringNotch/XPCHelperClient/XPCHelperClient.swift` | 新增凭据读取 client 方法 |
+| **修改** | `boringNotch/models/Constants.swift` | 添加 `showAIQuota` 配置项 |
+| **修改** | `boringNotch/enums/generic.swift` | NotchViews 新增 `.quota` |
+| **修改** | `boringNotch/ContentView.swift` | 路由 `.quota` 视图 |
+| **修改** | `boringNotch/components/Notch/BoringHeader.swift` | 添加 quota tab 入口 |
+| **修改** | `boringNotch/components/Settings/SettingsView.swift` | Additional features 添加开关 |
+| **修改** | `boringNotch/boringNotchApp.swift` | 生命周期连接 |
+| **修改** | `boringNotch.xcodeproj` | 将新文件添加到 Xcode 项目 |
+
+---
+
+## 注意事项
+
+1. **只读凭据**：我们只读取已有的 OAuth token，不实现登录/刷新流程。如果 token 过期，UI 提示用户重新运行 `claude` / `codex` CLI 登录
+2. **Sandbox 安全**：凭据读取全部在 unsandboxed XPC Helper 中完成；主 app 仅通过 XPC 接口获取 token 字符串，token 仅在内存中使用，不持久化到磁盘
+3. **网络权限**：主 app 已有 `com.apple.security.network.client` 权限，可直接调用 Anthropic 和 ChatGPT API
+4. **优雅降级**：如果凭据不存在或查询失败，不影响 notch 其他功能，quota tab 中显示提示状态
+5. **性能**：网络请求在后台 Task 执行，不阻塞 UI；仅在功能开启时刷新；5 分钟间隔避免频繁请求
+6. **隐私**：默认关闭（`showAIQuota` default: false），用户需手动在 Settings > Appearance > Additional features 中启用
+7. **兼容性**：解析逻辑保留对未知 API 响应窗口的前向兼容；UI 文案显示"已用 X%"（非"剩余额度"），准确反映 API 语义

--- a/BoringNotchXPCHelper/AICredentialReader.swift
+++ b/BoringNotchXPCHelper/AICredentialReader.swift
@@ -1,0 +1,215 @@
+//
+//  AICredentialReader.swift
+//  BoringNotchXPCHelper
+//
+
+import Foundation
+import Security
+
+enum AICredentialReader {
+    static func readClaudeCredentials() -> (accessToken: String?, status: String, message: String?) {
+        var diagLog: [String] = []
+
+        let keychainResult = readKeychainPassword(service: "Claude Code-credentials", diag: &diagLog)
+        if let keychain = keychainResult {
+            return parseClaudeCredentialsJSON(keychain)
+        }
+
+        let credentialsURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude")
+            .appendingPathComponent(".credentials.json")
+
+        diagLog.append("file:\(credentialsURL.path)")
+        guard FileManager.default.fileExists(atPath: credentialsURL.path) else {
+            diagLog.append("file:not_found")
+            return (nil, CredentialStatusValue.notFound.rawValue, "diag: \(diagLog.joined(separator: "; "))")
+        }
+
+        do {
+            let content = try String(contentsOf: credentialsURL, encoding: .utf8)
+            return parseClaudeCredentialsJSON(content)
+        } catch {
+            return (nil, CredentialStatusValue.parseError.rawValue, "Failed to read Claude credentials: \(error.localizedDescription)")
+        }
+    }
+
+    static func readCodexCredentials() -> (accessToken: String?, accountId: String?, status: String, message: String?) {
+        var diagLog: [String] = []
+        if let keychain = readKeychainPassword(service: "Codex Auth", diag: &diagLog) {
+            return parseCodexCredentialsJSON(keychain)
+        }
+
+        let authURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex")
+            .appendingPathComponent("auth.json")
+
+        guard FileManager.default.fileExists(atPath: authURL.path) else {
+            return (nil, nil, CredentialStatusValue.notFound.rawValue, nil)
+        }
+
+        do {
+            let content = try String(contentsOf: authURL, encoding: .utf8)
+            return parseCodexCredentialsJSON(content)
+        } catch {
+            return (nil, nil, CredentialStatusValue.parseError.rawValue, "Failed to read Codex auth: \(error.localizedDescription)")
+        }
+    }
+
+    private static func readKeychainPassword(service: String, diag: inout [String]) -> String? {
+        // Allow the system to show a Keychain access prompt if needed
+        SecKeychainSetUserInteractionAllowed(true)
+
+        // Approach 1: SecKeychainFindGenericPassword with explicit login keychain
+        let keychainPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Keychains/login.keychain-db").path
+
+        var loginKeychain: SecKeychain?
+        let openStatus = SecKeychainOpen(keychainPath, &loginKeychain)
+        diag.append("kc_open:\(openStatus)")
+
+        if openStatus == errSecSuccess, let keychain = loginKeychain {
+            var passwordLength: UInt32 = 0
+            var passwordData: UnsafeMutableRawPointer?
+            let findStatus = SecKeychainFindGenericPassword(
+                keychain,
+                UInt32(service.utf8.count), service,
+                0, nil,
+                &passwordLength, &passwordData,
+                nil
+            )
+            diag.append("kc_find:\(findStatus)")
+
+            if findStatus == errSecSuccess, let data = passwordData {
+                let value = String(
+                    bytesNoCopy: data,
+                    length: Int(passwordLength),
+                    encoding: .utf8,
+                    freeWhenDone: false
+                )?.trimmingCharacters(in: .whitespacesAndNewlines)
+                SecKeychainItemFreeContent(nil, data)
+                if let value, !value.isEmpty { return value }
+            }
+        }
+
+        // Approach 2: SecItemCopyMatching default search list
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        diag.append("si_copy:\(status)")
+
+        if status == errSecSuccess, let data = result as? Data {
+            let value = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let value, !value.isEmpty { return value }
+        }
+
+        return nil
+    }
+
+    private static func parseClaudeCredentialsJSON(_ content: String) -> (accessToken: String?, status: String, message: String?) {
+        guard
+            let data = content.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return (nil, CredentialStatusValue.parseError.rawValue, "Failed to parse Claude credentials JSON")
+        }
+
+        guard let oauth = object["claudeAiOauth"] as? [String: Any]
+            ?? object["claude.ai_oauth"] as? [String: Any]
+        else {
+            return (nil, CredentialStatusValue.parseError.rawValue, "No Claude OAuth entry found")
+        }
+
+        guard let accessToken = oauth["accessToken"] as? String, !accessToken.isEmpty else {
+            return (nil, CredentialStatusValue.parseError.rawValue, "Claude accessToken is missing")
+        }
+
+        if let expiresAt = oauth["expiresAt"], isExpired(expiresAt) {
+            return (accessToken, CredentialStatusValue.expired.rawValue, "Claude OAuth token has expired")
+        }
+
+        return (accessToken, CredentialStatusValue.valid.rawValue, nil)
+    }
+
+    private static func parseCodexCredentialsJSON(_ content: String) -> (accessToken: String?, accountId: String?, status: String, message: String?) {
+        guard
+            let data = content.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return (nil, nil, CredentialStatusValue.parseError.rawValue, "Failed to parse Codex auth JSON")
+        }
+
+        guard object["auth_mode"] as? String == "chatgpt" else {
+            return (nil, nil, CredentialStatusValue.notFound.rawValue, "Codex is not using ChatGPT OAuth mode")
+        }
+
+        guard let tokens = object["tokens"] as? [String: Any] else {
+            return (nil, nil, CredentialStatusValue.parseError.rawValue, "No Codex tokens found")
+        }
+
+        guard let accessToken = tokens["access_token"] as? String, !accessToken.isEmpty else {
+            return (nil, nil, CredentialStatusValue.parseError.rawValue, "Codex access_token is missing")
+        }
+
+        let accountId = tokens["account_id"] as? String
+        if let lastRefresh = object["last_refresh"] as? String, isCodexTokenStale(lastRefresh) {
+            return (accessToken, accountId, CredentialStatusValue.expired.rawValue, "Codex token may be stale")
+        }
+
+        return (accessToken, accountId, CredentialStatusValue.valid.rawValue, nil)
+    }
+
+    private static func isExpired(_ value: Any) -> Bool {
+        let now = Date()
+
+        if let number = value as? NSNumber {
+            let raw = number.doubleValue
+            let seconds = raw > 1_000_000_000_000 ? raw / 1_000 : raw
+            return Date(timeIntervalSince1970: seconds) < now
+        }
+
+        if let string = value as? String, let date = parseDate(string) {
+            return date < now
+        }
+
+        return false
+    }
+
+    private static func isCodexTokenStale(_ lastRefresh: String) -> Bool {
+        guard let date = parseDate(lastRefresh) else { return false }
+        return Date().timeIntervalSince(date) > 8 * 24 * 60 * 60
+    }
+
+    private static func parseDate(_ string: String) -> Date? {
+        if let date = ISO8601DateFormatter.withFractionalSeconds.date(from: string) {
+            return date
+        }
+        return ISO8601DateFormatter.standard.date(from: string)
+    }
+}
+
+private enum CredentialStatusValue: String {
+    case valid
+    case expired
+    case notFound = "not_found"
+    case parseError = "parse_error"
+}
+
+private extension ISO8601DateFormatter {
+    static let standard: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    static let withFractionalSeconds: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}

--- a/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
@@ -11,6 +11,15 @@ import IOKit
 import CoreGraphics
 
 class BoringNotchXPCHelper: NSObject, BoringNotchXPCHelperProtocol {
+    @objc func readClaudeCredentials(with reply: @escaping (String?, String?, String?) -> Void) {
+        let credentials = AICredentialReader.readClaudeCredentials()
+        reply(credentials.accessToken, credentials.status, credentials.message)
+    }
+
+    @objc func readCodexCredentials(with reply: @escaping (String?, String?, String?, String?) -> Void) {
+        let credentials = AICredentialReader.readCodexCredentials()
+        reply(credentials.accessToken, credentials.accountId, credentials.status, credentials.message)
+    }
     
     @objc func isAccessibilityAuthorized(with reply: @escaping (Bool) -> Void) {
         reply(AXIsProcessTrusted())

--- a/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
@@ -20,6 +20,9 @@ import Foundation
     func isScreenBrightnessAvailable(with reply: @escaping (Bool) -> Void)
     func currentScreenBrightness(with reply: @escaping (NSNumber?) -> Void)
     func setScreenBrightness(_ value: Float, with reply: @escaping (Bool) -> Void)
+    // AI CLI credential access (performed by the unsandboxed helper)
+    func readClaudeCredentials(with reply: @escaping (String?, String?, String?) -> Void)
+    func readCodexCredentials(with reply: @escaping (String?, String?, String?, String?) -> Void)
 }
 
 /*

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -142,6 +142,11 @@
 		B1F0A0022E60000100000001 /* BrightnessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0A0012E60000100000001 /* BrightnessManager.swift */; };
 		B1F747F92EC7E94000F841DB /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F747F82EC7E94000F841DB /* LottieView.swift */; };
 		B1FEB4992C7686630066EBBC /* PanGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FEB4982C7686630066EBBC /* PanGesture.swift */; };
+		C0DE00022F01000000000002 /* AIQuotaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00012F01000000000001 /* AIQuotaModels.swift */; };
+		C0DE00042F01000000000004 /* AIQuotaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00032F01000000000003 /* AIQuotaManager.swift */; };
+		C0DE00072F01000000000007 /* AIQuotaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00062F01000000000006 /* AIQuotaView.swift */; };
+		C0DE00092F01000000000009 /* QuotaCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00082F01000000000008 /* QuotaCardView.swift */; };
+		C0DE000B2F0100000000000B /* QuotaProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE000A2F0100000000000A /* QuotaProgressBar.swift */; };
 		F38DE6482D8243E7008B5C6D /* BatteryActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -308,6 +313,11 @@
 		B1F0A0012E60000100000001 /* BrightnessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrightnessManager.swift; sourceTree = "<group>"; };
 		B1F747F82EC7E94000F841DB /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
 		B1FEB4982C7686630066EBBC /* PanGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanGesture.swift; sourceTree = "<group>"; };
+		C0DE00012F01000000000001 /* AIQuotaModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIQuotaModels.swift; sourceTree = "<group>"; };
+		C0DE00032F01000000000003 /* AIQuotaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIQuotaManager.swift; sourceTree = "<group>"; };
+		C0DE00062F01000000000006 /* AIQuotaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIQuotaView.swift; sourceTree = "<group>"; };
+		C0DE00082F01000000000008 /* QuotaCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotaCardView.swift; sourceTree = "<group>"; };
+		C0DE000A2F0100000000000A /* QuotaProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotaProgressBar.swift; sourceTree = "<group>"; };
 		F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryActivityManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -489,6 +499,7 @@
 				B141C23B2CA5F50900AC8CC8 /* Onboarding */,
 				B1C448992C97375A001F0858 /* Tips */,
 				14C08BB72C8DE49E000F8AA0 /* Calendar */,
+				C0DE00052F01000000000005 /* AIQuota */,
 				9A987A042C73CA66005CA465 /* Shelf */,
 				149E0B982C737D26006418B1 /* Webcam */,
 				B18654312C6F45AE000B926A /* Live activities */,
@@ -518,6 +529,7 @@
 				14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */,
 				B1F0A0012E60000100000001 /* BrightnessManager.swift */,
 				59D8C23B2E589FAA00147B33 /* VolumeManager.swift */,
+				C0DE00032F01000000000003 /* AIQuotaManager.swift */,
 			);
 			path = managers;
 			sourceTree = "<group>";
@@ -536,6 +548,16 @@
 				14C08BB82C8DE4B1000F8AA0 /* BoringCalendar.swift */,
 			);
 			path = Calendar;
+			sourceTree = "<group>";
+		};
+		C0DE00052F01000000000005 /* AIQuota */ = {
+			isa = PBXGroup;
+			children = (
+				C0DE00062F01000000000006 /* AIQuotaView.swift */,
+				C0DE00082F01000000000008 /* QuotaCardView.swift */,
+				C0DE000A2F0100000000000A /* QuotaProgressBar.swift */,
+			);
+			path = AIQuota;
 			sourceTree = "<group>";
 		};
 		14CEF4092C5CAED200855D72 = {
@@ -630,6 +652,7 @@
 				118D1FD02E98FF5F00A2FF63 /* SharingStateManager.swift */,
 				1163988E2DF5CC870052E6AF /* CalendarModel.swift */,
 				1163988C2DF5CAB40052E6AF /* EventModel.swift */,
+				C0DE00012F01000000000001 /* AIQuotaModels.swift */,
 				B19016232CC15B4D00E3F12E /* Constants.swift */,
 				14D570C82C5F38890011E668 /* BoringViewModel.swift */,
 				14D570CA2C5F4B2C0011E668 /* BatteryStatusViewModel.swift */,
@@ -906,6 +929,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				115C12EC2ED3D003009754CA /* OpenNotchHUD.swift in Sources */,
+				C0DE00022F01000000000002 /* AIQuotaModels.swift in Sources */,
+				C0DE00042F01000000000004 /* AIQuotaManager.swift in Sources */,
+				C0DE00072F01000000000007 /* AIQuotaView.swift in Sources */,
+				C0DE00092F01000000000009 /* QuotaCardView.swift in Sources */,
+				C0DE000B2F0100000000000B /* QuotaProgressBar.swift in Sources */,
 				14C08BB92C8DE4B1000F8AA0 /* BoringCalendar.swift in Sources */,
 				5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */,
 				1100292A2E8691B400035A57 /* FileShareView.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -349,6 +349,8 @@ struct ContentView: View {
                         NotchHomeView(albumArtNamespace: albumArtNamespace)
                     case .shelf:
                         ShelfView()
+                    case .quota:
+                        AIQuotaView()
                     }
                 }
                 .transition(

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -2202,6 +2202,9 @@
         }
       }
     },
+    "AI Quota" : {
+
+    },
     "All-day" : {
       "localizations" : {
         "ar" : {
@@ -12009,6 +12012,9 @@
         }
       }
     },
+    "Loading" : {
+
+    },
     "Lottie JSON URL" : {
       "localizations" : {
         "ar" : {
@@ -16910,6 +16916,9 @@
         }
       }
     },
+    "Refresh AI quota" : {
+
+    },
     "Release name" : {
       "localizations" : {
         "ar" : {
@@ -17710,6 +17719,9 @@
         }
       }
     },
+    "Reset time unavailable" : {
+
+    },
     "Reset to Defaults" : {
       "localizations" : {
         "ar" : {
@@ -17809,6 +17821,9 @@
           }
         }
       }
+    },
+    "Resets in %@" : {
+
     },
     "Restart" : {
       "extractionState" : "stale",
@@ -18711,6 +18726,9 @@
           }
         }
       }
+    },
+    "Show AI quota (Claude & Codex)" : {
+
     },
     "Show battery indicator" : {
       "localizations" : {

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -22133,6 +22133,9 @@
         }
       }
     },
+    "Updated %@ ago" : {
+
+    },
     "Upgrade to Pro" : {
       "localizations" : {
         "ar" : {

--- a/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
+++ b/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
@@ -20,5 +20,7 @@ import Foundation
     func isScreenBrightnessAvailable(with reply: @escaping (Bool) -> Void)
     func currentScreenBrightness(with reply: @escaping (NSNumber?) -> Void)
     func setScreenBrightness(_ value: Float, with reply: @escaping (Bool) -> Void)
+    // AI CLI credential access (performed by the unsandboxed helper)
+    func readClaudeCredentials(with reply: @escaping (String?, String?, String?) -> Void)
+    func readCodexCredentials(with reply: @escaping (String?, String?, String?, String?) -> Void)
 }
-

--- a/boringNotch/XPCHelperClient/XPCHelperClient.swift
+++ b/boringNotch/XPCHelperClient/XPCHelperClient.swift
@@ -241,10 +241,41 @@ final class XPCHelperClient: NSObject {
             return false
         }
     }
+
+    // MARK: - AI CLI Credentials
+
+    nonisolated func readClaudeCredentials() async -> (accessToken: String?, status: String, message: String?) {
+        do {
+            let service = await MainActor.run {
+                ensureRemoteService()
+            }
+            return try await service.withContinuation { service, continuation in
+                service.readClaudeCredentials { accessToken, status, message in
+                    continuation.resume(returning: (accessToken, status ?? "parse_error", message))
+                }
+            }
+        } catch {
+            return (nil, "parse_error", error.localizedDescription)
+        }
+    }
+
+    nonisolated func readCodexCredentials() async -> (accessToken: String?, accountId: String?, status: String, message: String?) {
+        do {
+            let service = await MainActor.run {
+                ensureRemoteService()
+            }
+            return try await service.withContinuation { service, continuation in
+                service.readCodexCredentials { accessToken, accountId, status, message in
+                    continuation.resume(returning: (accessToken, accountId, status ?? "parse_error", message))
+                }
+            }
+        } catch {
+            return (nil, nil, "parse_error", error.localizedDescription)
+        }
+    }
 }
 
 extension Notification.Name {
     static let accessibilityAuthorizationChanged = Notification.Name("accessibilityAuthorizationChanged")
 }
-
 

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -26,6 +26,7 @@ struct DynamicNotchApp: App {
 
         // Initialize the settings window controller with the updater controller
         SettingsWindowController.shared.setUpdaterController(updaterController)
+        _ = AIQuotaManager.shared
     }
 
     var body: some Scene {

--- a/boringNotch/components/AIQuota/AIQuotaView.swift
+++ b/boringNotch/components/AIQuota/AIQuotaView.swift
@@ -1,0 +1,52 @@
+//
+//  AIQuotaView.swift
+//  boringNotch
+//
+
+import SwiftUI
+
+struct AIQuotaView: View {
+    @ObservedObject private var quotaManager = AIQuotaManager.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("AI Quota")
+                    .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.white)
+                Spacer()
+                Button {
+                    Task {
+                        await quotaManager.fetchAll()
+                    }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 12, weight: .semibold))
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(quotaManager.isLoading ? Color.secondary : Color.white)
+                .disabled(quotaManager.isLoading)
+                .help("Refresh AI quota")
+            }
+
+            HStack(spacing: 12) {
+                QuotaCardView(
+                    provider: .claude,
+                    result: quotaManager.claudeQuota,
+                    isLoading: quotaManager.isLoading
+                )
+                QuotaCardView(
+                    provider: .codex,
+                    result: quotaManager.codexQuota,
+                    isLoading: quotaManager.isLoading
+                )
+            }
+            .frame(maxHeight: .infinity)
+        }
+        .padding(.horizontal, 6)
+        .padding(.top, 4)
+        .padding(.bottom, 8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/boringNotch/components/AIQuota/QuotaCardView.swift
+++ b/boringNotch/components/AIQuota/QuotaCardView.swift
@@ -80,7 +80,7 @@ struct QuotaCardView: View {
                         .foregroundStyle(.secondary)
                         .frame(width: 42, alignment: .leading)
                     QuotaProgressBar(utilization: tier.utilization)
-                    Text("\(Int(tier.utilization.rounded()))%")
+                    Text("\(Int(floor(tier.utilization)))%")
                         .font(.system(size: 11, weight: .semibold, design: .rounded))
                         .foregroundStyle(.white)
                         .monospacedDigit()
@@ -92,16 +92,25 @@ struct QuotaCardView: View {
 
     @ViewBuilder
     private func resetText(_ tiers: [QuotaTier]) -> some View {
-        if let nextReset = tiers.compactMap(\.resetsAt).filter({ $0 > Date() }).min() {
-            Text("Resets in \(relativeResetTime(nextReset))")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-        } else {
-            Text("Reset time unavailable")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
+        VStack(alignment: .leading, spacing: 2) {
+            if let nextReset = tiers.compactMap(\.resetsAt).filter({ $0 > Date() }).min() {
+                Text("Resets in \(relativeResetTime(nextReset))")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            } else {
+                Text("Reset time unavailable")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            if let queriedAt = result?.queriedAt {
+                Text("Updated \(queriedAt, style: .relative) ago")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.quaternary)
+                    .lineLimit(1)
+            }
         }
     }
 

--- a/boringNotch/components/AIQuota/QuotaCardView.swift
+++ b/boringNotch/components/AIQuota/QuotaCardView.swift
@@ -1,0 +1,177 @@
+//
+//  QuotaCardView.swift
+//  boringNotch
+//
+
+import SwiftUI
+
+struct QuotaCardView: View {
+    let provider: AIProvider
+    let result: AIQuotaResult?
+    let isLoading: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+
+            if isLoading && result == nil {
+                loadingState
+            } else if let result, result.success {
+                quotaRows(result.tiers)
+                resetText(result.tiers)
+            } else {
+                statusState(result)
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Color.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    private var header: some View {
+        HStack(spacing: 7) {
+            Image(systemName: provider.iconName)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.white)
+            Text(provider.displayName)
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white)
+            Spacer(minLength: 0)
+            statusDot
+        }
+    }
+
+    @ViewBuilder
+    private var statusDot: some View {
+        if let result, result.success {
+            Circle()
+                .fill(Color.green)
+                .frame(width: 7, height: 7)
+        } else if result != nil {
+            Circle()
+                .fill(Color.orange)
+                .frame(width: 7, height: 7)
+        }
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: 8) {
+            Spacer(minLength: 12)
+            ProgressView()
+                .controlSize(.small)
+            Text("Loading")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func quotaRows(_ tiers: [QuotaTier]) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            ForEach(tiers.prefix(4)) { tier in
+                HStack(spacing: 8) {
+                    Text(tierLabel(tier.name))
+                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 42, alignment: .leading)
+                    QuotaProgressBar(utilization: tier.utilization)
+                    Text("\(Int(tier.utilization.rounded()))%")
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.white)
+                        .monospacedDigit()
+                        .frame(width: 34, alignment: .trailing)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func resetText(_ tiers: [QuotaTier]) -> some View {
+        if let nextReset = tiers.compactMap(\.resetsAt).filter({ $0 > Date() }).min() {
+            Text("Resets in \(relativeResetTime(nextReset))")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        } else {
+            Text("Reset time unavailable")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private func statusState(_ result: AIQuotaResult?) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Spacer(minLength: 12)
+            Text(statusTitle(result))
+                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white)
+            Text(statusMessage(result))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func tierLabel(_ name: String) -> String {
+        switch name {
+        case "five_hour":
+            return "5h"
+        case "seven_day":
+            return "7d"
+        case "seven_day_opus":
+            return "Opus"
+        case "seven_day_sonnet":
+            return "Sonnet"
+        default:
+            return name.replacingOccurrences(of: "_", with: " ")
+        }
+    }
+
+    private func relativeResetTime(_ date: Date) -> String {
+        Self.resetFormatter.string(from: Date(), to: date) ?? "--"
+    }
+
+    private func statusTitle(_ result: AIQuotaResult?) -> String {
+        switch result?.credentialStatus {
+        case .notFound:
+            return "Credentials not found"
+        case .expired:
+            return "Token expired"
+        case .parseError:
+            return "Credentials unreadable"
+        case .valid:
+            return "Usage unavailable"
+        case nil:
+            return "No data"
+        }
+    }
+
+    private func statusMessage(_ result: AIQuotaResult?) -> String {
+        if let error = result?.error, !error.isEmpty {
+            return error
+        }
+
+        switch provider {
+        case .claude:
+            return "Run claude to login again."
+        case .codex:
+            return "Run codex login with ChatGPT auth."
+        }
+    }
+
+    private static let resetFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.day, .hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        formatter.maximumUnitCount = 2
+        return formatter
+    }()
+}

--- a/boringNotch/components/AIQuota/QuotaProgressBar.swift
+++ b/boringNotch/components/AIQuota/QuotaProgressBar.swift
@@ -1,0 +1,38 @@
+//
+//  QuotaProgressBar.swift
+//  boringNotch
+//
+
+import SwiftUI
+
+struct QuotaProgressBar: View {
+    let utilization: Double
+
+    private var progress: CGFloat {
+        CGFloat(min(max(utilization, 0), 100) / 100)
+    }
+
+    private var progressColor: Color {
+        switch utilization {
+        case ..<50:
+            return .green
+        case ..<80:
+            return .yellow
+        default:
+            return .red
+        }
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.white.opacity(0.12))
+                Capsule()
+                    .fill(progressColor)
+                    .frame(width: geometry.size.width * progress)
+            }
+        }
+        .frame(height: 6)
+    }
+}

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -16,7 +16,7 @@ struct BoringHeader: View {
     var body: some View {
         HStack(spacing: 0) {
             HStack {
-                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
+                if Defaults[.showAIQuota] || ((!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf]) {
                     TabSelectionView()
                 } else if vm.notchState == .open {
                     EmptyView()

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -1390,6 +1390,9 @@ struct Appearance: View {
                 Defaults.Toggle(key: .showNotHumanFace) {
                     Text("Show cool face animation while inactive")
                 }
+                Defaults.Toggle(key: .showAIQuota) {
+                    Text("Show AI quota (Claude & Codex)")
+                }
             } header: {
                 HStack {
                     Text("Additional features")

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -5,29 +5,42 @@
 //  Created by Hugo Persson on 2024-08-25.
 //
 
+import Defaults
 import SwiftUI
 
 struct TabModel: Identifiable {
-    let id = UUID()
+    var id: NotchViews { view }
     let label: String
     let icon: String
     let view: NotchViews
 }
 
-let tabs = [
-    TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
-]
-
 struct TabSelectionView: View {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     @Namespace var animation
+
+    private var tabs: [TabModel] {
+        var items = [TabModel(label: "Home", icon: "house.fill", view: .home)]
+        if Defaults[.boringShelf] {
+            items.append(TabModel(label: "Shelf", icon: "tray.fill", view: .shelf))
+        }
+        if Defaults[.showAIQuota] {
+            items.append(TabModel(label: "AI", icon: "chart.bar.fill", view: .quota))
+        }
+        return items
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             ForEach(tabs) { tab in
                     TabButton(label: tab.label, icon: tab.icon, selected: coordinator.currentView == tab.view) {
                         withAnimation(.smooth) {
                             coordinator.currentView = tab.view
+                        }
+                        if tab.view == .quota {
+                            Task {
+                                await AIQuotaManager.shared.fetchAll()
+                            }
                         }
                     }
                     .frame(height: 26)

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -24,9 +24,10 @@ public enum NotchState {
     case open
 }
 
-public enum NotchViews {
+public enum NotchViews: Hashable {
     case home
     case shelf
+    case quota
 }
 
 enum SettingsEnum {

--- a/boringNotch/managers/AIQuotaManager.swift
+++ b/boringNotch/managers/AIQuotaManager.swift
@@ -18,6 +18,7 @@ final class AIQuotaManager: ObservableObject {
 
     private var refreshTask: Task<Void, Never>?
     private var defaultsCancellable: AnyCancellable?
+    private var refreshPolicy = AIQuotaRefreshPolicy()
 
     private init() {
         defaultsCancellable = Defaults.publisher(.showAIQuota)
@@ -49,7 +50,7 @@ final class AIQuotaManager: ObservableObject {
 
             while !Task.isCancelled {
                 do {
-                    try await Task.sleep(for: .seconds(300))
+                    try await Task.sleep(for: .seconds(120))
                 } catch {
                     return
                 }
@@ -72,17 +73,42 @@ final class AIQuotaManager: ObservableObject {
         async let claude = fetchClaudeQuota()
         async let codex = fetchCodexQuota()
 
-        claudeQuota = await claude
-        codexQuota = await codex
+        let newClaude = await claude
+        let newCodex = await codex
+
+        if newClaude.success || claudeQuota == nil {
+            claudeQuota = newClaude
+        }
+        if newCodex.success || codexQuota == nil {
+            codexQuota = newCodex
+        }
         isLoading = false
     }
 
     func fetchClaudeQuota() async -> AIQuotaResult {
-        // Try reading from Keychain directly in the main app (GUI app can show auth prompt)
+        if !refreshPolicy.canRequest(.claude),
+           let message = refreshPolicy.blockMessage(for: .claude) {
+            print("[AIQuota] Claude: skipping usage fetch, \(message)")
+            return .unavailable(
+                provider: .claude,
+                status: .valid,
+                message: message
+            )
+        }
+
+        // Try XPC helper first (file-based, no password prompt)
+        let credentials = await XPCHelperClient.shared.readClaudeCredentials()
+        let credentialStatus = CredentialStatus(rawStatus: credentials.status)
+        print("[AIQuota] Claude credentials via XPC: status=\(credentials.status), hasToken=\(credentials.accessToken != nil), message=\(credentials.message ?? "nil")")
+
+        if let token = credentials.accessToken, !token.isEmpty {
+            return await fetchClaudeUsage(token: token, credentialStatus: credentialStatus)
+        }
+
+        // Fall back to Keychain (may trigger macOS password prompt on unsigned builds)
         let keychainToken = Self.readKeychainPasswordFromMainApp(service: "Claude Code-credentials")
         if let keychainToken, !keychainToken.isEmpty {
             print("[AIQuota] Claude: got token from main-app Keychain read")
-            // Parse the JSON to extract the actual access token
             if let data = keychainToken.data(using: .utf8),
                let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let oauth = object["claudeAiOauth"] as? [String: Any] ?? object["claude.ai_oauth"] as? [String: Any],
@@ -91,20 +117,11 @@ final class AIQuotaManager: ObservableObject {
             }
         }
 
-        // Fall back to XPC helper (file-based reading)
-        let credentials = await XPCHelperClient.shared.readClaudeCredentials()
-        let credentialStatus = CredentialStatus(rawStatus: credentials.status)
-        print("[AIQuota] Claude credentials via XPC: status=\(credentials.status), hasToken=\(credentials.accessToken != nil), message=\(credentials.message ?? "nil")")
-
-        guard let token = credentials.accessToken, !token.isEmpty else {
-            return .unavailable(
-                provider: .claude,
-                status: credentialStatus,
-                message: credentials.message
-            )
-        }
-
-        return await fetchClaudeUsage(token: token, credentialStatus: credentialStatus)
+        return .unavailable(
+            provider: .claude,
+            status: credentialStatus,
+            message: credentials.message
+        )
     }
 
     private func fetchClaudeUsage(token: String, credentialStatus: CredentialStatus) async -> AIQuotaResult {
@@ -116,9 +133,28 @@ final class AIQuotaManager: ObservableObject {
 
         do {
             let data = try await data(for: request, provider: .claude)
-            return try AIQuotaParser.decodeClaudeQuota(from: data)
+            let result = try AIQuotaParser.decodeClaudeQuota(from: data)
+            refreshPolicy.recordSuccess(.claude)
+            return result
         } catch let error as AIQuotaRequestError {
-            return error.result(provider: .claude, fallbackStatus: credentialStatus)
+            switch error {
+            case .rateLimited(let retryAfter):
+                refreshPolicy.recordRateLimit(.claude, retryAfter: retryAfter)
+                return .unavailable(
+                    provider: .claude,
+                    status: credentialStatus,
+                    message: refreshPolicy.blockMessage(for: .claude) ?? "Rate limited. Will retry shortly."
+                )
+            case .expired:
+                refreshPolicy.recordAuthFailure(.claude)
+                return .unavailable(
+                    provider: .claude,
+                    status: .expired,
+                    message: refreshPolicy.blockMessage(for: .claude) ?? "Token expired. Re-login with CLI."
+                )
+            case .api:
+                return error.result(provider: .claude, fallbackStatus: credentialStatus)
+            }
         } catch {
             return .unavailable(
                 provider: .claude,
@@ -169,9 +205,16 @@ final class AIQuotaManager: ObservableObject {
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw AIQuotaRequestError.api("Invalid response")
             }
+            print("[AIQuota] \(provider.displayName): usage HTTP \(httpResponse.statusCode)")
 
             if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
                 throw AIQuotaRequestError.expired("Authentication failed. Re-login with \(provider.displayName) CLI.")
+            }
+
+            if httpResponse.statusCode == 429 {
+                let retryAfter = httpResponse.value(forHTTPHeaderField: "Retry-After")
+                    .flatMap(Int.init)
+                throw AIQuotaRequestError.rateLimited(retryAfter: retryAfter)
             }
 
             guard (200..<300).contains(httpResponse.statusCode) else {
@@ -212,6 +255,12 @@ final class AIQuotaManager: ObservableObject {
 private enum AIQuotaRequestError: Error {
     case expired(String)
     case api(String)
+    case rateLimited(retryAfter: Int?)
+
+    var isTransient: Bool {
+        if case .rateLimited = self { return true }
+        return false
+    }
 
     func result(provider: AIProvider, fallbackStatus: CredentialStatus) -> AIQuotaResult {
         switch self {
@@ -219,6 +268,8 @@ private enum AIQuotaRequestError: Error {
             return .unavailable(provider: provider, status: .expired, message: message)
         case .api(let message):
             return .unavailable(provider: provider, status: fallbackStatus, message: message)
+        case .rateLimited:
+            return .unavailable(provider: provider, status: fallbackStatus, message: "Rate limited. Will retry shortly.")
         }
     }
 }

--- a/boringNotch/managers/AIQuotaManager.swift
+++ b/boringNotch/managers/AIQuotaManager.swift
@@ -257,11 +257,6 @@ private enum AIQuotaRequestError: Error {
     case api(String)
     case rateLimited(retryAfter: Int?)
 
-    var isTransient: Bool {
-        if case .rateLimited = self { return true }
-        return false
-    }
-
     func result(provider: AIProvider, fallbackStatus: CredentialStatus) -> AIQuotaResult {
         switch self {
         case .expired(let message):

--- a/boringNotch/managers/AIQuotaManager.swift
+++ b/boringNotch/managers/AIQuotaManager.swift
@@ -1,0 +1,231 @@
+//
+//  AIQuotaManager.swift
+//  boringNotch
+//
+
+import Combine
+import Defaults
+import Foundation
+import Security
+
+@MainActor
+final class AIQuotaManager: ObservableObject {
+    static let shared = AIQuotaManager()
+
+    @Published var claudeQuota: AIQuotaResult?
+    @Published var codexQuota: AIQuotaResult?
+    @Published var isLoading = false
+
+    private var refreshTask: Task<Void, Never>?
+    private var defaultsCancellable: AnyCancellable?
+
+    private init() {
+        defaultsCancellable = Defaults.publisher(.showAIQuota)
+            .sink { [weak self] change in
+                Task { @MainActor in
+                    if change.newValue {
+                        self?.startAutoRefresh()
+                    } else {
+                        self?.stopAutoRefresh()
+                        if BoringViewCoordinator.shared.currentView == .quota {
+                            BoringViewCoordinator.shared.currentView = .home
+                        }
+                    }
+                }
+            }
+
+        if Defaults[.showAIQuota] {
+            startAutoRefresh()
+        }
+    }
+
+    func startAutoRefresh() {
+        guard Defaults[.showAIQuota] else { return }
+
+        refreshTask?.cancel()
+        refreshTask = Task { [weak self] in
+            guard let self else { return }
+            await self.fetchAll()
+
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(300))
+                } catch {
+                    return
+                }
+
+                guard !Task.isCancelled else { return }
+                await self.fetchAll()
+            }
+        }
+    }
+
+    func stopAutoRefresh() {
+        refreshTask?.cancel()
+        refreshTask = nil
+    }
+
+    func fetchAll() async {
+        guard Defaults[.showAIQuota] else { return }
+
+        isLoading = true
+        async let claude = fetchClaudeQuota()
+        async let codex = fetchCodexQuota()
+
+        claudeQuota = await claude
+        codexQuota = await codex
+        isLoading = false
+    }
+
+    func fetchClaudeQuota() async -> AIQuotaResult {
+        // Try reading from Keychain directly in the main app (GUI app can show auth prompt)
+        let keychainToken = Self.readKeychainPasswordFromMainApp(service: "Claude Code-credentials")
+        if let keychainToken, !keychainToken.isEmpty {
+            print("[AIQuota] Claude: got token from main-app Keychain read")
+            // Parse the JSON to extract the actual access token
+            if let data = keychainToken.data(using: .utf8),
+               let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let oauth = object["claudeAiOauth"] as? [String: Any] ?? object["claude.ai_oauth"] as? [String: Any],
+               let accessToken = oauth["accessToken"] as? String, !accessToken.isEmpty {
+                return await fetchClaudeUsage(token: accessToken, credentialStatus: .valid)
+            }
+        }
+
+        // Fall back to XPC helper (file-based reading)
+        let credentials = await XPCHelperClient.shared.readClaudeCredentials()
+        let credentialStatus = CredentialStatus(rawStatus: credentials.status)
+        print("[AIQuota] Claude credentials via XPC: status=\(credentials.status), hasToken=\(credentials.accessToken != nil), message=\(credentials.message ?? "nil")")
+
+        guard let token = credentials.accessToken, !token.isEmpty else {
+            return .unavailable(
+                provider: .claude,
+                status: credentialStatus,
+                message: credentials.message
+            )
+        }
+
+        return await fetchClaudeUsage(token: token, credentialStatus: credentialStatus)
+    }
+
+    private func fetchClaudeUsage(token: String, credentialStatus: CredentialStatus) async -> AIQuotaResult {
+        var request = URLRequest(url: URL(string: "https://api.anthropic.com/api/oauth/usage")!)
+        request.timeoutInterval = 10
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        do {
+            let data = try await data(for: request, provider: .claude)
+            return try AIQuotaParser.decodeClaudeQuota(from: data)
+        } catch let error as AIQuotaRequestError {
+            return error.result(provider: .claude, fallbackStatus: credentialStatus)
+        } catch {
+            return .unavailable(
+                provider: .claude,
+                status: credentialStatus,
+                message: "Failed to parse Claude usage: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    func fetchCodexQuota() async -> AIQuotaResult {
+        let credentials = await XPCHelperClient.shared.readCodexCredentials()
+        let credentialStatus = CredentialStatus(rawStatus: credentials.status)
+
+        guard let token = credentials.accessToken, !token.isEmpty else {
+            return .unavailable(
+                provider: .codex,
+                status: credentialStatus,
+                message: credentials.message
+            )
+        }
+
+        var request = URLRequest(url: URL(string: "https://chatgpt.com/backend-api/wham/usage")!)
+        request.timeoutInterval = 10
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("codex-cli", forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let accountId = credentials.accountId, !accountId.isEmpty {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+
+        do {
+            let data = try await data(for: request, provider: .codex)
+            return try AIQuotaParser.decodeCodexQuota(from: data)
+        } catch let error as AIQuotaRequestError {
+            return error.result(provider: .codex, fallbackStatus: credentialStatus)
+        } catch {
+            return .unavailable(
+                provider: .codex,
+                status: credentialStatus,
+                message: "Failed to parse Codex usage: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func data(for request: URLRequest, provider: AIProvider) async throws -> Data {
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw AIQuotaRequestError.api("Invalid response")
+            }
+
+            if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+                throw AIQuotaRequestError.expired("Authentication failed. Re-login with \(provider.displayName) CLI.")
+            }
+
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                let body = String(data: data, encoding: .utf8) ?? ""
+                throw AIQuotaRequestError.api("HTTP \(httpResponse.statusCode): \(body.truncatedForDisplay)")
+            }
+
+            return data
+        } catch let error as AIQuotaRequestError {
+            throw error
+        } catch {
+            throw AIQuotaRequestError.api("Network error: \(error.localizedDescription)")
+        }
+    }
+
+    /// Read a Keychain password directly from the main app process.
+    /// GUI apps can trigger the macOS Keychain authorization prompt.
+    private static func readKeychainPasswordFromMainApp(service: String) -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        print("[AIQuota] Main-app Keychain read for '\(service)': OSStatus \(status)")
+
+        guard status == errSecSuccess, let data = result as? Data else {
+            return nil
+        }
+
+        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private enum AIQuotaRequestError: Error {
+    case expired(String)
+    case api(String)
+
+    func result(provider: AIProvider, fallbackStatus: CredentialStatus) -> AIQuotaResult {
+        switch self {
+        case .expired(let message):
+            return .unavailable(provider: provider, status: .expired, message: message)
+        case .api(let message):
+            return .unavailable(provider: provider, status: fallbackStatus, message: message)
+        }
+    }
+}
+
+private extension String {
+    var truncatedForDisplay: String {
+        guard count > 180 else { return self }
+        return String(prefix(180)) + "..."
+    }
+}

--- a/boringNotch/models/AIQuotaModels.swift
+++ b/boringNotch/models/AIQuotaModels.swift
@@ -95,6 +95,52 @@ struct AIQuotaResult: Codable, Equatable {
     }
 }
 
+struct AIQuotaRefreshPolicy {
+    private static let defaultRateLimitBackoff: TimeInterval = 30 * 60
+    private static let authFailureBackoff: TimeInterval = 15 * 60
+
+    private var blockedUntil: [AIProvider: (date: Date, reason: BlockReason)] = [:]
+
+    enum BlockReason {
+        case rateLimited
+        case authFailed
+    }
+
+    func canRequest(_ provider: AIProvider, now: Date = Date()) -> Bool {
+        guard let entry = blockedUntil[provider] else {
+            return true
+        }
+        return now >= entry.date
+    }
+
+    mutating func recordRateLimit(_ provider: AIProvider, retryAfter: Int?, now: Date = Date()) {
+        let delay = TimeInterval(retryAfter ?? Int(Self.defaultRateLimitBackoff))
+        blockedUntil[provider] = (now.addingTimeInterval(max(delay, 1)), .rateLimited)
+    }
+
+    mutating func recordAuthFailure(_ provider: AIProvider, now: Date = Date()) {
+        blockedUntil[provider] = (now.addingTimeInterval(Self.authFailureBackoff), .authFailed)
+    }
+
+    mutating func recordSuccess(_ provider: AIProvider) {
+        blockedUntil[provider] = nil
+    }
+
+    func blockMessage(for provider: AIProvider, now: Date = Date()) -> String? {
+        guard let entry = blockedUntil[provider], entry.date > now else {
+            return nil
+        }
+
+        let minutes = max(1, Int(ceil(entry.date.timeIntervalSince(now) / 60)))
+        switch entry.reason {
+        case .rateLimited:
+            return "Rate limited. Will retry in \(minutes)m."
+        case .authFailed:
+            return "Token expired. Re-login with CLI. Retrying in \(minutes)m."
+        }
+    }
+}
+
 enum AIQuotaParser {
     static let knownClaudeTiers = [
         "five_hour",

--- a/boringNotch/models/AIQuotaModels.swift
+++ b/boringNotch/models/AIQuotaModels.swift
@@ -1,0 +1,252 @@
+//
+//  AIQuotaModels.swift
+//  boringNotch
+//
+
+import Foundation
+
+enum AIProvider: String, Codable, Equatable {
+    case claude
+    case codex
+
+    var displayName: String {
+        switch self {
+        case .claude: return "Claude"
+        case .codex: return "Codex"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .claude: return "cloud.fill"
+        case .codex: return "terminal.fill"
+        }
+    }
+}
+
+enum CredentialStatus: String, Codable, Equatable {
+    case valid
+    case expired
+    case notFound = "not_found"
+    case parseError = "parse_error"
+
+    init(rawStatus: String?) {
+        guard let rawStatus, let status = CredentialStatus(rawValue: rawStatus) else {
+            self = .parseError
+            return
+        }
+        self = status
+    }
+}
+
+struct QuotaTier: Codable, Equatable, Identifiable {
+    let id: UUID
+    let name: String
+    let utilization: Double
+    let resetsAt: Date?
+
+    init(id: UUID = UUID(), name: String, utilization: Double, resetsAt: Date?) {
+        self.id = id
+        self.name = name
+        self.utilization = utilization
+        self.resetsAt = resetsAt
+    }
+}
+
+struct ExtraUsage: Codable, Equatable {
+    let isEnabled: Bool
+    let monthlyLimit: Double?
+    let usedCredits: Double?
+    let utilization: Double?
+    let currency: String?
+
+    enum CodingKeys: String, CodingKey {
+        case isEnabled = "is_enabled"
+        case monthlyLimit = "monthly_limit"
+        case usedCredits = "used_credits"
+        case utilization
+        case currency
+    }
+}
+
+struct AIQuotaResult: Codable, Equatable {
+    let provider: AIProvider
+    let credentialStatus: CredentialStatus
+    let success: Bool
+    let tiers: [QuotaTier]
+    let extraUsage: ExtraUsage?
+    let error: String?
+    let queriedAt: Date?
+
+    static func unavailable(
+        provider: AIProvider,
+        status: CredentialStatus,
+        message: String?
+    ) -> AIQuotaResult {
+        AIQuotaResult(
+            provider: provider,
+            credentialStatus: status,
+            success: false,
+            tiers: [],
+            extraUsage: nil,
+            error: message,
+            queriedAt: Date()
+        )
+    }
+}
+
+enum AIQuotaParser {
+    static let knownClaudeTiers = [
+        "five_hour",
+        "seven_day",
+        "seven_day_opus",
+        "seven_day_sonnet",
+    ]
+
+    static func decodeClaudeQuota(from data: Data) throws -> AIQuotaResult {
+        let json = try JSONSerialization.jsonObject(with: data)
+        guard let object = json as? [String: Any] else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: [], debugDescription: "Expected top-level object")
+            )
+        }
+
+        var tiers: [QuotaTier] = []
+        var seen = Set<String>()
+
+        for tierName in knownClaudeTiers {
+            if let tier = parseClaudeTier(named: tierName, value: object[tierName]) {
+                tiers.append(tier)
+                seen.insert(tierName)
+            }
+        }
+
+        for key in object.keys.sorted() where key != "extra_usage" && !seen.contains(key) {
+            if let tier = parseClaudeTier(named: key, value: object[key]) {
+                tiers.append(tier)
+            }
+        }
+
+        let extraUsage: ExtraUsage?
+        if let extraObject = object["extra_usage"] {
+            let extraData = try JSONSerialization.data(withJSONObject: extraObject)
+            extraUsage = try JSONDecoder().decode(ExtraUsage.self, from: extraData)
+        } else {
+            extraUsage = nil
+        }
+
+        return AIQuotaResult(
+            provider: .claude,
+            credentialStatus: .valid,
+            success: true,
+            tiers: tiers,
+            extraUsage: extraUsage,
+            error: nil,
+            queriedAt: Date()
+        )
+    }
+
+    static func decodeCodexQuota(from data: Data) throws -> AIQuotaResult {
+        let response = try JSONDecoder().decode(CodexUsageResponse.self, from: data)
+        let windows = [
+            response.rateLimit?.primaryWindow,
+            response.rateLimit?.secondaryWindow,
+        ].compactMap { $0 }
+
+        let tiers = windows.compactMap { window -> QuotaTier? in
+            guard let usedPercent = window.usedPercent else { return nil }
+            let name = window.limitWindowSeconds.map(tierName(forWindowSeconds:)) ?? "unknown"
+            return QuotaTier(
+                name: name,
+                utilization: usedPercent,
+                resetsAt: window.resetAt.map { Date(timeIntervalSince1970: TimeInterval($0)) }
+            )
+        }
+
+        return AIQuotaResult(
+            provider: .codex,
+            credentialStatus: .valid,
+            success: true,
+            tiers: tiers,
+            extraUsage: nil,
+            error: nil,
+            queriedAt: Date()
+        )
+    }
+
+    static func tierName(forWindowSeconds seconds: Int) -> String {
+        switch seconds {
+        case 18_000:
+            return "five_hour"
+        case 604_800:
+            return "seven_day"
+        default:
+            let hours = seconds / 3_600
+            if hours >= 24 {
+                return "\(hours / 24)_day"
+            }
+            return "\(hours)_hour"
+        }
+    }
+
+    static func parseDate(_ string: String) -> Date? {
+        if let date = ISO8601DateFormatter.quotaWithFractionalSeconds.date(from: string) {
+            return date
+        }
+        return ISO8601DateFormatter.quota.date(from: string)
+    }
+
+    private static func parseClaudeTier(named name: String, value: Any?) -> QuotaTier? {
+        guard let object = value as? [String: Any] else { return nil }
+        let utilization = object["utilization"] as? Double
+            ?? (object["utilization"] as? NSNumber)?.doubleValue
+        guard let utilization else { return nil }
+
+        let resetsAt = (object["resets_at"] as? String).flatMap(parseDate)
+        return QuotaTier(name: name, utilization: utilization, resetsAt: resetsAt)
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static let quota: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    static let quotaWithFractionalSeconds: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}
+
+private struct CodexUsageResponse: Decodable {
+    let rateLimit: CodexRateLimit?
+
+    enum CodingKeys: String, CodingKey {
+        case rateLimit = "rate_limit"
+    }
+}
+
+private struct CodexRateLimit: Decodable {
+    let primaryWindow: CodexRateLimitWindow?
+    let secondaryWindow: CodexRateLimitWindow?
+
+    enum CodingKeys: String, CodingKey {
+        case primaryWindow = "primary_window"
+        case secondaryWindow = "secondary_window"
+    }
+}
+
+private struct CodexRateLimitWindow: Decodable {
+    let usedPercent: Double?
+    let limitWindowSeconds: Int?
+    let resetAt: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case usedPercent = "used_percent"
+        case limitWindowSeconds = "limit_window_seconds"
+        case resetAt = "reset_at"
+    }
+}

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -107,6 +107,7 @@ extension Defaults.Keys {
     static let showNotHumanFace = Key<Bool>("showNotHumanFace", default: false)
     static let tileShowLabels = Key<Bool>("tileShowLabels", default: false)
     static let showCalendar = Key<Bool>("showCalendar", default: false)
+    static let showAIQuota = Key<Bool>("showAIQuota", default: false)
     static let hideCompletedReminders = Key<Bool>("hideCompletedReminders", default: true)
     static let sliderColor = Key<SliderColorEnum>(
         "sliderUseAlbumArtColor",

--- a/scripts/test_ai_quota_refresh_policy.swift
+++ b/scripts/test_ai_quota_refresh_policy.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+@main
+struct AIQuotaRefreshPolicyTest {
+    static func main() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        var policy = AIQuotaRefreshPolicy()
+
+        assert(policy.canRequest(.claude, now: now), "Claude should be requestable before any rate limit")
+
+        policy.recordRateLimit(.claude, retryAfter: 300, now: now)
+        assert(!policy.canRequest(.claude, now: now.addingTimeInterval(299)), "Claude should wait until retry-after expires")
+        assert(policy.canRequest(.claude, now: now.addingTimeInterval(300)), "Claude should be requestable when retry-after expires")
+        assert(policy.canRequest(.codex, now: now), "Claude rate limit must not block Codex")
+
+        policy.recordRateLimit(.claude, retryAfter: nil, now: now)
+        assert(!policy.canRequest(.claude, now: now.addingTimeInterval(1_799)), "Claude should use default backoff when retry-after is missing")
+        assert(policy.canRequest(.claude, now: now.addingTimeInterval(1_800)), "Claude default backoff should expire after 30 minutes")
+
+        policy.recordRateLimit(.claude, retryAfter: 300, now: now)
+        policy.recordSuccess(.claude)
+        assert(policy.canRequest(.claude, now: now), "Successful refresh should clear Claude backoff")
+    }
+}

--- a/scripts/test_ai_quota_refresh_policy.swift
+++ b/scripts/test_ai_quota_refresh_policy.swift
@@ -6,19 +6,38 @@ struct AIQuotaRefreshPolicyTest {
         let now = Date(timeIntervalSince1970: 1_000)
         var policy = AIQuotaRefreshPolicy()
 
-        assert(policy.canRequest(.claude, now: now), "Claude should be requestable before any rate limit")
+        // Rate limit backoff
+        assert(policy.canRequest(.claude, now: now), "Should be requestable initially")
 
         policy.recordRateLimit(.claude, retryAfter: 300, now: now)
-        assert(!policy.canRequest(.claude, now: now.addingTimeInterval(299)), "Claude should wait until retry-after expires")
-        assert(policy.canRequest(.claude, now: now.addingTimeInterval(300)), "Claude should be requestable when retry-after expires")
+        assert(!policy.canRequest(.claude, now: now.addingTimeInterval(299)), "Should wait until retry-after expires")
+        assert(policy.canRequest(.claude, now: now.addingTimeInterval(300)), "Should be requestable when retry-after expires")
         assert(policy.canRequest(.codex, now: now), "Claude rate limit must not block Codex")
 
         policy.recordRateLimit(.claude, retryAfter: nil, now: now)
-        assert(!policy.canRequest(.claude, now: now.addingTimeInterval(1_799)), "Claude should use default backoff when retry-after is missing")
-        assert(policy.canRequest(.claude, now: now.addingTimeInterval(1_800)), "Claude default backoff should expire after 30 minutes")
+        assert(!policy.canRequest(.claude, now: now.addingTimeInterval(1_799)), "Should use default 30m backoff when retry-after is nil")
+        assert(policy.canRequest(.claude, now: now.addingTimeInterval(1_800)), "Default backoff should expire after 30 minutes")
 
+        // Auth failure backoff
+        policy.recordAuthFailure(.claude, now: now)
+        assert(!policy.canRequest(.claude, now: now.addingTimeInterval(899)), "Auth failure should block for 15 minutes")
+        assert(policy.canRequest(.claude, now: now.addingTimeInterval(900)), "Auth failure backoff should expire after 15 minutes")
+
+        // Block message
+        policy.recordAuthFailure(.claude, now: now)
+        let msg = policy.blockMessage(for: .claude, now: now)
+        assert(msg != nil && msg!.contains("Token expired"), "Auth failure message should mention token expiry")
+
+        policy.recordRateLimit(.claude, retryAfter: 60, now: now)
+        let rlMsg = policy.blockMessage(for: .claude, now: now)
+        assert(rlMsg != nil && rlMsg!.contains("Rate limited"), "Rate limit message should mention rate limiting")
+
+        // Success clears backoff
         policy.recordRateLimit(.claude, retryAfter: 300, now: now)
         policy.recordSuccess(.claude)
-        assert(policy.canRequest(.claude, now: now), "Successful refresh should clear Claude backoff")
+        assert(policy.canRequest(.claude, now: now), "Success should clear backoff")
+        assert(policy.blockMessage(for: .claude, now: now) == nil, "No block message after success")
+
+        print("All tests passed.")
     }
 }


### PR DESCRIPTION
## Summary
- **Auth failure backoff**: When Claude token expires (401), back off 15 minutes instead of retrying every 2 minutes until rate-limited (429)
- **Rate limit handling**: Parse `Retry-After` header on 429 responses, default 30-min backoff
- **XPC-first credential flow**: Try XPC helper before Keychain fallback to avoid macOS password prompts on unsigned builds
- **Preserve last successful data**: Don't overwrite working quota data with transient errors
- **UI improvements**: Show "Updated X ago" timestamp, use `floor()` for percentage display

## Problem
When the Claude OAuth access token expires, the app was:
1. Fetching with expired token → 401
2. Retrying every 2 minutes with the same bad token
3. Eventually getting rate-limited (429)
4. Only then backing off (30 min)

Now it detects the 401 immediately and backs off with a clear "Token expired. Re-login with CLI." message.

## Test plan
- [ ] Verify Claude quota displays correctly with valid token
- [ ] Verify expired token shows "Token expired" message and backs off
- [ ] Verify rate-limited state shows retry countdown
- [ ] Verify Codex quota unaffected
- [ ] Verify "Updated X ago" timestamp appears on quota cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)