### PR TITLE
Feature: Pomodoro Clock

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		11F748822ECB07A400F841DB /* MusicControlButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F748812ECB07A400F841DB /* MusicControlButton.swift */; };
 		11F748842ECB27DC00F841DB /* MusicSlotConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F748832ECB27DC00F841DB /* MusicSlotConfigurationView.swift */; };
 		14288DDC2C6E015000B9F80C /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14288DD62C6E015000B9F80C /* AudioPlayer.swift */; };
+		A1SND022F10D0000000002 /* SystemSoundPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1SND012F10D0000000001 /* SystemSoundPlayer.swift */; };
 		14288DE82C6E01C800B9F80C /* ProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14288DE72C6E01C800B9F80C /* ProgressIndicator.swift */; };
 		14288E0C2C6F8EC000B9F80C /* AppIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14288E0B2C6F8EC000B9F80C /* AppIcons.swift */; };
 		1443E7F32C609DCE0027C1FC /* matters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1443E7F22C609DCE0027C1FC /* matters.swift */; };
@@ -87,6 +88,8 @@
 		14A7E5972C65FD31008C1BE9 /* boring.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 14A7E5962C65FD31008C1BE9 /* boring.m4a */; };
 		14C08BB62C8DE42D000F8AA0 /* CalendarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */; };
 		14C08BB92C8DE4B1000F8AA0 /* BoringCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C08BB82C8DE4B1000F8AA0 /* BoringCalendar.swift */; };
+		A1P0M0022F10D0000000002 /* PomodoroManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1P0M0012F10D0000000001 /* PomodoroManager.swift */; };
+		A1P0M0042F10D0000000004 /* PomodoroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1P0M0032F10D0000000003 /* PomodoroView.swift */; };
 		14C08BC12C8E03AD000F8AA0 /* NSImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C08BC02C8E03AD000F8AA0 /* NSImage+Extensions.swift */; };
 		14CEF4162C5CAED300855D72 /* boringNotchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CEF4152C5CAED300855D72 /* boringNotchApp.swift */; };
 		14CEF4182C5CAED300855D72 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CEF4172C5CAED300855D72 /* ContentView.swift */; };
@@ -242,6 +245,7 @@
 		11F748812ECB07A400F841DB /* MusicControlButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicControlButton.swift; sourceTree = "<group>"; };
 		11F748832ECB27DC00F841DB /* MusicSlotConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicSlotConfigurationView.swift; sourceTree = "<group>"; };
 		14288DD62C6E015000B9F80C /* AudioPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioPlayer.swift; sourceTree = "<group>"; };
+		A1SND012F10D0000000001 /* SystemSoundPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSoundPlayer.swift; sourceTree = "<group>"; };
 		14288DE72C6E01C800B9F80C /* ProgressIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressIndicator.swift; sourceTree = "<group>"; };
 		14288E0B2C6F8EC000B9F80C /* AppIcons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcons.swift; sourceTree = "<group>"; };
 		1443E7F22C609DCE0027C1FC /* matters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = matters.swift; sourceTree = "<group>"; };
@@ -255,6 +259,8 @@
 		14A7E5962C65FD31008C1BE9 /* boring.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = boring.m4a; sourceTree = "<group>"; };
 		14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarManager.swift; sourceTree = "<group>"; };
 		14C08BB82C8DE4B1000F8AA0 /* BoringCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringCalendar.swift; sourceTree = "<group>"; };
+		A1P0M0012F10D0000000001 /* PomodoroManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroManager.swift; sourceTree = "<group>"; };
+		A1P0M0032F10D0000000003 /* PomodoroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroView.swift; sourceTree = "<group>"; };
 		14C08BC02C8E03AD000F8AA0 /* NSImage+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSImage+Extensions.swift"; sourceTree = "<group>"; };
 		14CEF4122C5CAED300855D72 /* boringNotch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = boringNotch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		14CEF4152C5CAED300855D72 /* boringNotchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = boringNotchApp.swift; sourceTree = "<group>"; };
@@ -459,6 +465,7 @@
 				11A45C782E34E63100CEB175 /* MediaChecker.swift */,
 				1153BD972D9881F900979FB0 /* AppleScriptHelper.swift */,
 				14288DD62C6E015000B9F80C /* AudioPlayer.swift */,
