### PR TITLE
Add optional media progress bar around the notch

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		14288E0C2C6F8EC000B9F80C /* AppIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14288E0B2C6F8EC000B9F80C /* AppIcons.swift */; };
 		1443E7F32C609DCE0027C1FC /* matters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1443E7F22C609DCE0027C1FC /* matters.swift */; };
 		147163982C5D35B70068B555 /* MusicVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147163972C5D35B70068B555 /* MusicVisualizer.swift */; };
+		B158C813C0C84091B5F469FA /* MediaProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743D0057B1284990B660D980 /* MediaProgressBar.swift */; };
 		1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147163992C5D35FF0068B555 /* MusicManager.swift */; };
 		1471A8592C6281BD0058408D /* BoringNotchWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1471A8582C6281BD0058408D /* BoringNotchWindow.swift */; };
 		149E0B972C737D00006418B1 /* WebcamManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149E0B962C737D00006418B1 /* WebcamManager.swift */; };
@@ -279,6 +280,7 @@
 		1443E7F22C609DCE0027C1FC /* matters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = matters.swift; sourceTree = "<group>"; };
 		1443E7F42C609E650027C1FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		147163972C5D35B70068B555 /* MusicVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicVisualizer.swift; sourceTree = "<group>"; };
+		743D0057B1284990B660D980 /* MediaProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProgressBar.swift; sourceTree = "<group>"; };
 		147163992C5D35FF0068B555 /* MusicManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicManager.swift; sourceTree = "<group>"; };
 		1471A8582C6281BD0058408D /* BoringNotchWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringNotchWindow.swift; sourceTree = "<group>"; };
 		149E0B962C737D00006418B1 /* WebcamManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcamManager.swift; sourceTree = "<group>"; };
@@ -792,6 +794,7 @@
 			isa = PBXGroup;
 			children = (
 				147163972C5D35B70068B555 /* MusicVisualizer.swift */,
+				743D0057B1284990B660D980 /* MediaProgressBar.swift */,
 			);
 			path = Music;
 			sourceTree = "<group>";
@@ -995,6 +998,7 @@
 				5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */,
 				1100292A2E8691B400035A57 /* FileShareView.swift in Sources */,
 				147163982C5D35B70068B555 /* MusicVisualizer.swift in Sources */,
