### PR TITLE
Allow opening notch while HUD is showing

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -579,7 +579,6 @@ struct ContentView: View {
             }
             
             guard vm.notchState == .closed,
-                  !coordinator.shouldShowSneakPeek(on: vm.screenUUID),
                   Defaults[.openNotchOnHover] else { return }
             
             hoverTask = Task {
@@ -588,8 +587,7 @@ struct ContentView: View {
                 
                 await MainActor.run {
                     guard self.vm.notchState == .closed,
-                          self.isHovering,
-                          !self.coordinator.shouldShowSneakPeek(on: self.vm.screenUUID) else { return }
+                          self.isHovering else { return }
                     
                     self.doOpen()
                 }


### PR DESCRIPTION
First off, this is one of the nicest apps I’ve used on my mac, it is incredibly smooth and stable !

I've noticed repeatedly that when the volume/brightness HUD is showing, hovering over the notch won't open it, while clicking still works. **While the animation is playing, the notch won't open on hover like it normally does.**

Since click already opens the notch in that state, I updated the hover behavior to match.


---

**Change**
- Removed the sneak-peek check in handleHover() so hover-open isn't blocked while the HUD is visible.


Attached before / after
https://github.com/user-attachments/assets/a361c2ab-efa4-4c9e-825b-7b39d9959edf
https://github.com/user-attachments/assets/9eb6dd05-899b-4c2e-a73f-1c6f9a6ad95f