+				A1SND012F10D0000000001 /* SystemSoundPlayer.swift */,
 				5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */,
 				14288E0B2C6F8EC000B9F80C /* AppIcons.swift */,
 			);
@@ -489,6 +496,7 @@
 				B141C23B2CA5F50900AC8CC8 /* Onboarding */,
 				B1C448992C97375A001F0858 /* Tips */,
 				14C08BB72C8DE49E000F8AA0 /* Calendar */,
+				A1P0M0052F10D0000000005 /* Pomodoro */,
 				9A987A042C73CA66005CA465 /* Shelf */,
 				149E0B982C737D26006418B1 /* Webcam */,
 				B18654312C6F45AE000B926A /* Live activities */,
@@ -516,6 +524,7 @@
 				147163992C5D35FF0068B555 /* MusicManager.swift */,
 				149E0B962C737D00006418B1 /* WebcamManager.swift */,
 				14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */,
+				A1P0M0012F10D0000000001 /* PomodoroManager.swift */,
 				B1F0A0012E60000100000001 /* BrightnessManager.swift */,
 				59D8C23B2E589FAA00147B33 /* VolumeManager.swift */,
 			);
@@ -536,6 +545,14 @@
 				14C08BB82C8DE4B1000F8AA0 /* BoringCalendar.swift */,
 			);
 			path = Calendar;