+				B158C813C0C84091B5F469FA /* MediaProgressBar.swift in Sources */,
 				11CC44A22CEE614100C7244B /* BoringViewCoordinator.swift in Sources */,
 				B186543C2C6F49AE000B926A /* ShortcutConstants.swift in Sources */,
 				11A45C792E34E63100CEB175 /* MediaChecker.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -66,22 +66,23 @@ struct ContentView: View {
         return max(0, baseClosedTop * scaleFactor)
     }
 
-    private var currentNotchShape: NotchShape {
+    private var currentBottomCornerRadius: CGFloat {
         // Scale bottom corner radius for closed notch shape when scaling is enabled.
         let baseClosedBottom = cornerRadiusInsets.closed.bottom
-        let bottomCorner: CGFloat
 
         if vm.notchState == .open {
-            bottomCorner = cornerRadiusInsets.opened.bottom
+            return cornerRadiusInsets.opened.bottom
         } else if let scaleFactor = cornerRadiusScaleFactor {
-            bottomCorner = max(0, baseClosedBottom * scaleFactor)
+            return max(0, baseClosedBottom * scaleFactor)
         } else {
-            bottomCorner = displayClosedNotchHeight > 0 ? baseClosedBottom : 0
+            return displayClosedNotchHeight > 0 ? baseClosedBottom : 0
         }
+    }
 
-        return NotchShape(
+    private var currentNotchShape: NotchShape {
+        NotchShape(
             topCornerRadius: topCornerRadius,
-            bottomCornerRadius: bottomCorner
+            bottomCornerRadius: currentBottomCornerRadius
         )
     }
 
@@ -113,6 +114,17 @@ struct ContentView: View {
 
     private var displayClosedNotchHeight: CGFloat { isNotchHeightZero ? 10 : vm.effectiveClosedNotchHeight }
 
+    /// Whether the media progress bar should currently be shown. Gated on the
+    /// notch being in its idle state (closed and not hovered) so the bar fades
+    /// out before the notch expands and only returns once it has settled back.
+    private var isProgressBarVisible: Bool {
+        vm.notchState == .closed
+            && !isHovering
+            && !vm.hideOnClosed
+            && musicManager.isPlaying
+            && musicManager.songDuration > 0
+    }
+
     var body: some View {
         // Calculate scale based on gesture progress only
         let gestureScale: CGFloat = {
@@ -138,6 +150,24 @@ struct ContentView: View {
                             .fill(.black)
                             .frame(height: 1)
                             .padding(.horizontal, topCornerRadius)
+                    }
+                    .overlay {
+                        if Defaults[.showMediaProgressBar] {
+                            MediaProgressBar(
+                                topCornerRadius: topCornerRadius,
+                                bottomCornerRadius: currentBottomCornerRadius
+                            )
+                            .allowsHitTesting(false)
+                            .opacity(isProgressBarVisible ? 1 : 0)
+                            // Fade out quickly (before the notch expands), and
+                            // fade back in only after the notch has settled.
+                            .animation(
+                                isProgressBarVisible
+                                    ? .easeOut(duration: 0.2).delay(0.5)
+                                    : .easeIn(duration: 0.12),
+                                value: isProgressBarVisible
+                            )
+                        }
                     }
                     .shadow(
                         color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow])

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -155,7 +155,8 @@ struct ContentView: View {
                         if Defaults[.showMediaProgressBar] {
                             MediaProgressBar(
                                 topCornerRadius: topCornerRadius,
-                                bottomCornerRadius: currentBottomCornerRadius
+                                bottomCornerRadius: currentBottomCornerRadius,
+                                isVisible: isProgressBarVisible
                             )
                             .allowsHitTesting(false)
                             .opacity(isProgressBarVisible ? 1 : 0)

--- a/boringNotch/components/Music/MediaProgressBar.swift
+++ b/boringNotch/components/Music/MediaProgressBar.swift
@@ -1,0 +1,181 @@
+//
+//  MediaProgressBar.swift
+//  boringNotch
+//
+//  Adds a minimal media playback progress indicator that traces the bottom
+//  outline of the notch and tapers to a point at both ends.
+//  Relates to #1333
+//
+
+import Defaults
+import SwiftUI
+
+/// A thin progress indicator that hugs the notch's bottom edge and fills
+/// left-to-right as the current track plays. Both bottom corners taper to a
+/// fine point; the moving leading edge stays full thickness mid-song and only
+/// tapers as it reaches the right corner. Tinted with the playing media's
+/// average color (the same source the audio visualizer uses), so it visually
+/// matches the rest of the live activity.
+///
+/// Designed to be used as an `.overlay` on the notch so it aligns with the
+/// clipped notch shape; pass the same corner radii the notch is using.
+struct MediaProgressBar: View {
+    @ObservedObject private var musicManager = MusicManager.shared
+
+    let topCornerRadius: CGFloat
+    let bottomCornerRadius: CGFloat
+
+    /// Thickness of the line, in points. Controlled by a slider in Settings → Media.
+    @Default(.mediaProgressBarThickness) private var thickness
+
+    /// Where the bar's color comes from. Controlled by a picker in Settings → Media.
+    @Default(.mediaProgressBarColor) private var colorSource
+
+    private var tint: Color {
+        switch colorSource {
+        case .albumArt:
+            return Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.6)
+        case .white:
+            return .white
+        case .accent:
+            return .effectiveAccent
+        }
+    }
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 0.5)) { context in
+            let duration = musicManager.songDuration
+            let position = musicManager.estimatedPlaybackPosition(at: context.date)
+            let fraction = duration > 0 ? min(max(position / duration, 0), 1) : 0
+
+            TaperedNotchProgress(
+                topCornerRadius: topCornerRadius,
+                bottomCornerRadius: bottomCornerRadius,
+                thickness: CGFloat(thickness),
+                fraction: CGFloat(fraction)
+            )
+            .fill(tint)
+            .animation(.linear(duration: 0.5), value: fraction)
+        }
+    }
+}
+
+/// Fills the bottom contour of the notch (up the left corner, across the bottom,
+/// up the right corner) from the start to `fraction` of its length, as a ribbon
+/// whose half-width ramps to zero at both ends of the full contour, so it tapers
+/// up around each corner. The moving leading edge keeps full thickness until it
+/// nears the right corner.
+struct TaperedNotchProgress: Shape {
+    var topCornerRadius: CGFloat
+    var bottomCornerRadius: CGFloat
+    var thickness: CGFloat
+    var fraction: CGFloat
+
+    /// Animate the fill by interpolating `fraction`, so it grows smoothly.
+    var animatableData: CGFloat {
+        get { fraction }
+        set { fraction = newValue }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        let f = min(max(fraction, 0), 1)
+        guard f > 0, thickness > 0 else { return Path() }
+
+        let tcr = topCornerRadius
+        let bcr = bottomCornerRadius
+
+        // Centerline control points (same contour as the notch's bottom edge).
+        let start = CGPoint(x: rect.minX + tcr, y: rect.maxY - bcr)
+        let blEnd = CGPoint(x: rect.minX + tcr + bcr, y: rect.maxY)
+        let blCtl = CGPoint(x: rect.minX + tcr, y: rect.maxY)
+        let brStart = CGPoint(x: rect.maxX - tcr - bcr, y: rect.maxY)
+        let end = CGPoint(x: rect.maxX - tcr, y: rect.maxY - bcr)
+        let brCtl = CGPoint(x: rect.maxX - tcr, y: rect.maxY)
+
+        // 1. Sample the contour into a dense polyline.
+        var pts: [CGPoint] = []
+        func quad(_ p0: CGPoint, _ c: CGPoint, _ p1: CGPoint, steps: Int, includeFirst: Bool) {
+            for i in (includeFirst ? 0 : 1) ... steps {
+                let t = CGFloat(i) / CGFloat(steps)
+                let mt = 1 - t
+                pts.append(CGPoint(
+                    x: mt * mt * p0.x + 2 * mt * t * c.x + t * t * p1.x,
+                    y: mt * mt * p0.y + 2 * mt * t * c.y + t * t * p1.y
+                ))
+            }
+        }
+        func line(_ p0: CGPoint, _ p1: CGPoint, steps: Int) {
+            for i in 1 ... steps {
+                let t = CGFloat(i) / CGFloat(steps)
+                pts.append(CGPoint(x: p0.x + (p1.x - p0.x) * t, y: p0.y + (p1.y - p0.y) * t))
+            }
+        }
+        quad(start, blCtl, blEnd, steps: 48, includeFirst: true)
+        line(blEnd, brStart, steps: 64)
+        quad(brStart, brCtl, end, steps: 48, includeFirst: false)
+
+        // 2. Cumulative arc length, and the target length for the current fraction.
+        var cum: [CGFloat] = [0]
+        for i in 1 ..< pts.count {
+            cum.append(cum[i - 1] + hypot(pts[i].x - pts[i - 1].x, pts[i].y - pts[i - 1].y))
+        }
+        guard let total = cum.last, total > 0 else { return Path() }
+        let target = f * total
+
+        // 3. Centerline points up to `target` (interpolating the final point).
+        var center: [CGPoint] = []
+        var arc: [CGFloat] = []
+        for i in 0 ..< pts.count {
+            if cum[i] <= target {
+                center.append(pts[i]); arc.append(cum[i])
+            } else {
+                let prev = i - 1
+                let seg = cum[i] - cum[prev]
+                let u = seg > 0 ? (target - cum[prev]) / seg : 0
+                center.append(CGPoint(
+                    x: pts[prev].x + (pts[i].x - pts[prev].x) * u,
+                    y: pts[prev].y + (pts[i].y - pts[prev].y) * u
+                ))
+                arc.append(target)
+                break
+            }
+        }
+        guard center.count >= 2 else { return Path() }
+
+        // 4. Offset each side by a half-width that tapers to zero at both the
+        //    start and the very end of the *full* contour, so the bar tapers up
+        //    around each corner symmetrically. Because the taper-out is anchored
+        //    to the contour's end (not the current progress point), the moving
+        //    leading edge stays full thickness mid-song and only narrows as it
+        //    reaches the right corner.
+        let halfMax = thickness / 2
+        let taper = min(14, total / 2)
+        func halfWidth(at s: CGFloat) -> CGFloat {
+            guard taper > 0 else { return halfMax }
+            let rampIn = min(s / taper, 1)
+            let rampOut = min((total - s) / taper, 1)
+            return halfMax * max(0, min(rampIn, rampOut))
+        }
+
+        var left: [CGPoint] = []
+        var right: [CGPoint] = []
+        for i in 0 ..< center.count {
+            let a = center[max(0, i - 1)]
+            let b = center[min(center.count - 1, i + 1)]
+            var tx = b.x - a.x, ty = b.y - a.y
+            let len = hypot(tx, ty)
+            if len > 0 { tx /= len; ty /= len }
+            let hw = halfWidth(at: arc[i])
+            left.append(CGPoint(x: center[i].x - ty * hw, y: center[i].y + tx * hw))
+            right.append(CGPoint(x: center[i].x + ty * hw, y: center[i].y - tx * hw))
+        }
+
+        // 5. Build the ribbon: forward along one edge, back along the other.
+        var path = Path()
+        path.move(to: left[0])
+        for p in left.dropFirst() { path.addLine(to: p) }
+        for p in right.reversed() { path.addLine(to: p) }
+        path.closeSubpath()
+        return path
+    }
+}

--- a/boringNotch/components/Music/MediaProgressBar.swift
+++ b/boringNotch/components/Music/MediaProgressBar.swift
@@ -36,6 +36,10 @@ struct MediaProgressBar: View {
     /// Where the bar's color comes from. Controlled by a picker in Settings → Media.
     @Default(.mediaProgressBarColor) private var colorSource
 
+    /// How often the bar re-samples the playback position, in seconds. Smaller
+    /// looks smoother (smaller steps); larger is cheaper. Set in Settings → Media.
+    @Default(.mediaProgressBarUpdateInterval) private var updateInterval
+
     private var tint: Color {
         switch colorSource {
         case .albumArt:
@@ -53,7 +57,7 @@ struct MediaProgressBar: View {
         // (no per-frame interpolation) looks identical while avoiding a full
         // geometry rebuild on every display frame.
         if isVisible {
-            TimelineView(.periodic(from: .now, by: 0.5)) { context in
+            TimelineView(.periodic(from: .now, by: updateInterval)) { context in
                 ribbon(at: context.date)
             }
         } else {

--- a/boringNotch/components/Music/MediaProgressBar.swift
+++ b/boringNotch/components/Music/MediaProgressBar.swift
@@ -24,6 +24,11 @@ struct MediaProgressBar: View {
 
     let topCornerRadius: CGFloat
     let bottomCornerRadius: CGFloat
+    /// Whether the bar is currently shown. When false, the periodic timeline is
+    /// torn down so it stops waking twice a second while hidden (open notch /
+    /// paused); a single static frame is rendered instead so the fade-out still
+    /// shows the bar at its last position.
+    var isVisible: Bool = true
 
     /// Thickness of the line, in points. Controlled by a slider in Settings → Media.
     @Default(.mediaProgressBarThickness) private var thickness
@@ -43,20 +48,32 @@ struct MediaProgressBar: View {
     }
 
     var body: some View {
-        TimelineView(.periodic(from: .now, by: 0.5)) { context in
-            let duration = musicManager.songDuration
-            let position = musicManager.estimatedPlaybackPosition(at: context.date)
-            let fraction = duration > 0 ? min(max(position / duration, 0), 1) : 0
-
-            TaperedNotchProgress(
-                topCornerRadius: topCornerRadius,
-                bottomCornerRadius: bottomCornerRadius,
-                thickness: CGFloat(thickness),
-                fraction: CGFloat(fraction)
-            )
-            .fill(tint)
-            .animation(.linear(duration: 0.5), value: fraction)
+        // Only drive the periodic timeline while visible. The bar advances well
+        // under a pixel per 0.5s step, so stepping straight to each new value
+        // (no per-frame interpolation) looks identical while avoiding a full
+        // geometry rebuild on every display frame.
+        if isVisible {
+            TimelineView(.periodic(from: .now, by: 0.5)) { context in
+                ribbon(at: context.date)
+            }
+        } else {
+            ribbon(at: .now)
         }
+    }
+
+    @ViewBuilder
+    private func ribbon(at date: Date) -> some View {
+        let duration = musicManager.songDuration
+        let position = musicManager.estimatedPlaybackPosition(at: date)
+        let fraction = duration > 0 ? min(max(position / duration, 0), 1) : 0
+
+        TaperedNotchProgress(
+            topCornerRadius: topCornerRadius,
+            bottomCornerRadius: bottomCornerRadius,
+            thickness: CGFloat(thickness),
+            fraction: CGFloat(fraction)
+        )
+        .fill(tint)
     }
 }
 
@@ -70,12 +87,6 @@ struct TaperedNotchProgress: Shape {
     var bottomCornerRadius: CGFloat
     var thickness: CGFloat
     var fraction: CGFloat
-
-    /// Animate the fill by interpolating `fraction`, so it grows smoothly.
-    var animatableData: CGFloat {
-        get { fraction }
-        set { fraction = newValue }
-    }
 
     func path(in rect: CGRect) -> Path {
         let f = min(max(fraction, 0), 1)
@@ -110,9 +121,11 @@ struct TaperedNotchProgress: Shape {
                 pts.append(CGPoint(x: p0.x + (p1.x - p0.x) * t, y: p0.y + (p1.y - p0.y) * t))
             }
         }
-        quad(start, blCtl, blEnd, steps: 48, includeFirst: true)
-        line(blEnd, brStart, steps: 64)
-        quad(brStart, brCtl, end, steps: 48, includeFirst: false)
+        // A ~1-5pt ribbon needs far fewer samples than the geometry can produce;
+        // the coarse outline deviates from the fine one by ~0.1pt worst case.
+        quad(start, blCtl, blEnd, steps: 12, includeFirst: true)
+        line(blEnd, brStart, steps: 16)
+        quad(brStart, brCtl, end, steps: 12, includeFirst: false)
 
         // 2. Cumulative arc length, and the target length for the current fraction.
         var cum: [CGFloat] = [0]

--- a/boringNotch/components/Settings/Views/MediaSettingsView.swift
+++ b/boringNotch/components/Settings/Views/MediaSettingsView.swift
@@ -18,6 +18,10 @@ struct Media: View {
 
     @Default(.enableLyrics) var enableLyrics
 
+    @Default(.showMediaProgressBar) private var showMediaProgressBar
+    @Default(.mediaProgressBarThickness) private var mediaProgressBarThickness
+    @Default(.mediaProgressBarColor) private var mediaProgressBarColor
+
     var body: some View {
         Form {
             Section {
@@ -61,6 +65,23 @@ struct Media: View {
                     "Show music live activity",
                     isOn: $coordinator.musicLiveActivityEnabled.animation()
                 )
+                Defaults.Toggle(key: .showMediaProgressBar) {
+                    Text("Show progress bar under notch")
+                }
+                if showMediaProgressBar {
+                    HStack {
+                        Text("Progress bar thickness")
+                        Spacer()
+                        Text("\(mediaProgressBarThickness, specifier: "%.1f") px")
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(value: $mediaProgressBarThickness, in: 1 ... 5, step: 0.5)
+                    Picker("Progress bar color", selection: $mediaProgressBarColor) {
+                        ForEach(SliderColorEnum.allCases, id: \.self) { option in
+                            Text(option.localizedString)
+                        }
+                    }
+                }
                 Toggle("Show sneak peek on playback changes", isOn: $enableSneakPeek)
                 Picker("Sneak Peek Style", selection: $sneakPeekStyles) {
                     ForEach(SneakPeekStyle.allCases) { style in

--- a/boringNotch/components/Settings/Views/MediaSettingsView.swift
+++ b/boringNotch/components/Settings/Views/MediaSettingsView.swift
@@ -21,6 +21,7 @@ struct Media: View {
     @Default(.showMediaProgressBar) private var showMediaProgressBar
     @Default(.mediaProgressBarThickness) private var mediaProgressBarThickness
     @Default(.mediaProgressBarColor) private var mediaProgressBarColor
+    @Default(.mediaProgressBarUpdateInterval) private var mediaProgressBarUpdateInterval
 
     var body: some View {
         Form {
@@ -80,6 +81,11 @@ struct Media: View {
                         ForEach(SliderColorEnum.allCases, id: \.self) { option in
                             Text(option.localizedString)
                         }
+                    }
+                    Picker("Progress bar smoothness", selection: $mediaProgressBarUpdateInterval) {
+                        Text("Power saver").tag(0.5)
+                        Text("Balanced").tag(0.2)
+                        Text("Smooth").tag(0.1)
                     }
                 }
                 Toggle("Show sneak peek on playback changes", isOn: $enableSneakPeek)

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -262,6 +262,9 @@ extension Defaults.Keys {
     
     // MARK: Media playback
     static let coloredSpectrogram = Key<Bool>("coloredSpectrogram", default: true)
+    static let showMediaProgressBar = Key<Bool>("showMediaProgressBar", default: false)
+    static let mediaProgressBarThickness = Key<Double>("mediaProgressBarThickness", default: 2)
+    static let mediaProgressBarColor = Key<SliderColorEnum>("mediaProgressBarColor", default: .albumArt)
     static let realtimeAudioWaveform = Key<Bool>("realtimeAudioWaveform", default: false)
     static let enableSneakPeek = Key<Bool>("enableSneakPeek", default: false)
     static let sneakPeekStyles = Key<SneakPeekStyle>("sneakPeekStyles", default: .standard)

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -265,6 +265,7 @@ extension Defaults.Keys {
     static let showMediaProgressBar = Key<Bool>("showMediaProgressBar", default: false)
     static let mediaProgressBarThickness = Key<Double>("mediaProgressBarThickness", default: 2)
     static let mediaProgressBarColor = Key<SliderColorEnum>("mediaProgressBarColor", default: .albumArt)
+    static let mediaProgressBarUpdateInterval = Key<Double>("mediaProgressBarUpdateInterval", default: 0.5)
     static let realtimeAudioWaveform = Key<Bool>("realtimeAudioWaveform", default: false)
     static let enableSneakPeek = Key<Bool>("enableSneakPeek", default: false)
     static let sneakPeekStyles = Key<SneakPeekStyle>("sneakPeekStyles", default: .standard)


### PR DESCRIPTION
## What

Adds a thin media progress indicator that traces the notch's bottom contour and fills left-to-right as the current track plays, so you can see song progress at a glance without opening the notch.

## Why

Relates to #1333. A minimal, non-intrusive way to track playback progress (e.g. while focused on work, or anticipating track transitions during long albums/sets).

## Demo
White
<img width="368" height="86" alt="image" src="https://github.com/user-attachments/assets/9bbc57ee-3b0b-45c8-b3b3-731f993cdb55" />
Match Album Color
<img width="371" height="58" alt="image" src="https://github.com/user-attachments/assets/adca143b-1139-4833-820d-4cbde3d2f877" />
Bar when you use the custom OSD.
<img width="318" height="76" alt="image" src="https://github.com/user-attachments/assets/2e0ab31a-1bc9-405b-b1d8-8cedad2f4e9c" />

Video Example

https://github.com/user-attachments/assets/f4bcdd6a-f7c7-4b0c-ad9c-d747d14b0191

Settings
<img width="1404" height="1200" alt="image" src="https://github.com/user-attachments/assets/2fe74efc-157f-4d13-9cb5-1d12c58f8d57" />
Color Dropdown for Settings.
<img width="475" height="151" alt="image" src="https://github.com/user-attachments/assets/33b36dc7-2014-4efb-8fdd-966502a87eae" />



## Details

- Draws a tapered ribbon along the notch's bottom edge (`MediaProgressBar` + `TaperedNotchProgress` in `boringNotch/components/Music/MediaProgressBar.swift`), aligned to the live notch corner radii.
- **Tapers up around both bottom corners.** The leading edge stays full thickness mid-song and only tapers as it nears the right corner, so it looks clean during normal playback.
- **Selectable color** via a picker in **Settings → Media**, **Album art / White / Accent**,  mirroring the existing Appearance "Slider color" option (reuses the same `SliderColorEnum`). Album art uses the playing media's average color (the source the audio visualizer uses); Accent uses the app's effective accent.
- **Adjustable thickness** via a slider in **Settings → Media** (1–5 px).
- **Disabled by default** (`showMediaProgressBar`). When enabled, it fades out *before* the notch expands on hover and fades back in once it settles, so it only shows in the idle state.
- Reads existing playback state from `MusicManager` (`estimatedPlaybackPosition`),  no changes to media plumbing.

## Testing

- `xcodebuild -scheme boringNotch ... build` → **BUILD SUCCEEDED**.
- Verified live: bar appears under the notch during playback, the thickness slider and color picker (Album art / White / Accent) update it in real time, it tapers around the corners, and it fades out/in correctly on hover.

## Note for reviewers

The color picker reuses the existing `SliderColorEnum` (Album art / White / Accent) and its already-translated labels rather than introducing a parallel enum, keeping it consistent with the Appearance "Slider color" option. The picker titles ("Progress bar color" / "Progress bar thickness") will be picked up by the string catalog on the next localization sync.
