### PR TITLE
Replaces WeatherKit usage with Open-Meteo API

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		1153BD9A2D98824300979FB0 /* SpotifyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BD992D98824300979FB0 /* SpotifyController.swift */; };
 		1153BD9C2D98853B00979FB0 /* NowPlayingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BD9B2D98853B00979FB0 /* NowPlayingController.swift */; };
 		1153BDA72D99B22200979FB0 /* YouTubeMusicController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BDA62D99B22200979FB0 /* YouTubeMusicController.swift */; };
-		115C12EC2ED3D003009754CA /* OpenNotchOSD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115C12EB2ED3D003009754CA /* OpenNotchOSD.swift */; };
+		115C12EC2ED3D003009754CA /* OpenNotchHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115C12EB2ED3D003009754CA /* OpenNotchHUD.swift */; };
 		1160F8D82DD98230006FBB94 /* NotchShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1160F8D72DD98230006FBB94 /* NotchShape.swift */; };
 		1163988D2DF5CAB40052E6AF /* EventModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1163988C2DF5CAB40052E6AF /* EventModel.swift */; };
 		1163988F2DF5CC870052E6AF /* CalendarModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1163988E2DF5CC870052E6AF /* CalendarModel.swift */; };
@@ -56,11 +56,6 @@
 		1194E8852EA57D23009C82D6 /* SkyLightWindow in Frameworks */ = {isa = PBXBuildFile; productRef = 1194E8842EA57D23009C82D6 /* SkyLightWindow */; };
 		1194E8872EA6DDA7009C82D6 /* BoringNotchSkyLightWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1194E8862EA6DDA7009C82D6 /* BoringNotchSkyLightWindow.swift */; };
 		1194E9402EACC652009C82D6 /* Color+AccentColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1194E93F2EACC652009C82D6 /* Color+AccentColor.swift */; };
-		11985BE02F37A3C800F81585 /* BetterDisplayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11985BDC2F37A3C800F81585 /* BetterDisplayManager.swift */; };
-		11985BE22F37A3C800F81585 /* LunarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11985BDE2F37A3C800F81585 /* LunarManager.swift */; };
-		11985BE62F37A3FC00F81585 /* BetterDisplayNotificationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11985BE42F37A3FC00F81585 /* BetterDisplayNotificationModels.swift */; };
-		11985BEF2F37E48900F81585 /* OSDIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11985BEE2F37E48900F81585 /* OSDIconView.swift */; };
-		11985BF42F38520A00F81585 /* DraggableProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11985BF32F38520A00F81585 /* DraggableProgressBar.swift */; };
 		11A45C792E34E63100CEB175 /* MediaChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A45C782E34E63100CEB175 /* MediaChecker.swift */; };
 		11C5E3132DFE85970065821E /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C5E3112DFE85970065821E /* SettingsWindowController.swift */; };
 		11C5E3162DFE88510065821E /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C5E3152DFE88510065821E /* SettingsView.swift */; };
@@ -71,18 +66,6 @@
 		11CFC6632E09918400748C80 /* MusicControllerSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CFC6622E09917B00748C80 /* MusicControllerSelectionView.swift */; };
 		11CFC6652E09C7B300748C80 /* OnboardingFinishView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CFC6642E09C7B300748C80 /* OnboardingFinishView.swift */; };
 		11D58EA22E760AE100FA8377 /* ImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D58EA12E760AE100FA8377 /* ImageService.swift */; };
-		11DB26662EDD0BE1001EA0CF /* LyricsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB26652EDD0BE1001EA0CF /* LyricsService.swift */; };
-		11DB26732EDD0CDF001EA0CF /* ShortcutsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB26712EDD0CDF001EA0CF /* ShortcutsSettingsView.swift */; };
-		11DB26742EDD0CDF001EA0CF /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB266C2EDD0CDF001EA0CF /* GeneralSettingsView.swift */; };
-		11DB26752EDD0CDF001EA0CF /* ShelfSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB26702EDD0CDF001EA0CF /* ShelfSettingsView.swift */; };
-		11DB26762EDD0CDF001EA0CF /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB26692EDD0CDF001EA0CF /* AppearanceSettingsView.swift */; };
-		11DB26772EDD0CDF001EA0CF /* SettingsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB266F2EDD0CDF001EA0CF /* SettingsHelpers.swift */; };
-		11DB26782EDD0CDF001EA0CF /* BatterySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB266A2EDD0CDF001EA0CF /* BatterySettingsView.swift */; };
-		11DB26792EDD0CDF001EA0CF /* AdvancedSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB26682EDD0CDF001EA0CF /* AdvancedSettingsView.swift */; };
-		11DB267A2EDD0CDF001EA0CF /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB26672EDD0CDF001EA0CF /* AboutView.swift */; };
-		11DB267B2EDD0CDF001EA0CF /* CalendarSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB266B2EDD0CDF001EA0CF /* CalendarSettingsView.swift */; };
-		11DB267C2EDD0CDF001EA0CF /* OSDSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB266D2EDD0CDF001EA0CF /* OSDSettingsView.swift */; };
-		11DB267D2EDD0CDF001EA0CF /* MediaSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB266E2EDD0CDF001EA0CF /* MediaSettingsView.swift */; };
 		11EFCD702E8E92D600D0B974 /* ShelfItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EFCD6F2E8E92D600D0B974 /* ShelfItemViewModel.swift */; };
 		11F747CE2EC75CEA00F841DB /* DragPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F747CD2EC75CEA00F841DB /* DragPreviewView.swift */; };
 		11F7485B2EC9AABA00F841DB /* BoringNotchXPCHelper.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 11F7484F2EC9AABA00F841DB /* BoringNotchXPCHelper.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -114,6 +97,7 @@
 		14D570B92C5E98A20011E668 /* drop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570B82C5E98A20011E668 /* drop.swift */; };
 		14D570BC2C5E98EB0011E668 /* generic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570BB2C5E98EB0011E668 /* generic.swift */; };
 		14D570C02C5EA5870011E668 /* AnimatedFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570BF2C5EA5870011E668 /* AnimatedFace.swift */; };
+		14D570C22C5EAFBF0011E668 /* EmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570C12C5EAFBF0011E668 /* EmptyState.swift */; };
 		14D570C62C5F38210011E668 /* BoringHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570C52C5F38210011E668 /* BoringHeader.swift */; };
 		14D570C92C5F38890011E668 /* BoringViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570C82C5F38890011E668 /* BoringViewModel.swift */; };
 		14D570CB2C5F4B2C0011E668 /* BatteryStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570CA2C5F4B2C0011E668 /* BatteryStatusViewModel.swift */; };
@@ -122,12 +106,12 @@
 		14E9FEAA2C70BF610062E83F /* DownloadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E9FEA92C70BF610062E83F /* DownloadView.swift */; };
 		14E9FEAE2C7325770062E83F /* Button+Bouncing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E9FEAD2C7325770062E83F /* Button+Bouncing.swift */; };
 		14FC6E502C7DED5600C7BEA5 /* DataTypes+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FC6E4F2C7DED5600C7BEA5 /* DataTypes+Extensions.swift */; };
-		201C3E071A104384B8629328 /* AudioOutputRouteResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFAD1670A870402D88BFFE47 /* AudioOutputRouteResolver.swift */; };
 		507266DB2C908E2E00A2D00D /* HoverButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507266DA2C908E2E00A2D00D /* HoverButton.swift */; };
 		5917FD112E57891600E87F1C /* MediaKeyInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5917FD102E57891600E87F1C /* MediaKeyInterceptor.swift */; };
 		5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */; };
 		59D8C23C2E589FAA00147B33 /* VolumeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D8C23B2E589FAA00147B33 /* VolumeManager.swift */; };
-		64FA50FB2F4D6F9E00008A28 /* WebcamSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FA50FA2F4D6F9E00008A28 /* WebcamSettingsView.swift */; };
+		67D4400A2F01B2C40017F574 /* WeatherManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D440092F01B2C40017F574 /* WeatherManager.swift */; };
+		67D4400D2F01B2DD0017F574 /* BoringWeather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D4400B2F01B2DD0017F574 /* BoringWeather.swift */; };
 		9A0887322C7A693000C160EA /* TabButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0887312C7A693000C160EA /* TabButton.swift */; };
 		9A0887352C7AFF8E00C160EA /* TabSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0887342C7AFF8E00C160EA /* TabSelectionView.swift */; };
 		9A987A0D2C73CA66005CA465 /* ShelfView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A987A032C73CA66005CA465 /* ShelfView.swift */; };
@@ -139,24 +123,27 @@
 		B1628B922CC260C0003D8DF3 /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = B1628B912CC260C0003D8DF3 /* SwiftUIIntrospect */; };
 		B17266DF2C64DFA00031BA0D /* BundleInfos.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17266DE2C64DFA00031BA0D /* BundleInfos.swift */; };
 		B17266E12C6532560031BA0D /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B17266E02C6532560031BA0D /* Localizable.xcstrings */; };
-		B172AAC02C95DA0B001623F1 /* InlineOSD.swift in Sources */ = {isa = PBXBuildFile; fileRef = B172AABF2C95DA0B001623F1 /* InlineOSD.swift */; };
+		B17266E32C65F7FB0031BA0D /* WhatsNewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17266E22C65F7FB0031BA0D /* WhatsNewView.swift */; };
+		B172AAC02C95DA0B001623F1 /* InlineHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = B172AABF2C95DA0B001623F1 /* InlineHUD.swift */; };
 		B18654392C6F4990000B926A /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = B18654382C6F4990000B926A /* KeyboardShortcuts */; };
 		B186543C2C6F49AE000B926A /* ShortcutConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B186543B2C6F49AE000B926A /* ShortcutConstants.swift */; };
 		B19016222CC15B3D00E3F12E /* Defaults in Frameworks */ = {isa = PBXBuildFile; productRef = B19016212CC15B3D00E3F12E /* Defaults */; };
 		B19016242CC15B5000E3F12E /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19016232CC15B4D00E3F12E /* Constants.swift */; };
+		B19424092CD0FF01003E5DC2 /* LottieAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19424082CD0FEFE003E5DC2 /* LottieAnimationView.swift */; };
 		B1A78C822C8BA08100BD51B0 /* FullscreenMediaDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A78C812C8BA08100BD51B0 /* FullscreenMediaDetection.swift */; };
 		B1B112912C6A572100093D8F /* EditPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B112902C6A572100093D8F /* EditPanelView.swift */; };
 		B1B112932C6A577E00093D8F /* MouseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B112922C6A577E00093D8F /* MouseTracker.swift */; };
 		B1C448962C9712C4001F0858 /* ActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C448952C9712C4001F0858 /* ActionBar.swift */; };
 		B1C448982C972CC4001F0858 /* ListItemPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C448972C972CC4001F0858 /* ListItemPopover.swift */; };
+		B1C4489B2C97376A001F0858 /* TipStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C4489A2C97376A001F0858 /* TipStore.swift */; };
 		B1C974342C642B6D0000E707 /* MarqueeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C974332C642B6D0000E707 /* MarqueeTextView.swift */; };
 		B1CE8CFE2C6F659400DD9871 /* KeyboardShortcutsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CE8CFD2C6F659400DD9871 /* KeyboardShortcutsHelper.swift */; };
 		B1D365CE2C6A979C0047BDBC /* LiveActivityModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D365CD2C6A979C0047BDBC /* LiveActivityModifier.swift */; };
 		B1D365D02C6A9A6C0047BDBC /* SystemEventIndicatorModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D365CF2C6A9A6C0047BDBC /* SystemEventIndicatorModifier.swift */; };
 		B1D6FD432C6603730015F173 /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D6FD422C6603730015F173 /* SoftwareUpdater.swift */; };
 		B1F0A0022E60000100000001 /* BrightnessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0A0012E60000100000001 /* BrightnessManager.swift */; };
+		B1F747F92EC7E94000F841DB /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F747F82EC7E94000F841DB /* LottieView.swift */; };
 		B1FEB4992C7686630066EBBC /* PanGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FEB4982C7686630066EBBC /* PanGesture.swift */; };
