### PR TITLE
feat: Add Pomodoro Timer - focus/break cycles with notch integration

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -143,6 +143,8 @@
 		B1F747F92EC7E94000F841DB /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F747F82EC7E94000F841DB /* LottieView.swift */; };
 		B1FEB4992C7686630066EBBC /* PanGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FEB4982C7686630066EBBC /* PanGesture.swift */; };
 		F38DE6482D8243E7008B5C6D /* BatteryActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */; };
+		AA0000012EF0000100000001 /* PomodoroManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000022EF0000100000001 /* PomodoroManager.swift */; };
+		AA0000032EF0000100000001 /* PomodoroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000042EF0000100000001 /* PomodoroView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -309,6 +311,8 @@
 		B1F747F82EC7E94000F841DB /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
 		B1FEB4982C7686630066EBBC /* PanGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanGesture.swift; sourceTree = "<group>"; };
 		F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryActivityManager.swift; sourceTree = "<group>"; };
+		AA0000022EF0000100000001 /* PomodoroManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroManager.swift; sourceTree = "<group>"; };
+		AA0000042EF0000100000001 /* PomodoroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -495,6 +499,7 @@
 				B18654302C6F4590000B926A /* Settings */,
 				B186542F2C6F455E000B926A /* Notch */,
 				9A0887332C7AFF7E00C160EA /* Tabs */,
+				AA0000052EF0000100000001 /* Pomodoro */,
 				B186542E2C6F453B000B926A /* Music */,
 				14D570BF2C5EA5870011E668 /* AnimatedFace.swift */,
 				14288DE72C6E01C800B9F80C /* ProgressIndicator.swift */,
@@ -505,6 +510,14 @@
 				B1F747F82EC7E94000F841DB /* LottieView.swift */,
 			);
 			path = components;
+			sourceTree = "<group>";
+		};
+		AA0000052EF0000100000001 /* Pomodoro */ = {
+			isa = PBXGroup;
+			children = (
+				AA0000042EF0000100000001 /* PomodoroView.swift */,
+			);
+			path = Pomodoro;
 			sourceTree = "<group>";
 		};
 		147163B52C5D804B0068B555 /* managers */ = {
@@ -518,6 +531,7 @@
 				14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */,
 				B1F0A0012E60000100000001 /* BrightnessManager.swift */,
 				59D8C23B2E589FAA00147B33 /* VolumeManager.swift */,
+				AA0000022EF0000100000001 /* PomodoroManager.swift */,
 			);
 			path = managers;
 			sourceTree = "<group>";
@@ -1020,6 +1034,8 @@
 				1100290C2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift in Sources */,
 				11CFC6632E09918400748C80 /* MusicControllerSelectionView.swift in Sources */,
 				B1F0A0022E60000100000001 /* BrightnessManager.swift in Sources */,
