### PR TITLE
AmazingNotch: optimize performance, resolve memory leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ build/
 *.xcarchive
 *.dSYM
 
+# Others
+graphify-out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+## 1. UI & First-Launch Fixes
+- ContentView (boringNotch/ContentView.swift)
+  * Added `.ignoresSafeArea()` to the outermost ZStack to prevent NSHostingView from being pushed down by the macOS menu bar safe area, correctly pinning the notch to the top edge.
+  * Removed the `if coordinator.firstLaunch { return }` early exit inside `handleHover(_:)` to allow the notch to close on hover out even during the first launch.
+- NotchHomeView (boringNotch/components/Notch/NotchHomeView.swift)
+  * Removed the `if !coordinator.firstLaunch` wrapper gating `mainContent` rendering so the home view displays immediately instead of remaining blank until onboarding completes.
+
+### 2. Leaks & Lifecycle Hardening
+- VolumeManager (boringNotch/managers/VolumeManager.swift)
+  * Solved CoreAudio `AudioObjectAddPropertyListenerBlock` registration memory leaks by tracking listener blocks inside a new `AudioListenerRegistration` array and removing them properly on `deinit` / via `removeAudioListeners()`. Added `[weak self]` capture checks.
+- AnimatedFace (boringNotch/components/AnimatedFace.swift)
+  * Fixed a lingering blink Timer leak by storing the timer instance and invalidating it on view disappearance (`.onDisappear`).
+- MusicVisualizer (boringNotch/components/Music/MusicVisualizer.swift)
+  * Added `dismantleNSView` handling in `AudioSpectrumView` to stop spectrum animation and invalidate the repeating timer when the view is removed.
+
+### 3. @Observable Migration & Rendering Efficiency
+- MusicManager (boringNotch/managers/MusicManager.swift)
+  * Migrated `MusicManager` from legacy `ObservableObject` to the modern Swift `@Observable` macro to enable fine-grained, property-level SwiftUI updates (especially for fast-changing fields like playback position and volume).
+  * Removed `@Published` attributes and replaced `@ObservedObject` references with standard properties. Marked non-UI/internal variables as `@ObservationIgnored`.
+- Consumers (ContentView.swift, NotchHomeView.swift, MusicSlotConfigurationView.swift)
+  * Updated declarations to use `@State` or plain properties instead of `@ObservedObject`.
+  * Preserved initial publisher behaviors by migrating Combine `.onReceive` patterns to Swift's `.onChange(of:initial:true)`.
+
+### 4. Crash Safety & Render Cleanups
+- BatteryActivityManager (boringNotch/managers/BatteryActivityManager.swift)
+  * Replaced an unsafe forced unwrap (`sources.first!`) with a safe `guard let` unwrapping.
+- WebcamManager (boringNotch/managers/WebcamManager.swift)
+  * Removed redundant manual `objectWillChange.send()` triggers on property mutations, letting the standard property tracking mechanisms handle UI refresh.

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
     @ObservedObject var webcamManager = WebcamManager.shared
 
     @ObservedObject var coordinator = BoringViewCoordinator.shared
-    @ObservedObject var musicManager = MusicManager.shared
+    @State private var musicManager = MusicManager.shared
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var brightnessManager = BrightnessManager.shared
     @ObservedObject var volumeManager = VolumeManager.shared
