### PR TITLE
feat: lock-screen unlock animation with privacy lockdown (#236)

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		149E0B972C737D00006418B1 /* WebcamManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149E0B962C737D00006418B1 /* WebcamManager.swift */; };
 		149E0B9A2C737D40006418B1 /* WebcamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149E0B992C737D40006418B1 /* WebcamView.swift */; };
 		14A7E5882C64A89C008C1BE9 /* HelloAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A7E5872C64A89C008C1BE9 /* HelloAnimation.swift */; };
+		549AADD9DEBF99A16F0E53E0 /* UnlockAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FDBCDFF02732D4F40308B3 /* UnlockAnimation.swift */; };
 		14A7E5972C65FD31008C1BE9 /* boring.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 14A7E5962C65FD31008C1BE9 /* boring.m4a */; };
 		14C08BB62C8DE42D000F8AA0 /* CalendarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */; };
 		14C08BB92C8DE4B1000F8AA0 /* BoringCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C08BB82C8DE4B1000F8AA0 /* BoringCalendar.swift */; };
@@ -284,6 +285,7 @@
 		149E0B962C737D00006418B1 /* WebcamManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcamManager.swift; sourceTree = "<group>"; };
 		149E0B992C737D40006418B1 /* WebcamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcamView.swift; sourceTree = "<group>"; };
 		14A7E5872C64A89C008C1BE9 /* HelloAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelloAnimation.swift; sourceTree = "<group>"; };
+		F7FDBCDFF02732D4F40308B3 /* UnlockAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockAnimation.swift; sourceTree = "<group>"; };
 		14A7E5962C65FD31008C1BE9 /* boring.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = boring.m4a; sourceTree = "<group>"; };
 		14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarManager.swift; sourceTree = "<group>"; };
 		14C08BB82C8DE4B1000F8AA0 /* BoringCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringCalendar.swift; sourceTree = "<group>"; };
@@ -707,6 +709,7 @@
 			children = (
 				14D570B82C5E98A20011E668 /* drop.swift */,
 				14A7E5872C64A89C008C1BE9 /* HelloAnimation.swift */,
+				F7FDBCDFF02732D4F40308B3 /* UnlockAnimation.swift */,
 			);
 			path = animations;
 			sourceTree = "<group>";
@@ -1044,6 +1047,7 @@
 				118EBE312E9717DB00D54B5A /* URL+SecurityScoped.swift in Sources */,
 				1132E5162E777C140068732D /* YouTubeMusicAuthentication.swift in Sources */,
 				14A7E5882C64A89C008C1BE9 /* HelloAnimation.swift in Sources */,
+				549AADD9DEBF99A16F0E53E0 /* UnlockAnimation.swift in Sources */,
 				111BEA612ED09B1B0079DD4E /* NSScreen+UUID.swift in Sources */,
 				1153BD8F2D986B1F00979FB0 /* MediaControllerProtocol.swift in Sources */,
 				11985BF42F38520A00F81585 /* DraggableProgressBar.swift in Sources */,

--- a/boringNotch/BoringViewCoordinator.swift
+++ b/boringNotch/BoringViewCoordinator.swift
@@ -54,6 +54,29 @@ class BoringViewCoordinator: ObservableObject {
 
     @Published var currentView: NotchViews = .home
     @Published var helloAnimationRunning: Bool = false
+    /// Drives the one-shot lock → open morph shown in the notch on unlock.
+    /// Self-healing: a backup timeout clears it even if the view is torn down
+    /// (display change / window recreation) before `onFinish` fires.
+    @Published var unlockAnimationRunning: Bool = false {
+        didSet {
+            guard unlockAnimationRunning, !oldValue else {
+                if !unlockAnimationRunning { unlockAnimationTask?.cancel() }
+                return
+            }
+            unlockAnimationTask?.cancel()
+            unlockAnimationTask = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(3))
+                guard let self, !Task.isCancelled else { return }
+                self.unlockAnimationRunning = false
+            }
+        }
+    }
+    private var unlockAnimationTask: Task<Void, Never>?
+    /// True for the ENTIRE duration the Mac is locked while we keep the notch on the lock
+    /// screen. No timeout — a Mac can stay locked for hours. Gates ALL notch content and
+    /// interactivity so nothing private is shown or reachable over the lock screen.
+    /// Set on lock, cleared on unlock / wake.
+    @Published var screenLocked: Bool = false
     private var sneakPeekDispatch: DispatchWorkItem?
     private var expandingViewDispatch: DispatchWorkItem?
     private var osdEnableTask: Task<Void, Never>?

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -181,6 +181,13 @@ struct ContentView: View {
                                 handlePreviousTrackGesture(translation: translation, phase: phase)
                             }
                     }