+				AA0000012EF0000100000001 /* PomodoroManager.swift in Sources */,
+				AA0000032EF0000100000001 /* PomodoroView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/boringNotch/BoringViewCoordinator.swift
+++ b/boringNotch/BoringViewCoordinator.swift
@@ -155,7 +155,13 @@ class BoringViewCoordinator: ObservableObject {
                                 await MediaKeyInterceptor.shared.start()
                             } else {
                                 Defaults[.hudReplacement] = false
-        }
+                            }
+                        }
+                    } else {
+                        MediaKeyInterceptor.shared.stop()
+                    }
+                }
+            }
 
         PomodoroManager.shared.$isRunning
             .sink { [weak self] running in
@@ -174,12 +180,6 @@ class BoringViewCoordinator: ObservableObject {
                 }
             }
             .store(in: &cancellables)
-    }
-                    } else {
-                        MediaKeyInterceptor.shared.stop()
-                    }
-                }
-            }
 
         Task { @MainActor in
             helloAnimationRunning = firstLaunch

--- a/boringNotch/BoringViewCoordinator.swift
+++ b/boringNotch/BoringViewCoordinator.swift
@@ -56,7 +56,6 @@ class BoringViewCoordinator: ObservableObject {
     private var sneakPeekDispatch: DispatchWorkItem?
     private var expandingViewDispatch: DispatchWorkItem?
     private var hudEnableTask: Task<Void, Never>?
-    private var cancellables = Set<AnyCancellable>()
 
     @AppStorage("firstLaunch") var firstLaunch: Bool = true
     @AppStorage("showWhatsNew") var showWhatsNew: Bool = true
@@ -162,24 +161,6 @@ class BoringViewCoordinator: ObservableObject {
                     }
                 }
             }
-
-        PomodoroManager.shared.$isRunning
-            .sink { [weak self] running in
-                guard let self = self else { return }
-                if running {
-                    self.toggleExpandingView(
-                        status: true,
-                        type: .pomodoro,
-                        value: 0
-                    )
-                } else {
-                    self.toggleExpandingView(
-                        status: false,
-                        type: .pomodoro
-                    )
-                }
-            }
-            .store(in: &cancellables)
 
         Task { @MainActor in
             helloAnimationRunning = firstLaunch

--- a/boringNotch/BoringViewCoordinator.swift
+++ b/boringNotch/BoringViewCoordinator.swift
@@ -18,6 +18,7 @@ enum SneakContentType {
     case mic
     case battery
     case download
+    case pomodoro
 }
 
 struct sneakPeek {
@@ -55,6 +56,7 @@ class BoringViewCoordinator: ObservableObject {
     private var sneakPeekDispatch: DispatchWorkItem?
     private var expandingViewDispatch: DispatchWorkItem?
     private var hudEnableTask: Task<Void, Never>?
+    private var cancellables = Set<AnyCancellable>()
 
     @AppStorage("firstLaunch") var firstLaunch: Bool = true
     @AppStorage("showWhatsNew") var showWhatsNew: Bool = true
@@ -153,8 +155,26 @@ class BoringViewCoordinator: ObservableObject {
                                 await MediaKeyInterceptor.shared.start()
                             } else {
                                 Defaults[.hudReplacement] = false
-                            }
-                        }
+        }
+
+        PomodoroManager.shared.$isRunning
+            .sink { [weak self] running in
+                guard let self = self else { return }
+                if running {
+                    self.toggleExpandingView(
+                        status: true,
+                        type: .pomodoro,
+                        value: 0
+                    )
+                } else {
+                    self.toggleExpandingView(
+                        status: false,
+                        type: .pomodoro
+                    )
+                }
+            }
+            .store(in: &cancellables)
+    }
                     } else {
                         MediaKeyInterceptor.shared.stop()
                     }
@@ -210,7 +230,7 @@ class BoringViewCoordinator: ObservableObject {
         icon: String = ""
     ) {
         sneakPeekDuration = duration
-        if type != .music {
+        if type != .music && type != .pomodoro {
             // close()
             if !Defaults[.hudReplacement] {
                 return

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentView: View {
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var brightnessManager = BrightnessManager.shared
     @ObservedObject var volumeManager = VolumeManager.shared
+    @ObservedObject var pomodoroManager = PomodoroManager.shared
     @State private var hoverTask: Task<Void, Never>?
     @State private var isHovering: Bool = false
     @State private var anyDropDebounceTask: Task<Void, Never>?
@@ -245,6 +246,7 @@ struct ContentView: View {
     @ViewBuilder
     func NotchLayout() -> some View {
         VStack(alignment: .leading) {
+            ZStack(alignment: .trailing) {
             VStack(alignment: .leading) {
                 if coordinator.helloAnimationRunning {
                     Spacer()
@@ -337,8 +339,8 @@ struct ContentView: View {
                           else if coordinator.sneakPeek.type == .pomodoro {
                               if vm.notchState == .closed && !vm.hideOnClosed {
                                   HStack(alignment: .center) {
-                                      Image(systemName: PomodoroManager.shared.phaseIcon)
-                                      Text("\(PomodoroManager.shared.phaseLabel) — \(PomodoroManager.shared.formattedTime)")
+                                      Image(systemName: pomodoroManager.phaseIcon)
+                                      Text("\(pomodoroManager.phaseLabel) — \(pomodoroManager.formattedTime)")
                                           .font(.caption)
                                   }
                                   .foregroundStyle(.gray)
@@ -352,31 +354,30 @@ struct ContentView: View {
                   view
                       .fixedSize()
               }
-              .padding(.trailing, PomodoroManager.shared.isRunning && vm.notchState == .closed && !vm.hideOnClosed && Defaults[.pomodoroShowLiveActivity] ? 64 : 0)
               .zIndex(2)
-              .overlay(alignment: .trailing) {
-                  if PomodoroManager.shared.isRunning
-                      && vm.notchState == .closed
-                      && !vm.hideOnClosed
-                      && Defaults[.pomodoroShowLiveActivity]
-                  {
-                      HStack(spacing: 3) {
-                          Image(systemName: PomodoroManager.shared.phaseIcon)
-                              .font(.system(size: 9))
-                              .foregroundStyle(PomodoroManager.shared.phase == .focus ? Color.orange : PomodoroManager.shared.phase == .shortBreak ? Color.green : Color.blue)
-                          Text(PomodoroManager.shared.formattedTime)
-                              .font(.system(size: 10, weight: .medium, design: .monospaced))
-                              .foregroundStyle(.white)
-                      }
-                      .padding(.horizontal, 6)
-                      .padding(.vertical, 3)
-                      .background(Color.black)
-                      .onTapGesture {
-                          coordinator.currentView = .pomodoro
-                          vm.open()
-                      }
+
+              if pomodoroManager.isRunning
+                  && vm.notchState == .closed
+                  && !vm.hideOnClosed
+                  && Defaults[.pomodoroShowLiveActivity]
+              {
+                  HStack(spacing: 3) {
+                      Image(systemName: pomodoroManager.phaseIcon)
+                          .font(.system(size: 9))
+                          .foregroundStyle(pomodoroManager.phase == .focus ? Color.orange : pomodoroManager.phase == .shortBreak ? Color.green : Color.blue)
+                      Text(pomodoroManager.formattedTime)
+                          .font(.system(size: 10, weight: .medium, design: .monospaced))
+                          .foregroundStyle(.white)
+                  }
+                  .padding(.horizontal, 6)
+                  .padding(.vertical, 3)
+                  .background(Color.black)
+                  .onTapGesture {
+                      coordinator.currentView = .pomodoro
+                      vm.open()
                   }
               }
+          }
             if vm.notchState == .open {
                 VStack {
                     switch coordinator.currentView {

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -298,7 +298,7 @@ struct ContentView: View {
                                .frame(height: max(24, vm.effectiveClosedNotchHeight))
                                .opacity(gestureProgress != 0 ? 1.0 - min(abs(gestureProgress) * 0.1, 0.3) : 1.0)
                        } else {
-                           Rectangle().fill(.clear).frame(width: vm.closedNotchSize.width - 20, height: vm.effectiveClosedNotchHeight)
+                            Rectangle().fill(.clear).frame(width: vm.closedNotchSize.width, height: vm.effectiveClosedNotchHeight)
                        }
 
                       if coordinator.sneakPeek.show {

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -354,6 +354,7 @@ struct ContentView: View {
                       .fixedSize()
               }
               .zIndex(2)
+              .padding(.trailing, pomodoroManager.isRunning && vm.notchState == .closed && Defaults[.pomodoroShowLiveActivity] ? 48 : 0)
               .overlay(alignment: .topTrailing) {
                   if pomodoroManager.isRunning
                       && vm.notchState == .closed
@@ -370,6 +371,7 @@ struct ContentView: View {
                       .padding(.horizontal, 4)
                       .padding(.vertical, 2)
                       .background(Color.black)
+                      .padding(.trailing, 8)
                       .onTapGesture {
                           coordinator.currentView = .pomodoro
                           vm.open()

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -349,6 +349,8 @@ struct ContentView: View {
                         NotchHomeView(albumArtNamespace: albumArtNamespace)
                     case .shelf:
                         ShelfView()
+                    case .pomodoro:
+                        PomodoroView()
                     }
                 }
                 .transition(

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -354,7 +354,7 @@ struct ContentView: View {
                       .fixedSize()
               }
               .zIndex(2)
-              .padding(.trailing, pomodoroManager.isRunning && vm.notchState == .closed && Defaults[.pomodoroShowLiveActivity] ? 48 : 0)
+              .padding(.trailing, pomodoroManager.isRunning && vm.notchState == .closed && Defaults[.pomodoroShowLiveActivity] ? (musicManager.isPlaying ? 48 : 64) : 0)
               .overlay(alignment: .topTrailing) {
                   if pomodoroManager.isRunning
                       && vm.notchState == .closed

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -113,28 +113,6 @@ struct ContentView: View {
                         color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow])
                             ? .black.opacity(0.7) : .clear, radius: Defaults[.cornerRadiusScaling] ? 6 : 4
                     )
-                    .overlay(alignment: .trailing) {
-                        if pomodoroManager.isRunning
-                            && vm.notchState == .closed
-                            && Defaults[.pomodoroShowLiveActivity]
-                        {
-                            HStack(spacing: 3) {
-                                Image(systemName: pomodoroManager.phaseIcon)
-                                    .font(.system(size: 9))
-                                    .foregroundStyle(pomodoroManager.phase == .focus ? Color.orange : pomodoroManager.phase == .shortBreak ? Color.green : Color.blue)
-                                Text(pomodoroManager.formattedTime)
-                                    .font(.system(size: 10, weight: .medium, design: .monospaced))
-                                    .foregroundStyle(.white)
-                            }
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 3)
-                            .background(Color.black)
-                            .onTapGesture {
-                                coordinator.currentView = .pomodoro
-                                vm.open()
-                            }
-                        }
-                    }
                     .padding(
                         .bottom,
                         vm.effectiveClosedNotchHeight == 0 ? 10 : 0
@@ -375,7 +353,30 @@ struct ContentView: View {
                   view
                       .fixedSize()
               }
+              .padding(.trailing, pomodoroManager.isRunning && vm.notchState == .closed && Defaults[.pomodoroShowLiveActivity] ? 64 : 0)
               .zIndex(2)
+              .overlay(alignment: .trailing) {
+                  if pomodoroManager.isRunning
+                      && vm.notchState == .closed
+                      && Defaults[.pomodoroShowLiveActivity]
+                  {
+                      HStack(spacing: 3) {
+                          Image(systemName: pomodoroManager.phaseIcon)
+                              .font(.system(size: 9))
+                              .foregroundStyle(pomodoroManager.phase == .focus ? Color.orange : pomodoroManager.phase == .shortBreak ? Color.green : Color.blue)
+                          Text(pomodoroManager.formattedTime)
+                              .font(.system(size: 10, weight: .medium, design: .monospaced))
+                              .foregroundStyle(.white)
+                      }
+                      .padding(.horizontal, 6)
+                      .padding(.vertical, 3)
+                      .background(Color.black)
+                      .onTapGesture {
+                          coordinator.currentView = .pomodoro
+                          vm.open()
+                      }
+                  }
+              }
             if vm.notchState == .open {
                 VStack {
                     switch coordinator.currentView {

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -371,7 +371,6 @@ struct ContentView: View {
                       .padding(.horizontal, 4)
                       .padding(.vertical, 2)
                       .background(Color.black)
-                      .padding(.trailing, 8)
                       .onTapGesture {
                           coordinator.currentView = .pomodoro
                           vm.open()

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -113,6 +113,28 @@ struct ContentView: View {
                         color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow])
                             ? .black.opacity(0.7) : .clear, radius: Defaults[.cornerRadiusScaling] ? 6 : 4
                     )
+                    .overlay(alignment: .trailing) {
+                        if pomodoroManager.isRunning
+                            && vm.notchState == .closed
+                            && Defaults[.pomodoroShowLiveActivity]
+                        {
+                            HStack(spacing: 3) {
+                                Image(systemName: pomodoroManager.phaseIcon)
+                                    .font(.system(size: 9))
+                                    .foregroundStyle(pomodoroManager.phase == .focus ? Color.orange : pomodoroManager.phase == .shortBreak ? Color.green : Color.blue)
+                                Text(pomodoroManager.formattedTime)
+                                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                                    .foregroundStyle(.white)
+                            }
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 3)
+                            .background(Color.black)
+                            .onTapGesture {
+                                coordinator.currentView = .pomodoro
+                                vm.open()
+                            }
+                        }
+                    }
                     .padding(
                         .bottom,
                         vm.effectiveClosedNotchHeight == 0 ? 10 : 0
@@ -246,7 +268,6 @@ struct ContentView: View {
     @ViewBuilder
     func NotchLayout() -> some View {
         VStack(alignment: .leading) {
-            ZStack(alignment: .trailing) {
             VStack(alignment: .leading) {
                 if coordinator.helloAnimationRunning {
                     Spacer()
@@ -355,29 +376,6 @@ struct ContentView: View {
                       .fixedSize()
               }
               .zIndex(2)
-
-              if pomodoroManager.isRunning
-                  && vm.notchState == .closed
-                  && !vm.hideOnClosed
-                  && Defaults[.pomodoroShowLiveActivity]
-              {
-                  HStack(spacing: 3) {
-                      Image(systemName: pomodoroManager.phaseIcon)
-                          .font(.system(size: 9))
-                          .foregroundStyle(pomodoroManager.phase == .focus ? Color.orange : pomodoroManager.phase == .shortBreak ? Color.green : Color.blue)
-                      Text(pomodoroManager.formattedTime)
-                          .font(.system(size: 10, weight: .medium, design: .monospaced))
-                          .foregroundStyle(.white)
-                  }
-                  .padding(.horizontal, 6)
-                  .padding(.vertical, 3)
-                  .background(Color.black)
-                  .onTapGesture {
-                      coordinator.currentView = .pomodoro
-                      vm.open()
-                  }
-              }
-          }
             if vm.notchState == .open {
                 VStack {
                     switch coordinator.currentView {

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -284,6 +284,35 @@ struct ContentView: View {
                             .frame(width: 76, alignment: .trailing)
                         }
                         .frame(height: vm.effectiveClosedNotchHeight, alignment: .center)
+                      } else if coordinator.expandingView.type == .pomodoro && coordinator.expandingView.show
+                          && vm.notchState == .closed && Defaults[.pomodoroShowLiveActivity]
+                      {
+                          HStack(spacing: 0) {
+                              HStack(spacing: 6) {
+                                  Image(systemName: PomodoroManager.shared.phaseIcon)
+                                      .font(.system(size: 12))
+                                  Text(PomodoroManager.shared.formattedTime)
+                                      .font(.system(size: 14, weight: .medium, design: .monospaced))
+                                      .foregroundStyle(.white)
+                                  ProgressView(value: PomodoroManager.shared.progress)
+                                      .tint(PomodoroManager.shared.phase == .focus ? .orange : .green)
+                                      .scaleEffect(x: 1, y: 0.8, anchor: .center)
+                                      .frame(width: 60)
+                              }
+
+                              Rectangle()
+                                  .fill(.black)
+                                  .frame(width: vm.closedNotchSize.width + 10)
+
+                              HStack {
+                                  Rectangle().fill(.clear).frame(width: 76)
+                              }
+                          }
+                          .frame(height: vm.effectiveClosedNotchHeight, alignment: .center)
+                          .onTapGesture {
+                              coordinator.currentView = .pomodoro
+                              vm.open()
+                          }
                       } else if coordinator.sneakPeek.show && Defaults[.inlineHUD] && (coordinator.sneakPeek.type != .music) && (coordinator.sneakPeek.type != .battery) && vm.notchState == .closed {
                           InlineHUD(type: $coordinator.sneakPeek.type, value: $coordinator.sneakPeek.value, icon: $coordinator.sneakPeek.icon, hoverAnimation: $isHovering, gestureProgress: $gestureProgress)
                               .transition(.opacity)

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -352,6 +352,7 @@ struct ContentView: View {
                   view
                       .fixedSize()
               }
+              .padding(.trailing, PomodoroManager.shared.isRunning && vm.notchState == .closed && !vm.hideOnClosed && Defaults[.pomodoroShowLiveActivity] ? 64 : 0)
               .zIndex(2)
               .overlay(alignment: .trailing) {
                   if PomodoroManager.shared.isRunning
@@ -369,6 +370,7 @@ struct ContentView: View {
                       }
                       .padding(.horizontal, 6)
                       .padding(.vertical, 3)
+                      .background(Color.black)
                       .onTapGesture {
                           coordinator.currentView = .pomodoro
                           vm.open()

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -330,7 +330,7 @@ struct ContentView: View {
                        }
 
                       if coordinator.sneakPeek.show {
-                          if (coordinator.sneakPeek.type != .music) && (coordinator.sneakPeek.type != .battery) && !Defaults[.inlineHUD] && vm.notchState == .closed {
+                           if (coordinator.sneakPeek.type != .music) && (coordinator.sneakPeek.type != .battery) && (coordinator.sneakPeek.type != .pomodoro) && !Defaults[.inlineHUD] && vm.notchState == .closed {
                               SystemEventIndicatorModifier(
                                   eventType: $coordinator.sneakPeek.type,
                                   value: $coordinator.sneakPeek.value,
@@ -358,6 +358,17 @@ struct ContentView: View {
                                       GeometryReader { geo in
                                           MarqueeText(.constant(musicManager.songTitle + " - " + musicManager.artistName),  textColor: Defaults[.playerColorTinting] ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.6) : .gray, minDuration: 1, frameWidth: geo.size.width)
                                       }
+                                  }
+                                  .foregroundStyle(.gray)
+                                  .padding(.bottom, 10)
+                              }
+                          }
+                          else if coordinator.sneakPeek.type == .pomodoro {
+                              if vm.notchState == .closed && !vm.hideOnClosed {
+                                  HStack(alignment: .center) {
+                                      Image(systemName: PomodoroManager.shared.phaseIcon)
+                                      Text("\(PomodoroManager.shared.phaseLabel) — \(PomodoroManager.shared.formattedTime)")
+                                          .font(.caption)
                                   }
                                   .foregroundStyle(.gray)
                                   .padding(.bottom, 10)

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -353,23 +353,23 @@ struct ContentView: View {
                   view
                       .fixedSize()
               }
-              .padding(.trailing, pomodoroManager.isRunning && vm.notchState == .closed && Defaults[.pomodoroShowLiveActivity] ? 64 : 0)
+              .padding(.trailing, pomodoroManager.isRunning && vm.notchState == .closed && Defaults[.pomodoroShowLiveActivity] ? 48 : 0)
               .zIndex(2)
-              .overlay(alignment: .trailing) {
+              .overlay(alignment: .topTrailing) {
                   if pomodoroManager.isRunning
                       && vm.notchState == .closed
                       && Defaults[.pomodoroShowLiveActivity]
                   {
-                      HStack(spacing: 3) {
+                      VStack(spacing: 1) {
                           Image(systemName: pomodoroManager.phaseIcon)
-                              .font(.system(size: 9))
+                              .font(.system(size: 8))
                               .foregroundStyle(pomodoroManager.phase == .focus ? Color.orange : pomodoroManager.phase == .shortBreak ? Color.green : Color.blue)
                           Text(pomodoroManager.formattedTime)
-                              .font(.system(size: 10, weight: .medium, design: .monospaced))
+                              .font(.system(size: 9, weight: .medium, design: .monospaced))
                               .foregroundStyle(.white)
                       }
-                      .padding(.horizontal, 6)
-                      .padding(.vertical, 3)
+                      .padding(.horizontal, 4)
+                      .padding(.vertical, 2)
                       .background(Color.black)
                       .onTapGesture {
                           coordinator.currentView = .pomodoro

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -353,7 +353,6 @@ struct ContentView: View {
                   view
                       .fixedSize()
               }
-              .padding(.trailing, pomodoroManager.isRunning && vm.notchState == .closed && Defaults[.pomodoroShowLiveActivity] ? 48 : 0)
               .zIndex(2)
               .overlay(alignment: .topTrailing) {
                   if pomodoroManager.isRunning

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -284,35 +284,6 @@ struct ContentView: View {
                             .frame(width: 76, alignment: .trailing)
                         }
                         .frame(height: vm.effectiveClosedNotchHeight, alignment: .center)
-                      } else if coordinator.expandingView.type == .pomodoro && coordinator.expandingView.show
-                          && vm.notchState == .closed && Defaults[.pomodoroShowLiveActivity]
-                      {
-                          HStack(spacing: 0) {
-                              HStack(spacing: 6) {
-                                  Image(systemName: PomodoroManager.shared.phaseIcon)
-                                      .font(.system(size: 12))
-                                  Text(PomodoroManager.shared.formattedTime)
-                                      .font(.system(size: 14, weight: .medium, design: .monospaced))
-                                      .foregroundStyle(.white)
-                                  ProgressView(value: PomodoroManager.shared.progress)
-                                      .tint(PomodoroManager.shared.phase == .focus ? .orange : .green)
-                                      .scaleEffect(x: 1, y: 0.8, anchor: .center)
-                                      .frame(width: 60)
-                              }
-
-                              Rectangle()
-                                  .fill(.black)
-                                  .frame(width: vm.closedNotchSize.width + 10)
-
-                              HStack {
-                                  Rectangle().fill(.clear).frame(width: 76)
-                              }
-                          }
-                          .frame(height: vm.effectiveClosedNotchHeight, alignment: .center)
-                          .onTapGesture {
-                              coordinator.currentView = .pomodoro
-                              vm.open()
-                          }
                       } else if coordinator.sneakPeek.show && Defaults[.inlineHUD] && (coordinator.sneakPeek.type != .music) && (coordinator.sneakPeek.type != .battery) && vm.notchState == .closed {
                           InlineHUD(type: $coordinator.sneakPeek.type, value: $coordinator.sneakPeek.value, icon: $coordinator.sneakPeek.icon, hoverAnimation: $isHovering, gestureProgress: $gestureProgress)
                               .transition(.opacity)
@@ -382,6 +353,28 @@ struct ContentView: View {
                       .fixedSize()
               }
               .zIndex(2)
+              .overlay(alignment: .trailing) {
+                  if PomodoroManager.shared.isRunning
+                      && vm.notchState == .closed
+                      && !vm.hideOnClosed
+                      && Defaults[.pomodoroShowLiveActivity]
+                  {
+                      HStack(spacing: 3) {
+                          Image(systemName: PomodoroManager.shared.phaseIcon)
+                              .font(.system(size: 9))
+                              .foregroundStyle(PomodoroManager.shared.phase == .focus ? Color.orange : PomodoroManager.shared.phase == .shortBreak ? Color.green : Color.blue)
+                          Text(PomodoroManager.shared.formattedTime)
+                              .font(.system(size: 10, weight: .medium, design: .monospaced))
+                              .foregroundStyle(.white)
+                      }
+                      .padding(.horizontal, 6)
+                      .padding(.vertical, 3)
+                      .onTapGesture {
+                          coordinator.currentView = .pomodoro
+                          vm.open()
+                      }
+                  }
+              }
             if vm.notchState == .open {
                 VStack {
                     switch coordinator.currentView {

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -701,6 +701,16 @@
         }
       }
     },
+    "%@ — %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ — %2$@"
+          }
+        }
+      }
+    },
     "%d%%" : {
       "localizations" : {
         "ar" : {
@@ -1000,6 +1010,9 @@
           }
         }
       }
+    },
+    "%lldm" : {
+
     },
     "• Bug fixes" : {
       "localizations" : {
@@ -2902,6 +2915,15 @@
         }
       }
     },
+    "Auto-Start" : {
+
+    },
+    "Auto-start breaks" : {
+
+    },
+    "Auto-start focus" : {
+
+    },
     "Automatically check for updates" : {
       "localizations" : {
         "ar" : {
@@ -3803,6 +3825,7 @@
       }
     },
     "boring.notch" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -7002,6 +7025,9 @@
         }
       }
     },
+    "Cycles" : {
+
+    },
     "Default" : {
       "localizations" : {
         "ar" : {
@@ -7404,6 +7430,9 @@
           }
         }
       }
+    },
+    "Display" : {
+
     },
     "Download" : {
       "localizations" : {
@@ -7905,6 +7934,9 @@
           }
         }
       }
+    },
+    "Durations" : {
+
     },
     "Easily copy, store, and manage your most-used content. Upgrade now for advanced features like multi-item storage and quick access!" : {
       "localizations" : {
@@ -9607,6 +9639,9 @@
           }
         }
       }
+    },
+    "Focus: %@ minutes" : {
+
     },
     "Full screen behavior" : {
       "localizations" : {
@@ -12008,6 +12043,9 @@
           }
         }
       }
+    },
+    "Long Break: %@ minutes" : {
+
     },
     "Lottie JSON URL" : {
       "localizations" : {
@@ -15510,6 +15548,9 @@
         }
       }
     },
+    "Notifications" : {
+
+    },
     "Open Calendar Settings" : {
       "localizations" : {
         "ar" : {
@@ -16309,6 +16350,12 @@
           }
         }
       }
+    },
+    "Pomodoro" : {
+
+    },
+    "Pomodoro Timer" : {
+
     },
     "Preferred display" : {
       "localizations" : {
@@ -18412,6 +18459,19 @@
         }
       }
     },
+    "Session %lld of %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Session %1$lld of %2$lld"
+          }
+        }
+      }
+    },
+    "Sessions before Long Break: %lld" : {
+
+    },
     "Settings" : {
       "localizations" : {
         "ar" : {
@@ -18611,6 +18671,9 @@
           }
         }
       }
+    },
+    "Short Break: %@ minutes" : {
+
     },
     "Shortcuts" : {
       "localizations" : {
@@ -19111,6 +19174,12 @@
           }
         }
       }
+    },
+    "Show countdown in menu bar" : {
+
+    },
+    "Show countdown on closed notch" : {
+
     },
     "Show HUD in open notch" : {
       "localizations" : {
@@ -20612,6 +20681,9 @@
         }
       }
     },
+    "Sound" : {
+
+    },
     "Speed" : {
       "localizations" : {
         "ar" : {
@@ -20811,6 +20883,9 @@
           }
         }
       }
+    },
+    "Start Focus" : {
+
     },
     "Stopped" : {
       "extractionState" : "stale",

--- a/boringNotch/Shortcuts/ShortcutConstants.swift
+++ b/boringNotch/Shortcuts/ShortcutConstants.swift
@@ -15,4 +15,6 @@ extension KeyboardShortcuts.Name {
     static let increaseBacklight = Self("increaseBacklight", default: .init(.f2, modifiers: [.command]))
     static let toggleSneakPeek = Self("toggleSneakPeek", default: .init(.h, modifiers: [.command, .shift]))
     static let toggleNotchOpen = Self("toggleNotchOpen", default: .init(.i, modifiers: [.command, .shift]))
+    static let pomodoroToggle = Self("pomodoroToggle", default: .init(.space, modifiers: [.command, .option]))
+    static let pomodoroSkip = Self("pomodoroSkip", default: .init(.rightArrow, modifiers: [.command]))
 }

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -412,6 +412,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        KeyboardShortcuts.onKeyDown(for: .pomodoroToggle) {
+            if PomodoroManager.shared.isRunning {
+                PomodoroManager.shared.pause()
+            } else {
+                PomodoroManager.shared.resume()
+            }
+        }
+
+        KeyboardShortcuts.onKeyDown(for: .pomodoroSkip) {
+            PomodoroManager.shared.skip()
+        }
+
         if !Defaults[.showOnAllDisplays] {
             let viewModel = self.vm
             let window = createBoringNotchWindow(

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -29,7 +29,7 @@ struct DynamicNotchApp: App {
     }
 
     var body: some Scene {
-        MenuBarExtra("boring.notch", systemImage: "sparkle", isInserted: $showMenuBarIcon) {
+        MenuBarExtra(isInserted: $showMenuBarIcon) {
             Button("Settings") {
                 DispatchQueue.main.async {
                     SettingsWindowController.shared.showWindow()
@@ -45,6 +45,8 @@ struct DynamicNotchApp: App {
                 NSApplication.shared.terminate(self)
             }
             .keyboardShortcut(KeyEquivalent("Q"), modifiers: .command)
+        } label: {
+            PomodoroMenuBarLabel()
         }
     }
 }
@@ -594,6 +596,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.activate(ignoringOtherApps: true)
         onboardingWindowController?.window?.makeKeyAndOrderFront(nil)
         onboardingWindowController?.window?.orderFrontRegardless()
+    }
+}
+
+struct PomodoroMenuBarLabel: View {
+    @ObservedObject var pomodoroManager = PomodoroManager.shared
+    @Default(.pomodoroShowInMenuBar) var showInMenuBar
+
+    var body: some View {
+        if pomodoroManager.isRunning && showInMenuBar {
+            Text(pomodoroManager.formattedTime)
+                .font(.system(size: 11, design: .monospaced))
+        } else {
+            Image(systemName: "sparkle")
+        }
     }
 }
 

--- a/boringNotch/components/Pomodoro/PomodoroView.swift
+++ b/boringNotch/components/Pomodoro/PomodoroView.swift
@@ -14,30 +14,26 @@ struct PomodoroView: View {
     @Default(.pomodoroSessionsBeforeLongBreak) var sessionsBeforeLongBreak
 
     var body: some View {
-        VStack(spacing: 8) {
-            if !pomodoroManager.isRunning
-                && pomodoroManager.remainingSeconds == pomodoroManager.totalSeconds
-            {
-                idleView
-            } else {
-                activeView
-            }
+        if !pomodoroManager.isRunning
+            && pomodoroManager.remainingSeconds == pomodoroManager.totalSeconds
+        {
+            idleView
+        } else {
+            activeView
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 12)
     }
 
     private var idleView: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 8) {
             Image(systemName: "timer")
-                .font(.system(size: 24))
+                .font(.system(size: 22))
                 .foregroundStyle(.gray)
 
             Text("Pomodoro Timer")
                 .font(.headline)
                 .foregroundStyle(.white)
 
-            HStack(spacing: 16) {
+            HStack(spacing: 12) {
                 durationButton(
                     icon: "target", label: "Focus", value: focusDuration / 60)
                 durationButton(
@@ -52,15 +48,16 @@ struct PomodoroView: View {
                 Text("Start Focus")
                     .font(.headline)
                     .padding(.horizontal, 32)
-                    .padding(.vertical, 8)
+                    .padding(.vertical, 6)
                     .background(Capsule().fill(Color.white.opacity(0.15)))
             }
             .buttonStyle(PlainButtonStyle())
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var activeView: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 6) {
             HStack(spacing: 6) {
                 Image(systemName: pomodoroManager.phaseIcon)
                     .font(.system(size: 14))
@@ -70,14 +67,14 @@ struct PomodoroView: View {
             .foregroundStyle(phaseColor.opacity(0.8))
 
             Text(pomodoroManager.formattedTime)
-                .font(.system(size: 36, weight: .bold, design: .monospaced))
+                .font(.system(size: 28, weight: .bold, design: .monospaced))
                 .foregroundStyle(.white)
                 .opacity(pomodoroManager.isRunning ? 1 : 0.6)
 
             ProgressView(value: pomodoroManager.progress)
                 .tint(phaseColor)
                 .scaleEffect(x: 1, y: 1.5, anchor: .center)
-                .padding(.horizontal, 20)
+                .padding(.horizontal, 40)
 
             if pomodoroManager.phase == .focus {
                 Text(
@@ -107,7 +104,7 @@ struct PomodoroView: View {
                     pomodoroManager.reset()
                 }
             }
-            .padding(.top, 4)
+            .padding(.top, 2)
 
             HStack(spacing: 12) {
                 quickSetting(
@@ -136,9 +133,10 @@ struct PomodoroView: View {
                     longBreakDuration = val * 60
                 }
             }
-            .padding(.top, 4)
+            .padding(.top, 2)
             .opacity(0.6)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func durationButton(icon: String, label: String, value: Int)

--- a/boringNotch/components/Pomodoro/PomodoroView.swift
+++ b/boringNotch/components/Pomodoro/PomodoroView.swift
@@ -44,29 +44,6 @@ struct PomodoroView: View {
                     value: longBreakDuration / 60)
             }
 
-            HStack(spacing: 12) {
-                quickSetting(
-                    icon: "target", current: focusDuration / 60,
-                    options: [15, 25, 30, 45, 60]
-                ) { val in
-                    focusDuration = val * 60
-                    pomodoroManager.remainingSeconds = val * 60
-                }
-                quickSetting(
-                    icon: "cup.and.saucer", current: shortBreakDuration / 60,
-                    options: [3, 5, 10, 15]
-                ) { val in
-                    shortBreakDuration = val * 60
-                }
-                quickSetting(
-                    icon: "cup.and.saucer.fill", current: longBreakDuration / 60,
-                    options: [10, 15, 20, 30]
-                ) { val in
-                    longBreakDuration = val * 60
-                }
-            }
-            .opacity(0.6)
-
             Button(action: { pomodoroManager.start() }) {
                 Text("Start Focus")
                     .font(.headline)
@@ -188,29 +165,6 @@ struct PomodoroView: View {
         }
         .buttonStyle(PlainButtonStyle())
         .foregroundStyle(.white.opacity(0.8))
-    }
-
-    private func quickSetting(
-        icon: String, current: Int, options: [Int],
-        onChange: @escaping (Int) -> Void
-    ) -> some View {
-        HStack(spacing: 4) {
-            Image(systemName: icon)
-                .font(.system(size: 8))
-            ForEach(options, id: \.self) { val in
-                Button(action: { onChange(val) }) {
-                    Text("\(val)")
-                        .font(
-                            .system(
-                                size: 9,
-                                weight: val == current ? .bold : .regular)
-                        )
-                        .foregroundStyle(
-                            val == current ? .white : .gray)
-                }
-                .buttonStyle(PlainButtonStyle())
-            }
-        }
     }
 
     private var phaseColor: Color {

--- a/boringNotch/components/Pomodoro/PomodoroView.swift
+++ b/boringNotch/components/Pomodoro/PomodoroView.swift
@@ -14,9 +14,7 @@ struct PomodoroView: View {
     @Default(.pomodoroSessionsBeforeLongBreak) var sessionsBeforeLongBreak
 
     var body: some View {
-        if !pomodoroManager.isRunning
-            && pomodoroManager.remainingSeconds == pomodoroManager.totalSeconds
-        {
+        if !pomodoroManager.hasStarted {
             idleView
         } else {
             activeView

--- a/boringNotch/components/Pomodoro/PomodoroView.swift
+++ b/boringNotch/components/Pomodoro/PomodoroView.swift
@@ -23,6 +23,8 @@ struct PomodoroView: View {
         }
     }
 
+    // MARK: - Idle
+
     private var idleView: some View {
         VStack(spacing: 8) {
             Image(systemName: "timer")
@@ -34,77 +36,15 @@ struct PomodoroView: View {
                 .foregroundStyle(.white)
 
             HStack(spacing: 12) {
-                durationButton(
+                durationPill(
                     icon: "target", label: "Focus", value: focusDuration / 60)
-                durationButton(
+                durationPill(
                     icon: "cup.and.saucer", label: "Break",
                     value: shortBreakDuration / 60)
-                durationButton(
+                durationPill(
                     icon: "cup.and.saucer.fill", label: "Long",
                     value: longBreakDuration / 60)
             }
-
-            Button(action: { pomodoroManager.start() }) {
-                Text("Start Focus")
-                    .font(.headline)
-                    .padding(.horizontal, 32)
-                    .padding(.vertical, 6)
-                    .background(Capsule().fill(Color.white.opacity(0.15)))
-            }
-            .buttonStyle(PlainButtonStyle())
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    private var activeView: some View {
-        VStack(spacing: 6) {
-            HStack(spacing: 6) {
-                Image(systemName: pomodoroManager.phaseIcon)
-                    .font(.system(size: 14))
-                Text(pomodoroManager.phaseLabel)
-                    .font(.subheadline.weight(.medium))
-            }
-            .foregroundStyle(phaseColor.opacity(0.8))
-
-            Text(pomodoroManager.formattedTime)
-                .font(.system(size: 28, weight: .bold, design: .monospaced))
-                .foregroundStyle(.white)
-                .opacity(pomodoroManager.isRunning ? 1 : 0.6)
-
-            ProgressView(value: pomodoroManager.progress)
-                .tint(phaseColor)
-                .scaleEffect(x: 1, y: 1.5, anchor: .center)
-                .padding(.horizontal, 40)
-
-            if pomodoroManager.phase == .focus {
-                Text(
-                    "Session \(pomodoroManager.completedSessions + 1) of \(sessionsBeforeLongBreak) until long break"
-                )
-                .font(.caption)
-                .foregroundStyle(.gray)
-            }
-
-            HStack(spacing: 20) {
-                controlButton(icon: "backward.end.fill", label: "Skip") {
-                    pomodoroManager.skip()
-                }
-
-                controlButton(
-                    icon: pomodoroManager.isRunning ? "pause.fill" : "play.fill",
-                    label: pomodoroManager.isRunning ? "Pause" : "Resume"
-                ) {
-                    if pomodoroManager.isRunning {
-                        pomodoroManager.pause()
-                    } else {
-                        pomodoroManager.resume()
-                    }
-                }
-
-                controlButton(icon: "arrow.counterclockwise", label: "Reset") {
-                    pomodoroManager.reset()
-                }
-            }
-            .padding(.top, 2)
 
             HStack(spacing: 12) {
                 quickSetting(
@@ -112,13 +52,7 @@ struct PomodoroView: View {
                     options: [15, 25, 30, 45, 60]
                 ) { val in
                     focusDuration = val * 60
-                    if case .focus = pomodoroManager.phase,
-                        !pomodoroManager.isRunning,
-                        pomodoroManager.remainingSeconds
-                            == pomodoroManager.totalSeconds
-                    {
-                        pomodoroManager.remainingSeconds = val * 60
-                    }
+                    pomodoroManager.remainingSeconds = val * 60
                 }
                 quickSetting(
                     icon: "cup.and.saucer", current: shortBreakDuration / 60,
@@ -133,13 +67,104 @@ struct PomodoroView: View {
                     longBreakDuration = val * 60
                 }
             }
-            .padding(.top, 2)
             .opacity(0.6)
+
+            Button(action: { pomodoroManager.start() }) {
+                Text("Start Focus")
+                    .font(.headline)
+                    .padding(.horizontal, 32)
+                    .padding(.vertical, 6)
+                    .background(Capsule().fill(Color.white.opacity(0.15)))
+            }
+            .buttonStyle(PlainButtonStyle())
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func durationButton(icon: String, label: String, value: Int)
+    // MARK: - Active
+
+    private var activeView: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            HStack(spacing: 6) {
+                Image(systemName: pomodoroManager.phaseIcon)
+                    .font(.system(size: 12))
+                Text(pomodoroManager.phaseLabel)
+                    .font(.caption.weight(.medium))
+            }
+            .foregroundStyle(phaseColor.opacity(0.7))
+
+            Text(pomodoroManager.formattedTime)
+                .font(.system(size: 32, weight: .bold, design: .monospaced))
+                .foregroundStyle(.white)
+                .opacity(pomodoroManager.isRunning ? 1 : 0.5)
+                .padding(.vertical, 6)
+
+            pomodoroProgress
+                .padding(.horizontal, 24)
+
+            if pomodoroManager.phase == .focus {
+                Text(
+                    "Session \(pomodoroManager.completedSessions + 1) of \(sessionsBeforeLongBreak)"
+                )
+                .font(.caption)
+                .foregroundStyle(.gray.opacity(0.6))
+                .padding(.top, 4)
+            }
+
+            Spacer()
+
+            HStack(spacing: 0) {
+                controlCapsule(icon: "backward.end.fill") {
+                    pomodoroManager.skip()
+                }
+
+                controlCapsule(
+                    icon: pomodoroManager.isRunning
+                        ? "pause.fill" : "play.fill"
+                ) {
+                    if pomodoroManager.isRunning {
+                        pomodoroManager.pause()
+                    } else {
+                        pomodoroManager.resume()
+                    }
+                }
+
+                controlCapsule(icon: "arrow.counterclockwise") {
+                    pomodoroManager.reset()
+                }
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Progress Bar
+
+    private var pomodoroProgress: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 2.5)
+                    .fill(phaseColor.opacity(0.15))
+                    .frame(height: 5)
+
+                RoundedRectangle(cornerRadius: 2.5)
+                    .fill(phaseColor)
+                    .frame(
+                        width: max(0, min(pomodoroManager.progress, 1))
+                            * geometry.size.width,
+                        height: 5
+                    )
+            }
+        }
+        .frame(height: 10)
+    }
+
+    // MARK: - Subviews
+
+    private func durationPill(icon: String, label: String, value: Int)
         -> some View
     {
         HStack(spacing: 4) {
@@ -154,20 +179,17 @@ struct PomodoroView: View {
         .background(Capsule().fill(Color.white.opacity(0.06)))
     }
 
-    private func controlButton(
-        icon: String, label: String, action: @escaping () -> Void
+    private func controlCapsule(
+        icon: String, action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            VStack(spacing: 2) {
-                Image(systemName: icon)
-                    .font(.system(size: 16))
-                Text(label)
-                    .font(.caption2)
-            }
-            .foregroundStyle(.white.opacity(0.8))
-            .frame(width: 50, height: 36)
+            Image(systemName: icon)
+                .font(.system(size: 16))
+                .padding(.horizontal, 15)
+                .contentShape(Capsule())
         }
         .buttonStyle(PlainButtonStyle())
+        .foregroundStyle(.white.opacity(0.8))
     }
 
     private func quickSetting(

--- a/boringNotch/components/Pomodoro/PomodoroView.swift
+++ b/boringNotch/components/Pomodoro/PomodoroView.swift
@@ -1,0 +1,205 @@
+//
+//  PomodoroView.swift
+//  boringNotch
+//
+
+import Defaults
+import SwiftUI
+
+struct PomodoroView: View {
+    @ObservedObject var pomodoroManager = PomodoroManager.shared
+    @Default(.pomodoroFocusDuration) var focusDuration
+    @Default(.pomodoroShortBreakDuration) var shortBreakDuration
+    @Default(.pomodoroLongBreakDuration) var longBreakDuration
+    @Default(.pomodoroSessionsBeforeLongBreak) var sessionsBeforeLongBreak
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if !pomodoroManager.isRunning
+                && pomodoroManager.remainingSeconds == pomodoroManager.totalSeconds
+            {
+                idleView
+            } else {
+                activeView
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+
+    private var idleView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "timer")
+                .font(.system(size: 24))
+                .foregroundStyle(.gray)
+
+            Text("Pomodoro Timer")
+                .font(.headline)
+                .foregroundStyle(.white)
+
+            HStack(spacing: 16) {
+                durationButton(
+                    icon: "target", label: "Focus", value: focusDuration / 60)
+                durationButton(
+                    icon: "cup.and.saucer", label: "Break",
+                    value: shortBreakDuration / 60)
+                durationButton(
+                    icon: "cup.and.saucer.fill", label: "Long",
+                    value: longBreakDuration / 60)
+            }
+
+            Button(action: { pomodoroManager.start() }) {
+                Text("Start Focus")
+                    .font(.headline)
+                    .padding(.horizontal, 32)
+                    .padding(.vertical, 8)
+                    .background(Capsule().fill(Color.white.opacity(0.15)))
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+    }
+
+    private var activeView: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: pomodoroManager.phaseIcon)
+                    .font(.system(size: 14))
+                Text(pomodoroManager.phaseLabel)
+                    .font(.subheadline.weight(.medium))
+            }
+            .foregroundStyle(phaseColor.opacity(0.8))
+
+            Text(pomodoroManager.formattedTime)
+                .font(.system(size: 36, weight: .bold, design: .monospaced))
+                .foregroundStyle(.white)
+                .opacity(pomodoroManager.isRunning ? 1 : 0.6)
+
+            ProgressView(value: pomodoroManager.progress)
+                .tint(phaseColor)
+                .scaleEffect(x: 1, y: 1.5, anchor: .center)
+                .padding(.horizontal, 20)
+
+            if pomodoroManager.phase == .focus {
+                Text(
+                    "Session \(pomodoroManager.completedSessions + 1) of \(sessionsBeforeLongBreak) until long break"
+                )
+                .font(.caption)
+                .foregroundStyle(.gray)
+            }
+
+            HStack(spacing: 20) {
+                controlButton(icon: "backward.end.fill", label: "Skip") {
+                    pomodoroManager.skip()
+                }
+
+                controlButton(
+                    icon: pomodoroManager.isRunning ? "pause.fill" : "play.fill",
+                    label: pomodoroManager.isRunning ? "Pause" : "Resume"
+                ) {
+                    if pomodoroManager.isRunning {
+                        pomodoroManager.pause()
+                    } else {
+                        pomodoroManager.resume()
+                    }
+                }
+
+                controlButton(icon: "arrow.counterclockwise", label: "Reset") {
+                    pomodoroManager.reset()
+                }
+            }
+            .padding(.top, 4)
+
+            HStack(spacing: 12) {
+                quickSetting(
+                    icon: "target", current: focusDuration / 60,
+                    options: [15, 25, 30, 45, 60]
+                ) { val in
+                    focusDuration = val * 60
+                    if case .focus = pomodoroManager.phase,
+                        !pomodoroManager.isRunning,
+                        pomodoroManager.remainingSeconds
+                            == pomodoroManager.totalSeconds
+                    {
+                        pomodoroManager.remainingSeconds = val * 60
+                    }
+                }
+                quickSetting(
+                    icon: "cup.and.saucer", current: shortBreakDuration / 60,
+                    options: [3, 5, 10, 15]
+                ) { val in
+                    shortBreakDuration = val * 60
+                }
+                quickSetting(
+                    icon: "cup.and.saucer.fill", current: longBreakDuration / 60,
+                    options: [10, 15, 20, 30]
+                ) { val in
+                    longBreakDuration = val * 60
+                }
+            }
+            .padding(.top, 4)
+            .opacity(0.6)
+        }
+    }
+
+    private func durationButton(icon: String, label: String, value: Int)
+        -> some View
+    {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 10))
+            Text("\(value)m")
+                .font(.caption2)
+        }
+        .foregroundStyle(.gray)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(Color.white.opacity(0.06)))
+    }
+
+    private func controlButton(
+        icon: String, label: String, action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            VStack(spacing: 2) {
+                Image(systemName: icon)
+                    .font(.system(size: 16))
+                Text(label)
+                    .font(.caption2)
+            }
+            .foregroundStyle(.white.opacity(0.8))
+            .frame(width: 50, height: 36)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+
+    private func quickSetting(
+        icon: String, current: Int, options: [Int],
+        onChange: @escaping (Int) -> Void
+    ) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 8))
+            ForEach(options, id: \.self) { val in
+                Button(action: { onChange(val) }) {
+                    Text("\(val)")
+                        .font(
+                            .system(
+                                size: 9,
+                                weight: val == current ? .bold : .regular)
+                        )
+                        .foregroundStyle(
+                            val == current ? .white : .gray)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+        }
+    }
+
+    private var phaseColor: Color {
+        switch pomodoroManager.phase {
+        case .focus: return Color.orange
+        case .shortBreak: return Color.green
+        case .longBreak: return Color.blue
+        }
+    }
+}

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -51,6 +51,9 @@ struct SettingsView: View {
                 NavigationLink(value: "Shelf") {
                     Label("Shelf", systemImage: "books.vertical")
                 }
+                NavigationLink(value: "Pomodoro") {
+                    Label("Pomodoro", systemImage: "timer")
+                }
                 NavigationLink(value: "Shortcuts") {
                     Label("Shortcuts", systemImage: "keyboard")
                 }
@@ -85,6 +88,8 @@ struct SettingsView: View {
                     Charge()
                 case "Shelf":
                     Shelf()
+                case "Pomodoro":
+                    PomodoroSettings()
                 case "Shortcuts":
                     Shortcuts()
                 case "Extensions":
@@ -1796,4 +1801,92 @@ func warningBadge(_ text: String, _ description: String) -> some View {
 
 #Preview {
     HUD()
+}
+
+struct PomodoroSettings: View {
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Stepper(
+                    key: .pomodoroFocusDuration,
+                    in: 300...3600,
+                    step: 300
+                ) {
+                    Text("Focus: \((Defaults[.pomodoroFocusDuration] / 60).formatted()) minutes")
+                }
+                Defaults.Stepper(
+                    key: .pomodoroShortBreakDuration,
+                    in: 60...1800,
+                    step: 60
+                ) {
+                    Text("Short Break: \((Defaults[.pomodoroShortBreakDuration] / 60).formatted()) minutes")
+                }
+                Defaults.Stepper(
+                    key: .pomodoroLongBreakDuration,
+                    in: 60...2700,
+                    step: 60
+                ) {
+                    Text("Long Break: \((Defaults[.pomodoroLongBreakDuration] / 60).formatted()) minutes")
+                }
+            } header: {
+                Text("Durations")
+            }
+
+            Section {
+                Defaults.Stepper(
+                    key: .pomodoroSessionsBeforeLongBreak,
+                    in: 1...10,
+                    step: 1
+                ) {
+                    Text("Sessions before Long Break: \(Defaults[.pomodoroSessionsBeforeLongBreak])")
+                }
+            } header: {
+                Text("Cycles")
+            }
+
+            Section {
+                Defaults.Toggle(key: .pomodoroAutoStartBreaks) {
+                    Text("Auto-start breaks")
+                }
+                Defaults.Toggle(key: .pomodoroAutoStartFocus) {
+                    Text("Auto-start focus")
+                }
+            } header: {
+                Text("Auto-Start")
+            }
+
+            Section {
+                Picker(selection: Defaults.dynamic(key: .pomodoroNotificationSound)) {
+                    ForEach(PomodoroSound.allCases, id: \.self) { sound in
+                        Text(soundLabel(sound)).tag(sound)
+                    }
+                } label: {
+                    Text("Sound")
+                }
+            } header: {
+                Text("Notifications")
+            }
+
+            Section {
+                Defaults.Toggle(key: .pomodoroShowLiveActivity) {
+                    Text("Show countdown on closed notch")
+                }
+                Defaults.Toggle(key: .pomodoroShowInMenuBar) {
+                    Text("Show countdown in menu bar")
+                }
+            } header: {
+                Text("Display")
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Pomodoro")
+    }
+
+    private func soundLabel(_ sound: PomodoroSound) -> String {
+        switch sound {
+        case .chime: return "Chime"
+        case .bell: return "Bell"
+        case .silent: return "Silent"
+        }
+    }
 }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -1804,41 +1804,31 @@ func warningBadge(_ text: String, _ description: String) -> some View {
 }
 
 struct PomodoroSettings: View {
+    @Default(.pomodoroFocusDuration) var focusDuration
+    @Default(.pomodoroShortBreakDuration) var shortBreakDuration
+    @Default(.pomodoroLongBreakDuration) var longBreakDuration
+    @Default(.pomodoroSessionsBeforeLongBreak) var sessionsBeforeLongBreak
+    @Default(.pomodoroNotificationSound) var notificationSound
+
     var body: some View {
         Form {
             Section {
-                Defaults.Stepper(
-                    key: .pomodoroFocusDuration,
-                    in: 300...3600,
-                    step: 300
-                ) {
-                    Text("Focus: \((Defaults[.pomodoroFocusDuration] / 60).formatted()) minutes")
+                Stepper(value: $focusDuration, in: 300...3600, step: 300) {
+                    Text("Focus: \((focusDuration / 60).formatted()) minutes")
                 }
-                Defaults.Stepper(
-                    key: .pomodoroShortBreakDuration,
-                    in: 60...1800,
-                    step: 60
-                ) {
-                    Text("Short Break: \((Defaults[.pomodoroShortBreakDuration] / 60).formatted()) minutes")
+                Stepper(value: $shortBreakDuration, in: 60...1800, step: 60) {
+                    Text("Short Break: \((shortBreakDuration / 60).formatted()) minutes")
                 }
-                Defaults.Stepper(
-                    key: .pomodoroLongBreakDuration,
-                    in: 60...2700,
-                    step: 60
-                ) {
-                    Text("Long Break: \((Defaults[.pomodoroLongBreakDuration] / 60).formatted()) minutes")
+                Stepper(value: $longBreakDuration, in: 60...2700, step: 60) {
+                    Text("Long Break: \((longBreakDuration / 60).formatted()) minutes")
                 }
             } header: {
                 Text("Durations")
             }
 
             Section {
-                Defaults.Stepper(
-                    key: .pomodoroSessionsBeforeLongBreak,
-                    in: 1...10,
-                    step: 1
-                ) {
-                    Text("Sessions before Long Break: \(Defaults[.pomodoroSessionsBeforeLongBreak])")
+                Stepper(value: $sessionsBeforeLongBreak, in: 1...10, step: 1) {
+                    Text("Sessions before Long Break: \(sessionsBeforeLongBreak)")
                 }
             } header: {
                 Text("Cycles")
@@ -1856,7 +1846,7 @@ struct PomodoroSettings: View {
             }
 
             Section {
-                Picker(selection: Defaults.dynamic(key: .pomodoroNotificationSound)) {
+                Picker(selection: $notificationSound) {
                     ForEach(PomodoroSound.allCases, id: \.self) { sound in
                         Text(soundLabel(sound)).tag(sound)
                     }

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -16,7 +16,8 @@ struct TabModel: Identifiable {
 
 let tabs = [
     TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
+    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf),
+    TabModel(label: "Pomodoro", icon: "timer", view: .pomodoro)
 ]
 
 struct TabSelectionView: View {

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -27,6 +27,7 @@ public enum NotchState {
 public enum NotchViews {
     case home
     case shelf
+    case pomodoro
 }
 
 enum SettingsEnum {
@@ -54,6 +55,18 @@ enum DownloadIconStyle: String, Defaults.Serializable {
 enum MirrorShapeEnum: String, Defaults.Serializable {
     case rectangle = "Rectangular"
     case circle = "Circular"
+}
+
+enum PomodoroPhase: String, CaseIterable, Codable, Defaults.Serializable {
+    case focus
+    case shortBreak
+    case longBreak
+}
+
+enum PomodoroSound: String, CaseIterable, Codable, Defaults.Serializable {
+    case chime
+    case bell
+    case silent
 }
 
 enum WindowHeightMode: String, Defaults.Serializable {

--- a/boringNotch/managers/PomodoroManager.swift
+++ b/boringNotch/managers/PomodoroManager.swift
@@ -16,6 +16,7 @@ class PomodoroManager: ObservableObject {
     @Published var remainingSeconds: Int = 1500
     @Published var isRunning: Bool = false
     @Published var completedSessions: Int = 0
+    @Published var hasStarted: Bool = false
 
     private var timerCancellable: AnyCancellable?
     private var notificationRequested = false
@@ -73,6 +74,7 @@ class PomodoroManager: ObservableObject {
     }
 
     func start() {
+        hasStarted = true
         requestNotificationPermissionIfNeeded()
         startTimer()
     }
@@ -93,6 +95,7 @@ class PomodoroManager: ObservableObject {
     }
 
     func reset() {
+        hasStarted = false
         pause()
         phase = .focus
         remainingSeconds = Defaults[.pomodoroFocusDuration]

--- a/boringNotch/managers/PomodoroManager.swift
+++ b/boringNotch/managers/PomodoroManager.swift
@@ -1,0 +1,226 @@
+//
+//  PomodoroManager.swift
+//  boringNotch
+//
+
+import AppKit
+import Combine
+import Defaults
+import SwiftUI
+import UserNotifications
+
+class PomodoroManager: ObservableObject {
+    static let shared = PomodoroManager()
+
+    @Published var phase: PomodoroPhase = .focus
+    @Published var remainingSeconds: Int = 1500
+    @Published var isRunning: Bool = false
+    @Published var completedSessions: Int = 0
+
+    private var timerCancellable: AnyCancellable?
+    private var notificationRequested = false
+
+    var totalSeconds: Int {
+        switch phase {
+        case .focus: return Defaults[.pomodoroFocusDuration]
+        case .shortBreak: return Defaults[.pomodoroShortBreakDuration]
+        case .longBreak: return Defaults[.pomodoroLongBreakDuration]
+        }
+    }
+
+    var progress: Double {
+        guard totalSeconds > 0 else { return 0 }
+        return Double(totalSeconds - remainingSeconds) / Double(totalSeconds)
+    }
+
+    var formattedTime: String {
+        let minutes = remainingSeconds / 60
+        let seconds = remainingSeconds % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    var nextPhase: PomodoroPhase {
+        switch phase {
+        case .focus:
+            if completedSessions + 1 >= Defaults[.pomodoroSessionsBeforeLongBreak] {
+                return .longBreak
+            } else {
+                return .shortBreak
+            }
+        case .shortBreak, .longBreak:
+            return .focus
+        }
+    }
+
+    var phaseLabel: String {
+        switch phase {
+        case .focus: return "Focus"
+        case .shortBreak: return "Short Break"
+        case .longBreak: return "Long Break"
+        }
+    }
+
+    var phaseIcon: String {
+        switch phase {
+        case .focus: return "target"
+        case .shortBreak: return "cup.and.saucer"
+        case .longBreak: return "cup.and.saucer.fill"
+        }
+    }
+
+    private init() {
+        remainingSeconds = Defaults[.pomodoroFocusDuration]
+    }
+
+    func start() {
+        requestNotificationPermissionIfNeeded()
+        startTimer()
+    }
+
+    func pause() {
+        timerCancellable?.cancel()
+        timerCancellable = nil
+        isRunning = false
+    }
+
+    func resume() {
+        start()
+    }
+
+    func skip() {
+        pause()
+        advancePhase()
+    }
+
+    func reset() {
+        pause()
+        phase = .focus
+        remainingSeconds = Defaults[.pomodoroFocusDuration]
+        completedSessions = 0
+    }
+
+    private func startTimer() {
+        timerCancellable?.cancel()
+        isRunning = true
+        timerCancellable = Timer.publish(every: 1, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                self?.tick()
+            }
+    }
+
+    private func tick() {
+        guard isRunning else { return }
+        if remainingSeconds > 0 {
+            remainingSeconds -= 1
+        }
+        if remainingSeconds <= 0 {
+            phaseComplete()
+        }
+    }
+
+    private func phaseComplete() {
+        timerCancellable?.cancel()
+        timerCancellable = nil
+        isRunning = false
+
+        playSound()
+        sendNotification()
+
+        if autoStartNext() {
+            advancePhase()
+            startTimer()
+        } else {
+            advancePhase()
+        }
+    }
+
+    private func advancePhase() {
+        switch phase {
+        case .focus:
+            completedSessions += 1
+            if completedSessions >= Defaults[.pomodoroSessionsBeforeLongBreak] {
+                phase = .longBreak
+                remainingSeconds = Defaults[.pomodoroLongBreakDuration]
+                completedSessions = 0
+            } else {
+                phase = .shortBreak
+                remainingSeconds = Defaults[.pomodoroShortBreakDuration]
+            }
+        case .shortBreak, .longBreak:
+            phase = .focus
+            remainingSeconds = Defaults[.pomodoroFocusDuration]
+        }
+
+        Task { @MainActor in
+            BoringViewCoordinator.shared.toggleSneakPeek(
+                status: true,
+                type: .pomodoro,
+                duration: 3.0,
+                value: 0,
+                icon: phaseIcon
+            )
+        }
+    }
+
+    private func autoStartNext() -> Bool {
+        switch phase {
+        case .focus: return Defaults[.pomodoroAutoStartBreaks]
+        case .shortBreak, .longBreak: return Defaults[.pomodoroAutoStartFocus]
+        }
+    }
+
+    private func playSound() {
+        let soundSetting = Defaults[.pomodoroNotificationSound]
+        guard soundSetting != .silent else { return }
+
+        let soundName: String
+        switch soundSetting {
+        case .chime: soundName = "Glass"
+        case .bell: soundName = "Funk"
+        case .silent: return
+        }
+
+        if let sound = NSSound(named: soundName) {
+            sound.play()
+        } else {
+            NSSound(named: NSSound.Name("Glass"))?.play()
+        }
+    }
+
+    private func sendNotification() {
+        let center = UNUserNotificationCenter.current()
+        let content = UNMutableNotificationContent()
+        content.title = "\(phaseLabel) Complete"
+        content.body = "Time for \(phaseLabel(for: nextPhase))."
+        content.sound = Defaults[.pomodoroNotificationSound] != .silent
+            ? .default
+            : nil
+
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+        center.add(request)
+    }
+
+    private func phaseLabel(for phase: PomodoroPhase) -> String {
+        switch phase {
+        case .focus: return "Focus (\(Defaults[.pomodoroFocusDuration] / 60)m)"
+        case .shortBreak: return "Short Break (\(Defaults[.pomodoroShortBreakDuration] / 60)m)"
+        case .longBreak: return "Long Break (\(Defaults[.pomodoroLongBreakDuration] / 60)m)"
+        }
+    }
+
+    private func requestNotificationPermissionIfNeeded() {
+        guard !notificationRequested else { return }
+        notificationRequested = true
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            if !granted {
+                Logger.log("Notification permission denied for Pomodoro", category: .warning)
+            }
+        }
+    }
+}

--- a/boringNotch/managers/PomodoroManager.swift
+++ b/boringNotch/managers/PomodoroManager.swift
@@ -219,7 +219,7 @@ class PomodoroManager: ObservableObject {
         let center = UNUserNotificationCenter.current()
         center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
             if !granted {
-                Logger.log("Notification permission denied for Pomodoro", category: .warning)
+                print("Pomodoro: Notification permission denied")
             }
         }
     }

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -179,6 +179,17 @@ extension Defaults.Keys {
     
     // MARK: Fullscreen Media Detection
     static let hideNotchOption = Key<HideNotchOption>("hideNotchOption", default: .nowPlayingOnly)
+
+    // MARK: Pomodoro
+    static let pomodoroFocusDuration = Key<Int>("pomodoroFocusDuration", default: 1500)
+    static let pomodoroShortBreakDuration = Key<Int>("pomodoroShortBreakDuration", default: 300)
+    static let pomodoroLongBreakDuration = Key<Int>("pomodoroLongBreakDuration", default: 900)
+    static let pomodoroSessionsBeforeLongBreak = Key<Int>("pomodoroSessionsBeforeLongBreak", default: 4)
+    static let pomodoroAutoStartBreaks = Key<Bool>("pomodoroAutoStartBreaks", default: true)
+    static let pomodoroAutoStartFocus = Key<Bool>("pomodoroAutoStartFocus", default: false)
+    static let pomodoroNotificationSound = Key<PomodoroSound>("pomodoroNotificationSound", default: .chime)
+    static let pomodoroShowLiveActivity = Key<Bool>("pomodoroShowLiveActivity", default: true)
+    static let pomodoroShowInMenuBar = Key<Bool>("pomodoroShowInMenuBar", default: false)
     
     // MARK: Media Controller
     static let mediaController = Key<MediaControllerType>("mediaController", default: defaultMediaController)


### PR DESCRIPTION
Adds a fully configurable Pomodoro timer to Boring Notch, integrated across the open-notch tab, closed-notch overlay, menu bar, and settings panel.

### Features

| | |
|---|---|
| **PomodoroManager** | Singleton `ObservableObject` - 1-second countdown, 3 phases (focus / short break / long break), `NSSound` alerts, `UNUserNotificationCenter` banners on phase transitions, auto-advance |
| **Open-notch tab** | New "Pomodoro" tab alongside Home and Shelf. Idle state shows phase durations + Start button. Active state shows large countdown, custom phase-colored progress bar, icon-only capsule controls (Skip / Pause‑Resume / Reset) |
| **Closed-notch badge** | Countdown badge (phase icon + monospaced time) shown on the right side of the closed notch while running, with trailing padding that adjusts between music-playing and no-music states to stay within the notch's rounded corners |
| **Sneak peek** | 3-second overlay below the closed notch on phase transitions showing the new phase label + duration |
| **Menu bar** | Optional countdown text replacing the sparkle icon when running (toggle in settings) |
| **Keyboard shortcuts** | `⌘⌥Space` toggles pause/resume, `⌘->` skips to next phase |
| **Settings** | New "Pomodoro" section - focus/break durations (sliders), sessions before long break, auto-start toggles, sound picker (Chime / Bell / Silent), closed-notch and menu-bar visibility |

### Why

The notch is an ideal always-visible surface for a productivity timer. This integrates cleanly with the existing tab architecture (`NotchViews` enum, `TabSelectionView`, `BoringViewCoordinator` sneak peek system) and follows the same patterns as `MusicManager` and `BatteryActivityManager`.

### Files

| File | Action |
|---|---|
| `managers/PomodoroManager.swift` | **New** - timer logic, sound, notifications |
| `components/Pomodoro/PomodoroView.swift` | **New** - idle + active tab views |
| `enums/generic.swift` | Edit - add `PomodoroPhase`, `PomodoroSound`, `.pomodoro` to `NotchViews` |
| `models/Constants.swift` | Edit - 9 new `Defaults.Keys` for all settings |
| `ContentView.swift` | Edit - closed-notch badge overlay, `.pomodoro` tab switch, `@ObservedObject` integration, sneak peek display |
| `BoringViewCoordinator.swift` | Edit - `.pomodoro` in `SneakContentType`, unblocked from HUD gate |
| `boringNotchApp.swift` | Edit - `PomodoroMenuBarLabel` view, dynamic `MenuBarExtra`, shortcut handlers |
| `Shortcuts/ShortcutConstants.swift` | Edit - `pomodoroToggle` + `pomodoroSkip` shortcuts |
| `components/Settings/SettingsView.swift` | Edit - `PomodoroSettings` section in sidebar |
| `components/Tabs/TabSelectionView.swift` | Edit - Pomodoro entry in `tabs` array |
| `boringNotch.xcodeproj/project.pbxproj` | Edit - project file references for new files |

### Screenshots

<img width="1327" height="452" alt="image" src="https://github.com/user-attachments/assets/b5a9e378-0797-45a2-b3fd-24f9b51c1a1d" />
<img width="1452" height="824" alt="image" src="https://github.com/user-attachments/assets/dfb49b8f-87e3-460b-b63c-168cb0fd484f" />
<img width="1478" height="695" alt="image" src="https://github.com/user-attachments/assets/03f99583-0a5f-4b27-afa5-d677485d1f4b" />
<img width="1502" height="748" alt="image" src="https://github.com/user-attachments/assets/e826ec52-6a64-40f9-8be0-65a43aaaa317" />
<img width="687" height="591" alt="image" src="https://github.com/user-attachments/assets/c0f1e12a-fa11-4b2a-99b9-2a61e590b5f4" />
<img width="1499" height="891" alt="image" src="https://github.com/user-attachments/assets/cc101a23-334b-4a67-b4c2-7b88dda4b7f1" />
<img width="690" height="592" alt="image" src="https://github.com/user-attachments/assets/976103d0-86ca-48c3-9a36-acc378a41b6b" />


### Tests done

- [x] Start pomodoro - timer counts down, badge appears on closed notch
- [x] Skip phase - advances to next phase, shows sneak peek
- [x] Pause/resume - timer pauses and resumes correctly
- [x] Phase completion - sound plays, notification appears, auto-advances
- [x] Music playing + pomodoro - badge sits on right, music on left, no overlap
- [x] No music + pomodoro - badge fully visible, no corner clipping
- [x] Settings - all steppers/toggles update `Defaults` and take effect immediately
- [x] Keyboard shortcuts - `⌘⌥Space` toggles, `⌘→` skips
- [x] Menu bar - countdown replaces sparkle icon when toggled on
- [x] Reset - returns to idle state with focus duration