@@ -214,6 +214,7 @@ struct ContentView: View {
         .background(dragDetector)
         .preferredColorScheme(.dark)
         .environmentObject(vm)
+        .ignoresSafeArea()
         .onChange(of: vm.anyDropZoneTargeting) { _, isTargeted in
             anyDropDebounceTask?.cancel()
 
@@ -511,7 +512,6 @@ struct ContentView: View {
     // MARK: - Hover Management
 
     private func handleHover(_ hovering: Bool) {
-        if coordinator.firstLaunch { return }
         hoverTask?.cancel()
         
         if hovering {

--- a/boringNotch/components/AnimatedFace.swift
+++ b/boringNotch/components/AnimatedFace.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 struct MinimalFaceFeatures: View {
     @State private var isBlinking = false
+    @State private var blinkTimer: Timer?
     @State var height:CGFloat = 20;
     @State var width:CGFloat = 30;
     
@@ -43,10 +44,15 @@ struct MinimalFaceFeatures: View {
         .onAppear {
             startBlinking()
         }
+        .onDisappear {
+            blinkTimer?.invalidate()
+            blinkTimer = nil
+        }
     }
-    
+
     func startBlinking() {
-        Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { _ in
+        blinkTimer?.invalidate()
+        blinkTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { _ in
             withAnimation(.spring(duration: 0.2)) {
                 isBlinking = true
             }

--- a/boringNotch/components/Music/MusicVisualizer.swift
+++ b/boringNotch/components/Music/MusicVisualizer.swift
@@ -116,6 +116,11 @@ struct AudioSpectrumView: NSViewRepresentable {
     func updateNSView(_ nsView: AudioSpectrum, context: Context) {
         nsView.setPlaying(isPlaying)
     }
+
+    static func dismantleNSView(_ nsView: AudioSpectrum, coordinator: ()) {
+        // Stop the repeating animation timer so it doesn't outlive the view on the run loop.
+        nsView.setPlaying(false)
+    }
 }
 
 #Preview {

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -25,7 +25,7 @@ struct MusicPlayerView: View {
 }
 
 struct AlbumArtView: View {
-    @ObservedObject var musicManager = MusicManager.shared
+    @State private var musicManager = MusicManager.shared
     @ObservedObject var vm: BoringViewModel
     let albumArtNamespace: Namespace.ID
 
@@ -110,7 +110,7 @@ struct AlbumArtView: View {
 }
 
 struct MusicControlsView: View {
-    @ObservedObject var musicManager = MusicManager.shared
+    @State private var musicManager = MusicManager.shared
         @EnvironmentObject var vm: BoringViewModel
         @ObservedObject var webcamManager = WebcamManager.shared
     @State private var sliderValue: Double = 0
@@ -299,7 +299,7 @@ struct MusicControlsView: View {
 }
 
 struct FavoriteControlButton: View {
-    @ObservedObject var musicManager = MusicManager.shared
+    @State private var musicManager = MusicManager.shared
 
     var body: some View {
         HoverButton(icon: iconName, iconColor: iconColor, scale: .medium) {
@@ -328,7 +328,7 @@ private extension Array where Element == MusicControlButton {
 // MARK: - Volume Control View
 
 struct VolumeControlView: View {
-    @ObservedObject var musicManager = MusicManager.shared
+    @State private var musicManager = MusicManager.shared
     @State private var volumeSliderValue: Double = 0.5
     @State private var dragging: Bool = false
     @State private var showVolumeSlider: Bool = false
@@ -375,12 +375,12 @@ struct VolumeControlView: View {
             }
         }
         .clipped()
-        .onReceive(musicManager.$volume) { volume in
+        .onChange(of: musicManager.volume, initial: true) { _, volume in
             if !dragging {
                 volumeSliderValue = volume
             }
         }
-        .onReceive(musicManager.$volumeControlSupported) { supported in
+        .onChange(of: musicManager.volumeControlSupported, initial: true) { _, supported in
             if !supported {
                 withAnimation(.easeInOut(duration: 0.2)) {
                     showVolumeSlider = false
@@ -427,9 +427,7 @@ struct NotchHomeView: View {
 
     var body: some View {
         Group {
-            if !coordinator.firstLaunch {
-                mainContent
-            }
+            mainContent
         }
         // simplified: use a straightforward opacity transition
         .transition(.opacity)

--- a/boringNotch/components/Settings/MusicSlotConfigurationView.swift
+++ b/boringNotch/components/Settings/MusicSlotConfigurationView.swift
@@ -11,7 +11,7 @@ import UniformTypeIdentifiers
 
 struct MusicSlotConfigurationView: View {
     @Default(.musicControlSlots) private var musicControlSlots
-    @ObservedObject private var musicManager = MusicManager.shared
+    @State private var musicManager = MusicManager.shared
     @State private var draggedSlot: MusicControlButton?
 
     private let fixedSlotCount: Int = 5

--- a/boringNotch/managers/BatteryActivityManager.swift
+++ b/boringNotch/managers/BatteryActivityManager.swift
@@ -223,8 +223,10 @@ class BatteryActivityManager {
                 throw BatteryError.batteryInfoUnavailable("No power sources available")
             }
             
-            let source = sources.first!
-            
+            guard let source = sources.first else {
+                throw BatteryError.batteryInfoUnavailable("No power sources available")
+            }
+
             guard let description = IOPSGetPowerSourceDescription(snapshot, source)?.takeUnretainedValue() as? [String: Any] else {
                 throw BatteryError.batteryInfoUnavailable("Could not get power source description")
             }

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -7,6 +7,7 @@
 import AppKit
 import Combine
 import Defaults
+import Observation
 import SwiftUI
 
 let defaultImage: NSImage = .init(
@@ -14,12 +15,12 @@ let defaultImage: NSImage = .init(
     accessibilityDescription: "Album Art"
 )!
 
-class MusicManager: ObservableObject {
+@Observable class MusicManager {
     // MARK: - Properties
     static let shared = MusicManager()
-    private var cancellables = Set<AnyCancellable>()
-    private var controllerCancellables = Set<AnyCancellable>()
-    private var debounceIdleTask: Task<Void, Never>?
+    @ObservationIgnored private var cancellables = Set<AnyCancellable>()
+    @ObservationIgnored private var controllerCancellables = Set<AnyCancellable>()
+    @ObservationIgnored private var debounceIdleTask: Task<Void, Never>?
 
     // Helper to check if macOS has removed support for NowPlayingController
     public private(set) var isNowPlayingDeprecated: Bool = false
@@ -28,31 +29,31 @@ class MusicManager: ObservableObject {
     // Active controller
     private var activeController: (any MediaControllerProtocol)?
 
-    // Published properties for UI
-    @Published var songTitle: String = "I'm Handsome"
-    @Published var artistName: String = "Me"
-    @Published var albumArt: NSImage = defaultImage
-    @Published var isPlaying = false
-    @Published var album: String = "Self Love"
-    @Published var isPlayerIdle: Bool = true
-    @Published var animations: BoringAnimations = .init()
-    @Published var avgColor: NSColor = .white
-    @Published var bundleIdentifier: String? = nil
-    @Published var songDuration: TimeInterval = 0
-    @Published var elapsedTime: TimeInterval = 0
-    @Published var timestampDate: Date = .init()
-    @Published var playbackRate: Double = 1
-    @Published var isShuffled: Bool = false
-    @Published var repeatMode: RepeatMode = .off
-    @Published var volume: Double = 0.5
-    @Published var volumeControlSupported: Bool = true
-    @ObservedObject var coordinator = BoringViewCoordinator.shared
-    @Published var usingAppIconForArtwork: Bool = false
-    @Published var currentLyrics: String = ""
-    @Published var isFetchingLyrics: Bool = false
-    @Published var syncedLyrics: [(time: Double, text: String)] = []
-    @Published var canFavoriteTrack: Bool = false
-    @Published var isFavoriteTrack: Bool = false
+    // UI-facing properties (observed by SwiftUI via @Observable)
+    var songTitle: String = "I'm Handsome"
+    var artistName: String = "Me"
+    var albumArt: NSImage = defaultImage
+    var isPlaying = false
+    var album: String = "Self Love"
+    var isPlayerIdle: Bool = true
+    var animations: BoringAnimations = .init()
+    var avgColor: NSColor = .white
+    var bundleIdentifier: String? = nil
+    var songDuration: TimeInterval = 0
+    var elapsedTime: TimeInterval = 0
+    var timestampDate: Date = .init()
+    var playbackRate: Double = 1
+    var isShuffled: Bool = false
+    var repeatMode: RepeatMode = .off
+    var volume: Double = 0.5
+    var volumeControlSupported: Bool = true
+    @ObservationIgnored let coordinator = BoringViewCoordinator.shared
+    var usingAppIconForArtwork: Bool = false
+    var currentLyrics: String = ""
+    var isFetchingLyrics: Bool = false
+    var syncedLyrics: [(time: Double, text: String)] = []
+    var canFavoriteTrack: Bool = false
+    var isFavoriteTrack: Bool = false
 
     private var artworkData: Data? = nil
 
@@ -62,11 +63,11 @@ class MusicManager: ObservableObject {
     private var lastArtworkAlbum: String = "Self Love"
     private var lastArtworkBundleIdentifier: String? = nil
 
-    @Published var isFlipping: Bool = false
-    private var flipWorkItem: DispatchWorkItem?
+    var isFlipping: Bool = false
+    @ObservationIgnored private var flipWorkItem: DispatchWorkItem?
 
-    @Published var isTransitioning: Bool = false
-    private var transitionWorkItem: DispatchWorkItem?
+    var isTransitioning: Bool = false
+    @ObservationIgnored private var transitionWorkItem: DispatchWorkItem?
 
     // MARK: - Initialization
     init() {
@@ -140,7 +141,14 @@ class MusicManager: ObservableObject {
                 .sink { [weak self] state in
                     guard let self = self,
                           self.activeController === controller else { return }
-                    self.updateFromPlaybackState(state)
+                    // .receive(on: DispatchQueue.main) guarantees main-thread delivery
+                    // at runtime, but doesn't satisfy Swift's static @MainActor check.
+                    // Wrap in Task @MainActor to make the isolation explicit.
+                    Task { @MainActor [weak self] in
+                        guard let self = self,
+                              self.activeController === controller else { return }
+                        self.updateFromPlaybackState(state)
+                    }
                 }
                 .store(in: &controllerCancellables)
         }
@@ -582,6 +590,7 @@ class MusicManager: ObservableObject {
         }
     }
 
+    @MainActor
     private func updateSneakPeek() {
         if isPlaying && Defaults[.enableSneakPeek] {
             if Defaults[.sneakPeekStyles] == .standard {

--- a/boringNotch/managers/VolumeManager.swift
+++ b/boringNotch/managers/VolumeManager.swift
@@ -25,10 +25,24 @@ final class VolumeManager: NSObject, ObservableObject {
     private var previousVolumeBeforeMute: Float32 = 0.2
     private var softwareMuted: Bool = false
 
+    // Registered CoreAudio property listeners, retained so they can be removed.
+    // Without this, AudioObjectAddPropertyListenerBlock registrations leak for the
+    // process lifetime and their blocks strongly capture self.
+    private struct AudioListenerRegistration {
+        let objectID: AudioObjectID
+        var address: AudioObjectPropertyAddress
+        let block: AudioObjectPropertyListenerBlock
+    }
+    private var audioListeners: [AudioListenerRegistration] = []
+
     private override init() {
         super.init()
         setupAudioListener()
         fetchCurrentVolume()
+    }
+
+    deinit {
+        removeAudioListeners()
     }
 
     var shouldShowOverlay: Bool { Date().timeIntervalSince(lastChangeAt) < visibleDuration }
@@ -178,11 +192,7 @@ final class VolumeManager: NSObject, ObservableObject {
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )
-        AudioObjectAddPropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject), &defaultDevAddr, nil
-        ) { _, _ in
-            self.fetchCurrentVolume()
-        }
+        addAudioListener(objectID: AudioObjectID(kAudioObjectSystemObject), address: &defaultDevAddr)
 
         var masterAddr = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyVolumeScalar,
@@ -190,9 +200,7 @@ final class VolumeManager: NSObject, ObservableObject {
             mElement: kAudioObjectPropertyElementMain
         )
         if AudioObjectHasProperty(deviceID, &masterAddr) {
-            AudioObjectAddPropertyListenerBlock(deviceID, &masterAddr, nil) { _, _ in
-                self.fetchCurrentVolume()
-            }
+            addAudioListener(objectID: deviceID, address: &masterAddr)
         } else {
             for ch in [UInt32(1), UInt32(2)] {
                 var chAddr = AudioObjectPropertyAddress(
@@ -201,9 +209,7 @@ final class VolumeManager: NSObject, ObservableObject {
                     mElement: ch
                 )
                 if AudioObjectHasProperty(deviceID, &chAddr) {
-                    AudioObjectAddPropertyListenerBlock(deviceID, &chAddr, nil) { _, _ in
-                        self.fetchCurrentVolume()
-                    }
+                    addAudioListener(objectID: deviceID, address: &chAddr)
                 }
             }
         }
@@ -215,10 +221,26 @@ final class VolumeManager: NSObject, ObservableObject {
             mElement: kAudioObjectPropertyElementMain
         )
         if AudioObjectHasProperty(deviceID, &muteAddr) {
-            AudioObjectAddPropertyListenerBlock(deviceID, &muteAddr, nil) { _, _ in
-                self.fetchCurrentVolume()
-            }
+            addAudioListener(objectID: deviceID, address: &muteAddr)
         }
+    }
+
+    /// Registers a CoreAudio property listener and retains it so it can be removed later.
+    private func addAudioListener(objectID: AudioObjectID, address: inout AudioObjectPropertyAddress) {
+        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            self?.fetchCurrentVolume()
+        }
+        let status = AudioObjectAddPropertyListenerBlock(objectID, &address, nil, block)
+        guard status == noErr else { return }
+        audioListeners.append(AudioListenerRegistration(objectID: objectID, address: address, block: block))
+    }
+
+    private func removeAudioListeners() {
+        for var listener in audioListeners {
+            AudioObjectRemovePropertyListenerBlock(
+                listener.objectID, &listener.address, nil, listener.block)
+        }
+        audioListeners.removeAll()
     }
 
     private func readVolumeInternal() -> Float32? {

--- a/boringNotch/managers/WebcamManager.swift
+++ b/boringNotch/managers/WebcamManager.swift
@@ -10,30 +10,16 @@ import SwiftUI
 class WebcamManager: NSObject, ObservableObject {
     static let shared = WebcamManager()
     
-    @Published var previewLayer: AVCaptureVideoPreviewLayer? {
-        didSet {
-            objectWillChange.send()
-        }
-    }
-    
+    // @Published already publishes via objectWillChange; an extra send() in didSet
+    // double-fires every change. Rely on @Published alone.
+    @Published var previewLayer: AVCaptureVideoPreviewLayer?
+
     private var captureSession: AVCaptureSession?
-    @Published var isSessionRunning: Bool = false {
-        didSet {
-            objectWillChange.send()
-        }
-    }
-    
-    @Published var authorizationStatus: AVAuthorizationStatus = .notDetermined {
-        didSet {
-            objectWillChange.send()
-        }
-    }
-    
-    @Published var cameraAvailable: Bool = false {
-        didSet {
-            objectWillChange.send()
-        }
-    }
+    @Published var isSessionRunning: Bool = false
+
+    @Published var authorizationStatus: AVAuthorizationStatus = .notDetermined
+
+    @Published var cameraAvailable: Bool = false
 
     private let sessionQueue = DispatchQueue(label: "BoringNotch.WebcamManager.SessionQueue", qos: .userInitiated)
     


### PR DESCRIPTION
## 1. UI & First-Launch Fixes
- ContentView (boringNotch/ContentView.swift)
  * Added `.ignoresSafeArea()` to the outermost ZStack to prevent NSHostingView from being pushed down by the macOS menu bar safe area, correctly pinning the notch to the top edge.
  * Removed the `if coordinator.firstLaunch { return }` early exit inside `handleHover(_:)` to allow the notch to close on hover out even during the first launch.
- NotchHomeView (boringNotch/components/Notch/NotchHomeView.swift)
  * Removed the `if !coordinator.firstLaunch` wrapper gating `mainContent` rendering so the home view displays immediately instead of remaining blank until onboarding completes.

### 2. Leaks & Lifecycle Hardening
- VolumeManager (boringNotch/managers/VolumeManager.swift)
  * Solved CoreAudio `AudioObjectAddPropertyListenerBlock` registration memory leaks by tracking listener blocks inside a new `AudioListenerRegistration` array and removing them properly on `deinit` / via `removeAudioListeners()`. Added `[weak self]` capture checks.
- AnimatedFace (boringNotch/components/AnimatedFace.swift)
  * Fixed a lingering blink Timer leak by storing the timer instance and invalidating it on view disappearance (`.onDisappear`).
- MusicVisualizer (boringNotch/components/Music/MusicVisualizer.swift)
  * Added `dismantleNSView` handling in `AudioSpectrumView` to stop spectrum animation and invalidate the repeating timer when the view is removed.

### 3. @Observable Migration & Rendering Efficiency
- MusicManager (boringNotch/managers/MusicManager.swift)
  * Migrated `MusicManager` from legacy `ObservableObject` to the modern Swift `@Observable` macro to enable fine-grained, property-level SwiftUI updates (especially for fast-changing fields like playback position and volume).
  * Removed `@Published` attributes and replaced `@ObservedObject` references with standard properties. Marked non-UI/internal variables as `@ObservationIgnored`.
- Consumers (ContentView.swift, NotchHomeView.swift, MusicSlotConfigurationView.swift)
  * Updated declarations to use `@State` or plain properties instead of `@ObservedObject`.
  * Preserved initial publisher behaviors by migrating Combine `.onReceive` patterns to Swift's `.onChange(of:initial:true)`.

### 4. Crash Safety & Render Cleanups
- BatteryActivityManager (boringNotch/managers/BatteryActivityManager.swift)
  * Replaced an unsafe forced unwrap (`sources.first!`) with a safe `guard let` unwrapping.
- WebcamManager (boringNotch/managers/WebcamManager.swift)
  * Removed redundant manual `objectWillChange.send()` triggers on property mutations, letting the standard property tracking mechanisms handle UI refresh.
