### PR TITLE
Fix typo: "vizualizers" → "visualizers" in Settings

### DIFF
--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -1368,7 +1368,7 @@ struct Appearance: View {
                 }
             } header: {
                 HStack(spacing: 0) {
-                    Text("Custom vizualizers (Lottie)")
+                    Text("Custom visualizers (Lottie)")
                     if !Defaults[.customVisualizers].isEmpty {
                         Text(" – \(Defaults[.customVisualizers].count)")
                             .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- Fixes a spelling mistake in the Settings view header label: `vizualizers` → `visualizers`

## Test plan
- [ ] Build and open Settings → confirm the "Custom visualizers (Lottie)" section header is spelled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)