### PR TITLE
fix: amend deprecated homebrew depends_on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,7 +425,7 @@ jobs:
               strategy :github_latest
             end
             auto_updates true
-            depends_on macos: ">= :sonoma"
+            depends_on macos: :sonoma
             app "boringNotch.app"
             
             postflight do


### PR DESCRIPTION
```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sonoma` instead.
Please report this issue to the theboredteam/homebrew-boring-notch tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/theboredteam/homebrew-boring-notch/Casks/boring-notch.rb:16
```

amended above