-		F1F2A0A100000000000000F1 /* AudioCaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */; };
 		F38DE6482D8243E7008B5C6D /* BatteryActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -224,7 +211,7 @@
 		1153BD992D98824300979FB0 /* SpotifyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyController.swift; sourceTree = "<group>"; };
 		1153BD9B2D98853B00979FB0 /* NowPlayingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingController.swift; sourceTree = "<group>"; };
 		1153BDA62D99B22200979FB0 /* YouTubeMusicController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeMusicController.swift; sourceTree = "<group>"; };
-		115C12EB2ED3D003009754CA /* OpenNotchOSD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenNotchOSD.swift; sourceTree = "<group>"; };
+		115C12EB2ED3D003009754CA /* OpenNotchHUD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenNotchHUD.swift; sourceTree = "<group>"; };
 		1160F8D72DD98230006FBB94 /* NotchShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchShape.swift; sourceTree = "<group>"; };
 		1163988C2DF5CAB40052E6AF /* EventModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventModel.swift; sourceTree = "<group>"; };
 		1163988E2DF5CC870052E6AF /* CalendarModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarModel.swift; sourceTree = "<group>"; };
@@ -239,11 +226,6 @@
 		1194E87B2EA19E09009C82D6 /* ImageProcessingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProcessingService.swift; sourceTree = "<group>"; };
 		1194E8862EA6DDA7009C82D6 /* BoringNotchSkyLightWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringNotchSkyLightWindow.swift; sourceTree = "<group>"; };
 		1194E93F2EACC652009C82D6 /* Color+AccentColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+AccentColor.swift"; sourceTree = "<group>"; };
-		11985BDC2F37A3C800F81585 /* BetterDisplayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetterDisplayManager.swift; sourceTree = "<group>"; };
-		11985BDE2F37A3C800F81585 /* LunarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunarManager.swift; sourceTree = "<group>"; };
-		11985BE42F37A3FC00F81585 /* BetterDisplayNotificationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetterDisplayNotificationModels.swift; sourceTree = "<group>"; };
-		11985BEE2F37E48900F81585 /* OSDIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDIconView.swift; sourceTree = "<group>"; };
-		11985BF32F38520A00F81585 /* DraggableProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggableProgressBar.swift; sourceTree = "<group>"; };
 		11A45C782E34E63100CEB175 /* MediaChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaChecker.swift; sourceTree = "<group>"; };
 		11C5E3112DFE85970065821E /* SettingsWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowController.swift; sourceTree = "<group>"; };
 		11C5E3152DFE88510065821E /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -254,18 +236,6 @@
 		11CFC6622E09917B00748C80 /* MusicControllerSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicControllerSelectionView.swift; sourceTree = "<group>"; };
 		11CFC6642E09C7B300748C80 /* OnboardingFinishView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFinishView.swift; sourceTree = "<group>"; };
 		11D58EA12E760AE100FA8377 /* ImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
-		11DB26652EDD0BE1001EA0CF /* LyricsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsService.swift; sourceTree = "<group>"; };
-		11DB26672EDD0CDF001EA0CF /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
-		11DB26682EDD0CDF001EA0CF /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
-		11DB26692EDD0CDF001EA0CF /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
-		11DB266A2EDD0CDF001EA0CF /* BatterySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatterySettingsView.swift; sourceTree = "<group>"; };
-		11DB266B2EDD0CDF001EA0CF /* CalendarSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSettingsView.swift; sourceTree = "<group>"; };
-		11DB266C2EDD0CDF001EA0CF /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
-		11DB266D2EDD0CDF001EA0CF /* OSDSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDSettingsView.swift; sourceTree = "<group>"; };
-		11DB266E2EDD0CDF001EA0CF /* MediaSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaSettingsView.swift; sourceTree = "<group>"; };
-		11DB266F2EDD0CDF001EA0CF /* SettingsHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHelpers.swift; sourceTree = "<group>"; };
-		11DB26702EDD0CDF001EA0CF /* ShelfSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelfSettingsView.swift; sourceTree = "<group>"; };
-		11DB26712EDD0CDF001EA0CF /* ShortcutsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsSettingsView.swift; sourceTree = "<group>"; };
 		11EFCD6F2E8E92D600D0B974 /* ShelfItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelfItemViewModel.swift; sourceTree = "<group>"; };
 		11F747CD2EC75CEA00F841DB /* DragPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragPreviewView.swift; sourceTree = "<group>"; };
 		11F7484F2EC9AABA00F841DB /* BoringNotchXPCHelper.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = BoringNotchXPCHelper.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -299,6 +269,7 @@
 		14D570B82C5E98A20011E668 /* drop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = drop.swift; sourceTree = "<group>"; };
 		14D570BB2C5E98EB0011E668 /* generic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = generic.swift; sourceTree = "<group>"; };
 		14D570BF2C5EA5870011E668 /* AnimatedFace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedFace.swift; sourceTree = "<group>"; };
+		14D570C12C5EAFBF0011E668 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
 		14D570C52C5F38210011E668 /* BoringHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringHeader.swift; sourceTree = "<group>"; };
 		14D570C82C5F38890011E668 /* BoringViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringViewModel.swift; sourceTree = "<group>"; };
 		14D570CA2C5F4B2C0011E668 /* BatteryStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryStatusViewModel.swift; sourceTree = "<group>"; };
@@ -311,33 +282,36 @@
 		5917FD102E57891600E87F1C /* MediaKeyInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaKeyInterceptor.swift; sourceTree = "<group>"; };
 		5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationRelauncher.swift; sourceTree = "<group>"; };
 		59D8C23B2E589FAA00147B33 /* VolumeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeManager.swift; sourceTree = "<group>"; };
-		64FA50FA2F4D6F9E00008A28 /* WebcamSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcamSettingsView.swift; sourceTree = "<group>"; };
+		67D440092F01B2C40017F574 /* WeatherManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherManager.swift; sourceTree = "<group>"; };
+		67D4400B2F01B2DD0017F574 /* BoringWeather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringWeather.swift; sourceTree = "<group>"; };
 		9A0887312C7A693000C160EA /* TabButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabButton.swift; sourceTree = "<group>"; };
 		9A0887342C7AFF8E00C160EA /* TabSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSelectionView.swift; sourceTree = "<group>"; };
 		9A987A032C73CA66005CA465 /* ShelfView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShelfView.swift; sourceTree = "<group>"; };
 		9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotchHomeView.swift; sourceTree = "<group>"; };
-		AFAD1670A870402D88BFFE47 /* AudioOutputRouteResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioOutputRouteResolver.swift; sourceTree = "<group>"; };
 		B10348D82C74E56000475897 /* ConditionalModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalModifier.swift; sourceTree = "<group>"; };
 		B10F84A22C6C9596009F3026 /* TestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView.swift; sourceTree = "<group>"; };
 		B141C2402CA5F53E00AC8CC8 /* SparkleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleView.swift; sourceTree = "<group>"; };
 		B17266DE2C64DFA00031BA0D /* BundleInfos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleInfos.swift; sourceTree = "<group>"; };
 		B17266E02C6532560031BA0D /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
-		B172AABF2C95DA0B001623F1 /* InlineOSD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineOSD.swift; sourceTree = "<group>"; };
+		B17266E22C65F7FB0031BA0D /* WhatsNewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewView.swift; sourceTree = "<group>"; };
+		B172AABF2C95DA0B001623F1 /* InlineHUD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineHUD.swift; sourceTree = "<group>"; };
 		B186543B2C6F49AE000B926A /* ShortcutConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutConstants.swift; sourceTree = "<group>"; };
 		B19016232CC15B4D00E3F12E /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		B19424082CD0FEFE003E5DC2 /* LottieAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieAnimationView.swift; sourceTree = "<group>"; };
 		B1A78C812C8BA08100BD51B0 /* FullscreenMediaDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenMediaDetection.swift; sourceTree = "<group>"; };
 		B1B112902C6A572100093D8F /* EditPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPanelView.swift; sourceTree = "<group>"; };
 		B1B112922C6A577E00093D8F /* MouseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseTracker.swift; sourceTree = "<group>"; };
 		B1C448952C9712C4001F0858 /* ActionBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionBar.swift; sourceTree = "<group>"; };
 		B1C448972C972CC4001F0858 /* ListItemPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemPopover.swift; sourceTree = "<group>"; };
+		B1C4489A2C97376A001F0858 /* TipStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipStore.swift; sourceTree = "<group>"; };
 		B1C974332C642B6D0000E707 /* MarqueeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarqueeTextView.swift; sourceTree = "<group>"; };
 		B1CE8CFD2C6F659400DD9871 /* KeyboardShortcutsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutsHelper.swift; sourceTree = "<group>"; };
 		B1D365CD2C6A979C0047BDBC /* LiveActivityModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityModifier.swift; sourceTree = "<group>"; };
 		B1D365CF2C6A9A6C0047BDBC /* SystemEventIndicatorModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemEventIndicatorModifier.swift; sourceTree = "<group>"; };
 		B1D6FD422C6603730015F173 /* SoftwareUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdater.swift; sourceTree = "<group>"; };
 		B1F0A0012E60000100000001 /* BrightnessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrightnessManager.swift; sourceTree = "<group>"; };
+		B1F747F82EC7E94000F841DB /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
 		B1FEB4982C7686630066EBBC /* PanGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanGesture.swift; sourceTree = "<group>"; };
-		F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureManager.swift; sourceTree = "<group>"; };
 		F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryActivityManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -473,74 +447,6 @@
 			path = Providers;
 			sourceTree = "<group>";
 		};
-		11985BDF2F37A3C800F81585 /* OSD */ = {
-			isa = PBXGroup;
-			children = (
-				11985BE72F37A4D100F81585 /* Managers */,
-				11985BE52F37A3FC00F81585 /* Models */,
-				11985BE92F37A55300F81585 /* Views */,
-			);
-			path = OSD;
-			sourceTree = "<group>";
-		};
-		11985BE52F37A3FC00F81585 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				11985BE42F37A3FC00F81585 /* BetterDisplayNotificationModels.swift */,
-			);
-			path = Models;
-			sourceTree = "<group>";
-		};
-		11985BE72F37A4D100F81585 /* Managers */ = {
-			isa = PBXGroup;
-			children = (
-				11985BDC2F37A3C800F81585 /* BetterDisplayManager.swift */,
-				11985BDE2F37A3C800F81585 /* LunarManager.swift */,
-				11985BE82F37A4E300F81585 /* XPC */,
-			);
-			path = Managers;
-			sourceTree = "<group>";
-		};
-		11985BE82F37A4E300F81585 /* XPC */ = {
-			isa = PBXGroup;
-			children = (
-				B1F0A0012E60000100000001 /* BrightnessManager.swift */,
-				59D8C23B2E589FAA00147B33 /* VolumeManager.swift */,
-			);
-			path = XPC;
-			sourceTree = "<group>";
-		};
-		11985BE92F37A55300F81585 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				11985BF32F38520A00F81585 /* DraggableProgressBar.swift */,
-				11985BEE2F37E48900F81585 /* OSDIconView.swift */,
-				B172AABF2C95DA0B001623F1 /* InlineOSD.swift */,
-				115C12EB2ED3D003009754CA /* OpenNotchOSD.swift */,
-				B1D365CF2C6A9A6C0047BDBC /* SystemEventIndicatorModifier.swift */,
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
-		11DB26722EDD0CDF001EA0CF /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				11DB26672EDD0CDF001EA0CF /* AboutView.swift */,
-				11DB26682EDD0CDF001EA0CF /* AdvancedSettingsView.swift */,
-				11DB26692EDD0CDF001EA0CF /* AppearanceSettingsView.swift */,
-				11DB266A2EDD0CDF001EA0CF /* BatterySettingsView.swift */,
-				11DB266B2EDD0CDF001EA0CF /* CalendarSettingsView.swift */,
-				11DB266C2EDD0CDF001EA0CF /* GeneralSettingsView.swift */,
-				11DB266D2EDD0CDF001EA0CF /* OSDSettingsView.swift */,
-				11DB266E2EDD0CDF001EA0CF /* MediaSettingsView.swift */,
-				11DB266F2EDD0CDF001EA0CF /* SettingsHelpers.swift */,
-				11DB26702EDD0CDF001EA0CF /* ShelfSettingsView.swift */,
-				11DB26712EDD0CDF001EA0CF /* ShortcutsSettingsView.swift */,
-				64FA50FA2F4D6F9E00008A28 /* WebcamSettingsView.swift */,
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
 		11F748672EC9AC9600F841DB /* XPCHelperClient */ = {
 			isa = PBXGroup;
 			children = (
@@ -559,7 +465,6 @@
 				14288DD62C6E015000B9F80C /* AudioPlayer.swift */,
 				5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */,
 				14288E0B2C6F8EC000B9F80C /* AppIcons.swift */,
-				AFAD1670A870402D88BFFE47 /* AudioOutputRouteResolver.swift */,
 			);
 			path = helpers;
 			sourceTree = "<group>";
@@ -585,8 +490,9 @@
 		1471639B2C5D362F0068B555 /* components */ = {
 			isa = PBXGroup;
 			children = (
-				11985BDF2F37A3C800F81585 /* OSD */,
+				67D4400C2F01B2DD0017F574 /* Weather */,
 				B141C23B2CA5F50900AC8CC8 /* Onboarding */,
+				B1C448992C97375A001F0858 /* Tips */,
 				14C08BB72C8DE49E000F8AA0 /* Calendar */,
 				9A987A042C73CA66005CA465 /* Shelf */,
 				149E0B982C737D26006418B1 /* Webcam */,
@@ -597,8 +503,11 @@
 				B186542E2C6F453B000B926A /* Music */,
 				14D570BF2C5EA5870011E668 /* AnimatedFace.swift */,
 				14288DE72C6E01C800B9F80C /* ProgressIndicator.swift */,
+				14D570C12C5EAFBF0011E668 /* EmptyState.swift */,
+				B17266E22C65F7FB0031BA0D /* WhatsNewView.swift */,
 				B10F84A22C6C9596009F3026 /* TestView.swift */,
 				507266DA2C908E2E00A2D00D /* HoverButton.swift */,
+				B1F747F82EC7E94000F841DB /* LottieView.swift */,
 			);
 			path = components;
 			sourceTree = "<group>";
@@ -606,14 +515,15 @@
 		147163B52C5D804B0068B555 /* managers */ = {
 			isa = PBXGroup;
 			children = (
-				11DB26652EDD0BE1001EA0CF /* LyricsService.swift */,
+				67D440092F01B2C40017F574 /* WeatherManager.swift */,
 				11D58EA12E760AE100FA8377 /* ImageService.swift */,
 				F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */,
 				112FB7342CCF16F70015238C /* NotchSpaceManager.swift */,
 				147163992C5D35FF0068B555 /* MusicManager.swift */,
-				F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */,
 				149E0B962C737D00006418B1 /* WebcamManager.swift */,
 				14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */,
+				B1F0A0012E60000100000001 /* BrightnessManager.swift */,
+				59D8C23B2E589FAA00147B33 /* VolumeManager.swift */,
 			);
 			path = managers;
 			sourceTree = "<group>";
@@ -734,6 +644,14 @@
 			path = models;
 			sourceTree = "<group>";
 		};
+		67D4400C2F01B2DD0017F574 /* Weather */ = {
+			isa = PBXGroup;
+			children = (
+				67D4400B2F01B2DD0017F574 /* BoringWeather.swift */,
+			);
+			path = Weather;
+			sourceTree = "<group>";
+		};
 		9A0887332C7AFF7E00C160EA /* Tabs */ = {
 			isa = PBXGroup;
 			children = (
@@ -791,6 +709,7 @@
 		B186542E2C6F453B000B926A /* Music */ = {
 			isa = PBXGroup;
 			children = (
+				B19424082CD0FEFE003E5DC2 /* LottieAnimationView.swift */,
 				147163972C5D35B70068B555 /* MusicVisualizer.swift */,
 			);
 			path = Music;
@@ -812,7 +731,6 @@
 		B18654302C6F4590000B926A /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				11DB26722EDD0CDF001EA0CF /* Views */,
 				11F748832ECB27DC00F841DB /* MusicSlotConfigurationView.swift */,
 				11C5E3152DFE88510065821E /* SettingsView.swift */,
 				11C5E3112DFE85970065821E /* SettingsWindowController.swift */,
@@ -826,10 +744,13 @@
 		B18654312C6F45AE000B926A /* Live activities */ = {
 			isa = PBXGroup;
 			children = (
+				115C12EB2ED3D003009754CA /* OpenNotchHUD.swift */,
 				14D570CC2C5F4BB70011E668 /* BoringBattery.swift */,
 				B1C974332C642B6D0000E707 /* MarqueeTextView.swift */,
 				B1D365CD2C6A979C0047BDBC /* LiveActivityModifier.swift */,
+				B1D365CF2C6A9A6C0047BDBC /* SystemEventIndicatorModifier.swift */,
 				14E9FEA92C70BF610062E83F /* DownloadView.swift */,
+				B172AABF2C95DA0B001623F1 /* InlineHUD.swift */,
 			);
 			path = "Live activities";
 			sourceTree = "<group>";
@@ -840,6 +761,14 @@
 				B186543B2C6F49AE000B926A /* ShortcutConstants.swift */,
 			);
 			path = Shortcuts;
+			sourceTree = "<group>";
+		};
+		B1C448992C97375A001F0858 /* Tips */ = {
+			isa = PBXGroup;
+			children = (
+				B1C4489A2C97376A001F0858 /* TipStore.swift */,
+			);
+			path = Tips;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -919,7 +848,7 @@
 					};
 					14CEF4112C5CAED300855D72 = {
 						CreatedOnToolsVersion = 15.4;
-						LastSwiftMigration = 1640;
+						LastSwiftMigration = 1540;
 					};
 				};
 			};
@@ -990,7 +919,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				115C12EC2ED3D003009754CA /* OpenNotchOSD.swift in Sources */,
+				115C12EC2ED3D003009754CA /* OpenNotchHUD.swift in Sources */,
 				14C08BB92C8DE4B1000F8AA0 /* BoringCalendar.swift in Sources */,
 				5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */,
 				1100292A2E8691B400035A57 /* FileShareView.swift in Sources */,
@@ -1010,7 +939,6 @@
 				14D570CB2C5F4B2C0011E668 /* BatteryStatusViewModel.swift in Sources */,
 				9A0887322C7A693000C160EA /* TabButton.swift in Sources */,
 				1153BD9C2D98853B00979FB0 /* NowPlayingController.swift in Sources */,
-				11985BEF2F37E48900F81585 /* OSDIconView.swift in Sources */,
 				1194E9402EACC652009C82D6 /* Color+AccentColor.swift in Sources */,
 				B141C2412CA5F53F00AC8CC8 /* SparkleView.swift in Sources */,
 				116398962DF5D6C00052E6AF /* CalendarServiceProviding.swift in Sources */,
@@ -1022,11 +950,12 @@
 				1163988F2DF5CC870052E6AF /* CalendarModel.swift in Sources */,
 				1153BD9A2D98824300979FB0 /* SpotifyController.swift in Sources */,
 				118EBE292E946B3F00D54B5A /* ShareServiceFinder.swift in Sources */,
+				B19424092CD0FF01003E5DC2 /* LottieAnimationView.swift in Sources */,
+				B1F747F92EC7E94000F841DB /* LottieView.swift in Sources */,
 				B1C974342C642B6D0000E707 /* MarqueeTextView.swift in Sources */,
 				14288DE82C6E01C800B9F80C /* ProgressIndicator.swift in Sources */,
 				1113ABC52E80E27000EC13B2 /* ShelfItemView.swift in Sources */,
 				1113ABC62E80E27000EC13B2 /* ShelfPersistenceService.swift in Sources */,
-				11DB26662EDD0BE1001EA0CF /* LyricsService.swift in Sources */,
 				1113ABC82E80E27000EC13B2 /* ShelfItem.swift in Sources */,
 				1113ABCA2E80E27000EC13B2 /* ShelfSelectionModel.swift in Sources */,
 				1113ABCB2E80E27000EC13B2 /* QuickLookService.swift in Sources */,
@@ -1038,7 +967,6 @@
 				14C08BC12C8E03AD000F8AA0 /* NSImage+Extensions.swift in Sources */,
 				149E0B9A2C737D40006418B1 /* WebcamView.swift in Sources */,
 				1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */,
-				F1F2A0A100000000000000F1 /* AudioCaptureManager.swift in Sources */,
 				B1B112932C6A577E00093D8F /* MouseTracker.swift in Sources */,
 				B1C448962C9712C4001F0858 /* ActionBar.swift in Sources */,
 				118EBE312E9717DB00D54B5A /* URL+SecurityScoped.swift in Sources */,
@@ -1046,11 +974,11 @@
 				14A7E5882C64A89C008C1BE9 /* HelloAnimation.swift in Sources */,
 				111BEA612ED09B1B0079DD4E /* NSScreen+UUID.swift in Sources */,
 				1153BD8F2D986B1F00979FB0 /* MediaControllerProtocol.swift in Sources */,
-				11985BF42F38520A00F81585 /* DraggableProgressBar.swift in Sources */,
 				9AB0C6BD2C73C9CB00F7CD30 /* NotchHomeView.swift in Sources */,
-				B172AAC02C95DA0B001623F1 /* InlineOSD.swift in Sources */,
+				B172AAC02C95DA0B001623F1 /* InlineHUD.swift in Sources */,
 				14E9FEAA2C70BF610062E83F /* DownloadView.swift in Sources */,
 				B1B112912C6A572100093D8F /* EditPanelView.swift in Sources */,
+				B1C4489B2C97376A001F0858 /* TipStore.swift in Sources */,
 				1153BD912D986DB300979FB0 /* PlaybackState.swift in Sources */,
 				B1A78C822C8BA08100BD51B0 /* FullscreenMediaDetection.swift in Sources */,
 				14E9FEAE2C7325770062E83F /* Button+Bouncing.swift in Sources */,
@@ -1058,18 +986,9 @@
 				14D570BC2C5E98EB0011E668 /* generic.swift in Sources */,
 				118EBE272E92DE8400D54B5A /* NSMenu+AssociatedObject.swift in Sources */,
 				B1CE8CFE2C6F659400DD9871 /* KeyboardShortcutsHelper.swift in Sources */,
-				11DB26732EDD0CDF001EA0CF /* ShortcutsSettingsView.swift in Sources */,
-				11DB26742EDD0CDF001EA0CF /* GeneralSettingsView.swift in Sources */,
-				11DB26752EDD0CDF001EA0CF /* ShelfSettingsView.swift in Sources */,
-				11DB26762EDD0CDF001EA0CF /* AppearanceSettingsView.swift in Sources */,
-				11DB26772EDD0CDF001EA0CF /* SettingsHelpers.swift in Sources */,
-				11DB26782EDD0CDF001EA0CF /* BatterySettingsView.swift in Sources */,
-				11DB26792EDD0CDF001EA0CF /* AdvancedSettingsView.swift in Sources */,
-				11DB267A2EDD0CDF001EA0CF /* AboutView.swift in Sources */,
-				11DB267B2EDD0CDF001EA0CF /* CalendarSettingsView.swift in Sources */,
-				11DB267C2EDD0CDF001EA0CF /* OSDSettingsView.swift in Sources */,
-				11DB267D2EDD0CDF001EA0CF /* MediaSettingsView.swift in Sources */,
 				14D570C62C5F38210011E668 /* BoringHeader.swift in Sources */,
+				67D4400A2F01B2C40017F574 /* WeatherManager.swift in Sources */,
+				B17266E32C65F7FB0031BA0D /* WhatsNewView.swift in Sources */,
 				14C08BB62C8DE42D000F8AA0 /* CalendarManager.swift in Sources */,
 				14D570CD2C5F4BB70011E668 /* BoringBattery.swift in Sources */,
 				B10F84A32C6C9596009F3026 /* TestView.swift in Sources */,
@@ -1079,7 +998,6 @@
 				11C5E3132DFE85970065821E /* SettingsWindowController.swift in Sources */,
 				110029272E84FD4C00035A57 /* TemporaryFileStorageService.swift in Sources */,
 				11CFC6652E09C7B300748C80 /* OnboardingFinishView.swift in Sources */,
-				64FA50FB2F4D6F9E00008A28 /* WebcamSettingsView.swift in Sources */,
 				507266DB2C908E2E00A2D00D /* HoverButton.swift in Sources */,
 				1471A8592C6281BD0058408D /* BoringNotchWindow.swift in Sources */,
 				14CEF4182C5CAED300855D72 /* ContentView.swift in Sources */,
@@ -1094,25 +1012,23 @@
 				F38DE6482D8243E7008B5C6D /* BatteryActivityManager.swift in Sources */,
 				B10348D92C74E56000475897 /* ConditionalModifier.swift in Sources */,
 				118D1FD12E98FF5F00A2FF63 /* SharingStateManager.swift in Sources */,
-				11985BE62F37A3FC00F81585 /* BetterDisplayNotificationModels.swift in Sources */,
+				14D570C22C5EAFBF0011E668 /* EmptyState.swift in Sources */,
 				118EBE252E92DCCB00D54B5A /* AssociatedObject.swift in Sources */,
 				11F748682EC9AC9600F841DB /* BoringNotchXPCHelperProtocol.swift in Sources */,
 				11F748692EC9AC9600F841DB /* XPCHelperClient.swift in Sources */,
 				118EBE2D2E97165600D54B5A /* Bookmark.swift in Sources */,
-				11985BE02F37A3C800F81585 /* BetterDisplayManager.swift in Sources */,
-				11985BE22F37A3C800F81585 /* LunarManager.swift in Sources */,
 				B1FEB4992C7686630066EBBC /* PanGesture.swift in Sources */,
 				11F748842ECB27DC00F841DB /* MusicSlotConfigurationView.swift in Sources */,
 				9A0887352C7AFF8E00C160EA /* TabSelectionView.swift in Sources */,
 				112FB7352CCF16F70015238C /* NotchSpaceManager.swift in Sources */,
 				14FC6E502C7DED5600C7BEA5 /* DataTypes+Extensions.swift in Sources */,
 				1153BD982D9881F900979FB0 /* AppleScriptHelper.swift in Sources */,
+				67D4400D2F01B2DD0017F574 /* BoringWeather.swift in Sources */,
 				11CFC6612E097F6800748C80 /* PermissionsRequestView.swift in Sources */,
 				14D570D22C5F6C6A0011E668 /* BoringExtrasMenu.swift in Sources */,
 				11D58EA22E760AE100FA8377 /* ImageService.swift in Sources */,
 				11F748822ECB07A400F841DB /* MusicControlButton.swift in Sources */,
 				14288DDC2C6E015000B9F80C /* AudioPlayer.swift in Sources */,
-				201C3E071A104384B8629328 /* AudioOutputRouteResolver.swift in Sources */,
 				149E0B972C737D00006418B1 /* WebcamManager.swift in Sources */,
 				14288E0C2C6F8EC000B9F80C /* AppIcons.swift in Sources */,
 				B1C448982C972CC4001F0858 /* ListItemPopover.swift in Sources */,
@@ -1142,14 +1058,14 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 272;
+				CURRENT_PROJECT_VERSION = 271;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BoringNotchXPCHelper/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BoringNotchXPCHelper;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = "2.8-beta.0";
+				MARKETING_VERSION = 2.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = theboringteam.boringnotch.BoringNotchXPCHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1167,14 +1083,14 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 272;
+				CURRENT_PROJECT_VERSION = 271;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BoringNotchXPCHelper/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BoringNotchXPCHelper;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = "2.8-beta.0";
+				MARKETING_VERSION = 2.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = theboringteam.boringnotch.BoringNotchXPCHelper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1314,7 +1230,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
-				AUTOMATION_APPLE_EVENTS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = boringNotch/boringNotch.entitlements;
@@ -1322,18 +1237,22 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 272;
+				CURRENT_PROJECT_VERSION = 271;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"boringNotch/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
 				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
 				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
 				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
 				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
-				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1341,7 +1260,7 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = boringNotch/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Boring Notch";
+				INFOPLIST_KEY_CFBundleDisplayName = TheBoringNotch;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSBackgroundOnly = NO;
 				INFOPLIST_KEY_LSUIElement = YES;
@@ -1355,16 +1274,10 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = "2.8-beta.0";
+				MARKETING_VERSION = 2.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = theboringteam.boringnotch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
-				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
-				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
-				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
-				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
-				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 5.0;
@@ -1381,7 +1294,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
-				AUTOMATION_APPLE_EVENTS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = boringNotch/boringNotch.entitlements;
@@ -1389,25 +1301,27 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 272;
+				CURRENT_PROJECT_VERSION = 271;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"boringNotch/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
 				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
 				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
 				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
 				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
-				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/mediaremote-adapter",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = boringNotch/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Boring Notch";
+				INFOPLIST_KEY_CFBundleDisplayName = TheBoringNotch;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSBackgroundOnly = NO;
 				INFOPLIST_KEY_LSUIElement = YES;
@@ -1421,16 +1335,10 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = "2.8-beta.0";
+				MARKETING_VERSION = 2.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = theboringteam.boringnotch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
-				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
-				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
-				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
-				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
-				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 5.0;
@@ -1478,8 +1386,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ChimeHQ/AsyncXPCConnection";
 			requirement = {
-				kind = exactVersion;
-				version = 1.3.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
 			};
 		};
 		111BEA6D2ED166E20079DD4E /* XCRemoteSwiftPackageReference "MacroVisionKit" */ = {
@@ -1494,8 +1402,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Lakr233/SkyLightWindow";
 			requirement = {
-				kind = exactVersion;
-				version = 1.0.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 		11F748712EC9DA9300F841DB /* XCRemoteSwiftPackageReference "lottie-spm" */ = {
@@ -1503,47 +1411,46 @@
 			repositoryURL = "https://github.com/airbnb/lottie-spm.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.6.1;
+				minimumVersion = 4.5.2;
 			};
 		};
 		14D032182C68F32E0096E6A1 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sindresorhus/LaunchAtLogin-Modern";
 			requirement = {
-				kind = exactVersion;
-				version = 1.1.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
 			};
 		};
 		14D0321B2C68F3350096E6A1 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
-				kind = exactVersion;
-				version = 2.9.2;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.8.0;
 			};
 		};
 		9A987A0E2C73CA8D005CA465 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-collections.git";
 			requirement = {
-				kind = exactVersion;
-				version = 1.6.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.2;
 			};
 		};
 		9A987A112C73CAA1005CA465 /* XCRemoteSwiftPackageReference "Pow" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/EmergeTools/Pow";
 			requirement = {
-				kind = exactVersion;
-				version = 1.0.6;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.4;
 			};
 		};
 		B1628B902CC260C0003D8DF3 /* XCRemoteSwiftPackageReference "swiftui-introspect" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/siteline/swiftui-introspect";
 			requirement = {
-				kind = versionRange;
-				maximumVersion = 27.0.0;
+				kind = upToNextMajorVersion;
 				minimumVersion = 1.3.0;
 			};
 		};
@@ -1551,16 +1458,16 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
 			requirement = {
-				kind = exactVersion;
-				version = 3.0.1;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.2.4;
 			};
 		};
 		B19016202CC15B3D00E3F12E /* XCRemoteSwiftPackageReference "Defaults" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sindresorhus/Defaults";
 			requirement = {
-				kind = exactVersion;
-				version = 9.0.8;
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.0.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/boringNotch/Info.plist
+++ b/boringNotch/Info.plist
@@ -27,5 +27,11 @@
 	<array>
 		<dict/>
 	</array>
+	<key>NSLocationUsageDescription</key>
+	<string>We need your location to show local weather information in the notch</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>We need your location to show local weather information in the notch</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>We need your location to show local weather information in the notch</string>
 </dict>
 </plist>

--- a/boringNotch/boringNotch.entitlements
+++ b/boringNotch/boringNotch.entitlements
@@ -22,6 +22,8 @@
 	<true/>
 	<key>com.apple.security.personal-information.calendars</key>
 	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
 	<key>com.apple.security.temporary-exception.apple-events</key>
 	<array>
 		<string>com.spotify.client</string>

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -3,7 +3,7 @@
 //  boringNotch
 //
 //  Created by Hugo Persson on 2024-08-18.
-//  Modified by Harsh Vardhan Goswami & Richard Kunkli & Mustafa Ramadan
+//  Modified by Harsh Vardhan Goswami & Richard Kunkli & Mustafa Ramadan & Arsh Anwar
 //
 
 import Combine
@@ -437,6 +437,32 @@ struct NotchHomeView: View {
     private var shouldShowCamera: Bool {
         Defaults[.showMirror] && webcamManager.cameraAvailable && vm.isCameraExpanded
     }
+    
+    private var shouldShowCalendar: Bool {
+        Defaults[.showCalendar]
+    }
+    
+    private var shouldShowWeather: Bool {
+        Defaults[.showWeather]
+    }
+    
+    private var additionalItemsCount: Int {
+        var count = 0
+        if shouldShowCalendar { count += 1 }
+        if shouldShowWeather { count += 1 }
+        if shouldShowCamera { count += 1 }
+        return count
+    }
+    
+    private var itemWidth: CGFloat {
+        switch additionalItemsCount {
+        case 0: return 215
+        case 1: return 215
+        case 2: return 170
+        case 3: return 150
+        default: return 150
+        }
+    }
 
     private var mainContent: some View {
         HStack(alignment: .top, spacing: (shouldShowCamera && Defaults[.showCalendar]) ? 10 : 15) {
@@ -446,12 +472,19 @@ struct NotchHomeView: View {
                 isHoveringMusicArea: $isHoveringMusicArea
             )
 
-            if Defaults[.showCalendar] {
+            if shouldShowCalendar {
                 CalendarView()
-                    .frame(width: shouldShowCamera ? 170 : 215)
+                    .frame(width: itemWidth)
                     .onHover { isHovering in
                         vm.isHoveringCalendar = isHovering
                     }
+                    .environmentObject(vm)
+                    .transition(.opacity)
+            }
+            
+            if shouldShowWeather {
+                WeatherView()
+                    .frame(width: itemWidth)
                     .environmentObject(vm)
                     .transition(.opacity)
             }

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -455,12 +455,20 @@ struct NotchHomeView: View {
     }
     
     private var itemWidth: CGFloat {
-        switch additionalItemsCount {
-        case 0: return 215
-        case 1: return 215
-        case 2: return 170
-        case 3: return 150
-        default: return 150
+        // Music player takes ~100px, we need to keep total under 640 for notch curve
+        // When camera is shown, it needs more space
+        if shouldShowCamera {
+            switch additionalItemsCount {
+            case 2: return 170  // calendar/weather + camera
+            case 3: return 130  // This shouldn't happen often
+            default: return 215
+            }
+        } else {
+            switch additionalItemsCount {
+            case 1: return 215  // Just calendar or weather
+            case 2: return 180  // Calendar + weather
+            default: return 215
+            }
         }
     }
 

--- a/boringNotch/components/Onboarding/OnboardingView.swift
+++ b/boringNotch/components/Onboarding/OnboardingView.swift
@@ -3,6 +3,7 @@
 //  boringNotch
 //
 //  Created by Alexander on 2025-06-23.
+//  Modified by Arsh Anwar
 //
 
 import SwiftUI
@@ -16,6 +17,7 @@ enum OnboardingStep {
     case calendarPermission
     case remindersPermission
     case audioCapturePermission
+    case weatherPermission
     case accessibilityPermission
     case musicPermission
     case softwareUpdatePermission
@@ -95,7 +97,29 @@ struct OnboardingView: View {
                             Task {
                                 await requestRemindersPermission()
                                 withAnimation(.easeInOut(duration: 0.6)) {
-                                    step = nextStepAfterReminders()
+                                    step = .weatherPermission
+                                }
+                            }
+                        },
+                        onSkip: {
+                            withAnimation(.easeInOut(duration: 0.6)) {
+                                step = .weatherPermission
+                            }
+                        }
+                    )
+                    .transition(.opacity)
+
+                case .weatherPermission:
+                    PermissionRequestView(
+                        icon: Image(systemName: "cloud.sun.fill"),
+                        title: "Enable Weather Access",
+                        description: "Boring Notch can display current weather conditions right in the notch. Location access is needed to show weather for your current location.",
+                        privacyNote: "Your location is only used to fetch weather data and is never shared or stored.",
+                        onAllow: {
+                            Task {
+                                await requestWeatherPermission()
+                                withAnimation(.easeInOut(duration: 0.6)) {
+                                    step = .accessibilityPermission
                                 }
                             }
                         },
@@ -209,6 +233,13 @@ struct OnboardingView: View {
         return .accessibilityPermission
     }
     
+    func requestWeatherPermission() async {
+        await WeatherManager.shared.checkLocationAuthorization()
+    }
+
+    func requestAccessibilityPermission() async {
+        await XPCHelperClient.shared.ensureAccessibilityAuthorization(promptIfNeeded: true)
+    }
 }
 
 struct SoftwareUpdatePermissionView: View {

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -3,6 +3,7 @@
 //  boringNotch
 //
 //  Created by Richard Kunkli on 07/08/2024.
+//  Modified by Arsh Anwar
 //
 
 import Sparkle
@@ -14,6 +15,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
     case appearance
     case media
     case calendar
+    case weather
     case osd
     case battery
     case shelf
@@ -30,6 +32,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .appearance: "Appearance"
         case .media: "Media"
         case .calendar: "Calendar"
+        case .weather: "Weather"
         case .osd: "OSD"
         case .battery: "Battery"
         case .shelf: "Shelf"
@@ -46,6 +49,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .appearance: "eye"
         case .media: "play.laptopcomputer"
         case .calendar: "calendar"
+        case .weather: "cloud.sun.fill"
         case .osd: "dial.medium.fill"
         case .battery: "battery.100.bolt"
         case .shelf: "books.vertical"
@@ -90,6 +94,8 @@ struct SettingsView: View {
                     Media()
                 case .calendar:
                     CalendarSettings()
+                case .weather:
+                    WeatherSettings()
                 case .osd:
                     OSDSettings()
                 case .battery:
@@ -135,3 +141,1763 @@ struct SettingsView: View {
         }
     }
 }
+
+struct GeneralSettings: View {
+    @State private var screens: [(uuid: String, name: String)] = NSScreen.screens.compactMap { screen in
+        guard let uuid = screen.displayUUID else { return nil }
+        return (uuid, screen.localizedName)
+    }
+    @EnvironmentObject var vm: BoringViewModel
+    @ObservedObject var coordinator = BoringViewCoordinator.shared
+
+    @Default(.mirrorShape) var mirrorShape
+    @Default(.showEmojis) var showEmojis
+    @Default(.gestureSensitivity) var gestureSensitivity
+    @Default(.minimumHoverDuration) var minimumHoverDuration
+    @Default(.nonNotchHeight) var nonNotchHeight
+    @Default(.nonNotchHeightMode) var nonNotchHeightMode
+    @Default(.notchHeight) var notchHeight
+    @Default(.notchHeightMode) var notchHeightMode
+    @Default(.showOnAllDisplays) var showOnAllDisplays
+    @Default(.automaticallySwitchDisplay) var automaticallySwitchDisplay
+    @Default(.enableGestures) var enableGestures
+    @Default(.openNotchOnHover) var openNotchOnHover
+    
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle(isOn: Binding(
+                    get: { Defaults[.menubarIcon] },
+                    set: { Defaults[.menubarIcon] = $0 }
+                )) {
+                    Text("Show menu bar icon")
+                }
+                .tint(.effectiveAccent)
+                LaunchAtLogin.Toggle("Launch at login")
+                Defaults.Toggle(key: .showOnAllDisplays) {
+                    Text("Show on all displays")
+                }
+                .onChange(of: showOnAllDisplays) {
+                    NotificationCenter.default.post(
+                        name: Notification.Name.showOnAllDisplaysChanged, object: nil)
+                }
+                Picker("Preferred display", selection: $coordinator.preferredScreenUUID) {
+                    ForEach(screens, id: \.uuid) { screen in
+                        Text(screen.name).tag(screen.uuid as String?)
+                    }
+                }
+                .onChange(of: NSScreen.screens) {
+                    screens = NSScreen.screens.compactMap { screen in
+                        guard let uuid = screen.displayUUID else { return nil }
+                        return (uuid, screen.localizedName)
+                    }
+                }
+                .disabled(showOnAllDisplays)
+                
+                Defaults.Toggle(key: .automaticallySwitchDisplay) {
+                    Text("Automatically switch displays")
+                }
+                    .onChange(of: automaticallySwitchDisplay) {
+                        NotificationCenter.default.post(
+                            name: Notification.Name.automaticallySwitchDisplayChanged, object: nil)
+                    }
+                    .disabled(showOnAllDisplays)
+            } header: {
+                Text("System features")
+            }
+
+            Section {
+                Picker(
+                    selection: $notchHeightMode,
+                    label:
+                        Text("Notch height on notch displays")
+                ) {
+                    Text("Match real notch height")
+                        .tag(WindowHeightMode.matchRealNotchSize)
+                    Text("Match menu bar height")
+                        .tag(WindowHeightMode.matchMenuBar)
+                    Text("Custom height")
+                        .tag(WindowHeightMode.custom)
+                }
+                .onChange(of: notchHeightMode) {
+                    switch notchHeightMode {
+                    case .matchRealNotchSize:
+                        notchHeight = 38
+                    case .matchMenuBar:
+                        notchHeight = 44
+                    case .custom:
+                        notchHeight = 38
+                    }
+                    NotificationCenter.default.post(
+                        name: Notification.Name.notchHeightChanged, object: nil)
+                }
+                if notchHeightMode == .custom {
+                    Slider(value: $notchHeight, in: 15...45, step: 1) {
+                        Text("Custom notch size - \(notchHeight, specifier: "%.0f")")
+                    }
+                    .onChange(of: notchHeight) {
+                        NotificationCenter.default.post(
+                            name: Notification.Name.notchHeightChanged, object: nil)
+                    }
+                }
+                Picker("Notch height on non-notch displays", selection: $nonNotchHeightMode) {
+                    Text("Match menubar height")
+                        .tag(WindowHeightMode.matchMenuBar)
+                    Text("Match real notch height")
+                        .tag(WindowHeightMode.matchRealNotchSize)
+                    Text("Custom height")
+                        .tag(WindowHeightMode.custom)
+                }
+                .onChange(of: nonNotchHeightMode) {
+                    switch nonNotchHeightMode {
+                    case .matchMenuBar:
+                        nonNotchHeight = 24
+                    case .matchRealNotchSize:
+                        nonNotchHeight = 32
+                    case .custom:
+                        nonNotchHeight = 32
+                    }
+                    NotificationCenter.default.post(
+                        name: Notification.Name.notchHeightChanged, object: nil)
+                }
+                if nonNotchHeightMode == .custom {
+                    Slider(value: $nonNotchHeight, in: 0...40, step: 1) {
+                        Text("Custom notch size - \(nonNotchHeight, specifier: "%.0f")")
+                    }
+                    .onChange(of: nonNotchHeight) {
+                        NotificationCenter.default.post(
+                            name: Notification.Name.notchHeightChanged, object: nil)
+                    }
+                }
+            } header: {
+                Text("Notch sizing")
+            }
+
+            NotchBehaviour()
+
+            gestureControls()
+        }
+        .toolbar {
+            Button("Quit app") {
+                NSApp.terminate(self)
+            }
+            .controlSize(.extraLarge)
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("General")
+        .onChange(of: openNotchOnHover) {
+            if !openNotchOnHover {
+                enableGestures = true
+            }
+        }
+    }
+
+    @ViewBuilder
+    func gestureControls() -> some View {
+        Section {
+            Defaults.Toggle(key: .enableGestures) {
+                Text("Enable gestures")
+            }
+                .disabled(!openNotchOnHover)
+            if enableGestures {
+                Toggle("Change media with horizontal gestures", isOn: .constant(false))
+                    .disabled(true)
+                Defaults.Toggle(key: .closeGestureEnabled) {
+                    Text("Close gesture")
+                }
+                Slider(value: $gestureSensitivity, in: 100...300, step: 100) {
+                    HStack {
+                        Text("Gesture sensitivity")
+                        Spacer()
+                        Text(
+                            Defaults[.gestureSensitivity] == 100
+                                ? "High" : Defaults[.gestureSensitivity] == 200 ? "Medium" : "Low"
+                        )
+                        .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        } header: {
+            HStack {
+                Text("Gesture control")
+                customBadge(text: "Beta")
+            }
+        } footer: {
+            Text(
+                "Two-finger swipe up on notch to close, two-finger swipe down on notch to open when **Open notch on hover** option is disabled"
+            )
+            .multilineTextAlignment(.trailing)
+            .foregroundStyle(.secondary)
+            .font(.caption)
+        }
+    }
+
+    @ViewBuilder
+    func NotchBehaviour() -> some View {
+        Section {
+            Defaults.Toggle(key: .openNotchOnHover) {
+                Text("Open notch on hover")
+            }
+            Defaults.Toggle(key: .enableHaptics) {
+                    Text("Enable haptic feedback")
+            }
+            Toggle("Remember last tab", isOn: $coordinator.openLastTabByDefault)
+            if openNotchOnHover {
+                Slider(value: $minimumHoverDuration, in: 0...1, step: 0.1) {
+                    HStack {
+                        Text("Hover delay")
+                        Spacer()
+                        Text("\(minimumHoverDuration, specifier: "%.1f")s")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .onChange(of: minimumHoverDuration) {
+                    NotificationCenter.default.post(
+                        name: Notification.Name.notchHeightChanged, object: nil)
+                }
+            }
+        } header: {
+            Text("Notch behavior")
+        }
+    }
+}
+
+struct Charge: View {
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Toggle(key: .showBatteryIndicator) {
+                    Text("Show battery indicator")
+                }
+                Defaults.Toggle(key: .showPowerStatusNotifications) {
+                    Text("Show power status notifications")
+                }
+            } header: {
+                Text("General")
+            }
+            Section {
+                Defaults.Toggle(key: .showBatteryPercentage) {
+                    Text("Show battery percentage")
+                }
+                Defaults.Toggle(key: .showPowerStatusIcons) {
+                    Text("Show power status icons")
+                }
+            } header: {
+                Text("Battery Information")
+            }
+        }
+        .onAppear {
+            Task { @MainActor in
+                await XPCHelperClient.shared.isAccessibilityAuthorized()
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Battery")
+    }
+}
+
+//struct Downloads: View {
+//    @Default(.selectedDownloadIndicatorStyle) var selectedDownloadIndicatorStyle
+//    @Default(.selectedDownloadIconStyle) var selectedDownloadIconStyle
+//    var body: some View {
+//        Form {
+//            warningBadge("We don't support downloads yet", "It will be supported later on.")
+//            Section {
+//                Defaults.Toggle(key: .enableDownloadListener) {
+//                    Text("Show download progress")
+//                }
+//                    .disabled(true)
+//                Defaults.Toggle(key: .enableSafariDownloads) {
+//                    Text("Enable Safari Downloads")
+//                }
+//                    .disabled(!Defaults[.enableDownloadListener])
+//                Picker("Download indicator style", selection: $selectedDownloadIndicatorStyle) {
+//                    Text("Progress bar")
+//                        .tag(DownloadIndicatorStyle.progress)
+//                    Text("Percentage")
+//                        .tag(DownloadIndicatorStyle.percentage)
+//                }
+//                Picker("Download icon style", selection: $selectedDownloadIconStyle) {
+//                    Text("Only app icon")
+//                        .tag(DownloadIconStyle.onlyAppIcon)
+//                    Text("Only download icon")
+//                        .tag(DownloadIconStyle.onlyIcon)
+//                    Text("Both")
+//                        .tag(DownloadIconStyle.iconAndAppIcon)
+//                }
+//
+//            } header: {
+//                HStack {
+//                    Text("Download indicators")
+//                    comingSoonTag()
+//                }
+//            }
+//            Section {
+//                List {
+//                    ForEach([].indices, id: \.self) { index in
+//                        Text("\(index)")
+//                    }
+//                }
+//                .frame(minHeight: 96)
+//                .overlay {
+//                    if true {
+//                        Text("No excluded apps")
+//                            .foregroundStyle(Color(.secondaryLabelColor))
+//                    }
+//                }
+//                .actionBar(padding: 0) {
+//                    Group {
+//                        Button {
+//                        } label: {
+//                            Image(systemName: "plus")
+//                                .frame(width: 25, height: 16, alignment: .center)
+//                                .contentShape(Rectangle())
+//                                .foregroundStyle(.secondary)
+//                        }
+//
+//                        Divider()
+//                        Button {
+//                        } label: {
+//                            Image(systemName: "minus")
+//                                .frame(width: 20, height: 16, alignment: .center)
+//                                .contentShape(Rectangle())
+//                                .foregroundStyle(.secondary)
+//                        }
+//                    }
+//                }
+//            } header: {
+//                HStack(spacing: 4) {
+//                    Text("Exclude apps")
+//                    comingSoonTag()
+//                }
+//            }
+//        }
+//        .navigationTitle("Downloads")
+//    }
+//}
+
+struct HUD: View {
+    @EnvironmentObject var vm: BoringViewModel
+    @Default(.inlineHUD) var inlineHUD
+    @Default(.enableGradient) var enableGradient
+    @Default(.optionKeyAction) var optionKeyAction
+    @Default(.hudReplacement) var hudReplacement
+    @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @State private var accessibilityAuthorized = false
+    
+    var body: some View {
+        Form {
+            Section {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Replace system HUD")
+                            .font(.headline)
+                        Text("Replaces the standard macOS volume, display brightness, and keyboard brightness HUDs with a custom design.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer(minLength: 40)
+                    Defaults.Toggle("", key: .hudReplacement)
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .controlSize(.large)
+                    .disabled(!accessibilityAuthorized)
+                }
+                
+                if !accessibilityAuthorized {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Accessibility access is required to replace the system HUD.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+
+                        HStack(spacing: 12) {
+                            Button("Request Accessibility") {
+                                XPCHelperClient.shared.requestAccessibilityAuthorization()
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
+                    }
+                    .padding(.top, 6)
+                }
+            }
+            
+            Section {
+                Picker("Option key behaviour", selection: $optionKeyAction) {
+                    ForEach(OptionKeyAction.allCases) { opt in
+                        Text(opt.rawValue).tag(opt)
+                    }
+                }
+                
+                Picker("Progress bar style", selection: $enableGradient) {
+                    Text("Hierarchical")
+                        .tag(false)
+                    Text("Gradient")
+                        .tag(true)
+                }
+                Defaults.Toggle(key: .systemEventIndicatorShadow) {
+                    Text("Enable glowing effect")
+                }
+                Defaults.Toggle(key: .systemEventIndicatorUseAccent) {
+                    Text("Tint progress bar with accent color")
+                }
+            } header: {
+                Text("General")
+            }
+            .disabled(!hudReplacement)
+            
+            Section {
+                Defaults.Toggle(key: .showOpenNotchHUD) {
+                    Text("Show HUD in open notch")
+                }
+                Defaults.Toggle(key: .showOpenNotchHUDPercentage) {
+                    Text("Show percentage")
+                }
+                .disabled(!Defaults[.showOpenNotchHUD])
+            } header: {
+                HStack {
+                    Text("Open Notch")
+                    customBadge(text: "Beta")
+                }
+            }
+            .disabled(!hudReplacement)
+            
+            Section {
+                Picker("HUD style", selection: $inlineHUD) {
+                    Text("Default")
+                        .tag(false)
+                    Text("Inline")
+                        .tag(true)
+                }
+                .onChange(of: Defaults[.inlineHUD]) {
+                    if Defaults[.inlineHUD] {
+                        withAnimation {
+                            Defaults[.systemEventIndicatorShadow] = false
+                            Defaults[.enableGradient] = false
+                        }
+                    }
+                }
+                
+                Defaults.Toggle(key: .showClosedNotchHUDPercentage) {
+                    Text("Show percentage")
+                }
+            } header: {
+                Text("Closed Notch")
+            }
+            .disabled(!Defaults[.hudReplacement])
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("HUDs")
+        .task {
+            accessibilityAuthorized = await XPCHelperClient.shared.isAccessibilityAuthorized()
+        }
+        .onAppear {
+            XPCHelperClient.shared.startMonitoringAccessibilityAuthorization()
+        }
+        .onDisappear {
+            XPCHelperClient.shared.stopMonitoringAccessibilityAuthorization()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .accessibilityAuthorizationChanged)) { notification in
+            if let granted = notification.userInfo?["granted"] as? Bool {
+                accessibilityAuthorized = granted
+            }
+        }
+    }
+}
+
+struct Media: View {
+    @Default(.waitInterval) var waitInterval
+    @Default(.mediaController) var mediaController
+    @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @Default(.hideNotchOption) var hideNotchOption
+    @Default(.enableSneakPeek) private var enableSneakPeek
+    @Default(.sneakPeekStyles) var sneakPeekStyles
+
+    @Default(.enableLyrics) var enableLyrics
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Music Source", selection: $mediaController) {
+                    ForEach(availableMediaControllers) { controller in
+                        Text(controller.rawValue).tag(controller)
+                    }
+                }
+                .onChange(of: mediaController) { _, _ in
+                    NotificationCenter.default.post(
+                        name: Notification.Name.mediaControllerChanged,
+                        object: nil
+                    )
+                }
+            } header: {
+                Text("Media Source")
+            } footer: {
+                if MusicManager.shared.isNowPlayingDeprecated {
+                    HStack {
+                        Text("YouTube Music requires this third-party app to be installed: ")
+                            .foregroundStyle(.secondary)
+                            .font(.caption)
+                        Link(
+                            "https://github.com/pear-devs/pear-desktop",
+                            destination: URL(string: "https://github.com/pear-devs/pear-desktop")!
+                        )
+                        .font(.caption)
+                        .foregroundColor(.blue)  // Ensures it's visibly a link
+                    }
+                } else {
+                    Text(
+                        "'Now Playing' was the only option on previous versions and works with all media apps."
+                    )
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+                }
+            }
+            
+            Section {
+                Toggle(
+                    "Show music live activity",
+                    isOn: $coordinator.musicLiveActivityEnabled.animation()
+                )
+                Toggle("Show sneak peek on playback changes", isOn: $enableSneakPeek)
+                Picker("Sneak Peek Style", selection: $sneakPeekStyles) {
+                    ForEach(SneakPeekStyle.allCases) { style in
+                        Text(style.rawValue).tag(style)
+                    }
+                }
+                HStack {
+                    Stepper(value: $waitInterval, in: 0...10, step: 1) {
+                        HStack {
+                            Text("Media inactivity timeout")
+                            Spacer()
+                            Text("\(Defaults[.waitInterval], specifier: "%.0f") seconds")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                Picker(
+                    selection: $hideNotchOption,
+                    label:
+                        HStack {
+                            Text("Full screen behavior")
+                            customBadge(text: "Beta")
+                        }
+                ) {
+                    Text("Hide for all apps").tag(HideNotchOption.always)
+                    Text("Hide for media app only").tag(
+                        HideNotchOption.nowPlayingOnly)
+                    Text("Never hide").tag(HideNotchOption.never)
+                }
+            } header: {
+                Text("Media playback live activity")
+            }
+            
+            Section {
+                MusicSlotConfigurationView()
+                Defaults.Toggle(key: .enableLyrics) {
+                    HStack {
+                        Text("Show lyrics below artist name")
+                        customBadge(text: "Beta")
+                    }
+                }
+            } header: {
+                Text("Media controls")
+            }  footer: {
+                Text("Customize which controls appear in the music player. Volume expands when active.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Media")
+    }
+
+    // Only show controller options that are available on this macOS version
+    private var availableMediaControllers: [MediaControllerType] {
+        if MusicManager.shared.isNowPlayingDeprecated {
+            return MediaControllerType.allCases.filter { $0 != .nowPlaying }
+        } else {
+            return MediaControllerType.allCases
+        }
+    }
+}
+
+struct CalendarSettings: View {
+    @ObservedObject private var calendarManager = CalendarManager.shared
+    @Default(.showCalendar) var showCalendar: Bool
+    @Default(.hideCompletedReminders) var hideCompletedReminders
+    @Default(.hideAllDayEvents) var hideAllDayEvents
+    @Default(.autoScrollToNextEvent) var autoScrollToNextEvent
+
+    var body: some View {
+        Form {
+            Defaults.Toggle(key: .showCalendar) {
+                Text("Show calendar")
+            }
+            Defaults.Toggle(key: .hideCompletedReminders) {
+                Text("Hide completed reminders")
+            }
+            Defaults.Toggle(key: .hideAllDayEvents) {
+                Text("Hide all-day events")
+            }
+            Defaults.Toggle(key: .autoScrollToNextEvent) {
+                Text("Auto-scroll to next event")
+            }
+            Defaults.Toggle(key: .showFullEventTitles) {
+                Text("Always show full event titles")
+            }
+            Section(header: Text("Calendars")) {
+                if calendarManager.calendarAuthorizationStatus != .fullAccess {
+                    Text("Calendar access is denied. Please enable it in System Settings.")
+                        .foregroundColor(.red)
+                        .multilineTextAlignment(.center)
+                        .padding()
+                    Button("Open Calendar Settings") {
+                        if let settingsURL = URL(
+                            string:
+                                "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars"
+                        ) {
+                            NSWorkspace.shared.open(settingsURL)
+                        }
+                    }
+                } else {
+                    List {
+                        ForEach(calendarManager.eventCalendars, id: \.id) { calendar in
+                            Toggle(
+                                isOn: Binding(
+                                    get: { calendarManager.getCalendarSelected(calendar) },
+                                    set: { isSelected in
+                                        Task {
+                                            await calendarManager.setCalendarSelected(
+                                                calendar, isSelected: isSelected)
+                                        }
+                                    }
+                                )
+                            ) {
+                                Text(calendar.title)
+                            }
+                            .accentColor(lighterColor(from: calendar.color))
+                            .disabled(!showCalendar)
+                        }
+                    }
+                }
+            }
+            Section(header: Text("Reminders")) {
+                if calendarManager.reminderAuthorizationStatus != .fullAccess {
+                    Text("Reminder access is denied. Please enable it in System Settings.")
+                        .foregroundColor(.red)
+                        .multilineTextAlignment(.center)
+                        .padding()
+                    Button("Open Reminder Settings") {
+                        if let settingsURL = URL(
+                            string:
+                                "x-apple.systempreferences:com.apple.preference.security?Privacy_Reminders"
+                        ) {
+                            NSWorkspace.shared.open(settingsURL)
+                        }
+                    }
+                } else {
+                    List {
+                        ForEach(calendarManager.reminderLists, id: \.id) { calendar in
+                            Toggle(
+                                isOn: Binding(
+                                    get: { calendarManager.getCalendarSelected(calendar) },
+                                    set: { isSelected in
+                                        Task {
+                                            await calendarManager.setCalendarSelected(
+                                                calendar, isSelected: isSelected)
+                                        }
+                                    }
+                                )
+                            ) {
+                                Text(calendar.title)
+                            }
+                            .accentColor(lighterColor(from: calendar.color))
+                            .disabled(!showCalendar)
+                        }
+                    }
+                }
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Calendar")
+        .onAppear {
+            Task {
+                await calendarManager.checkCalendarAuthorization()
+                await calendarManager.checkReminderAuthorization()
+            }
+        }
+    }
+}
+
+func lighterColor(from nsColor: NSColor, amount: CGFloat = 0.14) -> Color {
+    let srgb = nsColor.usingColorSpace(.sRGB) ?? nsColor
+    var (r, g, b, a): (CGFloat, CGFloat, CGFloat, CGFloat) = (0,0,0,0)
+    srgb.getRed(&r, green: &g, blue: &b, alpha: &a)
+
+    func lighten(_ c: CGFloat) -> CGFloat {
+        let increased = c + (1.0 - c) * amount
+        return min(max(increased, 0), 1)
+    }
+
+    let nr = lighten(r)
+    let ng = lighten(g)
+    let nb = lighten(b)
+
+    return Color(red: Double(nr), green: Double(ng), blue: Double(nb), opacity: Double(a))
+}
+
+struct About: View {
+    @State private var showBuildNumber: Bool = false
+    let updaterController: SPUStandardUpdaterController
+    @Environment(\.openWindow) var openWindow
+    var body: some View {
+        VStack {
+            Form {
+                Section {
+                    HStack {
+                        Text("Release name")
+                        Spacer()
+                        Text(Defaults[.releaseName])
+                            .foregroundStyle(.secondary)
+                    }
+                    HStack {
+                        Text("Version")
+                        Spacer()
+                        if showBuildNumber {
+                            Text("(\(Bundle.main.buildVersionNumber ?? ""))")
+                                .foregroundStyle(.secondary)
+                        }
+                        Text(Bundle.main.releaseVersionNumber ?? "unkown")
+                            .foregroundStyle(.secondary)
+                    }
+                    .onTapGesture {
+                        withAnimation {
+                            showBuildNumber.toggle()
+                        }
+                    }
+                } header: {
+                    Text("Version info")
+                }
+
+                UpdaterSettingsView(updater: updaterController.updater)
+
+                HStack(spacing: 30) {
+                    Spacer(minLength: 0)
+                    Button {
+                        if let url = URL(string: "https://github.com/TheBoredTeam/boring.notch") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    } label: {
+                        VStack(spacing: 5) {
+                            Image("Github")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 18)
+                            Text("GitHub")
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    Spacer(minLength: 0)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            VStack(spacing: 0) {
+                Divider()
+                Text("Made with 🫶🏻 by not so boring not.people")
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 5)
+                    .padding(.bottom, 7)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 10)
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .toolbar {
+            //            Button("Welcome window") {
+            //                openWindow(id: "onboarding")
+            //            }
+            //            .controlSize(.extraLarge)
+            CheckForUpdatesView(updater: updaterController.updater)
+        }
+        .navigationTitle("About")
+    }
+}
+
+struct Shelf: View {
+    
+    @Default(.shelfTapToOpen) var shelfTapToOpen: Bool
+    @Default(.quickShareProvider) var quickShareProvider
+    @Default(.expandedDragDetection) var expandedDragDetection: Bool
+    @StateObject private var quickShareService = QuickShareService.shared
+
+    private var selectedProvider: QuickShareProvider? {
+        quickShareService.availableProviders.first(where: { $0.id == quickShareProvider })
+    }
+    
+    init() {
+        Task { await QuickShareService.shared.discoverAvailableProviders() }
+    }
+    
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Toggle(key: .boringShelf) {
+                    Text("Enable shelf")
+                }
+                Defaults.Toggle(key: .openShelfByDefault) {
+                    Text("Open shelf by default if items are present")
+                }
+                Defaults.Toggle(key: .expandedDragDetection) {
+                    Text("Expanded drag detection area")
+                }
+                .onChange(of: expandedDragDetection) {
+                    NotificationCenter.default.post(
+                        name: Notification.Name.expandedDragDetectionChanged,
+                        object: nil
+                    )
+                }
+                Defaults.Toggle(key: .copyOnDrag) {
+                    Text("Copy items on drag")
+                }
+                Defaults.Toggle(key: .autoRemoveShelfItems) {
+                    Text("Remove from shelf after dragging")
+                }
+
+            } header: {
+                HStack {
+                    Text("General")
+                }
+            }
+            
+            Section {
+                Picker("Quick Share Service", selection: $quickShareProvider) {
+                    ForEach(quickShareService.availableProviders, id: \.id) { provider in
+                        HStack {
+                            Group {
+                                if let imgData = provider.imageData, let nsImg = NSImage(data: imgData) {
+                                    Image(nsImage: nsImg)
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                } else {
+                                    Image(systemName: "square.and.arrow.up")
+                                }
+                            }
+                            .frame(width: 16, height: 16)
+                            .foregroundColor(.accentColor)
+                            Text(provider.id)
+                        }
+                        .tag(provider.id)
+                    }
+                }
+                .pickerStyle(.menu)
+                
+                if let selectedProvider = selectedProvider {
+                    HStack {
+                        Group {
+                            if let imgData = selectedProvider.imageData, let nsImg = NSImage(data: imgData) {
+                                Image(nsImage: nsImg)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                            } else {
+                                Image(systemName: "square.and.arrow.up")
+                            }
+                        }
+                        .frame(width: 16, height: 16)
+                        .foregroundColor(.accentColor)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Currently selected: \(selectedProvider.id)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                            Text("Files dropped on the shelf will be shared via this service")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                // Providers are always enabled; user can pick default service above.
+                
+            } header: {
+                HStack {
+                    Text("Quick Share")
+                }
+            } footer: {
+                Text("Choose which service to use when sharing files from the shelf. Click the shelf button to select files, or drag files onto it to share immediately.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Shelf")
+    }
+}
+
+//struct Extensions: View {
+//    @State private var effectTrigger: Bool = false
+//    var body: some View {
+//        Form {
+//            Section {
+//                List {
+//                    ForEach(extensionManager.installedExtensions.indices, id: \.self) { index in
+//                        let item = extensionManager.installedExtensions[index]
+//                        HStack {
+//                            AppIcon(for: item.bundleIdentifier)
+//                                .resizable()
+//                                .frame(width: 24, height: 24)
+//                            Text(item.name)
+//                            ListItemPopover {
+//                                Text("Description")
+//                            }
+//                            Spacer(minLength: 0)
+//                            HStack(spacing: 6) {
+//                                Circle()
+//                                    .frame(width: 6, height: 6)
+//                                    .foregroundColor(
+//                                        isExtensionRunning(item.bundleIdentifier)
+//                                            ? .green : item.status == .disabled ? .gray : .red
+//                                    )
+//                                    .conditionalModifier(isExtensionRunning(item.bundleIdentifier))
+//                                { view in
+//                                    view
+//                                        .shadow(color: .green, radius: 3)
+//                                }
+//                                Text(
+//                                    isExtensionRunning(item.bundleIdentifier)
+//                                        ? "Running"
+//                                        : item.status == .disabled ? "Disabled" : "Stopped"
+//                                )
+//                                .contentTransition(.numericText())
+//                                .foregroundStyle(.secondary)
+//                                .font(.footnote)
+//                            }
+//                            .frame(width: 60, alignment: .leading)
+//
+//                            Menu(
+//                                content: {
+//                                    Button("Restart") {
+//                                        let ws = NSWorkspace.shared
+//
+//                                        if let ext = ws.runningApplications.first(where: {
+//                                            $0.bundleIdentifier == item.bundleIdentifier
+//                                        }) {
+//                                            ext.terminate()
+//                                        }
+//
+//                                        if let appURL = ws.urlForApplication(
+//                                            withBundleIdentifier: item.bundleIdentifier)
+//                                        {
+//                                            ws.openApplication(
+//                                                at: appURL, configuration: .init(),
+//                                                completionHandler: nil)
+//                                        }
+//                                    }
+//                                    .keyboardShortcut("R", modifiers: .command)
+//                                    Button("Disable") {
+//                                        if let ext = NSWorkspace.shared.runningApplications.first(
+//                                            where: { $0.bundleIdentifier == item.bundleIdentifier })
+//                                        {
+//                                            ext.terminate()
+//                                        }
+//                                        extensionManager.installedExtensions[index].status =
+//                                            .disabled
+//                                    }
+//                                    .keyboardShortcut("D", modifiers: .command)
+//                                    Divider()
+//                                    Button("Uninstall", role: .destructive) {
+//                                        //
+//                                    }
+//                                },
+//                                label: {
+//                                    Image(systemName: "ellipsis.circle")
+//                                        .foregroundStyle(.secondary)
+//                                }
+//                            )
+//                            .controlSize(.regular)
+//                        }
+//                        .buttonStyle(PlainButtonStyle())
+//                        .padding(.vertical, 5)
+//                    }
+//                }
+//                .frame(minHeight: 120)
+//                .actionBar {
+//                    Button {
+//                    } label: {
+//                        HStack(spacing: 3) {
+//                            Image(systemName: "plus")
+//                            Text("Add manually")
+//                        }
+//                        .foregroundStyle(.secondary)
+//                    }
+//                    .disabled(true)
+//                    Spacer()
+//                    Button {
+//                        withAnimation(.linear(duration: 1)) {
+//                            effectTrigger.toggle()
+//                        } completion: {
+//                            effectTrigger.toggle()
+//                        }
+//                        extensionManager.checkIfExtensionsAreInstalled()
+//                    } label: {
+//                        HStack(spacing: 3) {
+//                            Image(systemName: "arrow.triangle.2.circlepath")
+//                                .rotationEffect(effectTrigger ? .degrees(360) : .zero)
+//                        }
+//                        .foregroundStyle(.secondary)
+//                    }
+//                }
+//                .controlSize(.small)
+//                .buttonStyle(PlainButtonStyle())
+//                .overlay {
+//                    if extensionManager.installedExtensions.isEmpty {
+//                        Text("No extension installed")
+//                            .foregroundStyle(Color(.secondaryLabelColor))
+//                            .padding(.bottom, 22)
+//                    }
+//                }
+//            } header: {
+//                HStack(spacing: 0) {
+//                    Text("Installed extensions")
+//                    if !extensionManager.installedExtensions.isEmpty {
+//                        Text(" – \(extensionManager.installedExtensions.count)")
+//                            .foregroundStyle(.secondary)
+//                    }
+//                }
+//            }
+//        }
+//        .accentColor(.effectiveAccent)
+//        .navigationTitle("Extensions")
+//        // TipsView()
+//        // .padding(.horizontal, 19)
+//    }
+//}
+
+struct Appearance: View {
+    @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @Default(.mirrorShape) var mirrorShape
+    @Default(.sliderColor) var sliderColor
+    @Default(.useMusicVisualizer) var useMusicVisualizer
+    @Default(.customVisualizers) var customVisualizers
+    @Default(.selectedVisualizer) var selectedVisualizer
+
+    let icons: [String] = ["logo2"]
+    @State private var selectedIcon: String = "logo2"
+    @State private var selectedListVisualizer: CustomVisualizer? = nil
+    @State private var isPresented: Bool = false
+    @State private var name: String = ""
+    @State private var url: String = ""
+    @State private var speed: CGFloat = 1.0
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Always show tabs", isOn: $coordinator.alwaysShowTabs)
+                Defaults.Toggle(key: .settingsIconInNotch) {
+                    Text("Show settings icon in notch")
+                }
+
+            } header: {
+                Text("General")
+            }
+
+            Section {
+                Defaults.Toggle(key: .coloredSpectrogram) {
+                    Text("Colored spectrogram")
+                }
+                Defaults
+                    .Toggle("Player tinting", key: .playerColorTinting)
+                Defaults.Toggle(key: .lightingEffect) {
+                    Text("Enable blur effect behind album art")
+                }
+                Picker("Slider color", selection: $sliderColor) {
+                    ForEach(SliderColorEnum.allCases, id: \.self) { option in
+                        Text(option.rawValue)
+                    }
+                }
+            } header: {
+                Text("Media")
+            }
+
+            Section {
+                Toggle(
+                    "Use music visualizer spectrogram",
+                    isOn: $useMusicVisualizer.animation()
+                )
+                .disabled(true)
+                if !useMusicVisualizer {
+                    if customVisualizers.count > 0 {
+                        Picker(
+                            "Selected animation",
+                            selection: $selectedVisualizer
+                        ) {
+                            ForEach(
+                                customVisualizers,
+                                id: \.self
+                            ) { visualizer in
+                                Text(visualizer.name)
+                                    .tag(visualizer)
+                            }
+                        }
+                    } else {
+                        HStack {
+                            Text("Selected animation")
+                            Spacer()
+                            Text("No custom animation available")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            } header: {
+                HStack {
+                    Text("Custom music live activity animation")
+                    customBadge(text: "Coming soon")
+                }
+            }
+
+            Section {
+                List {
+                    ForEach(customVisualizers, id: \.self) { visualizer in
+                        HStack {
+                            LottieView(
+                                url: visualizer.url, speed: visualizer.speed,
+                                loopMode: .loop
+                            )
+                            .frame(width: 30, height: 30, alignment: .center)
+                            Text(visualizer.name)
+                            Spacer(minLength: 0)
+                            if selectedVisualizer == visualizer {
+                                Text("selected")
+                                    .font(.caption)
+                                    .fontWeight(.medium)
+                                    .foregroundStyle(.secondary)
+                                    .padding(.trailing, 8)
+                            }
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        .padding(.vertical, 2)
+                        .background(
+                            selectedListVisualizer != nil
+                                ? selectedListVisualizer == visualizer
+                                    ? Color.effectiveAccent : Color.clear : Color.clear,
+                            in: RoundedRectangle(cornerRadius: 5)
+                        )
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            if selectedListVisualizer == visualizer {
+                                selectedListVisualizer = nil
+                                return
+                            }
+                            selectedListVisualizer = visualizer
+                        }
+                    }
+                }
+                .safeAreaPadding(
+                    EdgeInsets(top: 5, leading: 0, bottom: 5, trailing: 0)
+                )
+                .frame(minHeight: 120)
+                .actionBar {
+                    HStack(spacing: 5) {
+                        Button {
+                            name = ""
+                            url = ""
+                            speed = 1.0
+                            isPresented.toggle()
+                        } label: {
+                            Image(systemName: "plus")
+                                .foregroundStyle(.secondary)
+                                .contentShape(Rectangle())
+                        }
+                        Divider()
+                        Button {
+                            if selectedListVisualizer != nil {
+                                let visualizer = selectedListVisualizer!
+                                selectedListVisualizer = nil
+                                customVisualizers.remove(
+                                    at: customVisualizers.firstIndex(of: visualizer)!)
+                                if visualizer == selectedVisualizer && customVisualizers.count > 0 {
+                                    selectedVisualizer = customVisualizers[0]
+                                }
+                            }
+                        } label: {
+                            Image(systemName: "minus")
+                                .foregroundStyle(.secondary)
+                                .contentShape(Rectangle())
+                        }
+                    }
+                }
+                .controlSize(.small)
+                .buttonStyle(PlainButtonStyle())
+                .overlay {
+                    if customVisualizers.isEmpty {
+                        Text("No custom visualizer")
+                            .foregroundStyle(Color(.secondaryLabelColor))
+                            .padding(.bottom, 22)
+                    }
+                }
+                .sheet(isPresented: $isPresented) {
+                    VStack(alignment: .leading) {
+                        Text("Add new visualizer")
+                            .font(.largeTitle.bold())
+                            .padding(.vertical)
+                        TextField("Name", text: $name)
+                        TextField("Lottie JSON URL", text: $url)
+                        HStack {
+                            Text("Speed")
+                            Spacer(minLength: 80)
+                            Text("\(speed, specifier: "%.1f")s")
+                                .multilineTextAlignment(.trailing)
+                                .foregroundStyle(.secondary)
+                            Slider(value: $speed, in: 0...2, step: 0.1)
+                        }
+                        .padding(.vertical)
+                        HStack {
+                            Button {
+                                isPresented.toggle()
+                            } label: {
+                                Text("Cancel")
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                            }
+
+                            Button {
+                                let visualizer: CustomVisualizer = .init(
+                                    UUID: UUID(),
+                                    name: name,
+                                    url: URL(string: url)!,
+                                    speed: speed
+                                )
+
+                                if !customVisualizers.contains(visualizer) {
+                                    customVisualizers.append(visualizer)
+                                }
+
+                                isPresented.toggle()
+                            } label: {
+                                Text("Add")
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                            }
+                            .buttonStyle(BorderedProminentButtonStyle())
+                        }
+                    }
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .controlSize(.extraLarge)
+                    .padding()
+                }
+            } header: {
+                HStack(spacing: 0) {
+                    Text("Custom vizualizers (Lottie)")
+                    if !Defaults[.customVisualizers].isEmpty {
+                        Text(" – \(Defaults[.customVisualizers].count)")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Section {
+                Defaults.Toggle(key: .showMirror) {
+                    Text("Enable boring mirror")
+                }
+                    .disabled(!checkVideoInput())
+                Picker("Mirror shape", selection: $mirrorShape) {
+                    Text("Circle")
+                        .tag(MirrorShapeEnum.circle)
+                    Text("Square")
+                        .tag(MirrorShapeEnum.rectangle)
+                }
+                Defaults.Toggle(key: .showNotHumanFace) {
+                    Text("Show cool face animation while inactive")
+                }
+            } header: {
+                HStack {
+                    Text("Additional features")
+                }
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Appearance")
+    }
+
+    func checkVideoInput() -> Bool {
+        if AVCaptureDevice.default(for: .video) != nil {
+            return true
+        }
+
+        return false
+    }
+}
+
+struct Advanced: View {
+    @Default(.useCustomAccentColor) var useCustomAccentColor
+    @Default(.customAccentColorData) var customAccentColorData
+    @Default(.extendHoverArea) var extendHoverArea
+    @Default(.showOnLockScreen) var showOnLockScreen
+    @Default(.hideFromScreenRecording) var hideFromScreenRecording
+    
+    @State private var customAccentColor: Color = .accentColor
+    @State private var selectedPresetColor: PresetAccentColor? = nil
+    let icons: [String] = ["logo2"]
+    @State private var selectedIcon: String = "logo2"
+    
+    // macOS accent colors
+    enum PresetAccentColor: String, CaseIterable, Identifiable {
+        case blue = "Blue"
+        case purple = "Purple"
+        case pink = "Pink"
+        case red = "Red"
+        case orange = "Orange"
+        case yellow = "Yellow"
+        case green = "Green"
+        case graphite = "Graphite"
+        
+        var id: String { self.rawValue }
+        
+        var color: Color {
+            switch self {
+            case .blue: return Color(red: 0.0, green: 0.478, blue: 1.0)
+            case .purple: return Color(red: 0.686, green: 0.322, blue: 0.871)
+            case .pink: return Color(red: 1.0, green: 0.176, blue: 0.333)
+            case .red: return Color(red: 1.0, green: 0.271, blue: 0.227)
+            case .orange: return Color(red: 1.0, green: 0.584, blue: 0.0)
+            case .yellow: return Color(red: 1.0, green: 0.8, blue: 0.0)
+            case .green: return Color(red: 0.4, green: 0.824, blue: 0.176)
+            case .graphite: return Color(red: 0.557, green: 0.557, blue: 0.576)
+            }
+        }
+    }
+    
+    var body: some View {
+        Form {
+            Section {
+                VStack(alignment: .leading, spacing: 16) {
+                    // Toggle between system and custom
+                    Picker("Accent color", selection: $useCustomAccentColor) {
+                        Text("System").tag(false)
+                        Text("Custom").tag(true)
+                    }
+                    .pickerStyle(.segmented)
+                    
+                    if !useCustomAccentColor {
+                        // System accent info
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack(spacing: 12) {
+                                AccentCircleButton(
+                                    isSelected: true,
+                                    color: .accentColor,
+                                    isSystemDefault: true
+                                ) {}
+                                
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Using System Accent")
+                                        .font(.body)
+                                    Text("Your macOS system accent color")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                            }
+                        }
+                    } else {
+                        // Custom color options
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Color Presets")
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                                .foregroundStyle(.secondary)
+                            
+                            HStack(spacing: 12) {
+                                ForEach(PresetAccentColor.allCases) { preset in
+                                    AccentCircleButton(
+                                        isSelected: selectedPresetColor == preset,
+                                        color: preset.color,
+                                        isMulticolor: false
+                                    ) {
+                                        selectedPresetColor = preset
+                                        customAccentColor = preset.color
+                                        saveCustomColor(preset.color)
+                                        forceUiUpdate()
+                                    }
+                                }
+                                Spacer()
+                            }
+                            
+                            Divider()
+                                .padding(.vertical, 4)
+                            
+                            // Custom color picker
+                            HStack(spacing: 12) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Pick a Color")
+                                        .font(.body)
+                                    Text("Choose any color")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                
+                                Spacer()
+                                
+                                ColorPicker(selection: Binding(
+                                    get: { customAccentColor },
+                                    set: { newColor in
+                                        customAccentColor = newColor
+                                        selectedPresetColor = nil
+                                        saveCustomColor(newColor)
+                                        forceUiUpdate()
+                                    }
+                                ), supportsOpacity: false) {
+                                    ZStack {
+                                        Circle()
+                                            .fill(customAccentColor)
+                                            .frame(width: 32, height: 32)
+                                        
+                                        if selectedPresetColor == nil {
+                                            Circle()
+                                                .strokeBorder(.primary.opacity(0.3), lineWidth: 2)
+                                                .frame(width: 32, height: 32)
+                                        }
+                                    }
+                                }
+                                .labelsHidden()
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Text("Accent color")
+            } footer: {
+                Text("Choose between your system accent color or customize it with your own selection.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+            .onAppear {
+                initializeAccentColorState()
+            }
+            
+            Section {
+                Defaults.Toggle(key: .enableShadow) {
+                    Text("Enable window shadow")
+                }
+                Defaults.Toggle(key: .cornerRadiusScaling) {
+                    Text("Corner radius scaling")
+                }
+            } header: {
+                Text("Window Appearance")
+            }
+            
+            Section {
+                HStack {
+                    ForEach(icons, id: \.self) { icon in
+                        Spacer()
+                        VStack {
+                            Image(icon)
+                                .resizable()
+                                .frame(width: 80, height: 80)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 20, style: .circular)
+                                        .strokeBorder(
+                                            icon == selectedIcon ? Color.effectiveAccent : .clear,
+                                            lineWidth: 2.5
+                                        )
+                                )
+
+                            Text("Default")
+                                .fontWeight(.medium)
+                                .font(.caption)
+                                .foregroundStyle(icon == selectedIcon ? .white : .secondary)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 3)
+                                .background(
+                                    Capsule()
+                                        .fill(icon == selectedIcon ? Color.effectiveAccent : .clear)
+                                )
+                        }
+                        .onTapGesture {
+                            withAnimation {
+                                selectedIcon = icon
+                            }
+                            NSApp.applicationIconImage = NSImage(named: icon)
+                        }
+                        Spacer()
+                    }
+                }
+                .disabled(true)
+            } header: {
+                HStack {
+                    Text("App icon")
+                    customBadge(text: "Coming soon")
+                }
+            }
+            
+            Section {
+                Defaults.Toggle(key: .extendHoverArea) {
+                    Text("Extend hover area")
+                }
+                Defaults.Toggle(key: .hideTitleBar) {
+                    Text("Hide title bar")
+                }
+                Defaults.Toggle(key: .showOnLockScreen) {
+                    Text("Show notch on lock screen")
+                }
+                Defaults.Toggle(key: .hideFromScreenRecording) {
+                    Text("Hide from screen recording")
+                }
+            } header: {
+                Text("Window Behavior")
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Advanced")
+        .onAppear {
+            loadCustomColor()
+        }
+    }
+    
+    private func forceUiUpdate() {
+        // Force refresh the UI
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: Notification.Name("AccentColorChanged"), object: nil)
+        }
+    }
+    
+    private func saveCustomColor(_ color: Color) {
+        let nsColor = NSColor(color)
+        if let colorData = try? NSKeyedArchiver.archivedData(withRootObject: nsColor, requiringSecureCoding: false) {
+            Defaults[.customAccentColorData] = colorData
+            forceUiUpdate()
+        }
+    }
+    
+    private func loadCustomColor() {
+        if let colorData = Defaults[.customAccentColorData],
+           let nsColor = try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSColor.self, from: colorData) {
+            customAccentColor = Color(nsColor: nsColor)
+            
+            // Check if loaded color matches a preset
+            selectedPresetColor = nil
+            for preset in PresetAccentColor.allCases {
+                if colorsAreEqual(Color(nsColor: nsColor), preset.color) {
+                    selectedPresetColor = preset
+                    break
+                }
+            }
+        }
+    }
+    
+    private func colorsAreEqual(_ color1: Color, _ color2: Color) -> Bool {
+        let nsColor1 = NSColor(color1).usingColorSpace(.sRGB) ?? NSColor(color1)
+        let nsColor2 = NSColor(color2).usingColorSpace(.sRGB) ?? NSColor(color2)
+        
+        return abs(nsColor1.redComponent - nsColor2.redComponent) < 0.01 &&
+               abs(nsColor1.greenComponent - nsColor2.greenComponent) < 0.01 &&
+               abs(nsColor1.blueComponent - nsColor2.blueComponent) < 0.01
+    }
+    
+    private func initializeAccentColorState() {
+        if !useCustomAccentColor {
+            selectedPresetColor = nil // Multicolor is selected when useCustomAccentColor is false
+        } else {
+            loadCustomColor()
+        }
+    }
+}
+
+// MARK: - Accent Circle Button Component
+struct AccentCircleButton: View {
+    let isSelected: Bool
+    let color: Color
+    var isSystemDefault: Bool = false
+    var isMulticolor: Bool = false
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                // Color circle
+                Circle()
+                    .fill(color)
+                    .frame(width: 32, height: 32)
+                
+                // Subtle border
+                Circle()
+                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1)
+                    .frame(width: 32, height: 32)
+                
+                // Apple-style highlight ring around the middle when selected
+                if isSelected {
+                    Circle()
+                        .strokeBorder(
+                            Color.white.opacity(0.5),
+                            lineWidth: 2
+                        )
+                        .frame(width: 28, height: 28)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .help(isSystemDefault ? "Use your macOS system accent color" : "")
+    }
+}
+
+struct Shortcuts: View {
+    var body: some View {
+        Form {
+            Section {
+                KeyboardShortcuts.Recorder("Toggle Sneak Peek:", name: .toggleSneakPeek)
+            } header: {
+                Text("Media")
+            } footer: {
+                Text(
+                    "Sneak Peek shows the media title and artist under the notch for a few seconds."
+                )
+                .multilineTextAlignment(.trailing)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+            }
+            Section {
+                KeyboardShortcuts.Recorder("Toggle Notch Open:", name: .toggleNotchOpen)
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Shortcuts")
+    }
+}
+
+func proFeatureBadge() -> some View {
+    Text("Upgrade to Pro")
+        .foregroundStyle(Color(red: 0.545, green: 0.196, blue: 0.98))
+        .font(.footnote.bold())
+        .padding(.vertical, 3)
+        .padding(.horizontal, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 4).stroke(
+                Color(red: 0.545, green: 0.196, blue: 0.98), lineWidth: 1))
+}
+
+func comingSoonTag() -> some View {
+    Text("Coming soon")
+        .foregroundStyle(.secondary)
+        .font(.footnote.bold())
+        .padding(.vertical, 3)
+        .padding(.horizontal, 6)
+        .background(Color(nsColor: .secondarySystemFill))
+        .clipShape(.capsule)
+}
+
+func customBadge(text: String) -> some View {
+    Text(text)
+        .foregroundStyle(.secondary)
+        .font(.footnote.bold())
+        .padding(.vertical, 3)
+        .padding(.horizontal, 6)
+        .background(Color(nsColor: .secondarySystemFill))
+        .clipShape(.capsule)
+}
+
+func warningBadge(_ text: String, _ description: String) -> some View {
+    Section {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 22))
+                .foregroundStyle(.yellow)
+            VStack(alignment: .leading) {
+                Text(text)
+                    .font(.headline)
+                Text(description)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+    }
+}
+
+struct WeatherSettings: View {
+    @ObservedObject private var weatherManager = WeatherManager.shared
+    @Default(.showWeather) var showWeather: Bool
+    
+    var body: some View {
+        Form {
+            Defaults.Toggle(key: .showWeather) {
+                Text("Show weather")
+            }
+            .onChange(of: showWeather) { _, newValue in
+                if newValue {
+                    // When weather is enabled, check and request location if needed
+                    weatherManager.checkLocationAuthorization()
+                }
+            }
+            
+            Section(header: Text("Location Access")) {
+                if weatherManager.locationAuthorizationStatus == .notDetermined {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Location access is required to show weather information.")
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.leading)
+                        Text("Enable 'Show weather' above to request location permission.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.leading)
+                    }
+                    .padding()
+                } else if weatherManager.locationAuthorizationStatus == .denied || weatherManager.locationAuthorizationStatus == .restricted {
+                    Text("Location access is denied. Please enable it in System Settings.")
+                        .foregroundColor(.red)
+                        .multilineTextAlignment(.center)
+                        .padding()
+                    Button("Open Location Settings") {
+                        if let settingsURL = URL(
+                            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices"
+                        ) {
+                            NSWorkspace.shared.open(settingsURL)
+                        }
+                    }
+                } else {
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                        Text("Location access granted")
+                            .foregroundColor(.secondary)
+                    }
+                    .padding()
+                }
+            }
+            
+            if let weather = weatherManager.currentWeather {
+                Section(header: Text("Current Weather")) {
+                    HStack {
+                        Text("Location")
+                        Spacer()
+                        Text(weather.location)
+                            .foregroundStyle(.secondary)
+                    }
+                    HStack {
+                        Text("Temperature")
+                        Spacer()
+                        Text(weather.temperatureString)
+                            .foregroundStyle(.secondary)
+                    }
+                    HStack {
+                        Text("Condition")
+                        Spacer()
+                        Text(weather.condition)
+                            .foregroundStyle(.secondary)
+                    }
+                    HStack {
+                        Text("Last Updated")
+                        Spacer()
+                        Text(weather.lastUpdated, style: .relative)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Weather")
+        .onAppear {
+            weatherManager.checkLocationAuthorization()
+        }
+    }
+}
+
+#Preview {
+    HUD()
+}
+

--- a/boringNotch/components/Weather/BoringWeather.swift
+++ b/boringNotch/components/Weather/BoringWeather.swift
@@ -1,0 +1,189 @@
+//
+//  BoringWeather.swift
+//  boringNotch
+//
+//  Created by Arsh Anwar on 26/12/25.
+//
+
+import SwiftUI
+import Defaults
+
+struct WeatherView: View {
+    @EnvironmentObject var vm: BoringViewModel
+    @ObservedObject private var weatherManager = WeatherManager.shared
+    
+    var body: some View {
+        VStack(spacing: 8) {
+            if weatherManager.isLoading {
+                loadingView
+            } else if let error = weatherManager.errorMessage {
+                errorView(message: error)
+            } else if let weather = weatherManager.currentWeather {
+                weatherContent(weather: weather)
+            } else {
+                emptyStateView
+            }
+        }
+        .frame(height: 120)
+        .onAppear {
+            weatherManager.checkLocationAuthorization()
+        }
+        .onChange(of: vm.notchState) { _, _ in
+            if vm.notchState == .open {
+                weatherManager.fetchWeather()
+            }
+        }
+    }
+    
+    private var loadingView: some View {
+        VStack(spacing: 8) {
+            ProgressView()
+                .scaleEffect(0.8)
+                .tint(.white)
+            Text("Loading weather...")
+                .font(.caption)
+                .foregroundColor(Color(white: 0.65))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    
+    private func errorView(message: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.title2)
+                .foregroundColor(.orange)
+            Text(message)
+                .font(.caption)
+                .foregroundColor(Color(white: 0.65))
+                .multilineTextAlignment(.center)
+            
+            if weatherManager.locationAuthorizationStatus == .denied {
+                Button("Open Settings") {
+                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices") {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+                .buttonStyle(.plain)
+                .font(.caption)
+                .foregroundColor(.effectiveAccent)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 12)
+    }
+    
+    private var emptyStateView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "cloud.fill")
+                .font(.title)
+                .foregroundColor(Color(white: 0.65))
+            Text("No weather data")
+                .font(.subheadline)
+                .foregroundColor(.white)
+            Text("Enable location access")
+                .font(.caption)
+                .foregroundColor(Color(white: 0.65))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    
+    private func weatherContent(weather: WeatherData) -> some View {
+        VStack(spacing: 8) {
+            // Location and main weather
+            HStack(alignment: .center, spacing: 8) {
+                // Weather icon
+                Image(systemName: weather.systemIconName)
+                    .font(.system(size: 36))
+                    .foregroundColor(.white)
+                    .frame(width: 40, height: 40)
+                
+                VStack(alignment: .leading, spacing: 2) {
+                    // Location
+                    Text(weather.location)
+                        .font(.caption)
+                        .foregroundColor(Color(white: 0.65))
+                        .lineLimit(1)
+                    
+                    // Temperature
+                    Text(weather.temperatureString)
+                        .font(.system(size: 28, weight: .light))
+                        .foregroundColor(.white)
+                }
+                
+                Spacer(minLength: 0)
+                
+                // Condition on the right
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(weather.condition)
+                        .font(.caption2)
+                        .foregroundColor(Color(white: 0.65))
+                        .lineLimit(1)
+                    
+                    Text("Feels \(String(format: "%.0f°", weather.feelsLike))")
+                        .font(.caption2)
+                        .foregroundColor(Color(white: 0.5))
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+            
+            Divider()
+                .background(Color(white: 0.3))
+                .padding(.horizontal, 12)
+            
+            // Weather details
+            HStack(spacing: 12) {
+                WeatherDetailItem(
+                    icon: "humidity.fill",
+                    label: "Humidity",
+                    value: "\(weather.humidityInt)%"
+                )
+                
+                Divider()
+                    .background(Color(white: 0.3))
+                    .frame(height: 20)
+                
+                WeatherDetailItem(
+                    icon: "wind",
+                    label: "Wind",
+                    value: String(format: "%.0f km/h", weather.windSpeed)
+                )
+            }
+            .padding(.horizontal, 12)
+            .padding(.bottom, 8)
+        }
+    }
+}
+
+struct WeatherDetailItem: View {
+    let icon: String
+    let label: String
+    let value: String
+    
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.caption2)
+                .foregroundColor(Color(white: 0.65))
+            
+            VStack(alignment: .leading, spacing: 0) {
+                Text(value)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundColor(.white)
+                
+                Text(label)
+                    .font(.caption2)
+                    .foregroundColor(Color(white: 0.5))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+#Preview {
+    WeatherView()
+        .frame(width: 215, height: 130)
+        .background(.black)
+        .environmentObject(BoringViewModel())
+}

--- a/boringNotch/components/Weather/BoringWeather.swift
+++ b/boringNotch/components/Weather/BoringWeather.swift
@@ -88,32 +88,32 @@ struct WeatherView: View {
     }
     
     private func weatherContent(weather: WeatherData) -> some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 6) {
             // Location and main weather
             HStack(alignment: .center, spacing: 8) {
                 // Weather icon
                 Image(systemName: weather.systemIconName)
-                    .font(.system(size: 36))
+                    .font(.system(size: 32))
                     .foregroundColor(.white)
-                    .frame(width: 40, height: 40)
+                    .frame(width: 36, height: 36)
                 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: 1) {
                     // Location
                     Text(weather.location)
-                        .font(.caption)
+                        .font(.caption2)
                         .foregroundColor(Color(white: 0.65))
                         .lineLimit(1)
                     
                     // Temperature
                     Text(weather.temperatureString)
-                        .font(.system(size: 28, weight: .light))
+                        .font(.system(size: 24, weight: .light))
                         .foregroundColor(.white)
                 }
                 
                 Spacer(minLength: 0)
                 
                 // Condition on the right
-                VStack(alignment: .trailing, spacing: 2) {
+                VStack(alignment: .trailing, spacing: 1) {
                     Text(weather.condition)
                         .font(.caption2)
                         .foregroundColor(Color(white: 0.65))
@@ -124,15 +124,15 @@ struct WeatherView: View {
                         .foregroundColor(Color(white: 0.5))
                 }
             }
-            .padding(.horizontal, 12)
-            .padding(.top, 8)
+            .padding(.horizontal, 10)
+            .padding(.top, 6)
             
             Divider()
                 .background(Color(white: 0.3))
-                .padding(.horizontal, 12)
+                .padding(.horizontal, 10)
             
             // Weather details
-            HStack(spacing: 12) {
+            HStack(spacing: 10) {
                 WeatherDetailItem(
                     icon: "humidity.fill",
                     label: "Humidity",
@@ -141,7 +141,7 @@ struct WeatherView: View {
                 
                 Divider()
                     .background(Color(white: 0.3))
-                    .frame(height: 20)
+                    .frame(height: 16)
                 
                 WeatherDetailItem(
                     icon: "wind",
@@ -149,8 +149,8 @@ struct WeatherView: View {
                     value: String(format: "%.0f km/h", weather.windSpeed)
                 )
             }
-            .padding(.horizontal, 12)
-            .padding(.bottom, 8)
+            .padding(.horizontal, 10)
+            .padding(.bottom, 6)
         }
     }
 }
@@ -161,19 +161,19 @@ struct WeatherDetailItem: View {
     let value: String
     
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: 3) {
             Image(systemName: icon)
-                .font(.caption2)
+                .font(.system(size: 10))
                 .foregroundColor(Color(white: 0.65))
             
             VStack(alignment: .leading, spacing: 0) {
                 Text(value)
-                    .font(.caption)
+                    .font(.system(size: 11))
                     .fontWeight(.medium)
                     .foregroundColor(.white)
                 
                 Text(label)
-                    .font(.caption2)
+                    .font(.system(size: 9))
                     .foregroundColor(Color(white: 0.5))
             }
         }

--- a/boringNotch/managers/WeatherManager.swift
+++ b/boringNotch/managers/WeatherManager.swift
@@ -1,0 +1,189 @@
+//
+//  WeatherManager.swift
+//  boringNotch
+//
+//  Created by Arsh Anwar on 26/12/25.
+//
+
+import Foundation
+import CoreLocation
+import SwiftUI
+import Combine
+import WeatherKit
+
+// MARK: - Weather Models
+
+struct WeatherData {
+    let temperature: Double
+    let condition: String
+    let symbolName: String
+    let humidity: Double
+    let windSpeed: Double
+    let feelsLike: Double
+    let high: Double
+    let low: Double
+    let location: String
+    let lastUpdated: Date
+    
+    var temperatureString: String {
+        return String(format: "%.0f°", temperature)
+    }
+    
+    var systemIconName: String {
+        return symbolName
+    }
+    
+    var humidityInt: Int {
+        return Int(humidity * 100)
+    }
+}
+
+// MARK: - WeatherManager
+
+@MainActor
+class WeatherManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+    static let shared = WeatherManager()
+    
+    @Published var currentWeather: WeatherData?
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+    @Published var locationAuthorizationStatus: CLAuthorizationStatus = .notDetermined
+    
+    private let locationManager = CLLocationManager()
+    private let weatherService = WeatherService.shared
+    private var updateTimer: Timer?
+    private var cancellables = Set<AnyCancellable>()
+    private let geocoder = CLGeocoder()
+    private var isRequestingLocation = false
+    
+    private override init() {
+        super.init()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyKilometer
+    }
+    
+    func checkLocationAuthorization() {
+        locationAuthorizationStatus = locationManager.authorizationStatus
+        
+        switch locationAuthorizationStatus {
+        case .notDetermined:
+            locationManager.requestAlwaysAuthorization()
+        case .authorizedAlways:
+            startUpdatingWeather()
+        case .denied, .restricted:
+            errorMessage = "Location access denied"
+        @unknown default:
+            break
+        }
+    }
+    
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        Task { @MainActor in
+            locationAuthorizationStatus = manager.authorizationStatus
+            
+            if locationAuthorizationStatus == .authorizedAlways {
+                startUpdatingWeather()
+            }
+        }
+    }
+    
+    func startUpdatingWeather() {
+        fetchWeather()
+        
+        // Update weather every 30 minutes
+        updateTimer?.invalidate()
+        updateTimer = Timer.scheduledTimer(withTimeInterval: 1800, repeats: true) { [weak self] _ in
+            self?.fetchWeather()
+        }
+    }
+    
+    func stopUpdatingWeather() {
+        updateTimer?.invalidate()
+        updateTimer = nil
+    }
+    
+    func fetchWeather() {
+        guard locationAuthorizationStatus == .authorizedAlways else {
+            return
+        }
+        
+        // Prevent multiple simultaneous location requests
+        guard !isRequestingLocation else {
+            return
+        }
+        
+        isRequestingLocation = true
+        locationManager.requestLocation()
+    }
+    
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.first else { return }
+        Task { @MainActor in
+            isRequestingLocation = false
+            fetchWeatherData(for: location)
+        }
+    }
+    
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        Task { @MainActor in
+            isRequestingLocation = false
+            errorMessage = "Failed to get location: \(error.localizedDescription)"
+            isLoading = false
+        }
+    }
+    
+    private func fetchWeatherData(for location: CLLocation) {
+        isLoading = true
+        errorMessage = nil
+        
+        Task {
+            do {
+                // Fetch weather using WeatherKit
+                let weather = try await weatherService.weather(for: location)
+                
+                // Get location name using reverse geocoding
+                let placemarks = try? await geocoder.reverseGeocodeLocation(location)
+                let locationName = placemarks?.first?.locality ?? placemarks?.first?.name ?? "Unknown"
+                
+                // Create weather data from WeatherKit response
+                let weatherData = WeatherData(
+                    temperature: weather.currentWeather.temperature.value,
+                    condition: weather.currentWeather.condition.description,
+                    symbolName: weather.currentWeather.symbolName,
+                    humidity: weather.currentWeather.humidity,
+                    windSpeed: weather.currentWeather.wind.speed.value,
+                    feelsLike: weather.currentWeather.apparentTemperature.value,
+                    high: weather.dailyForecast.first?.highTemperature.value ?? weather.currentWeather.temperature.value,
+                    low: weather.dailyForecast.first?.lowTemperature.value ?? weather.currentWeather.temperature.value,
+                    location: locationName,
+                    lastUpdated: Date()
+                )
+                
+                await MainActor.run {
+                    self.currentWeather = weatherData
+                    self.errorMessage = nil
+                    self.isLoading = false
+                }
+                
+            } catch {
+                await MainActor.run {
+                    // Provide a user-friendly error message
+                    let errorDescription = error.localizedDescription
+                    if errorDescription.contains("DTD") || errorDescription.contains("plist") {
+                        self.errorMessage = "Weather service unavailable. Please try again later."
+                    } else {
+                        self.errorMessage = "Failed to fetch weather: \(errorDescription)"
+                    }
+                    self.isLoading = false
+                    print("Weather fetch error: \(error)")
+                }
+            }
+        }
+    }
+    
+    nonisolated deinit {
+        Task { @MainActor in
+            stopUpdatingWeather()
+        }
+    }
+}

--- a/boringNotch/managers/WeatherManager.swift
+++ b/boringNotch/managers/WeatherManager.swift
@@ -9,7 +9,6 @@ import Foundation
 import CoreLocation
 import SwiftUI
 import Combine
-import WeatherKit
 
 // MARK: - Weather Models
 
@@ -24,17 +23,142 @@ struct WeatherData {
     let low: Double
     let location: String
     let lastUpdated: Date
-    
+
     var temperatureString: String {
         return String(format: "%.0f°", temperature)
     }
-    
+
     var systemIconName: String {
         return symbolName
     }
-    
+
     var humidityInt: Int {
         return Int(humidity * 100)
+    }
+}
+
+// MARK: - Open-Meteo Response Models
+
+private struct OpenMeteoResponse: Decodable {
+    let current: CurrentWeather
+    let daily: DailyForecast
+
+    struct CurrentWeather: Decodable {
+        let temperature2m: Double
+        let relativeHumidity2m: Int
+        let apparentTemperature: Double
+        let weatherCode: Int
+        let windSpeed10m: Double
+
+        enum CodingKeys: String, CodingKey {
+            case temperature2m = "temperature_2m"
+            case relativeHumidity2m = "relative_humidity_2m"
+            case apparentTemperature = "apparent_temperature"
+            case weatherCode = "weather_code"
+            case windSpeed10m = "wind_speed_10m"
+        }
+    }
+
+    struct DailyForecast: Decodable {
+        let temperature2mMax: [Double]
+        let temperature2mMin: [Double]
+
+        enum CodingKeys: String, CodingKey {
+            case temperature2mMax = "temperature_2m_max"
+            case temperature2mMin = "temperature_2m_min"
+        }
+    }
+}
+
+// MARK: - WMO Weather Code Helpers
+
+private func wmoSymbol(for code: Int) -> String {
+    switch code {
+    case 0:
+        return "sun.max.fill"
+    case 1:
+        return "sun.max.fill"
+    case 2:
+        return "cloud.sun.fill"
+    case 3:
+        return "cloud.fill"
+    case 45, 48:
+        return "cloud.fog.fill"
+    case 51, 53, 55:
+        return "cloud.drizzle.fill"
+    case 56, 57:
+        return "cloud.sleet.fill"
+    case 61, 63, 65:
+        return "cloud.rain.fill"
+    case 66, 67:
+        return "cloud.sleet.fill"
+    case 71, 73, 75, 77:
+        return "cloud.snow.fill"
+    case 80, 81, 82:
+        return "cloud.heavyrain.fill"
+    case 85, 86:
+        return "cloud.snow.fill"
+    case 95:
+        return "cloud.bolt.fill"
+    case 96, 99:
+        return "cloud.bolt.rain.fill"
+    default:
+        return "cloud.fill"
+    }
+}
+
+private func wmoCondition(for code: Int) -> String {
+    switch code {
+    case 0:
+        return String(localized: "Clear Sky")
+    case 1:
+        return String(localized: "Mainly Clear")
+    case 2:
+        return String(localized: "Partly Cloudy")
+    case 3:
+        return String(localized: "Overcast")
+    case 45:
+        return String(localized: "Foggy")
+    case 48:
+        return String(localized: "Icy Fog")
+    case 51:
+        return String(localized: "Light Drizzle")
+    case 53:
+        return String(localized: "Drizzle")
+    case 55:
+        return String(localized: "Heavy Drizzle")
+    case 56, 57:
+        return String(localized: "Freezing Drizzle")
+    case 61:
+        return String(localized: "Light Rain")
+    case 63:
+        return String(localized: "Rain")
+    case 65:
+        return String(localized: "Heavy Rain")
+    case 66, 67:
+        return String(localized: "Freezing Rain")
+    case 71:
+        return String(localized: "Light Snow")
+    case 73:
+        return String(localized: "Snow")
+    case 75:
+        return String(localized: "Heavy Snow")
+    case 77:
+        return String(localized: "Snow Grains")
+    case 80:
+        return String(localized: "Light Showers")
+    case 81:
+        return String(localized: "Rain Showers")
+    case 82:
+        return String(localized: "Heavy Showers")
+    case 85, 86:
+        return String(localized: "Snow Showers")
+    case 95:
+        return String(localized: "Thunderstorm")
+    case 96, 99:
+        return String(localized: "Thunderstorm with Hail")
+    default:
+        return String(localized: "Unknown")
     }
 }
 
@@ -43,28 +167,27 @@ struct WeatherData {
 @MainActor
 class WeatherManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     static let shared = WeatherManager()
-    
+
     @Published var currentWeather: WeatherData?
     @Published var isLoading: Bool = false
     @Published var errorMessage: String?
     @Published var locationAuthorizationStatus: CLAuthorizationStatus = .notDetermined
-    
+
     private let locationManager = CLLocationManager()
-    private let weatherService = WeatherService.shared
     private var updateTimer: Timer?
     private var cancellables = Set<AnyCancellable>()
     private let geocoder = CLGeocoder()
     private var isRequestingLocation = false
-    
+
     private override init() {
         super.init()
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyKilometer
     }
-    
+
     func checkLocationAuthorization() {
         locationAuthorizationStatus = locationManager.authorizationStatus
-        
+
         switch locationAuthorizationStatus {
         case .notDetermined:
             locationManager.requestAlwaysAuthorization()
@@ -76,46 +199,45 @@ class WeatherManager: NSObject, ObservableObject, CLLocationManagerDelegate {
             break
         }
     }
-    
+
     nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         Task { @MainActor in
             locationAuthorizationStatus = manager.authorizationStatus
-            
+
             if locationAuthorizationStatus == .authorizedAlways {
                 startUpdatingWeather()
             }
         }
     }
-    
+
     func startUpdatingWeather() {
         fetchWeather()
-        
+
         // Update weather every 30 minutes
         updateTimer?.invalidate()
         updateTimer = Timer.scheduledTimer(withTimeInterval: 1800, repeats: true) { [weak self] _ in
             self?.fetchWeather()
         }
     }
-    
+
     func stopUpdatingWeather() {
         updateTimer?.invalidate()
         updateTimer = nil
     }
-    
+
     func fetchWeather() {
         guard locationAuthorizationStatus == .authorizedAlways else {
             return
         }
-        
-        // Prevent multiple simultaneous location requests
+
         guard !isRequestingLocation else {
             return
         }
-        
+
         isRequestingLocation = true
         locationManager.requestLocation()
     }
-    
+
     nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.first else { return }
         Task { @MainActor in
@@ -123,7 +245,7 @@ class WeatherManager: NSObject, ObservableObject, CLLocationManagerDelegate {
             fetchWeatherData(for: location)
         }
     }
-    
+
     nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         Task { @MainActor in
             isRequestingLocation = false
@@ -131,56 +253,62 @@ class WeatherManager: NSObject, ObservableObject, CLLocationManagerDelegate {
             isLoading = false
         }
     }
-    
+
     private func fetchWeatherData(for location: CLLocation) {
         isLoading = true
         errorMessage = nil
-        
+
         Task {
             do {
-                // Fetch weather using WeatherKit
-                let weather = try await weatherService.weather(for: location)
-                
-                // Get location name using reverse geocoding
+                let lat = location.coordinate.latitude
+                let lon = location.coordinate.longitude
+
+                var components = URLComponents(string: "https://api.open-meteo.com/v1/forecast")!
+                components.queryItems = [
+                    URLQueryItem(name: "latitude", value: String(lat)),
+                    URLQueryItem(name: "longitude", value: String(lon)),
+                    URLQueryItem(name: "current", value: "temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m"),
+                    URLQueryItem(name: "daily", value: "temperature_2m_max,temperature_2m_min"),
+                    URLQueryItem(name: "timezone", value: "auto"),
+                    URLQueryItem(name: "forecast_days", value: "1"),
+                ]
+
+                let (data, _) = try await URLSession.shared.data(from: components.url!)
+                let response = try JSONDecoder().decode(OpenMeteoResponse.self, from: data)
+
                 let placemarks = try? await geocoder.reverseGeocodeLocation(location)
                 let locationName = placemarks?.first?.locality ?? placemarks?.first?.name ?? "Unknown"
-                
-                // Create weather data from WeatherKit response
+
+                let current = response.current
                 let weatherData = WeatherData(
-                    temperature: weather.currentWeather.temperature.value,
-                    condition: weather.currentWeather.condition.description,
-                    symbolName: weather.currentWeather.symbolName,
-                    humidity: weather.currentWeather.humidity,
-                    windSpeed: weather.currentWeather.wind.speed.value,
-                    feelsLike: weather.currentWeather.apparentTemperature.value,
-                    high: weather.dailyForecast.first?.highTemperature.value ?? weather.currentWeather.temperature.value,
-                    low: weather.dailyForecast.first?.lowTemperature.value ?? weather.currentWeather.temperature.value,
+                    temperature: current.temperature2m,
+                    condition: wmoCondition(for: current.weatherCode),
+                    symbolName: wmoSymbol(for: current.weatherCode),
+                    humidity: Double(current.relativeHumidity2m) / 100.0,
+                    windSpeed: current.windSpeed10m,
+                    feelsLike: current.apparentTemperature,
+                    high: response.daily.temperature2mMax.first ?? current.temperature2m,
+                    low: response.daily.temperature2mMin.first ?? current.temperature2m,
                     location: locationName,
                     lastUpdated: Date()
                 )
-                
+
                 await MainActor.run {
                     self.currentWeather = weatherData
                     self.errorMessage = nil
                     self.isLoading = false
                 }
-                
+
             } catch {
                 await MainActor.run {
-                    // Provide a user-friendly error message
-                    let errorDescription = error.localizedDescription
-                    if errorDescription.contains("DTD") || errorDescription.contains("plist") {
-                        self.errorMessage = "Weather service unavailable. Please try again later."
-                    } else {
-                        self.errorMessage = "Failed to fetch weather: \(errorDescription)"
-                    }
+                    self.errorMessage = "Failed to fetch weather: \(error.localizedDescription)"
                     self.isLoading = false
                     print("Weather fetch error: \(error)")
                 }
             }
         }
     }
-    
+
     nonisolated deinit {
         Task { @MainActor in
             stopUpdatingWeather()

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -3,7 +3,7 @@
 //  boringNotch
 //
 //  Created by Richard Kunkli on 2024. 10. 17..
-+//  Modified by Arsh Anwar
+//  Modified by Arsh Anwar
 //
 
 import SwiftUI

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -3,6 +3,7 @@
 //  boringNotch
 //
 //  Created by Richard Kunkli on 2024. 10. 17..
++//  Modified by Arsh Anwar
 //
 
 import SwiftUI
@@ -247,6 +248,7 @@ extension Defaults.Keys {
     static let showNotHumanFace = Key<Bool>("showNotHumanFace", default: false)
     static let tileShowLabels = Key<Bool>("tileShowLabels", default: false)
     static let showCalendar = Key<Bool>("showCalendar", default: false)
+    static let showWeather = Key<Bool>("showWeather", default: false)
     static let hideCompletedReminders = Key<Bool>("hideCompletedReminders", default: true)
     static let sliderColor = Key<SliderColorEnum>(
         "sliderUseAlbumArtColor",

--- a/boringNotch/sizing/matters.swift
+++ b/boringNotch/sizing/matters.swift
@@ -13,7 +13,7 @@ let downloadSneakSize: CGSize = .init(width: 65, height: 1)
 let batterySneakSize: CGSize = .init(width: 160, height: 1)
 
 let shadowPadding: CGFloat = 20
-let openNotchSize: CGSize = .init(width: 720, height: 190)
+let openNotchSize: CGSize = .init(width: 740, height: 190)
 let windowSize: CGSize = .init(width: openNotchSize.width, height: openNotchSize.height + shadowPadding)
 let cornerRadiusInsets: (opened: (top: CGFloat, bottom: CGFloat), closed: (top: CGFloat, bottom: CGFloat)) = (opened: (top: 19, bottom: 24), closed: (top: 6, bottom: 14))
 

--- a/boringNotch/sizing/matters.swift
+++ b/boringNotch/sizing/matters.swift
@@ -13,7 +13,7 @@ let downloadSneakSize: CGSize = .init(width: 65, height: 1)
 let batterySneakSize: CGSize = .init(width: 160, height: 1)
 
 let shadowPadding: CGFloat = 20
-let openNotchSize: CGSize = .init(width: 640, height: 190)
+let openNotchSize: CGSize = .init(width: 720, height: 190)
 let windowSize: CGSize = .init(width: openNotchSize.width, height: openNotchSize.height + shadowPadding)
 let cornerRadiusInsets: (opened: (top: CGFloat, bottom: CGFloat), closed: (top: CGFloat, bottom: CGFloat)) = (opened: (top: 19, bottom: 24), closed: (top: 6, bottom: 14))
 


### PR DESCRIPTION
Requires no API key (up to 10,000 calls per day). Also adds localization strings translated using a translator. Removes weatherkit permission. Is a completion of PR #935  which requests using Open-meteo instead of WeatherKit due to weather kit having API limitations and a paid developer account.