+                    .allowsHitTesting(!coordinator.screenLocked)   // lock screen: fully non-interactive
+                    .onChange(of: coordinator.screenLocked) { _, locked in
+                        // If the notch was open the instant the screen locked, snap it shut.
+                        if locked && vm.notchState == .open {
+                            withAnimation(animationSpring) { vm.close() }
+                        }
+                    }
                     .onReceive(NotificationCenter.default.publisher(for: .sharingDidFinish)) { _ in
                         if vm.notchState == .open && !isHovering && !vm.isBatteryPopoverActive {
                             hoverTask?.cancel()
@@ -293,6 +300,13 @@ struct ContentView: View {
                     )
                     .padding(.top, 40)
                     Spacer()
+                } else if coordinator.screenLocked && !coordinator.unlockAnimationRunning {
+                    // Locked: only the padlock (left) + the non-private soundwave (right, when
+                    // playing). No album art / title / calendar / shelf, and non-interactive.
+                    lockedNotchContent(morphing: false)
+                } else if coordinator.unlockAnimationRunning {
+                    // The padlock morphs open in place; the soundwave continues; then back to normal.
+                    lockedNotchContent(morphing: true)
                 } else {
                     if coordinator.expandingView.type == .battery && coordinator.expandingView.show
                         && vm.notchState == .closed && Defaults[.showPowerStatusNotifications]
@@ -348,7 +362,7 @@ struct ContentView: View {
                            Rectangle().fill(.clear).frame(width: vm.closedNotchSize.width - 20, height: displayClosedNotchHeight)
                        }
 
-                      if coordinator.shouldShowSneakPeek(on: vm.screenUUID) {
+                      if coordinator.shouldShowSneakPeek(on: vm.screenUUID) && !coordinator.screenLocked {
                           if (coordinator.sneakPeekState(for: vm.screenUUID).type != .music) && (coordinator.sneakPeekState(for: vm.screenUUID).type != .battery) && !Defaults[.inlineOSD] && vm.notchState == .closed {
                               SystemEventIndicatorModifier(
                                   eventType: coordinator.binding(for: vm.screenUUID).type,
@@ -391,7 +405,7 @@ struct ContentView: View {
                       .fixedSize()
               }
               .zIndex(1)
-            if vm.notchState == .open {
+            if vm.notchState == .open && !coordinator.screenLocked {
                 VStack {
                     switch coordinator.currentView {
                     case .home:
@@ -415,6 +429,45 @@ struct ContentView: View {
             }
         }
         .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], delegate: GeneralDropTargetDelegate(isTargeted: $vm.generalDropTargeting))
+    }
+
+    /// Locked notch: the padlock sits in the LEFT chin (where album art would be — but the
+    /// art/title are private, so the lock replaces them); the non-private audio soundwave
+    /// stays in the RIGHT chin while music plays. The notch widens horizontally just enough.
+    @ViewBuilder
+    private func lockedNotchContent(morphing: Bool) -> some View {
+        let musicPlaying = musicManager.isPlaying || !musicManager.isPlayerIdle
+        HStack(spacing: 0) {
+            Group {
+                if morphing {
+                    UnlockAnimation(immediate: true, onFinish: {
+                        withAnimation(.smooth(duration: 0.4)) {
+                            coordinator.unlockAnimationRunning = false
+                        }
+                    })
+                } else {
+                    UnlockAnimation(autoPlay: false)
+                }
+            }
+            .frame(width: 30)
+
+            Rectangle()
+                .fill(.black)
+                .frame(width: vm.closedNotchSize.width + 20)   // physical-notch gap
+
+            if musicPlaying {
+                // Abstract soundwave only — reveals nothing about the track.
+                AudioSpectrumView(
+                    isPlaying: musicManager.isPlaying,
+                    tintColor: Defaults[.coloredSpectrogram]
+                        ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.5)
+                        : Color.gray
+                )
+                .frame(width: 18, height: 12)
+                .frame(width: 30)
+            }
+        }
+        .frame(height: displayClosedNotchHeight, alignment: .center)
     }
 
     @ViewBuilder
@@ -540,7 +593,7 @@ struct ContentView: View {
 
     @ViewBuilder
     var dragDetector: some View {
-        if Defaults[.boringShelf] && vm.notchState == .closed {
+        if Defaults[.boringShelf] && vm.notchState == .closed && !coordinator.screenLocked {
             Color.clear
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .contentShape(Rectangle())
@@ -556,6 +609,7 @@ struct ContentView: View {
 
     @discardableResult
     private func doOpen() -> Bool {
+        guard !coordinator.screenLocked else { return false }
         var didOpen = false
         withAnimation(animationSpring) {
             didOpen = vm.open()
@@ -567,6 +621,7 @@ struct ContentView: View {
 
     private func handleHover(_ hovering: Bool) {
         if coordinator.firstLaunch { return }
+        if coordinator.screenLocked { return }   // no hover-open on the lock screen
         hoverTask?.cancel()
         
         if hovering {

--- a/boringNotch/animations/UnlockAnimation.swift
+++ b/boringNotch/animations/UnlockAnimation.swift
@@ -1,0 +1,70 @@
+//
+//  UnlockAnimation.swift
+//  boringNotch
+//
+//  A one-shot lock → open morph that plays in the notch when the Mac is unlocked.
+//  Uses native SF Symbol transitions (no image assets), tinted with the app accent.
+//
+
+import SwiftUI
+
+struct UnlockAnimation: View {
+    /// When false, render the lock fully visible (closed) with no timeline — the static
+    /// "locked, closed padlock over the lock screen" state.
+    var autoPlay: Bool
+    /// Unlock flow: skip the pop-in + initial hold and morph closed → open right away
+    /// (the lock was already shown closed over the lock screen).
+    var immediate: Bool
+    /// Called when the unlock animation has fully played out so the caller can clear its flag.
+    var onFinish: () -> Void
+
+    @State private var unlocked: Bool = false
+    @State private var appeared: Bool
+
+    init(autoPlay: Bool = true, immediate: Bool = false, onFinish: @escaping () -> Void = {}) {
+        self.autoPlay = autoPlay
+        self.immediate = immediate
+        self.onFinish = onFinish
+        // Already-visible cases (the unlock morph after the locked lock, or the pure static
+        // closed lock) skip the pop-in so the handoff is seamless.
+        _appeared = State(initialValue: immediate || !autoPlay)
+    }
+
+    var body: some View {
+        // A SINGLE Image expression (ternary on systemName) keeps view identity so the
+        // .replace transition morphs the glyph instead of hard-cutting. Do not add .id().
+        Image(systemName: unlocked ? "lock.open.fill" : "lock.fill")
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(Color.effectiveAccent)
+            .contentTransition(.symbolEffect(.replace))   // the closed → open morph
+            .symbolEffect(.bounce, value: unlocked)        // little flourish on the flip
+            .scaleEffect(appeared ? 1.0 : 0.6)
+            .opacity(appeared ? 1.0 : 0.0)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .task {
+                guard autoPlay else { return }
+                if immediate {
+                    try? await Task.sleep(for: .seconds(0.15))
+                } else {
+                    // Desktop flow: pop in, hold closed.
+                    withAnimation(StandardAnimations.bouncy) { appeared = true }
+                    try? await Task.sleep(for: .seconds(0.45))
+                }
+
+                // Morph to open (the swap must be inside withAnimation).
+                withAnimation(.easeInOut(duration: 0.35)) { unlocked = true }
+
+                // Hold open, then fade out and finish.
+                try? await Task.sleep(for: .seconds(0.9))
+                withAnimation(.easeOut(duration: 0.3)) { appeared = false }
+                try? await Task.sleep(for: .seconds(0.3))
+                onFinish()
+            }
+    }
+}
+
+#Preview {
+    UnlockAnimation(onFinish: {})
+        .frame(width: 185, height: 32)
+        .background(.black)
+}

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -80,6 +80,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var onboardingWindowController: NSWindowController?
     private var screenLockedObserver: Any?
     private var screenUnlockedObserver: Any?
+    private var screenWakeObserver: Any?
     private var isScreenLocked: Bool = false
     private var windowScreenDidChangeObserver: Any?
     private var dragDetectors: [String: DragDetector] = [:] // UUID -> DragDetector
@@ -102,6 +103,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             DistributedNotificationCenter.default().removeObserver(observer)
             screenUnlockedObserver = nil
         }
+        if let observer = screenWakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+            screenWakeObserver = nil
+        }
         MusicManager.shared.destroy()
         cleanupDragDetectors()
         cleanupWindows()
@@ -117,23 +122,90 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @MainActor
     func onScreenLocked(_ notification: Notification) {
         isScreenLocked = true
-        if !Defaults[.showOnLockScreen] {
-            cleanupWindows()
-        } else {
+
+        let wantLockShowcase = Defaults[.enableUnlockAnimation]
+            && !coordinator.firstLaunch
+            && !coordinator.helloAnimationRunning
+
+        if Defaults[.showOnLockScreen] || wantLockShowcase {
+            // 1. Lock down BEFORE the notch is presented over the lock screen, so there's never
+            //    a frame where a live, openable notch shows: this gates open(), renders only the
+            //    lock (+ soundwave), and force-closes any open notch.
+            withAnimation(.smooth(duration: 0.4)) {
+                coordinator.screenLocked = true
+                vm.close()
+                viewModels.values.forEach { $0.close() }
+            }
+            // 2. Kill AppKit-level mouse routing + tear down the global drag-to-open monitors.
+            setNotchWindowsIgnoreMouse(true)
+            cleanupDragDetectors()
+            // 3. Present the notch over the lock screen.
             enableSkyLightOnAllWindows()
+        } else {
+            // Feature off and not showing on the lock screen → destroy the notch (today's behavior).
+            coordinator.screenLocked = false
+            cleanupWindows()
         }
     }
 
     @MainActor
     func onScreenUnlocked(_ notification: Notification) {
         isScreenLocked = false
-        if !Defaults[.showOnLockScreen] {
-            adjustWindowPosition(changeAlpha: true)
+
+        // True iff onScreenLocked kept the notch window alive over the lock screen (showcase or
+        // showOnLockScreen). If so we just move it back to the desktop space; otherwise it was
+        // destroyed on lock and must be rebuilt. (Capture before we clear screenLocked below.)
+        let windowWasKeptAlive = coordinator.screenLocked
+
+        // 1. Re-enable interactivity FIRST so the morph runs on a live, controllable notch.
+        setNotchWindowsIgnoreMouse(false)
+
+        // 2. Clear lock state and hand off to the open morph atomically.
+        let willMorph = Defaults[.enableUnlockAnimation]
+            && !coordinator.firstLaunch
+            && !coordinator.helloAnimationRunning
+        if willMorph {
+            withAnimation(.smooth(duration: 0.45)) {
+                coordinator.unlockAnimationRunning = true
+                coordinator.screenLocked = false
+            }
         } else {
-            disableSkyLightOnAllWindows()
+            coordinator.screenLocked = false
         }
+
+        // 3. Window lifecycle. The kept-alive window stays on screen so the morph plays without a
+        // flash; `disableSkyLight` lifts it off the SkyLight space back onto the desktop. But that
+        // window is now SkyLight-tainted and swallows desktop clicks under the notch, so once the
+        // morph has finished and the notch is idle, seamlessly swap it for a pristine window
+        // (drawn over the old one before closing it → no flash, clicks restored).
+        if windowWasKeptAlive {
+            disableSkyLightOnAllWindows()
+            let swapDelay: Double = willMorph ? 2.4 : 0.3
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(swapDelay))
+                self.seamlesslyRebuildNotchWindows()
+            }
+        } else {
+            // Feature off: the window was destroyed on lock — rebuild it.
+            adjustWindowPosition(changeAlpha: true)
+        }
+
+        // 4. Rebuild the drag detectors torn down on lock.
+        setupDragDetectors()
     }
     
+    /// While locked, make the notch window(s) ignore mouse events so clicks/hover route straight
+    /// to the lock screen behind — belt-and-suspenders to SwiftUI's `allowsHitTesting`.
+    @MainActor
+    private func setNotchWindowsIgnoreMouse(_ ignore: Bool) {
+        let apply: (NSWindow) -> Void = { $0.ignoresMouseEvents = ignore }
+        if Defaults[.showOnAllDisplays] {
+            windows.values.forEach(apply)
+        } else if let window = window {
+            apply(window)
+        }
+    }
+
     @MainActor
     private func enableSkyLightOnAllWindows() {
         if Defaults[.showOnAllDisplays] {
@@ -166,6 +238,146 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                         skyWindow.disableSkyLight()
                     }
                 }
+            }
+        }
+    }
+
+    /// Retire each SkyLight-tainted notch window by moving its LIVE content onto a brand-new,
+    /// never-delegated window — pixel-seamlessly (no flash, no chin discontinuity).
+    ///
+    /// Why this exists: SkyLight delegation (`enableSkyLight` on lock) leaves persistent
+    /// server-side state on the window that survives `undelegateWindow` + re-adding it to the
+    /// high-level `notchSpace` (`disableSkyLight`). The symptom is that the transparent 640px
+    /// margins start swallowing desktop clicks near/under the notch after an unlock. A fresh
+    /// window — new `windowNumber`, never delegated to SkyLight — is the only reliable cure.
+    ///
+    /// Seamlessness has two independent requirements that together forced this design:
+    ///   • CHIN CONTINUITY → we must REUSE the same `NSHostingView`. A *fresh* view cannot match
+    ///     the old one for one frame: `AudioSpectrum` drives each bar with a `CAKeyframeAnimation`
+    ///     whose `beginTime` is `CACurrentMediaTime()`-relative (MusicVisualizer.swift), so a new
+    ///     instance re-phases the waveform; and the album art's `matchedGeometryEffect` namespace
+    ///     is per-`ContentView`. Reusing the instance keeps both byte-identical (a fresh view gave
+    ///     a 1-frame flash on the left/right chins).
+    ///   • NO BLANK FRAME → reparenting that live view detaches it from the old window the instant
+    ///     it is moved, while its layer's backing surface re-hosts onto the new window
+    ///     ASYNCHRONOUSLY — a sub-frame gap where the notch had no drawn pixels (an earlier reparent
+    ///     flashed the whole notch). We bridge that gap with a STATIC SNAPSHOT of the live view's
+    ///     current pixels, placed BENEATH the live view inside the new window. Something
+    ///     pixel-identical always occupies the notch during the re-host; once the live view's
+    ///     surface populates it covers the snapshot, and the snapshot is removed a runloop turn
+    ///     later. The reused view keeps animating throughout, so any residual delta is <1 frame.
+    ///
+    /// The container is a `NotchPassthroughContainerView` so transparent margins still pass desktop
+    /// clicks through exactly as when the hosting view is the window's content view directly.
+    /// State continuity holds because the moved view already binds the SAME view model.
+    /// Call this only once the unlock morph has finished and the notch is idle.
+    @MainActor
+    private func seamlesslyRebuildNotchWindows() {
+        /// Static bitmap of `view`'s current pixels (synchronous, in-process; unaffected by
+        /// `sharingType == .none`, which only blocks out-of-process capture).
+        func snapshotView(of view: NSView) -> NSImageView {
+            let b = view.bounds
+            let iv = NSImageView(frame: b)
+            iv.imageScaling = .scaleNone
+            iv.wantsLayer = true
+            iv.autoresizingMask = [.width, .height]
+            if b.width > 0, b.height > 0, let rep = view.bitmapImageRepForCachingDisplay(in: b) {
+                view.cacheDisplay(in: b, to: rep)
+                let img = NSImage(size: b.size)
+                img.addRepresentation(rep)
+                iv.image = img
+            }
+            return iv
+        }
+
+        /// Build the pristine replacement and move `oldWindow`'s live view onto it, bridged by a
+        /// snapshot. `oldWindow.contentView` is read but the snapshot/live both live in the NEW
+        /// window, so the notch position is never blank. Returns the new window + the snapshot to
+        /// drop later. Nil if the old window has no content view.
+        func bridgeReparent(from oldWindow: NSWindow, bind viewModel: BoringViewModel, on screen: NSScreen) -> (new: NSWindow, snapshot: NSImageView)? {
+            guard let liveView = oldWindow.contentView else { return nil }
+
+            let newWindow = createBoringNotchWindow(for: screen, with: viewModel, installContentView: false)
+            newWindow.alphaValue = 1
+            let f = screen.frame
+            newWindow.setFrameOrigin(NSPoint(
+                x: f.origin.x + (f.width / 2) - newWindow.frame.width / 2,
+                y: f.origin.y + f.height - newWindow.frame.height
+            ))
+
+            // Container: frozen snapshot at the bottom; the live view goes above it once the window
+            // is drawn. Passthrough hit-testing preserves margin click-through.
+            let container = NotchPassthroughContainerView(frame: NSRect(origin: .zero, size: newWindow.frame.size))
+            container.wantsLayer = true
+            container.autoresizesSubviews = true
+            let snapshot = snapshotView(of: liveView)   // captured while still on the old window
+            snapshot.frame = container.bounds
+            container.addSubview(snapshot)
+            newWindow.contentView = container
+
+            // Stack the new window above the old one and draw the frozen bitmap NOW.
+            newWindow.orderFrontRegardless()
+            NotchSpaceManager.shared.notchSpace.windows.insert(newWindow)
+            container.layoutSubtreeIfNeeded()
+            newWindow.displayIfNeeded()
+            CATransaction.flush()                       // frozen bitmap is live server-side
+
+            // Move the LIVE view above the snapshot. This detaches it from the old window (which
+            // goes blank, but is behind the new window's snapshot), and re-hosts its surface onto
+            // the new window — covered by the snapshot beneath until it populates.
+            liveView.frame = container.bounds
+            liveView.autoresizingMask = [.width, .height]
+            container.addSubview(liveView, positioned: .above, relativeTo: snapshot)
+            liveView.layoutSubtreeIfNeeded()
+            liveView.layer?.layoutIfNeeded()
+            CATransaction.flush()                       // force the live surface to populate
+            return (newWindow, snapshot)
+        }
+
+        /// One runloop turn later the live view is drawn: drop the snapshot and retire the old
+        /// window in one coalesced flush, revealing the live (same-phase, still-animating) view.
+        func finish(old: NSWindow, snapshot: NSImageView) {
+            NSDisableScreenUpdates()
+            old.orderOut(nil)
+            NotchSpaceManager.shared.notchSpace.windows.remove(old)
+            old.close()                                 // isReleasedWhenClosed == false
+            snapshot.removeFromSuperview()
+            NSEnableScreenUpdates()
+        }
+
+        if Defaults[.showOnAllDisplays] {
+            var pending: [(old: NSWindow, snapshot: NSImageView)] = []
+            for uuid in Array(windows.keys) {
+                guard let oldWindow = windows[uuid],
+                      let viewModel = viewModels[uuid],
+                      oldWindow.contentView != nil,
+                      let screen = oldWindow.screen ?? NSScreen.screen(withUUID: uuid) else { continue }
+                // createBoringNotchWindow overwrites `windowScreenDidChangeObserver` each call;
+                // remove the prior token per iteration (the old multi-display path leaked them).
+                let oldObserver = windowScreenDidChangeObserver
+                guard let r = bridgeReparent(from: oldWindow, bind: viewModel, on: screen) else { continue }
+                if let oldObserver { NotificationCenter.default.removeObserver(oldObserver) }
+                windows[uuid] = r.new
+                pending.append((oldWindow, r.snapshot))
+            }
+            DispatchQueue.main.async {
+                pending.forEach { finish(old: $0.old, snapshot: $0.snapshot) }
+                self.setupDragDetectors()
+                self.coordinator.applyOSDSources()
+            }
+        } else {
+            guard let oldWindow = window, oldWindow.contentView != nil,
+                  let screen = oldWindow.screen
+                    ?? NSScreen.screen(withUUID: coordinator.selectedScreenUUID)
+                    ?? NSScreen.main else { return }
+            let oldObserver = windowScreenDidChangeObserver
+            guard let r = bridgeReparent(from: oldWindow, bind: vm, on: screen) else { return }
+            window = r.new
+            if let oldObserver { NotificationCenter.default.removeObserver(oldObserver) }
+            DispatchQueue.main.async {
+                finish(old: oldWindow, snapshot: r.snapshot)
+                self.setupDragDetectors()
+                self.coordinator.applyOSDSources()
             }
         }
     }
@@ -263,26 +475,34 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func createBoringNotchWindow(for screen: NSScreen, with viewModel: BoringViewModel) -> NSWindow {
+    /// - Parameter installContentView: when `false`, the window is created bare — no hosting view,
+    ///   not ordered front, not inserted into `notchSpace`. The caller is then responsible for
+    ///   supplying a content view (e.g. by reparenting a live one) and doing the ordering/insertion,
+    ///   all under its own screen-updates guard. See `seamlesslyRebuildNotchWindows`.
+    private func createBoringNotchWindow(for screen: NSScreen, with viewModel: BoringViewModel, installContentView: Bool = true) -> NSWindow {
         let rect = NSRect(x: 0, y: 0, width: windowSize.width, height: windowSize.height)
         let styleMask: NSWindow.StyleMask = [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow]
-        
+
         let window = BoringNotchSkyLightWindow(contentRect: rect, styleMask: styleMask, backing: .buffered, defer: false)
-        
-        // Enable SkyLight only when screen is locked
+
+        // Enable SkyLight only when screen is locked; a window born during lock must also be
+        // non-interactive (no opening the notch on the lock screen).
         if isScreenLocked {
             window.enableSkyLight()
+            window.ignoresMouseEvents = true
         } else {
             window.disableSkyLight()
         }
 
-        window.contentView = NSHostingView(
-            rootView: ContentView()
-                .environmentObject(viewModel)
-        )
+        if installContentView {
+            window.contentView = NSHostingView(
+                rootView: ContentView()
+                    .environmentObject(viewModel)
+            )
 
-        window.orderFrontRegardless()
-        NotchSpaceManager.shared.notchSpace.windows.insert(window)
+            window.orderFrontRegardless()
+            NotchSpaceManager.shared.notchSpace.windows.insert(window)
+        }
 
         // Observe when the window's screen changes so we can update drag detectors
         windowScreenDidChangeObserver = NotificationCenter.default.addObserver(
@@ -380,6 +600,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             object: nil, queue: .main) { [weak self] notification in
                 Task { @MainActor in
                     self?.onScreenUnlocked(notification)
+                }
+        }
+
+        // Safety net: if the screen wakes without a lock-screen unlock event (e.g. sleep/wake
+        // with no password required), never leave the notch window stuck delegated to the
+        // SkyLight space above other apps.
+        screenWakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil, queue: .main) { [weak self] _ in
+                Task { @MainActor in
+                    guard let self, !self.isScreenLocked, self.coordinator.screenLocked else { return }
+                    self.coordinator.screenLocked = false
+                    self.setNotchWindowsIgnoreMouse(false)
+                    self.disableSkyLightOnAllWindows()
+                    self.setupDragDetectors()
+                    // The window was SkyLight-delegated on lock; swap it for a pristine one so it
+                    // stops swallowing desktop clicks under the notch (see seamlesslyRebuildNotchWindows).
+                    try? await Task.sleep(for: .seconds(0.3))
+                    self.seamlesslyRebuildNotchWindows()
                 }
         }
 
@@ -651,5 +890,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         onboardingWindowController?.window?.level = .floating
         onboardingWindowController?.window?.makeKeyAndOrderFront(nil)
         onboardingWindowController?.window?.orderFrontRegardless()
+    }
+}
+
+/// A notch-window content view that never claims a click for itself. It only returns hits on its
+/// subviews (the live notch hosting view); a point that lands on nothing but the container itself
+/// returns `nil`, so the transparent margins pass desktop clicks through to the window behind —
+/// exactly as when the `NSHostingView` is the window's content view directly. Used by
+/// `seamlesslyRebuildNotchWindows` to wrap the reused hosting view + its bridging snapshot without
+/// reintroducing the under-the-notch click-swallow bug.
+final class NotchPassthroughContainerView: NSView {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let hit = super.hitTest(point)
+        return hit === self ? nil : hit
     }
 }

--- a/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
@@ -11,23 +11,27 @@ import Defaults
 import Combine
 
 extension SkyLightOperator {
+    /// Remove the window from the SkyLight space.
+    ///
+    /// `delegateWindow` uses `SLSSpaceAddWindowsAndRemoveFromSpaces` (flag 7), which removes the
+    /// window from ALL its current spaces — including the app's high-level `notchSpace` CGSSpace —
+    /// and adds it to the SkyLight space. Undoing that here ONLY removes it from the SkyLight space;
+    /// the window is then in no space. The caller (`disableSkyLight`) immediately re-homes it into
+    /// `notchSpace` via `CGSSpace.reassert`, restoring the exact membership a fresh window has.
+    ///
+    /// We deliberately do NOT re-add the window to the active desktop space here: a normal-desktop
+    /// 640×210 transparent panel sits in the regular hit-test stack and swallows desktop clicks
+    /// across its margins. The high-level `notchSpace` is what isolates it from desktop hit-testing.
     func undelegateWindow(_ window: NSWindow) {
         typealias F_SLSRemoveWindowsFromSpaces = @convention(c) (Int32, CFArray, CFArray) -> Int32
-        
+
         let handler = dlopen("/System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight", RTLD_NOW)
-        guard let SLSRemoveWindowsFromSpaces = unsafeBitCast(
-            dlsym(handler, "SLSRemoveWindowsFromSpaces"),
-            to: F_SLSRemoveWindowsFromSpaces?.self
-        ) else {
-            return
+        let windowList = [window.windowNumber] as CFArray
+
+        if let SLSRemoveWindowsFromSpaces = unsafeBitCast(
+            dlsym(handler, "SLSRemoveWindowsFromSpaces"), to: F_SLSRemoveWindowsFromSpaces?.self) {
+            _ = SLSRemoveWindowsFromSpaces(connection, windowList, [space] as CFArray)
         }
-        
-        // Remove the window from the SkyLight space
-        _ = SLSRemoveWindowsFromSpaces(
-            connection,
-            [window.windowNumber] as CFArray,
-            [space] as CFArray
-        )
     }
 }
 
@@ -132,7 +136,14 @@ class BoringNotchSkyLightWindow: NSPanel {
     
     func disableSkyLight() {
         if isSkyLightEnabled {
+            // 1. Remove from the SkyLight space (window is now in no space).
             SkyLightOperator.shared.undelegateWindow(self)
+            // 2. Re-home into the app's high-level notchSpace — the exact CGS membership a fresh
+            //    window has. This is what stops the transparent margins from swallowing desktop
+            //    clicks after unlock. The notchSpace.windows Set still contains us (it was never
+            //    mutated on lock), so a plain insert would be a didSet no-op; reassert forces the
+            //    raw CGSAddWindowsToSpaces re-add. No window rebuild → no flash.
+            NotchSpaceManager.shared.notchSpace.reassert([self])
             isSkyLightEnabled = false
         }
     }

--- a/boringNotch/components/Settings/Views/GeneralSettingsView.swift
+++ b/boringNotch/components/Settings/Views/GeneralSettingsView.swift
@@ -31,6 +31,7 @@ struct GeneralSettings: View {
     @Default(.enableGestures) var enableGestures
     @Default(.openNotchOnHover) var openNotchOnHover
     @Default(.enableOpeningAnimation) var enableOpeningAnimation
+    @Default(.enableUnlockAnimation) var enableUnlockAnimation
     @Default(.animationSpeedMultiplier) var animationSpeedMultiplier
 
     var body: some View {
@@ -265,6 +266,7 @@ struct GeneralSettings: View {
                     }
                 }
             }
+            Toggle("Lock animation on unlock", isOn: $enableUnlockAnimation)
         } header: {
             Text("Notch behavior")
         }

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -197,6 +197,9 @@ class BoringViewModel: NSObject, ObservableObject {
     @discardableResult
     func open() -> Bool {
         guard !coordinator.firstLaunch else { return false }
+        // Never let the notch open while the screen is locked (privacy: no calendar/music/shelf
+        // on the lock screen). Neutralizes every open() caller — hover, tap, gesture, drag, shortcut.
+        guard !coordinator.screenLocked else { return false }
 
         self.notchSize = openNotchSize
         self.notchState = .open

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -215,6 +215,7 @@ extension Defaults.Keys {
     // MARK: Behavior
     static let minimumHoverDuration = Key<TimeInterval>("minimumHoverDuration", default: 0.3)
     static let enableOpeningAnimation = Key<Bool>("enableOpeningAnimation", default: true)
+    static let enableUnlockAnimation = Key<Bool>("enableUnlockAnimation", default: true)
     static let animationSpeedMultiplier = Key<Double>("animationSpeedMultiplier", default: 1.0)
     static let enableHaptics = Key<Bool>("enableHaptics", default: true)
     static let openNotchOnHover = Key<Bool>("openNotchOnHover", default: true)

--- a/boringNotch/private/CGSSpace.swift
+++ b/boringNotch/private/CGSSpace.swift
@@ -29,6 +29,21 @@ public final class CGSSpace {
         }
     }
 
+    /// Force-(re)add windows to THIS space at the window-server level, even when our
+    /// `windows` Set already lists them.
+    ///
+    /// SkyLight's `delegateWindow` evicts the window from this space out-of-band (its
+    /// `flag 7` removes the window from ALL current spaces), but no Swift code mutates the
+    /// `windows` Set, so `didSet` never re-fires and the window is never re-added. After
+    /// undelegating, call this to restore the window to this dedicated max-level space —
+    /// the exact CGS membership a freshly-built window has — so its transparent margins
+    /// stop swallowing desktop clicks. No window rebuild, so no flash.
+    public func reassert(_ windowsToReadd: Set<NSWindow>) {
+        CGSAddWindowsToSpaces(_CGSDefaultConnection(),
+                              windowsToReadd.map { $0.windowNumber } as NSArray,
+                              [self.identifier])
+    }
+
     /// Initialized `CGSSpace`s *MUST* be de-initialized upon app exit!
     public init(level: Int = 0) {
         let flag = 0x1 // this value MUST be 1, otherwise, Finder decides to draw desktop icons


### PR DESCRIPTION
Implements the unlock animation from #236.

## What it does
A closed padlock appears in the notch **over the macOS lock screen** and **morphs open** (`lock.fill` → `lock.open.fill`) the moment the Mac is unlocked. The notch widens horizontally just enough to show it.

🎥 **Demo:** https://makertube.net/w/fygAdGQPZ6yoKZuYmiY1dZ

- **Privacy lockdown while locked** — nothing private is shown (no calendar, track title, album art, or shelf) and the notch is non-interactive (can't be opened by hover / tap / gesture / drag / shortcut).
- **Music still works** — the non-private audio soundwave shows on the right while playing, and hardware media keys (play / skip / stop) keep working.
- **Toggle** — "Lock animation on unlock" in General settings.
- Drawing over the lock screen reuses the **SkyLight** window the existing `showOnLockScreen` feature already uses.

## Why the `boringNotchApp.swift` diff is large (the journey)
Presenting the notch over the lock screen surfaced a non-obvious bug; most of the added code is the fix, and it informs the design:

1. **Click-swallow after unlock.** SkyLight delegation leaves *persistent server-side state* on the window — after unlock its transparent margins swallow desktop clicks under/near the notch. Undelegating, re-homing into the high-level `notchSpace`, and moving back to the active space all failed to clear it. The only reliable cure is **replacing the window with a brand-new, never-delegated one**.
2. **Flash on swap.** A *fresh* `NSHostingView` shows a blank first frame (whole-notch flash); even reparenting flashed because the moved layer's surface re-hosts asynchronously (sub-frame gap); and a fresh view can't match the **chins** — `AudioSpectrum` uses a `CACurrentMediaTime()`-relative keyframe animation (re-phases the waveform) and album art uses a per-`ContentView` `matchedGeometryEffect` namespace.
3. **What works best (this PR).** Reparent the **same** `NSHostingView` onto the pristine window (keeps spectrum phase + album art continuous), bridge the async re-host with a **static snapshot of the live notch placed beneath it** (never blank), inside a passthrough container so margin clicks still pass through. The old window is retired one runloop turn later.

## Known tradeoff
A faint ~1–2px horizontal seam at the very top edge can briefly appear at the swap **only while media is playing**. With no media the notch is closed, so it never shows. Ideas welcome.

## Open questions
- Private SkyLight API — acceptable here (the existing `showOnLockScreen` already uses it)?
- Default-on vs opt-in for the toggle?
- Scope: keep the on-lock-screen padlock, or just the in-notch unlock morph?

Opening as **draft** to align on scope before polishing.