+			sourceTree = "<group>";
+		};
+		A1P0M0052F10D0000000005 /* Pomodoro */ = {
+			isa = PBXGroup;
+			children = (
+				A1P0M0032F10D0000000003 /* PomodoroView.swift */,
+			);
+			path = Pomodoro;
 			sourceTree = "<group>";
 		};
 		14CEF4092C5CAED200855D72 = {
@@ -975,6 +992,8 @@
 				14D570C62C5F38210011E668 /* BoringHeader.swift in Sources */,
 				B17266E32C65F7FB0031BA0D /* WhatsNewView.swift in Sources */,
 				14C08BB62C8DE42D000F8AA0 /* CalendarManager.swift in Sources */,
+				A1P0M0022F10D0000000002 /* PomodoroManager.swift in Sources */,
+				A1P0M0042F10D0000000004 /* PomodoroView.swift in Sources */,
 				14D570CD2C5F4BB70011E668 /* BoringBattery.swift in Sources */,
 				B10F84A32C6C9596009F3026 /* TestView.swift in Sources */,
 				1443E7F32C609DCE0027C1FC /* matters.swift in Sources */,
@@ -1013,6 +1032,7 @@
 				11D58EA22E760AE100FA8377 /* ImageService.swift in Sources */,
 				11F748822ECB07A400F841DB /* MusicControlButton.swift in Sources */,
 				14288DDC2C6E015000B9F80C /* AudioPlayer.swift in Sources */,
+				A1SND022F10D0000000002 /* SystemSoundPlayer.swift in Sources */,
 				149E0B972C737D00006418B1 /* WebcamManager.swift in Sources */,
 				14288E0C2C6F8EC000B9F80C /* AppIcons.swift in Sources */,
 				B1C448982C972CC4001F0858 /* ListItemPopover.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -347,6 +347,8 @@ struct ContentView: View {
                     switch coordinator.currentView {
                     case .home:
                         NotchHomeView(albumArtNamespace: albumArtNamespace)
+                    case .pomodoro:
+                        PomodoroView()
                     case .shelf:
                         ShelfView()
                     }

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -901,6 +901,9 @@
         }
       }
     },
+    "%lld min" : {
+
+    },
     "%lld%%" : {
       "localizations" : {
         "ar" : {
@@ -2201,6 +2204,9 @@
           }
         }
       }
+    },
+    "Alarm sound" : {
+
     },
     "All-day" : {
       "localizations" : {
@@ -5001,6 +5007,9 @@
           }
         }
       }
+    },
+    "Choose from macOS alert sounds. Sounds from System Settings → Sound appear here, including custom sounds saved to ~/Library/Sounds." : {
+
     },
     "Choose which service to use when sharing files from the shelf. Click the shelf button to select files, or drag files onto it to share immediately." : {
       "localizations" : {
@@ -7906,6 +7915,9 @@
         }
       }
     },
+    "Duration" : {
+
+    },
     "Easily copy, store, and manage your most-used content. Upgrade now for advanced features like multi-item storage and quick access!" : {
       "localizations" : {
         "ar" : {
@@ -9607,6 +9619,9 @@
           }
         }
       }
+    },
+    "Focus" : {
+
     },
     "Full screen behavior" : {
       "localizations" : {
@@ -13709,6 +13724,9 @@
         }
       }
     },
+    "min" : {
+
+    },
     "Mirror" : {
       "localizations" : {
         "ar" : {
@@ -16010,6 +16028,9 @@
         }
       }
     },
+    "Open Sound Settings" : {
+
+    },
     "Option key behaviour" : {
       "localizations" : {
         "ar" : {
@@ -16210,6 +16231,9 @@
         }
       }
     },
+    "Play sound when timer ends" : {
+
+    },
     "Plugged In" : {
       "localizations" : {
         "ar" : {
@@ -16409,6 +16433,9 @@
           }
         }
       }
+    },
+    "Preview sound" : {
+
     },
     "Progress bar style" : {
       "localizations" : {

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -16,7 +16,7 @@ struct BoringHeader: View {
     var body: some View {
         HStack(spacing: 0) {
             HStack {
-                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
+                if shouldShowTabs {
                     TabSelectionView()
                 } else if vm.notchState == .open {
                     EmptyView()
@@ -100,6 +100,10 @@ struct BoringHeader: View {
         }
         .foregroundColor(.gray)
         .environmentObject(vm)
+    }
+
+    private var shouldShowTabs: Bool {
+        vm.notchState == .open
     }
 
     func isHUDType(_ type: SneakContentType) -> Bool {

--- a/boringNotch/components/Pomodoro/PomodoroView.swift
+++ b/boringNotch/components/Pomodoro/PomodoroView.swift
@@ -1,0 +1,251 @@
+//
+//  PomodoroView.swift
+//  boringNotch
+//
+
+import Defaults
+import SwiftUI
+
+struct PomodoroView: View {
+    @ObservedObject private var pomodoro = PomodoroManager.shared
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 20) {
+            timerRing
+            durationControls
+            controlButtons
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .padding(.horizontal, 8)
+    }
+
+    // MARK: - Timer ring
+
+    private var timerRing: some View {
+        ZStack {
+            CircularProgressView(
+                progress: pomodoro.isRunning || pomodoro.isPaused ? pomodoro.progress : 0,
+                color: .effectiveAccent
+            )
+            .frame(width: 88, height: 88)
+
+            VStack(spacing: 2) {
+                Text(pomodoro.formattedRemaining)
+                    .font(.system(size: 22, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(.white)
+
+                Text(statusLabel)
+                    .font(.caption2)
+                    .foregroundStyle(Color(white: 0.65))
+            }
+        }
+        .frame(width: 100)
+    }
+
+    private var statusLabel: String {
+        if pomodoro.isRunning { return "Running" }
+        if pomodoro.isPaused { return "Paused" }
+        return "Ready"
+    }
+
+    // MARK: - Duration controls
+
+    private var durationControls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Duration")
+                .font(.caption)
+                .foregroundStyle(Color(white: 0.65))
+
+            presetButtons
+
+            DurationWheelPicker(
+                selectedMinutes: Binding(
+                    get: { pomodoro.durationMinutes },
+                    set: { pomodoro.setDuration(minutes: $0) }
+                ),
+                isEnabled: pomodoro.canEditDuration
+            )
+            .frame(width: 110, height: 100)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .opacity(pomodoro.canEditDuration ? 1 : 0.45)
+        .allowsHitTesting(pomodoro.canEditDuration)
+    }
+
+    private var presetButtons: some View {
+        HStack(spacing: 8) {
+            ForEach(PomodoroManager.presetDurations, id: \.self) { minutes in
+                Button {
+                    pomodoro.applyPreset(minutes)
+                    if Defaults[.enableHaptics] {
+                        NSHapticFeedbackManager.defaultPerformer.perform(
+                            .alignment,
+                            performanceTime: .now
+                        )
+                    }
+                } label: {
+                    Text("\(minutes) min")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(
+                            pomodoro.durationMinutes == minutes ? .white : Color(white: 0.75)
+                        )
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(
+                            pomodoro.durationMinutes == minutes
+                                ? Color.effectiveAccentBackground
+                                : Color(nsColor: .secondarySystemFill).opacity(0.5)
+                        )
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Controls
+
+    private var controlButtons: some View {
+        VStack(spacing: 8) {
+            HoverButton(
+                icon: pomodoro.isRunning ? "pause.fill" : "play.fill",
+                scale: .large
+            ) {
+                pomodoro.togglePlayPause()
+            }
+
+            HoverButton(icon: "arrow.counterclockwise", scale: .medium) {
+                pomodoro.reset()
+            }
+        }
+        .frame(width: 48)
+    }
+}
+
+// MARK: - Duration wheel
+
+private struct DurationWheelPicker: View {
+    @Binding var selectedMinutes: Int
+    let isEnabled: Bool
+
+    @State private var scrollIndex: Int?
+    @State private var isScrollingFromSelection = false
+
+    private let itemHeight: CGFloat = 32
+    private let visibleCount = 3
+    private var edgeInset: Int { (visibleCount - 1) / 2 }
+
+    private var minuteValues: [Int] {
+        Array(PomodoroManager.minuteRange)
+    }
+
+    private var totalItemCount: Int {
+        minuteValues.count + (edgeInset * 2)
+    }
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(nsColor: .secondarySystemFill).opacity(0.35))
+
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.effectiveAccentBackground.opacity(0.55))
+                .frame(height: itemHeight)
+                .padding(.horizontal, 4)
+
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVStack(spacing: 0) {
+                    ForEach(0..<totalItemCount, id: \.self) { index in
+                        if let minute = minute(at: index) {
+                            Text("\(minute)")
+                                .font(.system(
+                                    size: 16,
+                                    weight: selectedMinutes == minute ? .semibold : .regular,
+                                    design: .rounded
+                                ))
+                                .monospacedDigit()
+                                .foregroundStyle(selectedMinutes == minute ? .white : Color(white: 0.55))
+                                .frame(height: itemHeight)
+                                .frame(maxWidth: .infinity)
+                                .id(index)
+                        } else {
+                            Color.clear
+                                .frame(height: itemHeight)
+                                .id(index)
+                        }
+                    }
+                }
+                .scrollTargetLayout()
+            }
+            .scrollPosition(id: $scrollIndex, anchor: .center)
+            .scrollTargetBehavior(.viewAligned)
+            .scrollDisabled(!isEnabled)
+            .frame(height: itemHeight * CGFloat(visibleCount))
+            .mask(
+                LinearGradient(
+                    colors: [.clear, .black, .black, .clear],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .overlay(alignment: .trailing) {
+                Text("min")
+                    .font(.caption2)
+                    .foregroundStyle(Color(white: 0.55))
+                    .padding(.trailing, 8)
+            }
+        }
+        .onChange(of: scrollIndex) { _, newIndex in
+            guard !isScrollingFromSelection else { return }
+            guard let index = newIndex, let minute = minute(at: index), minute != selectedMinutes else {
+                return
+            }
+            selectedMinutes = minute
+            if Defaults[.enableHaptics] {
+                NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+            }
+        }
+        .onChange(of: selectedMinutes) { _, newValue in
+            scrollToMinute(newValue, animated: true)
+        }
+        .onAppear {
+            scrollToMinute(selectedMinutes, animated: false)
+        }
+    }
+
+    private func minute(at index: Int) -> Int? {
+        let minuteIndex = index - edgeInset
+        guard minuteIndex >= 0, minuteIndex < minuteValues.count else { return nil }
+        return minuteValues[minuteIndex]
+    }
+
+    private func index(for minute: Int) -> Int? {
+        guard let minuteIndex = minuteValues.firstIndex(of: minute) else { return nil }
+        return minuteIndex + edgeInset
+    }
+
+    private func scrollToMinute(_ minute: Int, animated: Bool) {
+        guard let targetIndex = index(for: minute) else { return }
+        guard scrollIndex != targetIndex else { return }
+
+        isScrollingFromSelection = true
+        if animated {
+            withAnimation(.smooth) {
+                scrollIndex = targetIndex
+            }
+        } else {
+            scrollIndex = targetIndex
+        }
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(50))
+            isScrollingFromSelection = false
+        }
+    }
+}
+
+#Preview {
+    PomodoroView()
+        .frame(width: 640, height: 140)
+        .background(.black)
+}

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -39,6 +39,9 @@ struct SettingsView: View {
                 NavigationLink(value: "Calendar") {
                     Label("Calendar", systemImage: "calendar")
                 }
+                NavigationLink(value: "Focus") {
+                    Label("Focus", systemImage: "timer")
+                }
                 NavigationLink(value: "HUD") {
                     Label("HUDs", systemImage: "dial.medium.fill")
                 }
@@ -79,6 +82,8 @@ struct SettingsView: View {
                     Media()
                 case "Calendar":
                     CalendarSettings()
+                case "Focus":
+                    PomodoroSettings()
                 case "HUD":
                     HUD()
                 case "Battery":
@@ -703,6 +708,61 @@ struct Media: View {
             return MediaControllerType.allCases.filter { $0 != .nowPlaying }
         } else {
             return MediaControllerType.allCases
+        }
+    }
+}
+
+struct PomodoroSettings: View {
+    @Default(.pomodoroPlayAlarmSound) private var playAlarmSound
+    @Default(.pomodoroAlarmSoundName) private var alarmSoundName
+    @State private var availableSounds: [String] = SystemSoundPlayer.availableSoundNames()
+
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Toggle(key: .pomodoroPlayAlarmSound) {
+                    Text("Play sound when timer ends")
+                }
+            }
+
+            Section {
+                Picker("Alarm sound", selection: $alarmSoundName) {
+                    ForEach(availableSounds, id: \.self) { sound in
+                        Text(sound).tag(sound)
+                    }
+                }
+                .disabled(!playAlarmSound)
+
+                HStack {
+                    Button("Preview sound") {
+                        SystemSoundPlayer.play(soundName: alarmSoundName)
+                    }
+                    .disabled(!playAlarmSound)
+
+                    Spacer()
+
+                    Button("Open Sound Settings") {
+                        SystemSoundPlayer.openSoundSettings()
+                    }
+                }
+            } footer: {
+                Text(
+                    "Choose from macOS alert sounds. Sounds from System Settings → Sound appear here, including custom sounds saved to ~/Library/Sounds."
+                )
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Focus")
+        .onAppear {
+            refreshAvailableSounds()
+        }
+    }
+
+    private func refreshAvailableSounds() {
+        availableSounds = SystemSoundPlayer.availableSoundNames()
+        let resolved = SystemSoundPlayer.resolvedSoundName(alarmSoundName)
+        if resolved != alarmSoundName {
+            alarmSoundName = resolved
         }
     }
 }

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -5,6 +5,7 @@
 //  Created by Hugo Persson on 2024-08-25.
 //
 
+import Defaults
 import SwiftUI
 
 struct TabModel: Identifiable {
@@ -14,13 +15,20 @@ struct TabModel: Identifiable {
     let view: NotchViews
 }
 
-let tabs = [
-    TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
-]
+var tabs: [TabModel] {
+    var items = [
+        TabModel(label: "Home", icon: "house.fill", view: .home),
+        TabModel(label: "Focus", icon: "timer", view: .pomodoro),
+    ]
+    if Defaults[.boringShelf] {
+        items.append(TabModel(label: "Shelf", icon: "tray.fill", view: .shelf))
+    }
+    return items
+}
 
 struct TabSelectionView: View {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @Default(.boringShelf) private var boringShelf
     @Namespace var animation
     var body: some View {
         HStack(spacing: 0) {
@@ -47,6 +55,11 @@ struct TabSelectionView: View {
             }
         }
         .clipShape(Capsule())
+        .onChange(of: boringShelf) { _, isEnabled in
+            if !isEnabled, coordinator.currentView == .shelf {
+                coordinator.currentView = .home
+            }
+        }
     }
 }
 

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -26,6 +26,7 @@ public enum NotchState {
 
 public enum NotchViews {
     case home
+    case pomodoro
     case shelf
 }
 

--- a/boringNotch/helpers/SystemSoundPlayer.swift
+++ b/boringNotch/helpers/SystemSoundPlayer.swift
@@ -1,0 +1,105 @@
+//
+//  SystemSoundPlayer.swift
+//  boringNotch
+//
+
+import AppKit
+import Foundation
+
+enum SystemSoundPlayer {
+    private static var currentlyPlaying: NSSound?
+
+    private static let supportedExtensions = ["aiff", "aif", "caf", "wav"]
+    private static let systemSoundsDirectory = URL(fileURLWithPath: "/System/Library/Sounds")
+    private static let userSoundsDirectory = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Sounds", isDirectory: true)
+
+    static let defaultSoundName = "Glass"
+
+    static func availableSoundNames() -> [String] {
+        var names = Set<String>()
+
+        for directory in soundDirectories() {
+            guard
+                let files = try? FileManager.default.contentsOfDirectory(
+                    at: directory,
+                    includingPropertiesForKeys: nil
+                )
+            else { continue }
+
+            for file in files {
+                guard supportedExtensions.contains(file.pathExtension.lowercased()) else { continue }
+                names.insert(file.deletingPathExtension().lastPathComponent)
+            }
+        }
+
+        if names.isEmpty {
+            return [defaultSoundName]
+        }
+
+        return names.sorted {
+            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+        }
+    }
+
+    static func resolvedSoundName(_ preferred: String) -> String {
+        let sounds = availableSoundNames()
+        if sounds.contains(preferred) {
+            return preferred
+        }
+        if sounds.contains(defaultSoundName) {
+            return defaultSoundName
+        }
+        return sounds.first ?? defaultSoundName
+    }
+
+    static func play(soundName: String) {
+        currentlyPlaying?.stop()
+        currentlyPlaying = nil
+
+        let resolved = resolvedSoundName(soundName)
+
+        if let sound = NSSound(named: NSSound.Name(resolved)) {
+            currentlyPlaying = sound
+            sound.play()
+            return
+        }
+
+        if let url = url(for: resolved), let sound = NSSound(contentsOf: url, byReference: true) {
+            currentlyPlaying = sound
+            sound.play()
+            return
+        }
+
+        NSSound.beep()
+    }
+
+    static func openSoundSettings() {
+        let candidates = [
+            "x-apple.systempreferences:com.apple.Sound-Settings.extension",
+            "x-apple.systempreferences:com.apple.preference.sound",
+        ]
+
+        for candidate in candidates {
+            if let url = URL(string: candidate), NSWorkspace.shared.open(url) {
+                return
+            }
+        }
+    }
+
+    private static func soundDirectories() -> [URL] {
+        [systemSoundsDirectory, userSoundsDirectory]
+    }
+
+    private static func url(for soundName: String) -> URL? {
+        for directory in soundDirectories() {
+            for ext in supportedExtensions {
+                let candidate = directory.appendingPathComponent("\(soundName).\(ext)")
+                if FileManager.default.fileExists(atPath: candidate.path) {
+                    return candidate
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/boringNotch/managers/PomodoroManager.swift
+++ b/boringNotch/managers/PomodoroManager.swift
@@ -1,0 +1,122 @@
+//
+//  PomodoroManager.swift
+//  boringNotch
+//
+
+import AppKit
+import Combine
+import Defaults
+import Foundation
+
+@MainActor
+final class PomodoroManager: ObservableObject {
+    static let shared = PomodoroManager()
+
+    static let presetDurations = [1, 10, 30]
+    static let minuteRange = 1...180
+
+    @Published private(set) var durationMinutes: Int
+    @Published private(set) var remainingSeconds: Int
+    @Published private(set) var isRunning = false
+    @Published private(set) var isPaused = false
+
+    private var timerTask: Task<Void, Never>?
+
+    var progress: Double {
+        let total = durationMinutes * 60
+        guard total > 0 else { return 0 }
+        return min(1, max(0, 1 - Double(remainingSeconds) / Double(total)))
+    }
+
+    var formattedRemaining: String {
+        let minutes = remainingSeconds / 60
+        let seconds = remainingSeconds % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    var canEditDuration: Bool {
+        !isRunning
+    }
+
+    private init() {
+        let saved = Defaults[.pomodoroDurationMinutes]
+        let clamped = Self.clampMinutes(saved)
+        durationMinutes = clamped
+        remainingSeconds = clamped * 60
+    }
+
+    func setDuration(minutes: Int) {
+        guard canEditDuration else { return }
+        let clamped = Self.clampMinutes(minutes)
+        durationMinutes = clamped
+        remainingSeconds = clamped * 60
+        Defaults[.pomodoroDurationMinutes] = clamped
+    }
+
+    func applyPreset(_ minutes: Int) {
+        setDuration(minutes: minutes)
+    }
+
+    func start() {
+        if remainingSeconds <= 0 {
+            remainingSeconds = durationMinutes * 60
+        }
+        isRunning = true
+        isPaused = false
+        runTimer()
+    }
+
+    func pause() {
+        guard isRunning else { return }
+        isRunning = false
+        isPaused = true
+        timerTask?.cancel()
+        timerTask = nil
+    }
+
+    func togglePlayPause() {
+        if isRunning {
+            pause()
+        } else {
+            start()
+        }
+    }
+
+    func reset() {
+        timerTask?.cancel()
+        timerTask = nil
+        isRunning = false
+        isPaused = false
+        remainingSeconds = durationMinutes * 60
+    }
+
+    private func runTimer() {
+        timerTask?.cancel()
+        timerTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                guard let self, !Task.isCancelled, self.isRunning else { return }
+
+                if self.remainingSeconds > 0 {
+                    self.remainingSeconds -= 1
+                }
+
+                if self.remainingSeconds <= 0 {
+                    self.isRunning = false
+                    self.isPaused = false
+                    self.playCompletionAlarm()
+                    return
+                }
+            }
+        }
+    }
+
+    func playCompletionAlarm() {
+        guard Defaults[.pomodoroPlayAlarmSound] else { return }
+        SystemSoundPlayer.play(soundName: Defaults[.pomodoroAlarmSoundName])
+    }
+
+    private static func clampMinutes(_ minutes: Int) -> Int {
+        min(max(minutes, minuteRange.lowerBound), minuteRange.upperBound)
+    }
+}

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -171,6 +171,14 @@ extension Defaults.Keys {
     static let autoRemoveShelfItems = Key<Bool>("autoRemoveShelfItems", default: false)
     static let expandedDragDetection = Key<Bool>("expandedDragDetection", default: true)
     
+    // MARK: Pomodoro
+    static let pomodoroDurationMinutes = Key<Int>("pomodoroDurationMinutes", default: 10)
+    static let pomodoroPlayAlarmSound = Key<Bool>("pomodoroPlayAlarmSound", default: true)
+    static let pomodoroAlarmSoundName = Key<String>(
+        "pomodoroAlarmSoundName",
+        default: SystemSoundPlayer.defaultSoundName
+    )
+
     // MARK: Calendar
     static let calendarSelectionState = Key<CalendarSelectionState>("calendarSelectionState", default: .all)
     static let hideAllDayEvents = Key<Bool>("hideAllDayEvents", default: false)


### PR DESCRIPTION
## Summary
- Adds a new **Focus** tab to the open notch with a pomodoro-style countdown timer
- Users can set duration via preset chips (1, 10, 30 min) or a scroll wheel (1–180 min)
- Adds **Settings → Focus** to choose a macOS alert sound for timer completion, with preview and a link to System Sound settings
- Timer shows a circular progress ring with play/pause/reset controls and persists the selected duration

## Changes
- `PomodoroManager` — timer logic and completion alarm
- `PomodoroView` — Focus tab UI (presets + scroll wheel)
- `SystemSoundPlayer` — macOS system sound discovery and playback
- `PomodoroSettings` — alarm sound configuration in Settings
- Tab/navigation wiring for `NotchViews.pomodoro`

## Test plan
- [ ] Open notch → switch to Focus tab (timer icon)
- [ ] Select 1, 10, and 30 min presets; confirm countdown updates
- [ ] Scroll wheel to 1 min and 180 min; confirm both are selectable
- [ ] Start timer → duration controls disabled; pause/resume works
- [ ] Reset returns to full duration
- [ ] Let timer finish → selected alarm sound plays
- [ ] Settings → Focus → preview sound, change alarm, disable sound toggle
- [ ] Quit and relaunch → duration preference persists
- [ ] Disable Shelf in settings → Shelf tab hidden; Focus tab still works