### PR TITLE
Add optional AI agent, weather, and Pomodoro dashboards

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		111BEA5F2ED07A340079DD4E /* MacroVisionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 111BEA5E2ED07A340079DD4E /* MacroVisionKit */; };
 		111BEA612ED09B1B0079DD4E /* NSScreen+UUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111BEA602ED09B1B0079DD4E /* NSScreen+UUID.swift */; };
 		111BEA6F2ED166E20079DD4E /* MacroVisionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 111BEA6E2ED166E20079DD4E /* MacroVisionKit */; };
+		C0D600012F00000100000001 /* AIWeatherManagers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D600022F00000100000001 /* AIWeatherManagers.swift */; };
+		C0D600032F00000100000001 /* AIWeatherViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D600042F00000100000001 /* AIWeatherViews.swift */; };
 		112B0EB82E30DD0F00562D6C /* MediaRemoteAdapterTestClient in Resources */ = {isa = PBXBuildFile; fileRef = 112B0EB52E30DD0F00562D6C /* MediaRemoteAdapterTestClient */; };
 		112B0EB92E30DD0F00562D6C /* mediaremote-adapter.pl in Resources */ = {isa = PBXBuildFile; fileRef = 112B0EB32E30DD0F00562D6C /* mediaremote-adapter.pl */; };
 		112B0EBB2E30DD5000562D6C /* MediaRemoteAdapter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 112B0EBA2E30DD5000562D6C /* MediaRemoteAdapter.framework */; };
@@ -255,6 +257,8 @@
 		11CFC6642E09C7B300748C80 /* OnboardingFinishView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFinishView.swift; sourceTree = "<group>"; };
 		11D58EA12E760AE100FA8377 /* ImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
 		11DB26652EDD0BE1001EA0CF /* LyricsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsService.swift; sourceTree = "<group>"; };
+		C0D600022F00000100000001 /* AIWeatherManagers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIWeatherManagers.swift; sourceTree = "<group>"; };
+		C0D600042F00000100000001 /* AIWeatherViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIWeatherViews.swift; sourceTree = "<group>"; };
 		11DB26672EDD0CDF001EA0CF /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		11DB26682EDD0CDF001EA0CF /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
 		11DB26692EDD0CDF001EA0CF /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
@@ -607,6 +611,7 @@
 			isa = PBXGroup;
 			children = (
 				11DB26652EDD0BE1001EA0CF /* LyricsService.swift */,
+				C0D600022F00000100000001 /* AIWeatherManagers.swift */,
 				11D58EA12E760AE100FA8377 /* ImageService.swift */,
 				F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */,
 				112FB7342CCF16F70015238C /* NotchSpaceManager.swift */,
@@ -802,6 +807,7 @@
 				1194E8862EA6DDA7009C82D6 /* BoringNotchSkyLightWindow.swift */,
 				1160F8D72DD98230006FBB94 /* NotchShape.swift */,
 				9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */,
+				C0D600042F00000100000001 /* AIWeatherViews.swift */,
 				14D570C52C5F38210011E668 /* BoringHeader.swift */,
 				14D570D12C5F6C6A0011E668 /* BoringExtrasMenu.swift */,
 				1471A8582C6281BD0058408D /* BoringNotchWindow.swift */,
@@ -990,6 +996,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C0D600012F00000100000001 /* AIWeatherManagers.swift in Sources */,
+				C0D600032F00000100000001 /* AIWeatherViews.swift in Sources */,
 				115C12EC2ED3D003009754CA /* OpenNotchOSD.swift in Sources */,
 				14C08BB92C8DE4B1000F8AA0 /* BoringCalendar.swift in Sources */,
 				5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -11,7 +11,6 @@ import Combine
 import Defaults
 import KeyboardShortcuts
 import SwiftUI
-import SwiftUIIntrospect
 
 @MainActor
 struct ContentView: View {
@@ -25,6 +24,7 @@ struct ContentView: View {
     @ObservedObject var volumeManager = VolumeManager.shared
     @State private var hoverTask: Task<Void, Never>?
     @State private var isHovering: Bool = false
+    @State private var hoverOpenedAt: Date?
     @State private var anyDropDebounceTask: Task<Void, Never>?
 
     @State private var gestureProgress: CGFloat = .zero
@@ -37,12 +37,16 @@ struct ContentView: View {
     @Namespace var albumArtNamespace
 
     @Default(.showNotHumanFace) var showNotHumanFace
+    @Default(.aiChatPanelWidth) var aiChatPanelWidth
+    @Default(.aiChatPanelHeight) var aiChatPanelHeight
 
     // Use standardized animations from StandardAnimations enum
     private let animationSpring = StandardAnimations.interactive
 
     private let extendedHoverPadding: CGFloat = 30
     private let zeroHeightHoverPadding: CGFloat = 10
+    private let hoverExitDelay: UInt64 = 140_000_000
+    private let hoverExitDelayAfterOpen: UInt64 = 420_000_000
 
     // MARK: - Corner Radius Scaling
     private var cornerRadiusScaleFactor: CGFloat? {
@@ -113,6 +117,10 @@ struct ContentView: View {
 
     private var displayClosedNotchHeight: CGFloat { isNotchHeightZero ? 10 : vm.effectiveClosedNotchHeight }
 
+    private var shouldKeepOpenForInteraction: Bool {
+        vm.preventAutoClose || coordinator.currentView == .assistant
+    }
+
     var body: some View {
         // Calculate scale based on gesture progress only
         let gestureScale: CGFloat = {
@@ -120,6 +128,7 @@ struct ContentView: View {
             let scaleFactor = 1.0 + gestureProgress * 0.01
             return max(0.6, scaleFactor)
         }()
+        let contentWindowSize = hostingWindowSize(for: vm.notchSize)
         
         ZStack(alignment: .top) {
             VStack(spacing: 0) {
@@ -130,6 +139,7 @@ struct ContentView: View {
                         vm.notchState == .open ? cornerRadiusInsets.opened.top : cornerRadiusInsets.closed.bottom
                     )
                     .padding([.horizontal, .bottom], vm.notchState == .open ? 12 : 0)
+                    .frame(width: vm.notchSize.width, alignment: .top)
                     .background(.black)
                     .clipShape(currentNotchShape)
                           .overlay(alignment: .top) {
@@ -158,15 +168,18 @@ struct ContentView: View {
                         handleHover(hovering)
                     }
                     .onTapGesture {
+                        guard vm.notchState == .closed else { return }
                         doOpen()
                     }
-                    .conditionalModifier(Defaults[.enableGestures]) { view in
+                    .conditionalModifier(Defaults[.enableGestures] && vm.notchState == .closed) { view in
                         view
                             .panGesture(direction: .down) { translation, phase in
                                 handleDownGesture(translation: translation, phase: phase)
                             }
                     }
-                    .conditionalModifier(Defaults[.closeGestureEnabled] && Defaults[.enableGestures]) { view in
+                    .conditionalModifier(
+                        Defaults[.closeGestureEnabled] && Defaults[.enableGestures] && vm.notchState == .open
+                    ) { view in
                         view
                             .panGesture(direction: .up) { translation, phase in
                                 handleUpGesture(translation: translation, phase: phase)
@@ -182,13 +195,13 @@ struct ContentView: View {
                             }
                     }
                     .onReceive(NotificationCenter.default.publisher(for: .sharingDidFinish)) { _ in
-                        if vm.notchState == .open && !isHovering && !vm.isBatteryPopoverActive {
+                        if vm.notchState == .open && !isHovering && !vm.isBatteryPopoverActive && !shouldKeepOpenForInteraction {
                             hoverTask?.cancel()
                             hoverTask = Task {
                                 try? await Task.sleep(for: .milliseconds(100))
                                 guard !Task.isCancelled else { return }
                                 await MainActor.run {
-                                    if self.vm.notchState == .open && !self.isHovering && !self.vm.isBatteryPopoverActive && !SharingStateManager.shared.preventNotchClose {
+                                    if self.vm.notchState == .open && !self.isHovering && !self.vm.isBatteryPopoverActive && !self.shouldKeepOpenForInteraction && !SharingStateManager.shared.preventNotchClose {
                                         self.vm.close()
                                     }
                                 }
@@ -203,13 +216,13 @@ struct ContentView: View {
                         }
                     }
                     .onChange(of: vm.isBatteryPopoverActive) {
-                        if !vm.isBatteryPopoverActive && !isHovering && vm.notchState == .open && !SharingStateManager.shared.preventNotchClose {
+                        if !vm.isBatteryPopoverActive && !isHovering && vm.notchState == .open && !shouldKeepOpenForInteraction && !SharingStateManager.shared.preventNotchClose {
                             hoverTask?.cancel()
                             hoverTask = Task {
                                 try? await Task.sleep(for: .milliseconds(100))
                                 guard !Task.isCancelled else { return }
                                 await MainActor.run {
-                                    if !self.vm.isBatteryPopoverActive && !self.isHovering && self.vm.notchState == .open && !SharingStateManager.shared.preventNotchClose {
+                                    if !self.vm.isBatteryPopoverActive && !self.isHovering && self.vm.notchState == .open && !self.shouldKeepOpenForInteraction && !SharingStateManager.shared.preventNotchClose {
                                         self.vm.close()
                                     }
                                 }
@@ -238,8 +251,7 @@ struct ContentView: View {
             }
         }
         .padding(.bottom, 8)
-        .frame(maxWidth: windowSize.width, maxHeight: windowSize.height, alignment: .top)
-        .ignoresSafeArea(.all)
+        .frame(width: contentWindowSize.width, height: contentWindowSize.height, alignment: .top)
         .compositingGroup()
         .scaleEffect(
             x: gestureScale,
@@ -276,6 +288,15 @@ struct ContentView: View {
                     vm.close()
                 }
             }
+        }
+        .onChange(of: coordinator.currentView) { _, _ in
+            vm.updateOpenSizeForCurrentView()
+        }
+        .onChange(of: aiChatPanelWidth) { _, _ in
+            vm.updateOpenSizeForCurrentView()
+        }
+        .onChange(of: aiChatPanelHeight) { _, _ in
+            vm.updateOpenSizeForCurrentView()
         }
     }
 
@@ -402,6 +423,12 @@ struct ContentView: View {
                         )
                     case .shelf:
                         ShelfView()
+                    case .assistant:
+                        AIChatView()
+                    case .weather:
+                        WeatherDashboardView()
+                    case .pomodoro:
+                        PomodoroDashboardView()
                     }
                 }
                 .transition(
@@ -556,6 +583,8 @@ struct ContentView: View {
 
     @discardableResult
     private func doOpen() -> Bool {
+        guard vm.notchState == .closed else { return false }
+        hoverOpenedAt = Date()
         var didOpen = false
         withAnimation(animationSpring) {
             didOpen = vm.open()
@@ -596,20 +625,33 @@ struct ContentView: View {
             }
         } else {
             hoverTask = Task {
-                try? await Task.sleep(for: .milliseconds(100))
+                let delay = recentlyOpenedFromHover ? hoverExitDelayAfterOpen : hoverExitDelay
+                try? await Task.sleep(nanoseconds: delay)
                 guard !Task.isCancelled else { return }
                 
                 await MainActor.run {
+                    if self.vm.isMouseHovering() {
+                        withAnimation(animationSpring) {
+                            self.isHovering = true
+                        }
+                        return
+                    }
+
                     withAnimation(animationSpring) {
                         self.isHovering = false
                     }
                     
-                    if self.vm.notchState == .open && !self.vm.isBatteryPopoverActive && !SharingStateManager.shared.preventNotchClose {
+                    if self.vm.notchState == .open && !self.vm.isBatteryPopoverActive && !self.shouldKeepOpenForInteraction && !SharingStateManager.shared.preventNotchClose {
                         self.vm.close()
                     }
                 }
             }
         }
+    }
+
+    private var recentlyOpenedFromHover: Bool {
+        guard let hoverOpenedAt else { return false }
+        return Date().timeIntervalSince(hoverOpenedAt) < 0.45
     }
 
     // MARK: - Gesture Handling

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -11,7 +11,6 @@ import Combine
 import Defaults
 import KeyboardShortcuts
 import SwiftUI
-import SwiftUIIntrospect
 
 @MainActor
 struct ContentView: View {
@@ -25,6 +24,7 @@ struct ContentView: View {
     @ObservedObject var volumeManager = VolumeManager.shared
     @State private var hoverTask: Task<Void, Never>?
     @State private var isHovering: Bool = false
+    @State private var hoverOpenedAt: Date?
     @State private var anyDropDebounceTask: Task<Void, Never>?
 
     @State private var gestureProgress: CGFloat = .zero
@@ -37,12 +37,16 @@ struct ContentView: View {
     @Namespace var albumArtNamespace
 
     @Default(.showNotHumanFace) var showNotHumanFace
+    @Default(.aiChatPanelWidth) var aiChatPanelWidth
+    @Default(.aiChatPanelHeight) var aiChatPanelHeight
 
     // Use standardized animations from StandardAnimations enum
     private let animationSpring = StandardAnimations.interactive
 
     private let extendedHoverPadding: CGFloat = 30
     private let zeroHeightHoverPadding: CGFloat = 10
+    private let hoverExitDelay: UInt64 = 140_000_000
+    private let hoverExitDelayAfterOpen: UInt64 = 420_000_000
 
     // MARK: - Corner Radius Scaling
     private var cornerRadiusScaleFactor: CGFloat? {
@@ -113,6 +117,10 @@ struct ContentView: View {
 
     private var displayClosedNotchHeight: CGFloat { isNotchHeightZero ? 10 : vm.effectiveClosedNotchHeight }
 
+    private var shouldKeepOpenForInteraction: Bool {
+        vm.preventAutoClose || coordinator.currentView == .assistant
+    }
+
     var body: some View {
         // Calculate scale based on gesture progress only
         let gestureScale: CGFloat = {
@@ -120,6 +128,7 @@ struct ContentView: View {
             let scaleFactor = 1.0 + gestureProgress * 0.01
             return max(0.6, scaleFactor)
         }()
+        let contentWindowSize = hostingWindowSize(for: vm.notchSize)
         
         ZStack(alignment: .top) {
             VStack(spacing: 0) {
@@ -130,6 +139,7 @@ struct ContentView: View {
                         vm.notchState == .open ? cornerRadiusInsets.opened.top : cornerRadiusInsets.closed.bottom
                     )
                     .padding([.horizontal, .bottom], vm.notchState == .open ? 12 : 0)
+                    .frame(width: vm.notchSize.width, alignment: .top)
                     .background(.black)
                     .clipShape(currentNotchShape)
                           .overlay(alignment: .top) {
@@ -158,15 +168,18 @@ struct ContentView: View {
                         handleHover(hovering)
                     }
                     .onTapGesture {
+                        guard vm.notchState == .closed else { return }
                         doOpen()
                     }
-                    .conditionalModifier(Defaults[.enableGestures]) { view in
+                    .conditionalModifier(Defaults[.enableGestures] && vm.notchState == .closed) { view in
                         view
                             .panGesture(direction: .down) { translation, phase in
                                 handleDownGesture(translation: translation, phase: phase)
                             }
                     }
-                    .conditionalModifier(Defaults[.closeGestureEnabled] && Defaults[.enableGestures]) { view in
+                    .conditionalModifier(
+                        Defaults[.closeGestureEnabled] && Defaults[.enableGestures] && vm.notchState == .open
+                    ) { view in
                         view
                             .panGesture(direction: .up) { translation, phase in
                                 handleUpGesture(translation: translation, phase: phase)
@@ -182,13 +195,13 @@ struct ContentView: View {
                             }
                     }
                     .onReceive(NotificationCenter.default.publisher(for: .sharingDidFinish)) { _ in
-                        if vm.notchState == .open && !isHovering && !vm.isBatteryPopoverActive {
+                        if vm.notchState == .open && !isHovering && !vm.isBatteryPopoverActive && !shouldKeepOpenForInteraction {
                             hoverTask?.cancel()
                             hoverTask = Task {
                                 try? await Task.sleep(for: .milliseconds(100))
                                 guard !Task.isCancelled else { return }
                                 await MainActor.run {
-                                    if self.vm.notchState == .open && !self.isHovering && !self.vm.isBatteryPopoverActive && !SharingStateManager.shared.preventNotchClose {
+                                    if self.vm.notchState == .open && !self.isHovering && !self.vm.isBatteryPopoverActive && !self.shouldKeepOpenForInteraction && !SharingStateManager.shared.preventNotchClose {
                                         self.vm.close()
                                     }
                                 }
@@ -203,13 +216,13 @@ struct ContentView: View {
                         }
                     }
                     .onChange(of: vm.isBatteryPopoverActive) {
-                        if !vm.isBatteryPopoverActive && !isHovering && vm.notchState == .open && !SharingStateManager.shared.preventNotchClose {
+                        if !vm.isBatteryPopoverActive && !isHovering && vm.notchState == .open && !shouldKeepOpenForInteraction && !SharingStateManager.shared.preventNotchClose {
                             hoverTask?.cancel()
                             hoverTask = Task {
                                 try? await Task.sleep(for: .milliseconds(100))
                                 guard !Task.isCancelled else { return }
                                 await MainActor.run {
-                                    if !self.vm.isBatteryPopoverActive && !self.isHovering && self.vm.notchState == .open && !SharingStateManager.shared.preventNotchClose {
+                                    if !self.vm.isBatteryPopoverActive && !self.isHovering && self.vm.notchState == .open && !self.shouldKeepOpenForInteraction && !SharingStateManager.shared.preventNotchClose {
                                         self.vm.close()
                                     }
                                 }
@@ -238,8 +251,7 @@ struct ContentView: View {
             }
         }
         .padding(.bottom, 8)
-        .frame(maxWidth: windowSize.width, maxHeight: windowSize.height, alignment: .top)
-        .ignoresSafeArea(.all)
+        .frame(width: contentWindowSize.width, height: contentWindowSize.height, alignment: .top)
         .compositingGroup()
         .scaleEffect(
             x: gestureScale,
@@ -276,6 +288,15 @@ struct ContentView: View {
                     vm.close()
                 }
             }
+        }
+        .onChange(of: coordinator.currentView) { _, _ in
+            vm.updateOpenSizeForCurrentView()
+        }
+        .onChange(of: aiChatPanelWidth) { _, _ in
+            vm.updateOpenSizeForCurrentView()
+        }
+        .onChange(of: aiChatPanelHeight) { _, _ in
+            vm.updateOpenSizeForCurrentView()
         }
     }
 
@@ -403,6 +424,12 @@ struct ContentView: View {
                         )
                     case .shelf:
                         ShelfView()
+                    case .assistant:
+                        AIChatView()
+                    case .weather:
+                        WeatherDashboardView()
+                    case .pomodoro:
+                        PomodoroDashboardView()
                     }
                 }
                 .transition(
@@ -557,6 +584,8 @@ struct ContentView: View {
 
     @discardableResult
     private func doOpen() -> Bool {
+        guard vm.notchState == .closed else { return false }
+        hoverOpenedAt = Date()
         var didOpen = false
         withAnimation(animationSpring) {
             didOpen = vm.open()
@@ -597,20 +626,33 @@ struct ContentView: View {
             }
         } else {
             hoverTask = Task {
-                try? await Task.sleep(for: .milliseconds(100))
+                let delay = recentlyOpenedFromHover ? hoverExitDelayAfterOpen : hoverExitDelay
+                try? await Task.sleep(nanoseconds: delay)
                 guard !Task.isCancelled else { return }
                 
                 await MainActor.run {
+                    if self.vm.isMouseHovering() {
+                        withAnimation(animationSpring) {
+                            self.isHovering = true
+                        }
+                        return
+                    }
+
                     withAnimation(animationSpring) {
                         self.isHovering = false
                     }
                     
-                    if self.vm.notchState == .open && !self.vm.isBatteryPopoverActive && !SharingStateManager.shared.preventNotchClose {
+                    if self.vm.notchState == .open && !self.vm.isBatteryPopoverActive && !self.shouldKeepOpenForInteraction && !SharingStateManager.shared.preventNotchClose {
                         self.vm.close()
                     }
                 }
             }
         }
+    }
+
+    private var recentlyOpenedFromHover: Bool {
+        guard let hoverOpenedAt else { return false }
+        return Date().timeIntervalSince(hoverOpenedAt) < 0.45
     }
 
     // MARK: - Gesture Handling

--- a/boringNotch/Info.plist
+++ b/boringNotch/Info.plist
@@ -15,6 +15,10 @@
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>
 	<string>boring.notch analyzes audio from your music app to draw a real-time waveform in the notch. Audio is processed locally and never leaves your Mac.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>Boring Notch uses your location to show local weather.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Boring Notch uses your location to show local weather.</string>
 	<key>SUEnableDownloaderService</key>
 	<true/>
 	<key>SUEnableInstallerLauncherService</key>

--- a/boringNotch/Providers/CalendarServiceProviding.swift
+++ b/boringNotch/Providers/CalendarServiceProviding.swift
@@ -14,6 +14,7 @@ protocol CalendarServiceProviding {
     func requestAccess(to type: EKEntityType) async throws -> Bool
     func calendars() async -> [CalendarModel]
     func events(from start: Date, to end: Date, calendars: [String]) async -> [EventModel]
+    func createEvents(_ drafts: [CalendarEventDraft], preferredCalendarIDs: [String]) async throws -> [CreatedCalendarEvent]
 }
 
 class CalendarService: CalendarServiceProviding {
@@ -112,6 +113,83 @@ class CalendarService: CalendarServiceProviding {
             try store.save(reminder, commit: true)
         } catch {
             print("Failed to update reminder completion: \(error)")
+        }
+    }
+
+    func createEvents(_ drafts: [CalendarEventDraft], preferredCalendarIDs: [String]) async throws -> [CreatedCalendarEvent] {
+        guard hasAccess(to: .event) else {
+            throw CalendarWriteError.accessDenied
+        }
+
+        guard let targetCalendar = writableCalendar(preferredCalendarIDs: preferredCalendarIDs) else {
+            throw CalendarWriteError.noWritableCalendar
+        }
+
+        var createdEvents: [CreatedCalendarEvent] = []
+        for draft in drafts {
+            let event = EKEvent(eventStore: store)
+            event.calendar = targetCalendar
+            event.title = draft.title
+            event.startDate = draft.start
+            event.endDate = max(draft.end, draft.start.addingTimeInterval(60 * 30))
+            event.notes = draft.notes
+            event.location = draft.location
+
+            try store.save(event, span: .thisEvent, commit: false)
+            createdEvents.append(
+                CreatedCalendarEvent(
+                    title: draft.title,
+                    start: event.startDate,
+                    end: event.endDate,
+                    calendarTitle: targetCalendar.title
+                )
+            )
+        }
+
+        try store.commit()
+        return createdEvents
+    }
+
+    private func writableCalendar(preferredCalendarIDs: [String]) -> EKCalendar? {
+        let eventCalendars = store.calendars(for: .event).filter(\.allowsContentModifications)
+
+        if let selected = eventCalendars.first(where: { preferredCalendarIDs.contains($0.calendarIdentifier) }) {
+            return selected
+        }
+
+        if let defaultCalendar = store.defaultCalendarForNewEvents, defaultCalendar.allowsContentModifications {
+            return defaultCalendar
+        }
+
+        return eventCalendars.first
+    }
+}
+
+struct CalendarEventDraft: Equatable {
+    let title: String
+    let start: Date
+    let end: Date
+    let notes: String?
+    let location: String?
+}
+
+struct CreatedCalendarEvent: Equatable {
+    let title: String
+    let start: Date
+    let end: Date
+    let calendarTitle: String
+}
+
+enum CalendarWriteError: LocalizedError {
+    case accessDenied
+    case noWritableCalendar
+
+    var errorDescription: String? {
+        switch self {
+        case .accessDenied:
+            return "Calendar access is not available. Enable it in Settings > Calendar."
+        case .noWritableCalendar:
+            return "No writable calendar is available for new events."
         }
     }
 }

--- a/boringNotch/boringNotch.entitlements
+++ b/boringNotch/boringNotch.entitlements
@@ -22,6 +22,8 @@
 	<true/>
 	<key>com.apple.security.personal-information.calendars</key>
 	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
 	<key>com.apple.security.temporary-exception.apple-events</key>
 	<array>
 		<string>com.spotify.client</string>

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -33,7 +33,7 @@ struct DynamicNotchApp: App {
     }
 
     var body: some Scene {
-        MenuBarExtra("boring.notch", systemImage: "sparkle", isInserted: $showMenuBarIcon) {
+        MenuBarExtra("Boring Notch", systemImage: "sparkle", isInserted: $showMenuBarIcon) {
             Button("Settings") {
                 DispatchQueue.main.async {
                     SettingsWindowController.shared.showWindow()
@@ -264,7 +264,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func createBoringNotchWindow(for screen: NSScreen, with viewModel: BoringViewModel) -> NSWindow {
-        let rect = NSRect(x: 0, y: 0, width: windowSize.width, height: windowSize.height)
+        let initialSize = hostingWindowSize(for: viewModel.notchSize)
+        let rect = NSRect(x: 0, y: 0, width: initialSize.width, height: initialSize.height)
         let styleMask: NSWindow.StyleMask = [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow]
         
         let window = BoringNotchSkyLightWindow(contentRect: rect, styleMask: styleMask, backing: .buffered, defer: false)
@@ -297,18 +298,48 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @MainActor
-    private func positionWindow(_ window: NSWindow, on screen: NSScreen, changeAlpha: Bool = false) {
+    private func positionWindow(
+        _ window: NSWindow,
+        on screen: NSScreen,
+        notchSize: CGSize,
+        changeAlpha: Bool = false
+    ) {
         if changeAlpha {
             window.alphaValue = 0
         }
 
         let screenFrame = screen.frame
-        window.setFrameOrigin(
-            NSPoint(
-                x: screenFrame.origin.x + (screenFrame.width / 2) - window.frame.width / 2,
-                y: screenFrame.origin.y + screenFrame.height - window.frame.height
-            ))
+        let targetSize = hostingWindowSize(for: notchSize)
+        let targetFrame = NSRect(
+            x: screenFrame.origin.x + (screenFrame.width / 2) - targetSize.width / 2,
+            y: screenFrame.origin.y + screenFrame.height - targetSize.height,
+            width: targetSize.width,
+            height: targetSize.height
+        )
+        window.setFrame(targetFrame, display: true)
         window.alphaValue = 1
+    }
+
+    @MainActor
+    private func refreshWindowFrames(changeAlpha: Bool = false) {
+        if Defaults[.showOnAllDisplays] {
+            for (uuid, window) in windows {
+                guard
+                    let screen = NSScreen.screen(withUUID: uuid),
+                    let viewModel = viewModels[uuid]
+                else { continue }
+
+                positionWindow(window, on: screen, notchSize: viewModel.notchSize, changeAlpha: changeAlpha)
+            }
+        } else if let window {
+            let screen = window.screen
+                ?? NSScreen.screen(withUUID: coordinator.selectedScreenUUID)
+                ?? NSScreen.main
+
+            if let screen {
+                positionWindow(window, on: screen, notchSize: vm.notchSize, changeAlpha: changeAlpha)
+            }
+        }
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -335,6 +366,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor in
                 self?.adjustWindowPosition()
                 self?.setupDragDetectors()
+            }
+        })
+
+        observers.append(NotificationCenter.default.addObserver(
+            forName: Notification.Name.notchPanelSizeChanged, object: nil, queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.refreshWindowFrames()
             }
         })
 
@@ -551,11 +590,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
 
                 if let window = windows[uuid], let viewModel = viewModels[uuid] {
-                    positionWindow(window, on: screen, changeAlpha: changeAlpha)
-
                     if viewModel.notchState == .closed {
                         viewModel.close()
+                    } else {
+                        viewModel.updateOpenSizeForCurrentView()
                     }
+
+                    positionWindow(window, on: screen, notchSize: viewModel.notchSize, changeAlpha: changeAlpha)
                 }
             }
         } else {
@@ -576,18 +617,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             vm.screenUUID = selectedScreen.displayUUID
-            vm.notchSize = getClosedNotchSize(screenUUID: selectedScreen.displayUUID)
+            if vm.notchState == .closed {
+                vm.close()
+            } else {
+                vm.updateOpenSizeForCurrentView()
+            }
 
             if window == nil {
                 window = createBoringNotchWindow(for: selectedScreen, with: vm)
             }
 
             if let window = window {
-                positionWindow(window, on: selectedScreen, changeAlpha: changeAlpha)
-
-                if vm.notchState == .closed {
-                    vm.close()
-                }
+                positionWindow(window, on: selectedScreen, notchSize: vm.notchSize, changeAlpha: changeAlpha)
             }
         }
 

--- a/boringNotch/components/Notch/AIWeatherViews.swift
+++ b/boringNotch/components/Notch/AIWeatherViews.swift
@@ -1,0 +1,2235 @@
+//
+//  AIWeatherViews.swift
+//  boringNotch
+//
+//  Created by Codex on 2026-06-06.
+//
+
+import AppKit
+import Defaults
+import PDFKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+private struct AgentAttachedFile: Identifiable, Equatable {
+    let id = UUID()
+    let name: String
+    let path: String
+    let content: String
+    let byteCount: Int
+}
+
+private struct AgentFileReadError: LocalizedError {
+    let errorDescription: String?
+
+    init(_ message: String) {
+        self.errorDescription = message
+    }
+}
+
+private func readAgentImportableFile(at url: URL) throws -> (content: String, byteCount: Int) {
+    let byteCount = try agentFileByteCount(at: url)
+
+    if url.pathExtension.lowercased() == "pdf" {
+        guard byteCount <= 20_000_000 else {
+            throw AgentFileReadError("PDF 太大，当前限制 20 MB。")
+        }
+        guard let document = PDFDocument(url: url) else {
+            throw AgentFileReadError("无法打开 PDF。")
+        }
+        let pageTexts = (0..<document.pageCount).compactMap { index in
+            document.page(at: index)?.string?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let text = pageTexts.joined(separator: "\n\n")
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AgentFileReadError("PDF 没有可抽取文本，当前不做 OCR。")
+        }
+        return ("[PDF text extracted]\n\(String(text.prefix(24_000)))", byteCount)
+    }
+
+    let data = try Data(contentsOf: url)
+    guard data.count <= 512_000 else {
+        throw AgentFileReadError("文件太大，当前限制 500 KB。")
+    }
+
+    guard let text = String(data: data, encoding: .utf8)
+        ?? String(data: data, encoding: .unicode)
+        ?? String(data: data, encoding: .utf16)
+    else {
+        throw AgentFileReadError("不是可读取的文本文件。")
+    }
+
+    return (String(text.prefix(16_000)), data.count)
+}
+
+private func agentFileByteCount(at url: URL) throws -> Int {
+    let values = try url.resourceValues(forKeys: [.fileSizeKey])
+    if let fileSize = values.fileSize {
+        return fileSize
+    }
+    let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+    return attributes[.size] as? Int ?? 0
+}
+
+private func agentAllowedImportTypes() -> [UTType] {
+    let extraTextTypes = [
+        "md", "markdown", "swift", "py", "js", "ts", "tsx", "jsx",
+        "html", "css", "xml", "yaml", "yml", "java", "c", "cpp", "h"
+    ].compactMap { UTType(filenameExtension: $0) }
+    return [.plainText, .utf8PlainText, .text, .json, .commaSeparatedText, .pdf] + extraTextTypes
+}
+
+private enum AgentInspectorMode: String, Identifiable {
+    case plugins
+    case skills
+    case memory
+    case knowledge
+
+    var id: String { rawValue }
+}
+
+private enum AgentFileImportMode {
+    case attach
+    case knowledge
+}
+
+private enum AgentResizeAxis: Equatable {
+    case horizontal
+    case vertical
+    case both
+}
+
+private let agentResizeStep: CGFloat = 12
+private let agentResizeHorizontalSensitivity: CGFloat = 1.15
+
+private struct AgentSlashCommand: Identifiable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let symbolName: String
+}
+
+struct AIChatView: View {
+    @Default(.aiChatEnabled) private var aiChatEnabled
+
+    @EnvironmentObject var vm: BoringViewModel
+    @ObservedObject private var manager = AIChatManager.shared
+    @State private var draft: String = ""
+    @State private var showsTrace: Bool = false
+    @State private var inspectorMode: AgentInspectorMode?
+    @State private var attachedFiles: [AgentAttachedFile] = []
+    @State private var fileError: String?
+    @State private var resizeStartSize: CGSize?
+    @State private var activeResizeAxis: AgentResizeAxis?
+    @FocusState private var isComposerFocused: Bool
+
+    private let slashCommands: [AgentSlashCommand] = [
+        .init(id: "/new", title: "新对话", subtitle: "创建一个独立会话页", symbolName: "plus.bubble"),
+        .init(id: "/chats", title: "会话", subtitle: "查看并切换多个对话页", symbolName: "rectangle.3.group.bubble"),
+        .init(id: "/plugins", title: "插件", subtitle: "查看可用工具、权限和风险等级", symbolName: "puzzlepiece.extension"),
+        .init(id: "/skills", title: "Skills", subtitle: "查看任务技能手册", symbolName: "sparkles"),
+        .init(id: "/memory", title: "记忆", subtitle: "查看工作记忆和长期记忆", symbolName: "brain.head.profile"),
+        .init(id: "/knowledge", title: "知识库", subtitle: "查看资料；add 导入文件；seed 导入 GitHub 示例", symbolName: "books.vertical"),
+        .init(id: "/kb", title: "知识库", subtitle: "同 /knowledge，可输入 add 或 seed", symbolName: "books.vertical"),
+        .init(id: "/remember", title: "记住", subtitle: "把一句稳定偏好写入长期记忆", symbolName: "plus.circle"),
+        .init(id: "/forget", title: "遗忘", subtitle: "按关键词删除长期记忆，留空则清空", symbolName: "minus.circle"),
+        .init(id: "/file", title: "上传文件", subtitle: "把本地文本文件作为下一条消息上下文", symbolName: "paperclip"),
+        .init(id: "/clear", title: "清空", subtitle: "清除当前会话消息和轨迹", symbolName: "trash"),
+        .init(id: "/help", title: "帮助", subtitle: "生成命令、插件和 Skills 说明", symbolName: "questionmark.circle"),
+    ]
+
+    var body: some View {
+        VStack(spacing: 10) {
+            header
+
+            if !aiChatEnabled {
+                featureDisabledState(
+                    title: "AI 已关闭",
+                    subtitle: "请在 设置 > AI 中启用智能体。"
+                )
+            } else if Defaults[.aiServiceAPIKey].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                featureDisabledState(
+                    title: "缺少 API Key",
+                    subtitle: "请在 设置 > AI 中填写 Base URL、模型和 API Key。"
+                )
+            } else {
+                conversationTabs
+                messagesPanel
+                if let inspectorMode {
+                    AgentInventoryPanel(mode: inspectorMode) {
+                        self.inspectorMode = nil
+                        isComposerFocused = true
+                    }
+                }
+                if let trace = manager.lastAgentTrace {
+                    AgentTracePanel(trace: trace, isExpanded: $showsTrace)
+                        .layoutPriority(0)
+                }
+                composer
+                    .layoutPriority(2)
+            }
+        }
+        .padding(.horizontal, 4)
+        .padding(.bottom, 4)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .overlay(resizeHandles)
+        .onExitCommand {
+            if inspectorMode != nil {
+                inspectorMode = nil
+                isComposerFocused = true
+            }
+        }
+        .onAppear {
+            vm.preventAutoClose = true
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(150))
+                isComposerFocused = true
+            }
+        }
+        .onDisappear {
+            vm.preventAutoClose = false
+            isComposerFocused = false
+
+            if SettingsWindowController.shared.window?.isVisible != true {
+                NSApp.setActivationPolicy(.accessory)
+            }
+        }
+        .onChange(of: manager.isSending) { _, isSending in
+            if isSending {
+                showsTrace = false
+            }
+        }
+        .onChange(of: manager.lastAgentTrace?.id) { _, _ in
+            showsTrace = false
+        }
+    }
+
+    private var resizeHandles: some View {
+        ZStack {
+            HStack {
+                Spacer()
+                resizeEdge(axis: .horizontal, width: 12, height: nil)
+            }
+
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer(minLength: 40)
+                    resizeEdge(axis: .vertical, width: nil, height: 12)
+                    Spacer(minLength: 40)
+                }
+            }
+
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    resizeCorner
+                }
+            }
+        }
+        .allowsHitTesting(true)
+        .zIndex(20)
+    }
+
+    private func resizeEdge(axis: AgentResizeAxis, width: CGFloat?, height: CGFloat?) -> some View {
+        Rectangle()
+            .fill(activeResizeAxis == axis ? Color.effectiveAccent.opacity(0.28) : Color.white.opacity(0.001))
+            .frame(width: width, height: height)
+            .contentShape(Rectangle())
+            .gesture(resizeGesture(axis: axis))
+            .help(axis == .horizontal ? "拖拽调整宽度" : "拖拽调整高度")
+    }
+
+    private var resizeCorner: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Rectangle()
+                .fill(Color.white.opacity(0.001))
+                .frame(width: 34, height: 34)
+            Image(systemName: "arrow.down.right.and.arrow.up.left")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(activeResizeAxis == .both ? Color.effectiveAccent : Color.white.opacity(0.38))
+                .padding(7)
+        }
+        .contentShape(Rectangle())
+        .gesture(resizeGesture(axis: .both))
+        .help("拖拽调整宽高")
+    }
+
+    private func resizeGesture(axis: AgentResizeAxis) -> some Gesture {
+        DragGesture(minimumDistance: 4)
+            .onChanged { value in
+                let startSize = resizeStartSize ?? vm.notchSize
+                resizeStartSize = startSize
+                activeResizeAxis = axis
+
+                var nextWidth = startSize.width
+                var nextHeight = startSize.height
+
+                switch axis {
+                case .horizontal:
+                    nextWidth = startSize.width + value.translation.width * agentResizeHorizontalSensitivity
+                case .vertical:
+                    nextHeight = startSize.height + value.translation.height
+                case .both:
+                    nextWidth = startSize.width + value.translation.width * agentResizeHorizontalSensitivity
+                    nextHeight = startSize.height + value.translation.height
+                }
+
+                vm.resizeAssistantPanel(
+                    to: CGSize(
+                        width: quantizedResizeValue(nextWidth),
+                        height: quantizedResizeValue(nextHeight)
+                    ),
+                    persist: false
+                )
+            }
+            .onEnded { _ in
+                vm.resizeAssistantPanel(to: vm.notchSize)
+                resizeStartSize = nil
+                activeResizeAxis = nil
+            }
+    }
+
+    private func quantizedResizeValue(_ value: CGFloat) -> CGFloat {
+        (value / agentResizeStep).rounded() * agentResizeStep
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Boring Notch Agent")
+                    .font(.headline)
+                Text(manager.displayedModelName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            if manager.isSending {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Button {
+                manager.clearConversation()
+            } label: {
+                Image(systemName: "trash")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("清空当前会话")
+        }
+    }
+
+    private var conversationTabs: some View {
+        HStack(spacing: 6) {
+            Button {
+                manager.startNewConversation()
+                isComposerFocused = true
+            } label: {
+                Image(systemName: "plus.bubble")
+                    .font(.system(size: 13, weight: .semibold))
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.effectiveAccent)
+            .help("新建对话")
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(manager.conversations) { conversation in
+                        ConversationTabButton(
+                            conversation: conversation,
+                            isActive: manager.activeConversationID == conversation.id,
+                            canDelete: manager.conversations.count > 1,
+                            onSelect: {
+                                manager.selectConversation(conversation.id)
+                                isComposerFocused = true
+                            },
+                            onDelete: {
+                                manager.deleteConversation(conversation.id)
+                            }
+                        )
+                    }
+                }
+            }
+
+            Button {
+                inspectorMode = inspectorMode == .knowledge ? nil : .knowledge
+            } label: {
+                Image(systemName: "books.vertical")
+                    .font(.system(size: 13, weight: .semibold))
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(inspectorMode == .knowledge ? Color.effectiveAccent : .secondary)
+            .help("知识库")
+        }
+        .frame(height: 30)
+    }
+
+    private var messagesPanel: some View {
+        ScrollViewReader { proxy in
+            ScrollView(showsIndicators: false) {
+                LazyVStack(spacing: 8) {
+                    if manager.messages.isEmpty {
+                        emptyConversationState
+                    } else {
+                        ForEach(manager.messages) { message in
+                            ChatBubble(message: message)
+                                .id(message.id)
+                        }
+                    }
+
+                    if let lastError = manager.lastError {
+                        Label(lastError, systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.white.opacity(0.04))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .onChange(of: manager.messages.count) { _, _ in
+                if let lastID = manager.messages.last?.id {
+                    withAnimation(.smooth(duration: 0.2)) {
+                        proxy.scrollTo(lastID, anchor: .bottom)
+                    }
+                }
+            }
+        }
+        .layoutPriority(1)
+    }
+
+    private var emptyConversationState: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("输入任务，或使用 / 调出命令。")
+                .font(.subheadline.weight(.semibold))
+            Text("上方可以切换多个会话页；知识库资料会跨会话检索，当前对话只保留自己的短期记忆。")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+    }
+
+    private var composer: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if shouldShowSlashMenu {
+                SlashCommandMenu(
+                    commands: filteredSlashCommands,
+                    onSelect: runSlashCommand
+                )
+            }
+
+            if !attachedFiles.isEmpty || fileError != nil {
+                attachmentStrip
+            }
+
+            HStack(spacing: 8) {
+                Button {
+                    openFilePicker(mode: .attach)
+                } label: {
+                    Image(systemName: "paperclip")
+                        .font(.system(size: 15, weight: .semibold))
+                        .frame(width: 26, height: 26)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("上传文件作为上下文")
+
+                TextField("输入问题，或输入 / 查看命令...", text: $draft)
+                    .textFieldStyle(.plain)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                    .background(Color.white.opacity(0.06))
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .focused($isComposerFocused)
+                    .onSubmit(sendDraft)
+
+                Button(action: sendDraft) {
+                    Image(systemName: manager.isSending ? "ellipsis.circle.fill" : "arrow.up.circle.fill")
+                        .font(.system(size: 24))
+                        .foregroundColor(canSend ? .effectiveAccent : .secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSend)
+            }
+            .padding(.trailing, 24)
+        }
+    }
+
+    private var shouldShowSlashMenu: Bool {
+        isComposerFocused && draft.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("/")
+    }
+
+    private var filteredSlashCommands: [AgentSlashCommand] {
+        let query = draft.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard query.count > 1 else { return slashCommands }
+        return slashCommands.filter { command in
+            command.id.lowercased().contains(query)
+                || command.title.lowercased().contains(query)
+                || command.subtitle.lowercased().contains(query)
+        }
+    }
+
+    private var attachmentStrip: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if !attachedFiles.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(attachedFiles) { file in
+                            HStack(spacing: 6) {
+                                Image(systemName: "doc.text")
+                                    .font(.caption)
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text(file.name)
+                                        .font(.caption2.weight(.semibold))
+                                        .lineLimit(1)
+                                    Text("\(file.byteCount / 1024 + 1) KB")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Button {
+                                    attachedFiles.removeAll { $0.id == file.id }
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .font(.caption)
+                                }
+                                .buttonStyle(.plain)
+                                .foregroundStyle(.secondary)
+                            }
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 5)
+                            .background(Color.white.opacity(0.05))
+                            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        }
+                    }
+                }
+            }
+
+            if let fileError {
+                Label(fileError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private var canSend: Bool {
+        aiChatEnabled
+            && !manager.isSending
+            && !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func sendDraft() {
+        let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else { return }
+
+        if prompt.hasPrefix("/") {
+            runSlashCommand(matching: prompt)
+            return
+        }
+
+        let finalPrompt = promptWithAttachedFiles(prompt)
+        let displayPrompt = displayPromptWithAttachedFiles(prompt)
+        draft = ""
+        attachedFiles.removeAll()
+        showsTrace = false
+        Task {
+            await manager.send(prompt: finalPrompt, displayPrompt: displayPrompt)
+        }
+    }
+
+    private func runSlashCommand(matching rawValue: String) {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowered = trimmed.lowercased()
+        let command = slashCommands.first { lowered.hasPrefix($0.id) } ?? filteredSlashCommands.first
+        if let command {
+            runSlashCommand(command, rawValue: trimmed)
+        }
+    }
+
+    private func runSlashCommand(_ command: AgentSlashCommand) {
+        runSlashCommand(command, rawValue: command.id)
+    }
+
+    private func runSlashCommand(_ command: AgentSlashCommand, rawValue: String) {
+        let argument = slashArgument(from: rawValue, commandID: command.id)
+        switch command.id {
+        case "/plugins":
+            inspectorMode = inspectorMode == .plugins ? nil : .plugins
+            draft = ""
+        case "/skills":
+            inspectorMode = inspectorMode == .skills ? nil : .skills
+            draft = ""
+        case "/memory":
+            if argument == "clear" {
+                manager.clearLongTermMemory()
+                manager.appendLocalAssistantMessage("已清空长期记忆。")
+            } else if ["reveal", "open", "file"].contains(argument.lowercased()) {
+                manager.revealLongTermMemoryFile()
+                manager.appendLocalAssistantMessage("已在 Finder 中定位长期记忆文件。")
+            } else {
+                inspectorMode = inspectorMode == .memory ? nil : .memory
+            }
+            draft = ""
+        case "/remember":
+            if argument.isEmpty {
+                draft = "/remember "
+                isComposerFocused = true
+            } else if let record = manager.rememberMemory(argument) {
+                inspectorMode = .memory
+                draft = ""
+                manager.appendLocalAssistantMessage("已写入长期记忆：[\(record.kind.displayName)] \(record.content)")
+            }
+        case "/forget":
+            let removedCount = manager.forgetMemory(matching: argument)
+            inspectorMode = .memory
+            draft = ""
+            if argument.isEmpty {
+                manager.appendLocalAssistantMessage("已清空长期记忆，共删除 \(removedCount) 条。")
+            } else {
+                manager.appendLocalAssistantMessage("已删除 \(removedCount) 条匹配“\(argument)”的长期记忆。")
+            }
+        case "/file":
+            draft = ""
+            openFilePicker(mode: .attach)
+        case "/knowledge", "/kb":
+            if ["add", "import", "导入", "添加"].contains(argument.lowercased()) {
+                draft = ""
+                openFilePicker(mode: .knowledge)
+            } else if ["seed", "demo", "github", "示例", "样例"].contains(argument.lowercased()) {
+                let count = manager.installStarterKnowledgeBase()
+                inspectorMode = .knowledge
+                draft = ""
+                manager.appendLocalAssistantMessage("已导入 \(count) 份 GitHub/官方文档启发的示例知识库。")
+            } else if ["clear", "清空"].contains(argument.lowercased()) {
+                manager.clearKnowledgeBase()
+                inspectorMode = .knowledge
+                draft = ""
+                manager.appendLocalAssistantMessage("已清空本地知识库。")
+            } else {
+                inspectorMode = inspectorMode == .knowledge ? nil : .knowledge
+                draft = ""
+            }
+        case "/new":
+            draft = ""
+            attachedFiles.removeAll()
+            inspectorMode = nil
+            manager.startNewConversation()
+        case "/chats":
+            draft = ""
+            attachedFiles.removeAll()
+            inspectorMode = nil
+            isComposerFocused = true
+        case "/clear":
+            draft = ""
+            attachedFiles.removeAll()
+            inspectorMode = nil
+            manager.clearConversation()
+        case "/help":
+            draft = "请用中文说明你支持的 / 命令、插件和 Skills，并举 3 个示例任务。"
+            sendDraft()
+        default:
+            break
+        }
+    }
+
+    private func slashArgument(from rawValue: String, commandID: String) -> String {
+        guard rawValue.lowercased().hasPrefix(commandID) else { return "" }
+        return rawValue
+            .dropFirst(commandID.count)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func openFilePicker(mode: AgentFileImportMode) {
+        fileError = nil
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = agentAllowedImportTypes()
+
+        guard panel.runModal() == .OK else { return }
+
+        var importedKnowledgeTitles: [String] = []
+        let maxFiles = mode == .knowledge ? 8 : 4
+
+        for url in panel.urls.prefix(maxFiles) {
+            do {
+                let file = try readAgentImportableFile(at: url)
+
+                switch mode {
+                case .attach:
+                    attachedFiles.append(
+                        AgentAttachedFile(
+                            name: url.lastPathComponent,
+                            path: url.path,
+                            content: file.content,
+                            byteCount: file.byteCount
+                        )
+                    )
+                case .knowledge:
+                    if let document = manager.addKnowledgeDocument(
+                        name: url.lastPathComponent,
+                        path: url.path,
+                        content: file.content,
+                        byteCount: file.byteCount
+                    ) {
+                        importedKnowledgeTitles.append(document.title)
+                    }
+                }
+            } catch {
+                fileError = "\(url.lastPathComponent) 读取失败：\(error.localizedDescription)"
+            }
+        }
+
+        if mode == .knowledge {
+            inspectorMode = .knowledge
+            if !importedKnowledgeTitles.isEmpty {
+                manager.appendLocalAssistantMessage("已导入知识库：\(importedKnowledgeTitles.joined(separator: "、"))")
+            }
+        }
+    }
+
+    private func readAttachableFile(at url: URL) throws -> (content: String, byteCount: Int) {
+        let byteCount = try fileByteCount(at: url)
+
+        if url.pathExtension.lowercased() == "pdf" {
+            guard byteCount <= 20_000_000 else {
+                throw AgentFileReadError("PDF 太大，当前限制 20 MB。")
+            }
+            guard let document = PDFDocument(url: url) else {
+                throw AgentFileReadError("无法打开 PDF。")
+            }
+            let pageTexts = (0..<document.pageCount).compactMap { index in
+                document.page(at: index)?.string?.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            let text = pageTexts.joined(separator: "\n\n")
+            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw AgentFileReadError("PDF 没有可抽取文本，当前不做 OCR。")
+            }
+            return ("[PDF text extracted]\n\(String(text.prefix(24_000)))", byteCount)
+        }
+
+        let data = try Data(contentsOf: url)
+        guard data.count <= 512_000 else {
+            throw AgentFileReadError("文件太大，当前限制 500 KB。")
+        }
+
+        guard let text = String(data: data, encoding: .utf8)
+            ?? String(data: data, encoding: .unicode)
+            ?? String(data: data, encoding: .utf16)
+        else {
+            throw AgentFileReadError("不是可读取的文本文件。")
+        }
+
+        return (String(text.prefix(16_000)), data.count)
+    }
+
+    private func fileByteCount(at url: URL) throws -> Int {
+        let values = try url.resourceValues(forKeys: [.fileSizeKey])
+        if let fileSize = values.fileSize {
+            return fileSize
+        }
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return attributes[.size] as? Int ?? 0
+    }
+
+    private func promptWithAttachedFiles(_ prompt: String) -> String {
+        guard !attachedFiles.isEmpty else { return prompt }
+
+        let fileBlocks = attachedFiles.map { file in
+            """
+            [file: \(file.name)]
+            path: \(file.path)
+            content:
+            \(file.content)
+            """
+        }.joined(separator: "\n\n")
+
+        return """
+        用户问题：
+        \(prompt)
+
+        本地文件上下文：
+        \(fileBlocks)
+        """
+    }
+
+    private func displayPromptWithAttachedFiles(_ prompt: String) -> String {
+        guard !attachedFiles.isEmpty else { return prompt }
+        return "\(prompt)\n\n已附加文件：\(attachedFiles.map(\.name).joined(separator: "、"))"
+    }
+
+    private func featureDisabledState(title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Button("打开设置") {
+                SettingsWindowController.shared.showWindow()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(12)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct SlashCommandMenu: View {
+    let commands: [AgentSlashCommand]
+    let onSelect: (AgentSlashCommand) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(commands) { command in
+                Button {
+                    onSelect(command)
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: command.symbolName)
+                            .font(.system(size: 13, weight: .semibold))
+                            .frame(width: 18)
+                            .foregroundStyle(Color.effectiveAccent)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("\(command.id)  \(command.title)")
+                                .font(.caption.weight(.semibold))
+                            Text(command.subtitle)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(6)
+        .background(Color.white.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct ConversationTabButton: View {
+    let conversation: AgentChatConversation
+    let isActive: Bool
+    let canDelete: Bool
+    let onSelect: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: isActive ? "bubble.left.and.bubble.right.fill" : "bubble.left")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(isActive ? Color.effectiveAccent : .secondary)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(conversation.title)
+                    .font(.caption2.weight(.semibold))
+                    .lineLimit(1)
+                Text("\(conversation.messages.count) 条")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            if canDelete {
+                Button(action: onDelete) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("删除会话")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(isActive ? Color.effectiveAccent.opacity(0.18) : Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onSelect)
+        .frame(maxWidth: 170)
+    }
+}
+
+private struct AgentInventoryPanel: View {
+    let mode: AgentInspectorMode
+    let onClose: () -> Void
+    @ObservedObject private var manager = AIChatManager.shared
+    @State private var selectedSkillCategory: String = "全部"
+    @State private var knowledgeImportError: String?
+    private let columns = [GridItem(.adaptive(minimum: 250, maximum: 360), spacing: 6)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label(panelTitle, systemImage: panelIcon)
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Text(panelCount)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Button(action: onClose) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.cancelAction)
+                .help("关闭面板")
+            }
+
+            ScrollView(showsIndicators: true) {
+                switch mode {
+                case .plugins:
+                    LazyVGrid(columns: columns, spacing: 6) {
+                        ForEach(manager.availablePlugins) { plugin in
+                            PluginInventoryCard(plugin: plugin)
+                        }
+                    }
+                case .skills:
+                    VStack(alignment: .leading, spacing: 8) {
+                        skillCategoryPicker
+                        LazyVGrid(columns: columns, spacing: 6) {
+                            ForEach(filteredSkills) { skill in
+                                SkillInventoryCard(skill: skill)
+                            }
+                        }
+                    }
+                case .memory:
+                    memoryPanel
+                case .knowledge:
+                    knowledgePanel
+                }
+            }
+            .frame(maxHeight: 360)
+        }
+        .padding(10)
+        .background(Color.white.opacity(0.045))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private var skillCategoryPicker: some View {
+        HStack(spacing: 6) {
+            ForEach(skillCategories, id: \.self) { category in
+                Button {
+                    selectedSkillCategory = category
+                } label: {
+                    Text(category)
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            selectedSkillCategory == category
+                            ? Color.effectiveAccent.opacity(0.26)
+                            : Color.white.opacity(0.05)
+                        )
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var skillCategories: [String] {
+        let categories = manager.availableSkills.map(\.category)
+        return ["全部"] + Array(Set(categories)).sorted()
+    }
+
+    private var filteredSkills: [AgentSkillDescriptor] {
+        guard selectedSkillCategory != "全部" else {
+            return manager.availableSkills
+        }
+        return manager.availableSkills.filter { $0.category == selectedSkillCategory }
+    }
+
+    private var panelTitle: String {
+        switch mode {
+        case .plugins: return "插件总览"
+        case .skills: return "Skills 总览"
+        case .memory: return "记忆系统"
+        case .knowledge: return "本地知识库"
+        }
+    }
+
+    private var panelIcon: String {
+        switch mode {
+        case .plugins: return "puzzlepiece.extension"
+        case .skills: return "sparkles"
+        case .memory: return "brain.head.profile"
+        case .knowledge: return "books.vertical"
+        }
+    }
+
+    private var panelCount: String {
+        switch mode {
+        case .plugins: return "\(manager.availablePlugins.count) 个插件"
+        case .skills: return "\(filteredSkills.count)/\(manager.availableSkills.count) 个技能"
+        case .memory: return "\(manager.longTermMemories.count) 条长期记忆"
+        case .knowledge: return "\(manager.knowledgeDocuments.count) 份资料"
+        }
+    }
+
+    private var memoryPanel: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            LazyVGrid(columns: columns, spacing: 6) {
+                MemoryLayerCard(
+                    title: "短期记忆",
+                    value: "\(min(manager.messages.count, 6)) 条",
+                    detail: "最近会话窗口，直接进入上下文",
+                    symbolName: "text.bubble"
+                )
+                MemoryLayerCard(
+                    title: "工作记忆",
+                    value: manager.lastAgentTrace?.workingMemory == nil ? "待生成" : "已生成",
+                    detail: "当前目标、进度、实体和待澄清问题",
+                    symbolName: "list.clipboard"
+                )
+                MemoryLayerCard(
+                    title: "长期记忆",
+                    value: "\(manager.longTermMemories.count) 条",
+                    detail: "显式写入，本地检索后按需注入",
+                    symbolName: "externaldrive"
+                )
+            }
+
+            if let workingMemory = manager.lastAgentTrace?.workingMemory {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("工作记忆")
+                        .font(.caption2.weight(.semibold))
+                    Text(workingMemory.contextText)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(8)
+                .background(Color.white.opacity(0.04))
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+
+            if manager.longTermMemories.isEmpty {
+                Text("还没有长期记忆。只有当用户明确说“记住/以后/我的偏好”等稳定信息时才会写入。")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.white.opacity(0.04))
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            } else {
+                ForEach(manager.longTermMemories.prefix(5)) { memory in
+                    MemoryInventoryCard(memory: memory)
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button("定位记忆文件") {
+                    manager.revealLongTermMemoryFile()
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+
+                Button("清空长期记忆") {
+                    manager.clearLongTermMemory()
+                    manager.appendLocalAssistantMessage("已清空长期记忆。")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var knowledgePanel: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            LazyVGrid(columns: columns, spacing: 6) {
+                MemoryLayerCard(
+                    title: "资料数量",
+                    value: "\(manager.knowledgeDocuments.count) 份",
+                    detail: "跨会话检索，不属于某一个聊天页",
+                    symbolName: "books.vertical"
+                )
+                MemoryLayerCard(
+                    title: "检索方式",
+                    value: "Hybrid",
+                    detail: "关键词 + 语义词 + 时间权重 Top-3 注入",
+                    symbolName: "magnifyingglass"
+                )
+                MemoryLayerCard(
+                    title: "存储",
+                    value: "JSON",
+                    detail: manager.knowledgeStorageLocation.lastPathComponent,
+                    symbolName: "externaldrive"
+                )
+            }
+
+            if manager.knowledgeDocuments.isEmpty {
+                Text("还没有导入资料。使用 /knowledge add，或点击下面的“导入资料”按钮导入文本、Markdown、JSON、CSV 或 PDF。")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.white.opacity(0.04))
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            } else {
+                ForEach(manager.knowledgeDocuments.prefix(8)) { document in
+                    KnowledgeInventoryCard(document: document) {
+                        manager.removeKnowledgeDocument(id: document.id)
+                    }
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button("导入 GitHub 示例") {
+                    let count = manager.installStarterKnowledgeBase()
+                    manager.appendLocalAssistantMessage("已导入 \(count) 份 GitHub/官方文档启发的示例知识库。")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+
+                Button("导入资料") {
+                    openKnowledgeImporter()
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+
+                Button("清空知识库") {
+                    manager.clearKnowledgeBase()
+                    manager.appendLocalAssistantMessage("已清空本地知识库。")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .foregroundStyle(.red)
+            }
+
+            if let knowledgeImportError {
+                Label(knowledgeImportError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private func openKnowledgeImporter() {
+        knowledgeImportError = nil
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = agentAllowedImportTypes()
+
+        guard panel.runModal() == .OK else { return }
+
+        var imported: [String] = []
+        for url in panel.urls.prefix(8) {
+            do {
+                let file = try readAgentImportableFile(at: url)
+                if let document = manager.addKnowledgeDocument(
+                    name: url.lastPathComponent,
+                    path: url.path,
+                    content: file.content,
+                    byteCount: file.byteCount
+                ) {
+                    imported.append(document.title)
+                }
+            } catch {
+                knowledgeImportError = "\(url.lastPathComponent) 读取失败：\(error.localizedDescription)"
+            }
+        }
+
+        if !imported.isEmpty {
+            manager.appendLocalAssistantMessage("已导入知识库：\(imported.joined(separator: "、"))")
+        }
+    }
+}
+
+private struct MemoryLayerCard: View {
+    let title: String
+    let value: String
+    let detail: String
+    let symbolName: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 5) {
+                Image(systemName: symbolName)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Color.effectiveAccent)
+                Text(title)
+                    .font(.caption2.weight(.semibold))
+                Spacer()
+                Text(value)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+            Text(detail)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct MemoryInventoryCard: View {
+    let memory: AgentMemoryRecord
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(memory.kind.displayName)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Color.effectiveAccent)
+                Spacer()
+                Text(memory.updatedAt, style: .relative)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Text(memory.content)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+            HStack(spacing: 6) {
+                Text("重要 \(Int((memory.importance * 100).rounded()))%")
+                Text("置信 \(Int((memory.confidence * 100).rounded()))%")
+                Text("访问 \(memory.accessCount)")
+                if let score = memory.retrievalScore {
+                    Text("命中 \(Int((score * 100).rounded()))%")
+                }
+            }
+            .font(.caption2.monospaced())
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            if let reason = memory.retrievalReason {
+                Text(reason)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Text(memory.keywords.prefix(8).joined(separator: ", "))
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct KnowledgeInventoryCard: View {
+    let document: AgentKnowledgeDocument
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(document.title)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                Spacer()
+                Text(document.updatedAt, style: .relative)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Button(action: onDelete) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("移出知识库")
+            }
+            Text(document.summary.isEmpty ? "无摘要" : document.summary)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+            Text(document.sourcePath)
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            HStack(spacing: 6) {
+                Text("\(document.byteCount / 1024 + 1) KB")
+                Text(document.keywords.prefix(6).joined(separator: ", "))
+            }
+            .font(.caption2.monospaced())
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct PluginInventoryCard: View {
+    let plugin: AgentPluginDescriptor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(plugin.name)
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Text(plugin.riskLevel)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(plugin.riskLevel == "中" ? .orange : .green)
+            }
+            Text(plugin.summary)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            HStack(spacing: 4) {
+                ForEach(plugin.typeTags, id: \.self) { tag in
+                    Text(tag)
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(Color.effectiveAccent.opacity(0.12))
+                        .clipShape(Capsule())
+                }
+            }
+            Text(plugin.toolNames.joined(separator: ", "))
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Text(plugin.permission)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct SkillInventoryCard: View {
+    let skill: AgentSkillDescriptor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(skill.name)
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Text(skill.riskLevel)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(skill.riskLevel == "中" ? .orange : .green)
+            }
+            Text(skill.summary)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                Text(skill.category)
+                    .font(.caption2.weight(.semibold))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.effectiveAccent.opacity(0.16))
+                    .clipShape(Capsule())
+                Text(skill.source == "built-in" ? "内置" : skill.source)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Text(skill.workflowSteps.joined(separator: " -> "))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            Text(skill.requiredTools.joined(separator: ", "))
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct AgentTracePanel: View {
+    let trace: AgentRunTrace
+    @Binding var isExpanded: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                withAnimation(.smooth(duration: 0.18)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption2.weight(.semibold))
+                        .frame(width: 10)
+                    Text("智能体轨迹")
+                        .font(.caption.weight(.semibold))
+                    statusPill(trace.status)
+                    metricChip("路由", "\(Int((trace.routeConfidence * 100).rounded()))%")
+                    metricChip("工具", "\(trace.selectedToolNames.count)")
+                    Spacer()
+                    Text(trace.routeName)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded, trace.routeKind == "general_chat" {
+                compactGeneralTrace
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            } else if isExpanded {
+                ScrollView(showsIndicators: true) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(spacing: 6) {
+                            metricChip("Skills", "\(trace.selectedSkills.count)")
+                            metricChip("记忆", "\(trace.retrievedMemories.count)")
+                            if trace.requiresConfirmation {
+                                metricChip("风险", "写入")
+                            }
+                        }
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("任务理解")
+                                .font(.caption2.weight(.semibold))
+                            Text("\(trace.taskUnderstanding.taskType) / \(trace.taskUnderstanding.complexity) / \(trace.reasoningProfile.mode)")
+                                .font(.caption2.monospaced())
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+
+                        if !trace.discoveredPlugins.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Tool Discovery")
+                                    .font(.caption2.weight(.semibold))
+                                ForEach(trace.discoveredPlugins.prefix(4)) { match in
+                                    discoveryRow(match)
+                                }
+                            }
+                        }
+
+                        if !trace.selectedPlugins.isEmpty {
+                            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 6) {
+                                ForEach(trace.selectedPlugins) { plugin in
+                                    pluginChip(plugin)
+                                }
+                            }
+                        }
+
+                        if !trace.selectedSkills.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Skills")
+                                    .font(.caption2.weight(.semibold))
+                                ForEach(trace.selectedSkills) { skill in
+                                    skillChip(skill)
+                                }
+                            }
+                        }
+
+                        if let workingMemory = trace.workingMemory {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Working Memory")
+                                    .font(.caption2.weight(.semibold))
+                                Text(workingMemory.contextText)
+                                    .font(.caption2.monospaced())
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(5)
+                            }
+                        }
+
+                        if !trace.retrievedMemories.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Long-Term Memory")
+                                    .font(.caption2.weight(.semibold))
+                                ForEach(trace.retrievedMemories.prefix(3)) { memory in
+                                    Text("[\(memory.kind.displayName)] \(memory.content) \(memory.retrievalReason ?? "")")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(2)
+                                }
+                            }
+                        }
+
+                        if !trace.planSteps.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Plan")
+                                    .font(.caption2.weight(.semibold))
+                                ForEach(trace.planSteps.prefix(4)) { step in
+                                    Text("\(step.order). \(step.title)：\(step.status)")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                        }
+
+                        if !trace.recoveryStrategies.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Recovery")
+                                    .font(.caption2.weight(.semibold))
+                                ForEach(trace.recoveryStrategies.prefix(2)) { strategy in
+                                    Text("\(strategy.trigger) -> \(strategy.strategy)")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                        }
+
+                        VStack(alignment: .leading, spacing: 5) {
+                            ForEach(trace.steps.suffix(5)) { step in
+                                HStack(alignment: .top, spacing: 6) {
+                                    Circle()
+                                        .fill(statusColor(step.status))
+                                        .frame(width: 6, height: 6)
+                                        .padding(.top, 5)
+                                    VStack(alignment: .leading, spacing: 1) {
+                                        Text(step.title)
+                                            .font(.caption2.weight(.semibold))
+                                        Text(step.detail)
+                                            .font(.caption2)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(2)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding(.trailing, 6)
+                }
+                .frame(maxHeight: 210)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(10)
+        .background(Color.white.opacity(0.045))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private var compactGeneralTrace: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("普通对话：轻量轨迹")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            ForEach(trace.steps.suffix(3)) { step in
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(statusColor(step.status))
+                        .frame(width: 6, height: 6)
+                    Text(step.title)
+                        .font(.caption2.weight(.semibold))
+                    Text(step.detail)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+    }
+
+    private func statusPill(_ status: String) -> some View {
+        Text(status)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(statusColor(status))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(statusColor(status).opacity(0.14))
+            .clipShape(Capsule())
+    }
+
+    private func metricChip(_ title: String, _ value: String) -> some View {
+        HStack(spacing: 4) {
+            Text(title)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .fontWeight(.semibold)
+        }
+        .font(.caption2)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 4)
+        .background(Color.white.opacity(0.05))
+        .clipShape(Capsule())
+    }
+
+    private func pluginChip(_ plugin: AgentPluginDescriptor) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 4) {
+                Text(plugin.name)
+                    .font(.caption2.weight(.semibold))
+                    .lineLimit(1)
+                Spacer(minLength: 4)
+                Text(plugin.riskLevel)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Text(plugin.category)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(Color.effectiveAccent)
+                .lineLimit(1)
+            Text(plugin.toolNames.joined(separator: ", "))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 6)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+    }
+
+    private func discoveryRow(_ match: AgentPluginMatch) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: match.selected ? "checkmark.circle.fill" : "circle")
+                .font(.caption2)
+                .foregroundStyle(match.selected ? Color.effectiveAccent : .secondary)
+            Text(match.pluginName)
+                .font(.caption2.weight(.semibold))
+                .lineLimit(1)
+            Text("\(Int((match.score * 100).rounded()))%")
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+            Text(match.reason)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func skillChip(_ skill: AgentSkillDescriptor) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(skill.name)
+                .font(.caption2.weight(.semibold))
+            Text(skill.workflowSteps.joined(separator: " -> "))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 6)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+    }
+
+    private func statusColor(_ status: String) -> Color {
+        switch status.lowercased() {
+        case "done", "completed", "已完成":
+            return .green
+        case "prepared", "已准备":
+            return Color.effectiveAccent
+        case "fallback", "skipped":
+            return .orange
+        case "error", "failed":
+            return .red
+        default:
+            return .secondary
+        }
+    }
+}
+
+private struct ChatBubble: View {
+    let message: AIChatMessage
+
+    var body: some View {
+        HStack {
+            if message.role == .user { Spacer(minLength: 36) }
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(message.role == .user ? "你" : "助手")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                MarkdownMessageText(content: message.content)
+                    .font(.caption)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                message.role == .user
+                    ? Color.effectiveAccentBackground
+                    : Color.white.opacity(0.06)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .frame(maxWidth: 360, alignment: message.role == .user ? .trailing : .leading)
+
+            if message.role == .assistant { Spacer(minLength: 36) }
+        }
+        .frame(maxWidth: .infinity, alignment: message.role == .user ? .trailing : .leading)
+        .padding(.horizontal, 10)
+    }
+}
+
+private struct MarkdownMessageText: View {
+    let content: String
+
+    var body: some View {
+        Text(attributedContent)
+    }
+
+    private var attributedContent: AttributedString {
+        (try? AttributedString(markdown: content)) ?? AttributedString(content)
+    }
+}
+
+struct WeatherDashboardView: View {
+    @Default(.weatherFeatureEnabled) private var weatherFeatureEnabled
+
+    @ObservedObject private var manager = WeatherManager.shared
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 4)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+
+            if !weatherFeatureEnabled {
+                featureState(
+                    title: "天气已关闭",
+                    subtitle: "在设置 > Weather 中开启后即可获取实时天气。"
+                )
+            } else if let snapshot = manager.snapshot {
+                weatherContent(snapshot: snapshot)
+            } else if manager.isRefreshing {
+                loadingState
+            } else {
+                featureState(
+                    title: "天气不可用",
+                    subtitle: manager.lastError ?? "检查设置里的城市后再试一次。"
+                )
+            }
+        }
+        .task {
+            await manager.refreshWeather(force: false)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("天气")
+                    .font(.headline)
+                Text(
+                    (manager.snapshot?.locationName).flatMap { $0.isEmpty ? nil : $0 }
+                        ?? {
+                            let city = Defaults[.weatherCity].trimmingCharacters(in: .whitespacesAndNewlines)
+                            return city.isEmpty ? defaultWeatherCityName() : city
+                        }()
+                )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            if manager.isRefreshing {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Button {
+                Task {
+                    await manager.refreshWeather(force: true)
+                }
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("刷新天气")
+        }
+    }
+
+    private func weatherContent(snapshot: WeatherSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 14) {
+                WeatherConditionIcon(symbolName: snapshot.current.symbolName, size: 44)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text(temperatureLabel(snapshot.current.temperature, unit: snapshot.current.unitSymbol))
+                            .font(.system(size: 34, weight: .semibold, design: .rounded))
+                        Text(snapshot.current.condition)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack(spacing: 8) {
+                        Text("体感 \(temperatureLabel(snapshot.current.feelsLike, unit: snapshot.current.unitSymbol))")
+                        if let high = snapshot.current.highTemperature, let low = snapshot.current.lowTemperature {
+                            Text("最高 \(temperatureLabel(high, unit: snapshot.current.unitSymbol))")
+                            Text("最低 \(temperatureLabel(low, unit: snapshot.current.unitSymbol))")
+                        }
+                    }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+            }
+
+            if let high = snapshot.current.highTemperature, let low = snapshot.current.lowTemperature {
+                WeatherRangeBar(
+                    low: low,
+                    high: high,
+                    current: snapshot.current.temperature,
+                    unit: snapshot.current.unitSymbol
+                )
+            }
+
+            LazyVGrid(columns: columns, spacing: 8) {
+                WeatherMetricTile(systemImage: "humidity.fill", title: "湿度", value: "\(snapshot.current.humidity)%")
+                WeatherMetricTile(systemImage: "wind", title: "风速", value: "\(Int(snapshot.current.windSpeed.rounded())) \(snapshot.current.windUnit)")
+                WeatherMetricTile(systemImage: "drop.fill", title: "降水", value: precipitationLabel(snapshot.current.precipitation))
+                WeatherMetricTile(systemImage: "clock", title: "更新", value: refreshLabel(snapshot.updatedAt))
+            }
+
+            if !snapshot.hourly.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(snapshot.hourly) { entry in
+                            WeatherHourChip(entry: entry)
+                        }
+                    }
+                    .padding(.vertical, 1)
+                }
+            }
+
+            if let lastError = manager.lastError {
+                Text(lastError)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var loadingState: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text("正在获取最新天气...")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(12)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private func featureState(title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Button("打开设置") {
+                SettingsWindowController.shared.showWindow()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(12)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private func temperatureLabel(_ value: Double, unit: String) -> String {
+        "\(Int(value.rounded()))\(unit)"
+    }
+
+    private func precipitationLabel(_ value: Double) -> String {
+        "\(String(format: "%.1f", value)) mm"
+    }
+
+    private func refreshLabel(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: date)
+    }
+}
+
+private struct WeatherMetricTile: View {
+    let systemImage: String
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 5) {
+                Image(systemName: systemImage)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Color.effectiveAccent)
+                Text(title)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Text(value)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct WeatherHourChip: View {
+    let entry: WeatherSnapshot.HourlyEntry
+
+    var body: some View {
+        VStack(spacing: 5) {
+            Text(entry.timeLabel)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            WeatherConditionIcon(symbolName: entry.symbolName, size: 22, cornerRadius: 6)
+            Text("\(Int(entry.temperature.rounded()))\(entry.unitSymbol)")
+                .font(.caption.weight(.semibold))
+            if let probability = entry.precipitationProbability {
+                HStack(spacing: 2) {
+                    Image(systemName: "drop.fill")
+                    Text("\(probability)%")
+                }
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+        }
+        .frame(width: 58)
+        .padding(.vertical, 7)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct WeatherConditionIcon: View {
+    let symbolName: String
+    let size: CGFloat
+    var cornerRadius: CGFloat = 10
+
+    var body: some View {
+        let palette = weatherSymbolPalette(for: symbolName)
+
+        Image(systemName: symbolName)
+            .symbolRenderingMode(.palette)
+            .font(.system(size: size * 0.58, weight: .semibold))
+            .foregroundStyle(palette.primary, palette.secondary)
+            .frame(width: size, height: size)
+            .background(
+                LinearGradient(
+                    colors: [
+                        palette.primary.opacity(0.22),
+                        palette.secondary.opacity(0.10)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    }
+}
+
+private struct WeatherRangeBar: View {
+    let low: Double
+    let high: Double
+    let current: Double
+    let unit: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text("今日温度")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("\(Int(low.rounded()))\(unit) - \(Int(high.rounded()))\(unit)")
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            GeometryReader { proxy in
+                let width = max(proxy.size.width - 8, 1)
+                let ratio = normalizedCurrentTemperature
+
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(
+                            LinearGradient(
+                                colors: [.green, .yellow, .orange, .pink, .purple],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                    Circle()
+                        .fill(Color.white)
+                        .frame(width: 8, height: 8)
+                        .shadow(color: .black.opacity(0.25), radius: 2, y: 1)
+                        .offset(x: width * ratio)
+                }
+            }
+            .frame(height: 8)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private var normalizedCurrentTemperature: Double {
+        guard high > low else { return 0.5 }
+        return min(max((current - low) / (high - low), 0), 1)
+    }
+}
+
+private func weatherSymbolPalette(for symbolName: String) -> (primary: Color, secondary: Color) {
+    if symbolName.contains("sun") {
+        return (.yellow, .orange)
+    }
+    if symbolName.contains("moon") {
+        return (.indigo, .cyan)
+    }
+    if symbolName.contains("bolt") {
+        return (.yellow, .purple)
+    }
+    if symbolName.contains("snow") {
+        return (.cyan, .blue)
+    }
+    if symbolName.contains("rain") || symbolName.contains("drizzle") {
+        return (.cyan, .blue)
+    }
+    if symbolName.contains("fog") {
+        return (.gray, .white.opacity(0.8))
+    }
+    return (.gray, .blue)
+}
+
+struct PomodoroDashboardView: View {
+    @Default(.pomodoroEnabled) private var pomodoroEnabled
+
+    @ObservedObject private var manager = PomodoroManager.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+
+            if !pomodoroEnabled {
+                featureDisabledState(
+                    title: "Pomodoro is disabled",
+                    subtitle: "Enable it in Settings > Pomodoro to use the focus timer."
+                )
+            } else {
+                timerCard
+                phaseSelector
+                statsRow
+                controls
+            }
+        }
+        .padding(.horizontal, 4)
+        .padding(.bottom, 4)
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Pomodoro")
+                    .font(.headline)
+                Text(manager.phase.rawValue)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Image(systemName: manager.phase.symbolName)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(accentColor(for: manager.phase))
+        }
+    }
+
+    private var timerCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(manager.formattedRemaining)
+                    .font(.system(size: 34, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+
+                Spacer()
+
+                Text(manager.isRunning ? "Running" : "Ready")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+
+            ProgressView(value: manager.progress)
+                .progressViewStyle(.linear)
+                .tint(accentColor(for: manager.phase))
+
+            Text("Next: \(manager.nextPhaseTitle)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(12)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private var phaseSelector: some View {
+        HStack(spacing: 8) {
+            ForEach(PomodoroPhase.allCases) { phase in
+                Button {
+                    manager.selectPhase(phase)
+                } label: {
+                    Text(phase.shortLabel)
+                        .font(.caption.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 7)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .fill(manager.phase == phase ? accentColor(for: phase).opacity(0.24) : Color.white.opacity(0.05))
+                        )
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(manager.phase == phase ? Color.effectiveAccent : .primary)
+            }
+        }
+    }
+
+    private var statsRow: some View {
+        HStack(spacing: 8) {
+            PomodoroStatTile(title: "Session", value: manager.currentCycleIndexLabel)
+            PomodoroStatTile(title: "Completed", value: "\(manager.completedFocusSessions)")
+            PomodoroStatTile(title: "Auto-start", value: Defaults[.pomodoroAutoStartNextPhase] ? "On" : "Off")
+        }
+    }
+
+    private var controls: some View {
+        HStack(spacing: 8) {
+            Button {
+                manager.toggleRunning()
+            } label: {
+                Label(manager.isRunning ? "Pause" : "Start", systemImage: manager.isRunning ? "pause.fill" : "play.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(accentColor(for: manager.phase))
+
+            Button {
+                manager.resetCurrentPhase()
+            } label: {
+                Image(systemName: "arrow.counterclockwise")
+                    .frame(width: 28)
+            }
+            .buttonStyle(.bordered)
+            .help("Reset current phase")
+
+            Button {
+                manager.skipPhase()
+            } label: {
+                Image(systemName: "forward.fill")
+                    .frame(width: 28)
+            }
+            .buttonStyle(.bordered)
+            .help("Skip to next phase")
+
+            Button {
+                manager.resetCycle()
+            } label: {
+                Image(systemName: "stop.fill")
+                    .frame(width: 28)
+            }
+            .buttonStyle(.bordered)
+            .help("Reset full cycle")
+        }
+        .controlSize(.small)
+    }
+
+    private func featureDisabledState(title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Button("Open Settings") {
+                SettingsWindowController.shared.showWindow()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(12)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private func accentColor(for phase: PomodoroPhase) -> Color {
+        switch phase {
+        case .focus:
+            return Color.effectiveAccent
+        case .shortBreak:
+            return .green
+        case .longBreak:
+            return .orange
+        }
+    }
+}
+
+private struct PomodoroStatTile: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -12,14 +12,12 @@ struct BoringHeader: View {
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var coordinator = BoringViewCoordinator.shared
-    @StateObject var tvm = ShelfStateViewModel.shared
+
     var body: some View {
         HStack(spacing: 0) {
             HStack {
-                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
+                if vm.notchState == .open {
                     TabSelectionView()
-                } else if vm.notchState == .open {
-                    EmptyView()
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -104,6 +102,8 @@ struct BoringHeader: View {
             .blur(radius: vm.notchState == .closed ? 20 : 0)
             .zIndex(2)
         }
+        .padding(.horizontal, 12)
+        .padding(.top, 4)
         .foregroundColor(.gray)
         .environmentObject(vm)
     }

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -12,14 +12,12 @@ struct BoringHeader: View {
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var coordinator = BoringViewCoordinator.shared
-    @StateObject var tvm = ShelfStateViewModel.shared
+
     var body: some View {
         HStack(spacing: 0) {
             HStack {
-                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
+                if vm.notchState == .open {
                     TabSelectionView()
-                } else if vm.notchState == .open {
-                    EmptyView()
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -105,6 +103,8 @@ struct BoringHeader: View {
             .blur(radius: vm.notchState == .closed ? 20 : 0)
             .zIndex(2)
         }
+        .padding(.horizontal, 12)
+        .padding(.top, 4)
         .foregroundColor(.gray)
         .environmentObject(vm)
     }

--- a/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
@@ -58,6 +58,7 @@ class BoringNotchSkyLightWindow: NSPanel {
         titlebarAppearsTransparent = true
         backgroundColor = .clear
         isMovable = false
+        becomesKeyOnlyIfNeeded = true
         level = .mainMenu + 3
         hasShadow = false
         isReleasedWhenClosed = false
@@ -146,6 +147,6 @@ class BoringNotchSkyLightWindow: NSPanel {
         }
     }
     
-    override var canBecomeKey: Bool { false }
-    override var canBecomeMain: Bool { false }
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
 }

--- a/boringNotch/components/Notch/BoringNotchWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchWindow.swift
@@ -27,6 +27,7 @@ class BoringNotchWindow: NSPanel {
         titlebarAppearsTransparent = true
         backgroundColor = .clear
         isMovable = false
+        becomesKeyOnlyIfNeeded = true
         
         collectionBehavior = [
             .fullScreenAuxiliary,
@@ -41,10 +42,10 @@ class BoringNotchWindow: NSPanel {
     }
     
     override var canBecomeKey: Bool {
-        false
+        true
     }
     
     override var canBecomeMain: Bool {
-        false
+        true
     }
 }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -5,6 +5,7 @@
 //  Created by Richard Kunkli on 07/08/2024.
 //
 
+import Defaults
 import Sparkle
 import SwiftUI
 import SwiftUIIntrospect
@@ -13,7 +14,10 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case appearance
     case media
+    case ai
     case calendar
+    case weather
+    case pomodoro
     case osd
     case battery
     case shelf
@@ -29,7 +33,10 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: "General"
         case .appearance: "Appearance"
         case .media: "Media"
+        case .ai: "AI"
         case .calendar: "Calendar"
+        case .weather: "Weather"
+        case .pomodoro: "Pomodoro"
         case .osd: "OSD"
         case .battery: "Battery"
         case .shelf: "Shelf"
@@ -45,7 +52,10 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: "gear"
         case .appearance: "eye"
         case .media: "play.laptopcomputer"
+        case .ai: "sparkles"
         case .calendar: "calendar"
+        case .weather: "cloud.sun"
+        case .pomodoro: "timer"
         case .osd: "dial.medium.fill"
         case .battery: "battery.100.bolt"
         case .shelf: "books.vertical"
@@ -88,8 +98,14 @@ struct SettingsView: View {
                     Appearance()
                 case .media:
                     Media()
+                case .ai:
+                    AISettings()
                 case .calendar:
                     CalendarSettings()
+                case .weather:
+                    WeatherSettings()
+                case .pomodoro:
+                    PomodoroSettings()
                 case .osd:
                     OSDSettings()
                 case .battery:
@@ -133,5 +149,394 @@ struct SettingsView: View {
         .onReceive(NotificationCenter.default.publisher(for: .accentColorChanged)) { _ in
             accentColorUpdateTrigger = UUID()
         }
+    }
+}
+
+struct AISettings: View {
+    @ObservedObject private var aiManager = AIChatManager.shared
+
+    @Default(.aiChatEnabled) var aiChatEnabled
+    @Default(.aiCalendarContextEnabled) var aiCalendarContextEnabled
+    @Default(.aiCalendarWriteEnabled) var aiCalendarWriteEnabled
+    @Default(.aiServiceBaseURL) var aiServiceBaseURL
+    @Default(.aiServiceModel) var aiServiceModel
+    @Default(.aiServiceAPIKey) var aiServiceAPIKey
+    @Default(.aiSystemPrompt) var aiSystemPrompt
+    @Default(.aiChatPanelWidth) var aiChatPanelWidth
+    @Default(.aiChatPanelHeight) var aiChatPanelHeight
+
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Toggle(key: .aiChatEnabled) {
+                    Text("Enable AI chat")
+                }
+
+                TextField("Base URL", text: $aiServiceBaseURL)
+                    .textFieldStyle(.roundedBorder)
+                TextField("Model", text: $aiServiceModel)
+                    .textFieldStyle(.roundedBorder)
+                SecureField("API Key", text: $aiServiceAPIKey)
+                    .textFieldStyle(.roundedBorder)
+            } header: {
+                Text("OpenAI-compatible API")
+            } footer: {
+                Text("Supports OpenAI-compatible chat completions endpoints such as https://api.openai.com or compatible gateways.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                Defaults.Toggle(key: .aiCalendarContextEnabled) {
+                    Text("Let AI read calendar context")
+                }
+                Defaults.Toggle(key: .aiCalendarWriteEnabled) {
+                    Text("Let AI create calendar events")
+                }
+            } header: {
+                Text("Calendar integration")
+            } footer: {
+                Text("The assistant can read selected calendars to avoid conflicts. It only writes events when the user explicitly asks and this setting is enabled.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        Text("Width")
+                        Spacer()
+                        Text("\(Int(aiChatPanelWidth)) px")
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(value: $aiChatPanelWidth, in: aiChatPanelMinSize.width...aiChatPanelMaxSize.width, step: 10)
+
+                    HStack {
+                        Text("Height")
+                        Spacer()
+                        Text("\(Int(aiChatPanelHeight)) px")
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(value: $aiChatPanelHeight, in: aiChatPanelMinSize.height...aiChatPanelMaxSize.height, step: 10)
+
+                    Button("Reset size") {
+                        aiChatPanelWidth = aiChatPanelDefaultSize.width
+                        aiChatPanelHeight = aiChatPanelDefaultSize.height
+                    }
+                    .controlSize(.small)
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Text("AI panel size")
+            } footer: {
+                Text("The AI panel can also be resized directly from the notch by dragging the right edge, bottom edge, or bottom-right corner.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(aiManager.availablePlugins) { plugin in
+                        AIPluginSettingsRow(plugin: plugin)
+                    }
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Text("Agent plugins")
+            } footer: {
+                Text("The current implementation uses a built-in plugin registry. It does not execute third-party dynamic code.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(aiManager.availableSkills) { skill in
+                        AISkillSettingsRow(skill: skill)
+                    }
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Text("Skills")
+            } footer: {
+                Text("Skills describe task workflows that can be injected into model context when a matching task is routed.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                TextField("System prompt", text: $aiSystemPrompt)
+                    .textFieldStyle(.roundedBorder)
+            } header: {
+                Text("Assistant behavior")
+            } footer: {
+                Text("This prompt is prepended to each request from the notch chat tab.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("AI")
+    }
+}
+
+private struct AIPluginSettingsRow: View {
+    let plugin: AgentPluginDescriptor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(plugin.name)
+                        .font(.headline)
+                    Text(plugin.category)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(plugin.riskLevel)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(plugin.riskLevel == "medium" ? .orange : .green)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background((plugin.riskLevel == "medium" ? Color.orange : Color.green).opacity(0.12))
+                    .clipShape(Capsule())
+            }
+
+            Text(plugin.summary)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 6) {
+                ForEach(plugin.typeTags, id: \.self) { tag in
+                    Text(tag)
+                        .font(.caption.weight(.semibold))
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 3)
+                        .background(Color.effectiveAccent.opacity(0.12))
+                        .clipShape(Capsule())
+                }
+            }
+
+            HStack(alignment: .top, spacing: 8) {
+                Label(plugin.toolNames.joined(separator: ", "), systemImage: "wrench.and.screwdriver")
+                Spacer()
+                Label(plugin.permission, systemImage: "lock.shield")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .padding(12)
+        .background(.quaternary.opacity(0.35))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct AISkillSettingsRow: View {
+    let skill: AgentSkillDescriptor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(skill.name)
+                        .font(.headline)
+                    Text(skill.id)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(skill.riskLevel)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(skill.riskLevel == "medium" ? .orange : .green)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background((skill.riskLevel == "medium" ? Color.orange : Color.green).opacity(0.12))
+                    .clipShape(Capsule())
+            }
+
+            Text(skill.summary)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text(skill.workflowSteps.joined(separator: " -> "))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text("Triggers: \(skill.triggerKeywords.joined(separator: ", "))")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Label(skill.requiredTools.joined(separator: ", "), systemImage: "link")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(12)
+        .background(.quaternary.opacity(0.35))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+struct WeatherSettings: View {
+    @ObservedObject private var weatherManager = WeatherManager.shared
+
+    @Default(.weatherFeatureEnabled) var weatherFeatureEnabled
+    @Default(.weatherLocationMode) var weatherLocationMode
+    @Default(.weatherCity) var weatherCity
+    @Default(.weatherTemperatureUnit) var weatherTemperatureUnit
+
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Toggle(key: .weatherFeatureEnabled) {
+                    Text("Enable weather")
+                }
+
+                Picker("Source", selection: $weatherLocationMode) {
+                    ForEach(WeatherLocationMode.allCases) { mode in
+                        Text(mode.rawValue).tag(mode)
+                    }
+                }
+
+                if weatherLocationMode == .automatic {
+                    HStack {
+                        Text("Location access")
+                        Spacer()
+                        Text(weatherManager.locationAuthorizationDescription)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack(spacing: 8) {
+                        if weatherManager.locationAuthorizationStatus == .notDetermined {
+                            Button("Allow location access") {
+                                Task {
+                                    await weatherManager.requestLocationAuthorization()
+                                }
+                            }
+                        } else if !weatherManager.locationServicesEnabled {
+                            Button("Open Location Settings") {
+                                weatherManager.openLocationSettings()
+                            }
+                        }
+
+                        if weatherManager.locationAuthorizationStatus == .denied
+                            || weatherManager.locationAuthorizationStatus == .restricted
+                        {
+                            Button("Open Location Settings") {
+                                weatherManager.openLocationSettings()
+                            }
+                        }
+                    }
+                } else {
+                    TextField("City", text: $weatherCity)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                Picker("Temperature unit", selection: $weatherTemperatureUnit) {
+                    ForEach(WeatherTemperatureUnit.allCases) { unit in
+                        Text(unit.rawValue).tag(unit)
+                    }
+                }
+            } header: {
+                Text("Forecast source")
+            } footer: {
+                Text("Weather uses Open-Meteo. Automatic mode uses your current location through macOS Location Services. Manual mode uses the city entered here.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                Button("Refresh now") {
+                    Task {
+                        await WeatherManager.shared.refreshWeather(force: true)
+                    }
+                }
+                .disabled(!weatherFeatureEnabled)
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Weather")
+        .onAppear {
+            weatherManager.refreshLocationAccessState()
+        }
+        .onChange(of: weatherLocationMode) { _, newMode in
+            weatherManager.refreshLocationAccessState()
+
+            guard newMode == .automatic else { return }
+
+            Task {
+                if weatherManager.locationAuthorizationStatus == .notDetermined {
+                    await weatherManager.requestLocationAuthorization()
+                } else {
+                    await weatherManager.refreshWeather(force: true)
+                }
+            }
+        }
+    }
+}
+
+struct PomodoroSettings: View {
+    @Default(.pomodoroEnabled) var pomodoroEnabled
+    @Default(.pomodoroFocusMinutes) var pomodoroFocusMinutes
+    @Default(.pomodoroShortBreakMinutes) var pomodoroShortBreakMinutes
+    @Default(.pomodoroLongBreakMinutes) var pomodoroLongBreakMinutes
+    @Default(.pomodoroLongBreakInterval) var pomodoroLongBreakInterval
+    @Default(.pomodoroAutoStartNextPhase) var pomodoroAutoStartNextPhase
+
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Toggle(key: .pomodoroEnabled) {
+                    Text("Enable Pomodoro timer")
+                }
+
+                Defaults.Toggle(key: .pomodoroAutoStartNextPhase) {
+                    Text("Auto-start next phase")
+                }
+                .disabled(!pomodoroEnabled)
+            } header: {
+                Text("Timer behavior")
+            } footer: {
+                Text("The Pomodoro timer runs locally inside the app. No external API is used.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                Stepper(value: $pomodoroFocusMinutes, in: 1 ... 120) {
+                    Text("Focus duration: \(pomodoroFocusMinutes) min")
+                }
+
+                Stepper(value: $pomodoroShortBreakMinutes, in: 1 ... 60) {
+                    Text("Short break: \(pomodoroShortBreakMinutes) min")
+                }
+
+                Stepper(value: $pomodoroLongBreakMinutes, in: 1 ... 90) {
+                    Text("Long break: \(pomodoroLongBreakMinutes) min")
+                }
+
+                Stepper(value: $pomodoroLongBreakInterval, in: 2 ... 8) {
+                    Text("Long break every \(pomodoroLongBreakInterval) focus sessions")
+                }
+            } header: {
+                Text("Durations")
+            } footer: {
+                Text("The notch tab lets users start, pause, skip, and reset the current cycle.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+            .disabled(!pomodoroEnabled)
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Pomodoro")
     }
 }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -154,13 +154,15 @@ struct SettingsView: View {
 
 struct AISettings: View {
     @ObservedObject private var aiManager = AIChatManager.shared
+    @State private var aiServiceAPIKey = ""
+    @State private var aiCredentialError: String?
+    @State private var hasLoadedAICredential = false
 
     @Default(.aiChatEnabled) var aiChatEnabled
     @Default(.aiCalendarContextEnabled) var aiCalendarContextEnabled
     @Default(.aiCalendarWriteEnabled) var aiCalendarWriteEnabled
     @Default(.aiServiceBaseURL) var aiServiceBaseURL
     @Default(.aiServiceModel) var aiServiceModel
-    @Default(.aiServiceAPIKey) var aiServiceAPIKey
     @Default(.aiSystemPrompt) var aiSystemPrompt
     @Default(.aiChatPanelWidth) var aiChatPanelWidth
     @Default(.aiChatPanelHeight) var aiChatPanelHeight
@@ -178,6 +180,11 @@ struct AISettings: View {
                     .textFieldStyle(.roundedBorder)
                 SecureField("API Key", text: $aiServiceAPIKey)
                     .textFieldStyle(.roundedBorder)
+                if let aiCredentialError {
+                    Text(aiCredentialError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
             } header: {
                 Text("OpenAI-compatible API")
             } footer: {
@@ -283,6 +290,29 @@ struct AISettings: View {
         }
         .accentColor(.effectiveAccent)
         .navigationTitle("AI")
+        .onAppear {
+            guard !hasLoadedAICredential else { return }
+            Task {
+                let storedAPIKey = await AIProviderCredentialStore.loadAPIKey()
+                guard !Task.isCancelled else { return }
+                aiServiceAPIKey = storedAPIKey
+                await Task.yield()
+                hasLoadedAICredential = true
+            }
+        }
+        .task(id: aiServiceAPIKey) {
+            guard hasLoadedAICredential else { return }
+            do {
+                try await Task.sleep(for: .milliseconds(350))
+                try Task.checkCancellation()
+                try await AIProviderCredentialStore.saveAPIKey(aiServiceAPIKey)
+                aiCredentialError = nil
+            } catch is CancellationError {
+                return
+            } catch {
+                aiCredentialError = error.localizedDescription
+            }
+        }
     }
 }
 

--- a/boringNotch/components/Settings/SettingsWindowController.swift
+++ b/boringNotch/components/Settings/SettingsWindowController.swift
@@ -31,16 +31,10 @@ class SettingsWindowController: NSWindowController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func setUpdaterController(_ controller: SPUStandardUpdaterController) {
-        self.updaterController = controller
-        // Recreate the content view with the proper updater controller
-        setupWindow()
-    }
-    
     private func setupWindow() {
         guard let window = window else { return }
         
-        window.title = "Boring Notch Settings"
+        window.title = "Boring Notch设置"
         window.titlebarAppearsTransparent = false
         window.titleVisibility = .visible
         window.toolbarStyle = .unified
@@ -57,10 +51,7 @@ class SettingsWindowController: NSWindowController {
         window.isRestorable = true
         window.identifier = NSUserInterfaceItemIdentifier("BoringNotchSettingsWindow")
         
-        // Create the SwiftUI content
-        let settingsView = SettingsView(updaterController: updaterController)
-        let hostingView = NSHostingView(rootView: settingsView)
-        window.contentView = hostingView
+        refreshContentView()
         
         // Handle window closing
         window.delegate = self
@@ -91,6 +82,11 @@ class SettingsWindowController: NSWindowController {
             self?.window?.makeKeyAndOrderFront(nil)
         }
     }
+
+    func setUpdaterController(_ updaterController: SPUStandardUpdaterController) {
+        self.updaterController = updaterController
+        refreshContentView()
+    }
     
     override func close() {
         super.close()
@@ -102,6 +98,11 @@ class SettingsWindowController: NSWindowController {
         
         // Set app back to accessory mode immediately
         NSApp.setActivationPolicy(.accessory)
+    }
+
+    private func refreshContentView() {
+        guard let window else { return }
+        window.contentView = NSHostingView(rootView: SettingsView(updaterController: updaterController))
     }
 }
 

--- a/boringNotch/components/Tabs/TabButton.swift
+++ b/boringNotch/components/Tabs/TabButton.swift
@@ -15,11 +15,19 @@ struct TabButton: View {
     
     var body: some View {
         Button(action: onClick) {
-            Image(systemName: icon)
-                .padding(.horizontal, 15)
-                .contentShape(Capsule())
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 12, weight: .semibold))
+                Text(label)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 26)
+            .contentShape(Capsule())
         }
         .buttonStyle(PlainButtonStyle())
+        .help(label)
     }
 }
 

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -5,6 +5,7 @@
 //  Created by Hugo Persson on 2024-08-25.
 //
 
+import Defaults
 import SwiftUI
 
 struct TabModel: Identifiable {
@@ -14,39 +15,72 @@ struct TabModel: Identifiable {
     let view: NotchViews
 }
 
-let tabs = [
-    TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
-]
-
 struct TabSelectionView: View {
+    @Default(.boringShelf) private var boringShelf
+    @Default(.aiChatEnabled) private var aiChatEnabled
+
     @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @StateObject private var shelfState = ShelfStateViewModel.shared
     @Namespace var animation
+
+    private var visibleTabs: [TabModel] {
+        var items: [TabModel] = [
+            TabModel(label: "Home", icon: "house.fill", view: .home)
+        ]
+
+        if boringShelf && (!shelfState.isEmpty || coordinator.alwaysShowTabs) {
+            items.append(TabModel(label: "Shelf", icon: "tray.fill", view: .shelf))
+        }
+        if aiChatEnabled {
+            items.append(TabModel(label: "AI", icon: "sparkles", view: .assistant))
+        }
+
+        return items
+    }
+
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(tabs) { tab in
-                    TabButton(label: tab.label, icon: tab.icon, selected: coordinator.currentView == tab.view) {
-                        withAnimation(.smooth) {
-                            coordinator.currentView = tab.view
-                        }
+            ForEach(visibleTabs) { tab in
+                TabButton(label: tab.label, icon: tab.icon, selected: coordinator.currentView == tab.view) {
+                    withAnimation(.smooth) {
+                        coordinator.currentView = tab.view
                     }
-                    .frame(height: 26)
-                    .foregroundStyle(tab.view == coordinator.currentView ? .white : .gray)
-                    .background {
-                        if tab.view == coordinator.currentView {
-                            Capsule()
-                                .fill(coordinator.currentView == tab.view ? Color(nsColor: .secondarySystemFill) : Color.clear)
-                                .matchedGeometryEffect(id: "capsule", in: animation)
-                        } else {
-                            Capsule()
-                                .fill(coordinator.currentView == tab.view ? Color(nsColor: .secondarySystemFill) : Color.clear)
-                                .matchedGeometryEffect(id: "capsule", in: animation)
-                                .hidden()
-                        }
+                }
+                .frame(height: 26)
+                .foregroundStyle(tab.view == coordinator.currentView ? .white : .gray)
+                .background {
+                    if tab.view == coordinator.currentView {
+                        Capsule()
+                            .fill(coordinator.currentView == tab.view ? Color(nsColor: .secondarySystemFill) : Color.clear)
+                            .matchedGeometryEffect(id: "capsule", in: animation)
+                    } else {
+                        Capsule()
+                            .fill(coordinator.currentView == tab.view ? Color(nsColor: .secondarySystemFill) : Color.clear)
+                            .matchedGeometryEffect(id: "capsule", in: animation)
+                            .hidden()
                     }
+                }
             }
         }
+        .padding(3)
+        .background(Color.white.opacity(0.06))
         .clipShape(Capsule())
+        .onAppear(perform: normalizeSelection)
+        .onChange(of: aiChatEnabled) { _, _ in
+            normalizeSelection()
+        }
+        .onChange(of: boringShelf) { _, _ in
+            normalizeSelection()
+        }
+        .onChange(of: shelfState.isEmpty) { _, _ in
+            normalizeSelection()
+        }
+    }
+
+    private func normalizeSelection() {
+        if !visibleTabs.contains(where: { $0.view == coordinator.currentView }) {
+            coordinator.currentView = .home
+        }
     }
 }
 

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -18,9 +18,12 @@ public enum NotchState {
     case open
 }
 
-public enum NotchViews {
+public enum NotchViews: Equatable {
     case home
     case shelf
+    case assistant
+    case weather
+    case pomodoro
 }
 
 enum DownloadIndicatorStyle: String, Defaults.Serializable {

--- a/boringNotch/managers/AIWeatherManagers.swift
+++ b/boringNotch/managers/AIWeatherManagers.swift
@@ -1,0 +1,3851 @@
+//
+//  AIWeatherManagers.swift
+//  boringNotch
+//
+//  Created by Codex on 2026-06-06.
+//
+
+import AppKit
+import Combine
+import CoreLocation
+import Defaults
+import Foundation
+
+struct AIChatMessage: Identifiable, Equatable, Codable {
+    enum Role: String, Codable {
+        case user
+        case assistant
+    }
+
+    let id: UUID
+    let role: Role
+    let content: String
+    let createdAt: Date
+
+    init(id: UUID = UUID(), role: Role, content: String, createdAt: Date = Date()) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.createdAt = createdAt
+    }
+}
+
+struct AgentChatConversation: Identifiable, Equatable, Codable {
+    let id: UUID
+    var title: String
+    var createdAt: Date
+    var updatedAt: Date
+    var messages: [AIChatMessage]
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        messages: [AIChatMessage] = []
+    ) {
+        self.id = id
+        self.title = title
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.messages = messages
+    }
+}
+
+struct AgentKnowledgeDocument: Identifiable, Equatable, Codable {
+    let id: UUID
+    var title: String
+    var sourcePath: String
+    var summary: String
+    var content: String
+    var keywords: [String]
+    var byteCount: Int
+    var createdAt: Date
+    var updatedAt: Date
+}
+
+struct AgentKnowledgeSearchHit: Identifiable, Equatable {
+    let id: UUID
+    let document: AgentKnowledgeDocument
+    let score: Double
+    let reason: String
+}
+
+struct AgentPluginDescriptor: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let typeTags: [String]
+    let summary: String
+    let toolNames: [String]
+    let permission: String
+    let riskLevel: String
+    let discoveryKeywords: [String]
+    let manifestPreview: String
+
+    var category: String {
+        typeTags.joined(separator: "/")
+    }
+}
+
+struct AgentSkillDescriptor: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let summary: String
+    let category: String
+    let source: String
+    let requiredTools: [String]
+    let riskLevel: String
+    let triggerKeywords: [String]
+    let workflowSteps: [String]
+    let frontMatterPreview: String
+
+    init(
+        id: String,
+        name: String,
+        summary: String,
+        category: String = "桌面",
+        source: String = "built-in",
+        requiredTools: [String],
+        riskLevel: String,
+        triggerKeywords: [String],
+        workflowSteps: [String],
+        frontMatterPreview: String
+    ) {
+        self.id = id
+        self.name = name
+        self.summary = summary
+        self.category = category
+        self.source = source
+        self.requiredTools = requiredTools
+        self.riskLevel = riskLevel
+        self.triggerKeywords = triggerKeywords
+        self.workflowSteps = workflowSteps
+        self.frontMatterPreview = frontMatterPreview
+    }
+}
+
+struct AgentPluginMatch: Identifiable, Equatable {
+    let id: String
+    let pluginName: String
+    let score: Double
+    let reason: String
+    let selected: Bool
+}
+
+struct AgentTaskUnderstanding: Equatable {
+    let taskType: String
+    let complexity: String
+    let riskLevel: String
+    let needsTools: Bool
+    let needsMemory: Bool
+    let requiresClarification: Bool
+    let summary: String
+    let signals: [String]
+
+    var contextText: String {
+        """
+        task_type: \(taskType)
+        complexity: \(complexity)
+        risk_level: \(riskLevel)
+        needs_tools: \(needsTools ? "yes" : "no")
+        needs_memory: \(needsMemory ? "yes" : "no")
+        requires_clarification: \(requiresClarification ? "yes" : "no")
+        signals: \(signals.isEmpty ? "无" : signals.joined(separator: ", "))
+        summary: \(summary)
+        """
+    }
+}
+
+struct AgentReasoningProfile: Equatable {
+    let mode: String
+    let loop: String
+    let shouldPlan: Bool
+    let maxReviewRounds: Int
+    let stopCondition: String
+
+    var contextText: String {
+        """
+        mode: \(mode)
+        loop: \(loop)
+        should_plan: \(shouldPlan ? "yes" : "no")
+        max_review_rounds: \(maxReviewRounds)
+        stop_condition: \(stopCondition)
+        """
+    }
+}
+
+struct AgentPlanStep: Identifiable, Equatable {
+    let id = UUID()
+    let order: Int
+    let title: String
+    let detail: String
+    let status: String
+}
+
+struct AgentRecoveryStrategy: Identifiable, Equatable {
+    let id = UUID()
+    let trigger: String
+    let strategy: String
+    let fallback: String
+    let status: String
+}
+
+struct AgentWorkingMemory: Equatable {
+    let currentGoal: String
+    let taskProgress: String
+    let keyEntities: [String]
+    let pendingQuestions: [String]
+
+    var contextText: String {
+        """
+        current_goal: \(currentGoal)
+        task_progress: \(taskProgress)
+        key_entities: \(keyEntities.joined(separator: ", "))
+        pending_questions: \(pendingQuestions.isEmpty ? "无" : pendingQuestions.joined(separator: "；"))
+        """
+    }
+}
+
+struct AgentMemoryRecord: Identifiable, Codable, Equatable {
+    enum Kind: String, Codable {
+        case fact
+        case episodic
+        case procedural
+
+        var displayName: String {
+            switch self {
+            case .fact:
+                return "事实记忆"
+            case .episodic:
+                return "情景记忆"
+            case .procedural:
+                return "程序记忆"
+            }
+        }
+    }
+
+    let id: UUID
+    var kind: Kind
+    var content: String
+    var keywords: [String]
+    var createdAt: Date
+    var updatedAt: Date
+    var source: String
+    var importance: Double
+    var confidence: Double
+    var accessCount: Int
+    var lastAccessedAt: Date?
+    var retrievalScore: Double?
+    var retrievalReason: String?
+
+    init(
+        id: UUID = UUID(),
+        kind: Kind,
+        content: String,
+        keywords: [String],
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        source: String,
+        importance: Double = 0.55,
+        confidence: Double = 0.82,
+        accessCount: Int = 0,
+        lastAccessedAt: Date? = nil,
+        retrievalScore: Double? = nil,
+        retrievalReason: String? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.content = content
+        self.keywords = keywords
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.source = source
+        self.importance = importance
+        self.confidence = confidence
+        self.accessCount = accessCount
+        self.lastAccessedAt = lastAccessedAt
+        self.retrievalScore = retrievalScore
+        self.retrievalReason = retrievalReason
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case kind
+        case content
+        case keywords
+        case createdAt
+        case updatedAt
+        case source
+        case importance
+        case confidence
+        case accessCount
+        case lastAccessedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        kind = try container.decodeIfPresent(Kind.self, forKey: .kind) ?? .fact
+        content = try container.decode(String.self, forKey: .content)
+        keywords = try container.decodeIfPresent([String].self, forKey: .keywords) ?? []
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+        updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? createdAt
+        source = try container.decodeIfPresent(String.self, forKey: .source) ?? "legacy"
+        importance = try container.decodeIfPresent(Double.self, forKey: .importance) ?? 0.55
+        confidence = try container.decodeIfPresent(Double.self, forKey: .confidence) ?? 0.82
+        accessCount = try container.decodeIfPresent(Int.self, forKey: .accessCount) ?? 0
+        lastAccessedAt = try container.decodeIfPresent(Date.self, forKey: .lastAccessedAt)
+        retrievalScore = nil
+        retrievalReason = nil
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(content, forKey: .content)
+        try container.encode(keywords, forKey: .keywords)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encode(source, forKey: .source)
+        try container.encode(importance, forKey: .importance)
+        try container.encode(confidence, forKey: .confidence)
+        try container.encode(accessCount, forKey: .accessCount)
+        try container.encodeIfPresent(lastAccessedAt, forKey: .lastAccessedAt)
+    }
+}
+
+struct AgentTraceStep: Identifiable, Equatable {
+    let id = UUID()
+    let title: String
+    let detail: String
+    let status: String
+}
+
+struct AgentRunTrace: Identifiable, Equatable {
+    let id = UUID()
+    var routeKind: String
+    var routeName: String
+    var routeConfidence: Double
+    var taskUnderstanding: AgentTaskUnderstanding
+    var reasoningProfile: AgentReasoningProfile
+    var discoveredPlugins: [AgentPluginMatch]
+    var selectedPlugins: [AgentPluginDescriptor]
+    var selectedSkills: [AgentSkillDescriptor]
+    var planSteps: [AgentPlanStep]
+    var workingMemory: AgentWorkingMemory?
+    var retrievedMemories: [AgentMemoryRecord]
+    var storedMemory: AgentMemoryRecord?
+    var recoveryStrategies: [AgentRecoveryStrategy]
+    var steps: [AgentTraceStep]
+    var safetyNotes: [String]
+    var status: String
+    var requiresConfirmation: Bool
+
+    var selectedToolNames: [String] {
+        selectedPlugins.flatMap(\.toolNames)
+    }
+}
+
+private struct AgentPreparedRun {
+    var trace: AgentRunTrace
+    let systemContext: String
+    let calendarContext: String?
+    let route: AgentRoute
+}
+
+private struct AgentRoute {
+    enum Kind: String {
+        case generalChat = "general_chat"
+        case schedulePlanning = "schedule_planning"
+        case calendarWrite = "calendar_write"
+        case weatherDecision = "weather_decision"
+        case focusCoaching = "focus_coaching"
+        case assignmentPlanning = "assignment_planning"
+        case agentArchitecture = "agent_architecture"
+        case fileProcessing = "file_processing"
+        case researchPlanning = "research_planning"
+    }
+
+    let kind: Kind
+    let confidence: Double
+}
+
+@MainActor
+private final class AgentMemoryStore {
+    static let shared = AgentMemoryStore()
+
+    private(set) var records: [AgentMemoryRecord] = []
+    private let fileURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    private let semanticKeywords = [
+        "日历", "日程", "会议", "空闲", "天气", "户外", "跑步", "学习", "复习", "作业", "大作业",
+        "评分", "提交", "番茄钟", "专注", "偏好", "习惯", "周末", "晚上", "早上", "local", "论文",
+        "记忆", "长期记忆", "工作记忆", "短期记忆", "智能体", "插件", "技能", "架构", "文件",
+        "calendar", "schedule", "weather", "assignment", "homework", "study", "focus", "pomodoro",
+        "preference", "habit", "deadline", "paper", "memory", "agent", "plugin", "skill", "file"
+    ]
+
+    private init() {
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+
+        let baseDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? temporaryDirectory
+        let directory = baseDirectory
+            .appendingPathComponent("BoringNotchAgent", isDirectory: true)
+        fileURL = directory.appendingPathComponent("memories.json")
+
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        migrateLegacyMemoryIfNeeded(from: baseDirectory)
+        load()
+    }
+
+    var recentRecords: [AgentMemoryRecord] {
+        Array(records.sorted { $0.updatedAt > $1.updatedAt }.prefix(20))
+    }
+
+    var storageURL: URL {
+        fileURL
+    }
+
+    private func migrateLegacyMemoryIfNeeded(from baseDirectory: URL) {
+        let legacyDirectoryName = "Nook" + "XAgent"
+        let legacyURL = baseDirectory
+            .appendingPathComponent(legacyDirectoryName, isDirectory: true)
+            .appendingPathComponent("memories.json")
+        let previousDirectoryName = "Notch" + "MindAgent"
+        let previousURL = baseDirectory
+            .appendingPathComponent(previousDirectoryName, isDirectory: true)
+            .appendingPathComponent("memories.json")
+
+        let fileManager = FileManager.default
+        guard !fileManager.fileExists(atPath: fileURL.path) else {
+            return
+        }
+
+        if fileManager.fileExists(atPath: previousURL.path) {
+            try? fileManager.copyItem(at: previousURL, to: fileURL)
+        } else if fileManager.fileExists(atPath: legacyURL.path) {
+            try? fileManager.copyItem(at: legacyURL, to: fileURL)
+        }
+    }
+
+    func retrieve(prompt: String, route: AgentRoute, limit: Int = 5) -> [AgentMemoryRecord] {
+        let queryKeywords = keywords(for: prompt + " " + route.kind.rawValue)
+        guard !records.isEmpty, !queryKeywords.isEmpty else { return [] }
+
+        let now = Date()
+        let matches = records
+            .enumerated()
+            .map { index, record -> (index: Int, score: Double, reason: String) in
+                let recordKeywords = Set(record.keywords)
+                let matchedKeywords = Array(queryKeywords.intersection(recordKeywords)).sorted()
+                let overlap = matchedKeywords.count
+                let semanticScore = Double(overlap) / Double(max(queryKeywords.count, 1))
+                let contentScore = queryKeywords.reduce(0.0) { partial, keyword in
+                    record.content.lowercased().contains(keyword.lowercased()) ? partial + 0.05 : partial
+                }
+                let ageDays = max(0, now.timeIntervalSince(record.updatedAt) / 86_400)
+                let recencyScore = max(0, 0.18 - min(ageDays, 30) * 0.006)
+                let typeBoost = record.kind == .fact ? 0.08 : 0.03
+                let importanceBoost = min(record.importance, 1.0) * 0.07
+                let confidenceBoost = min(record.confidence, 1.0) * 0.04
+                let score = semanticScore
+                    + min(contentScore, 0.2)
+                    + recencyScore
+                    + typeBoost
+                    + importanceBoost
+                    + confidenceBoost
+                let reason = retrievalReason(
+                    matchedKeywords: matchedKeywords,
+                    contentScore: contentScore,
+                    recencyScore: recencyScore,
+                    kind: record.kind
+                )
+                return (index, score, reason)
+            }
+            .filter { $0.score > 0.08 }
+            .sorted { $0.score > $1.score }
+            .prefix(limit)
+
+        guard !matches.isEmpty else { return [] }
+
+        for match in matches {
+            records[match.index].accessCount += 1
+            records[match.index].lastAccessedAt = now
+        }
+        save()
+
+        return matches.map { match in
+            var record = records[match.index]
+            record.retrievalScore = match.score
+            record.retrievalReason = match.reason
+            return record
+        }
+    }
+
+    func storeIfUseful(prompt: String, route: AgentRoute) -> AgentMemoryRecord? {
+        guard shouldPersist(prompt) else { return nil }
+
+        let content = normalizedMemoryContent(from: prompt)
+        return store(content: content, routeKind: route.kind.rawValue, source: "explicit-user-message")
+    }
+
+    func storeManual(_ content: String) -> AgentMemoryRecord? {
+        store(content: content, routeKind: "manual_memory", source: "slash-remember")
+    }
+
+    func forget(matching query: String) -> Int {
+        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedQuery.isEmpty else {
+            let count = records.count
+            clear()
+            return count
+        }
+
+        let queryKeywords = keywords(for: normalizedQuery)
+        let beforeCount = records.count
+        records.removeAll { record in
+            record.content.localizedCaseInsensitiveContains(normalizedQuery)
+                || Set(record.keywords).intersection(queryKeywords).count >= 2
+        }
+        let removedCount = beforeCount - records.count
+        if removedCount > 0 {
+            save()
+        }
+        return removedCount
+    }
+
+    private func store(content rawContent: String, routeKind: String, source: String) -> AgentMemoryRecord? {
+        let content = rawContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        let record = AgentMemoryRecord(
+            id: UUID(),
+            kind: memoryKind(for: content, routeKind: routeKind),
+            content: String(content.prefix(320)),
+            keywords: Array(keywords(for: content + " " + routeKind)).sorted(),
+            createdAt: Date(),
+            updatedAt: Date(),
+            source: source,
+            importance: importance(for: content, source: source),
+            confidence: confidence(for: source)
+        )
+        guard !record.content.isEmpty else { return nil }
+
+        if let existingIndex = records.firstIndex(where: { existing in
+            Set(existing.keywords).intersection(record.keywords).count >= 2
+                && existing.content.localizedCaseInsensitiveContains(String(record.content.prefix(24)))
+        }) {
+            records[existingIndex].content = record.content
+            records[existingIndex].keywords = record.keywords
+            records[existingIndex].kind = record.kind
+            records[existingIndex].source = record.source
+            records[existingIndex].importance = max(records[existingIndex].importance, record.importance)
+            records[existingIndex].confidence = max(records[existingIndex].confidence, record.confidence)
+            records[existingIndex].updatedAt = Date()
+            save()
+            return records[existingIndex]
+        }
+
+        records.append(record)
+        records = Array(records.sorted { $0.updatedAt > $1.updatedAt }.prefix(100))
+        save()
+        return record
+    }
+
+    func clear() {
+        records.removeAll()
+        save()
+    }
+
+    func keywords(for text: String) -> Set<String> {
+        let lowered = text.lowercased()
+        var result = Set(
+            lowered
+                .split { !$0.isLetter && !$0.isNumber }
+                .map(String.init)
+                .filter { $0.count >= 2 && $0.count <= 28 }
+        )
+
+        for keyword in semanticKeywords where lowered.contains(keyword.lowercased()) {
+            result.insert(keyword.lowercased())
+        }
+
+        return result
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        records = (try? decoder.decode([AgentMemoryRecord].self, from: data)) ?? []
+    }
+
+    private func save() {
+        guard let data = try? encoder.encode(records) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    private func shouldPersist(_ prompt: String) -> Bool {
+        let lowered = prompt.lowercased()
+        let explicitSignals = [
+            "记住", "记一下", "请记", "以后", "我的偏好", "我的习惯", "我喜欢", "我不喜欢",
+            "默认", "remember", "my preference", "i prefer", "always", "never"
+        ]
+        return explicitSignals.contains(where: lowered.contains)
+    }
+
+    private func normalizedMemoryContent(from prompt: String) -> String {
+        let withoutFiles = prompt
+            .components(separatedBy: "本地文件上下文：")
+            .first ?? prompt
+        return withoutFiles
+            .replacingOccurrences(of: "请记住", with: "")
+            .replacingOccurrences(of: "记住", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func memoryKind(for content: String, routeKind: String) -> AgentMemoryRecord.Kind {
+        let lowered = content.lowercased()
+        if lowered.contains("流程") || lowered.contains("步骤") || lowered.contains("workflow") {
+            return .procedural
+        }
+        if routeKind == AgentRoute.Kind.assignmentPlanning.rawValue
+            || lowered.contains("上次")
+            || lowered.contains("过去")
+        {
+            return .episodic
+        }
+        return .fact
+    }
+
+    private func importance(for content: String, source: String) -> Double {
+        let lowered = content.lowercased()
+        var score = source == "slash-remember" ? 0.72 : 0.58
+        if ["默认", "偏好", "习惯", "喜欢", "不喜欢", "always", "never", "prefer"].contains(where: lowered.contains) {
+            score += 0.2
+        }
+        if ["流程", "步骤", "workflow", "以后"].contains(where: lowered.contains) {
+            score += 0.12
+        }
+        return min(score, 1.0)
+    }
+
+    private func confidence(for source: String) -> Double {
+        source == "slash-remember" ? 0.96 : 0.9
+    }
+
+    private func retrievalReason(
+        matchedKeywords: [String],
+        contentScore: Double,
+        recencyScore: Double,
+        kind: AgentMemoryRecord.Kind
+    ) -> String {
+        var reasons: [String] = []
+        if !matchedKeywords.isEmpty {
+            reasons.append("关键词 \(matchedKeywords.prefix(4).joined(separator: ", "))")
+        }
+        if contentScore > 0 {
+            reasons.append("内容命中")
+        }
+        if recencyScore > 0.12 {
+            reasons.append("近期更新")
+        }
+        if kind == .fact {
+            reasons.append("稳定事实")
+        }
+        return reasons.isEmpty ? "低权重相关" : reasons.joined(separator: " + ")
+    }
+}
+
+@MainActor
+private final class AgentKnowledgeStore {
+    static let shared = AgentKnowledgeStore()
+
+    private(set) var documents: [AgentKnowledgeDocument] = []
+    private let fileURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private let semanticKeywords = [
+        "知识库", "资料库", "local", "作业", "评分", "提交", "论文", "文献", "报告", "计划",
+        "插件", "技能", "智能体", "记忆", "天气", "日程", "番茄钟", "knowledge", "rag",
+        "assignment", "rubric", "paper", "research", "agent", "plugin", "skill", "memory"
+    ]
+
+    private init() {
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+
+        let directory = Self.storageDirectory()
+        fileURL = directory.appendingPathComponent("knowledge.json")
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        load()
+    }
+
+    var storageURL: URL {
+        fileURL
+    }
+
+    @discardableResult
+    func addDocument(
+        title rawTitle: String,
+        sourcePath: String,
+        content rawContent: String,
+        byteCount: Int
+    ) -> AgentKnowledgeDocument? {
+        let content = rawContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !content.isEmpty else { return nil }
+
+        let title = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "未命名资料"
+            : rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let now = Date()
+        let summary = summarize(content)
+        let keywords = Array(keywords(for: "\(title) \(summary) \(content.prefix(2400))")).sorted()
+
+        if let index = documents.firstIndex(where: { $0.sourcePath == sourcePath }) {
+            documents[index].title = title
+            documents[index].summary = summary
+            documents[index].content = String(content.prefix(32_000))
+            documents[index].keywords = keywords
+            documents[index].byteCount = byteCount
+            documents[index].updatedAt = now
+            save()
+            return documents[index]
+        }
+
+        let document = AgentKnowledgeDocument(
+            id: UUID(),
+            title: title,
+            sourcePath: sourcePath,
+            summary: summary,
+            content: String(content.prefix(32_000)),
+            keywords: keywords,
+            byteCount: byteCount,
+            createdAt: now,
+            updatedAt: now
+        )
+        documents.insert(document, at: 0)
+        documents = Array(documents.sorted { $0.updatedAt > $1.updatedAt }.prefix(80))
+        save()
+        return document
+    }
+
+    func retrieve(query: String, limit: Int = 3) -> [AgentKnowledgeSearchHit] {
+        let queryKeywords = keywords(for: query)
+        let lowered = query.lowercased()
+        guard !documents.isEmpty else { return [] }
+
+        return documents.compactMap { document in
+            let documentKeywords = Set(document.keywords)
+            let matched = documentKeywords.intersection(queryKeywords)
+            let titleHit = document.title.lowercased().contains(lowered) && lowered.count >= 2
+            let contentHit = document.content.lowercased().contains(lowered) && lowered.count >= 3
+            let age = max(0, Date().timeIntervalSince(document.updatedAt))
+            let recency = max(0.0, 0.12 - min(age / 604_800, 1.0) * 0.12)
+            let score = min(Double(matched.count) * 0.18 + (titleHit ? 0.24 : 0) + (contentHit ? 0.16 : 0) + recency, 1.0)
+            guard score >= 0.18 else { return nil }
+
+            let reason = matched.isEmpty
+                ? "标题/正文命中"
+                : "关键词 \(matched.prefix(5).joined(separator: ", "))"
+            return AgentKnowledgeSearchHit(
+                id: document.id,
+                document: document,
+                score: score,
+                reason: reason
+            )
+        }
+        .sorted { $0.score > $1.score }
+        .prefix(limit)
+        .map { $0 }
+    }
+
+    func hasRelevantContent(for query: String) -> Bool {
+        !retrieve(query: query, limit: 1).isEmpty
+    }
+
+    func removeDocument(id: UUID) {
+        documents.removeAll { $0.id == id }
+        save()
+    }
+
+    func clear() {
+        documents.removeAll()
+        save()
+    }
+
+    private static func storageDirectory() -> URL {
+        let baseDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? temporaryDirectory
+        return baseDirectory.appendingPathComponent("BoringNotchAgent", isDirectory: true)
+    }
+
+    private func summarize(_ content: String) -> String {
+        let cleanedLines = content
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let seed = cleanedLines.prefix(3).joined(separator: " ")
+        return String(seed.prefix(220))
+    }
+
+    private func keywords(for text: String) -> Set<String> {
+        let lowered = text.lowercased()
+        var result = Set(
+            lowered
+                .split { !$0.isLetter && !$0.isNumber }
+                .map(String.init)
+                .filter { $0.count >= 2 && $0.count <= 28 }
+        )
+
+        for keyword in semanticKeywords where lowered.contains(keyword.lowercased()) {
+            result.insert(keyword.lowercased())
+        }
+        return result
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        documents = (try? decoder.decode([AgentKnowledgeDocument].self, from: data)) ?? []
+    }
+
+    private func save() {
+        guard let data = try? encoder.encode(documents) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+}
+
+@MainActor
+private final class AgentOrchestrator {
+    static let shared = AgentOrchestrator()
+    private static let weatherCalendarKeywords = [
+        "schedule", "calendar", "available", "outdoor", "run",
+        "安排", "计划", "日程", "行程", "空闲", "会议", "户外", "跑步", "出门", "运动"
+    ]
+
+    let plugins: [AgentPluginDescriptor] = [
+        .init(
+            id: "calendar",
+            name: "日程管理",
+            typeTags: ["context", "action"],
+            summary: "读取近期日程，并在明确要求时创建日历计划。",
+            toolNames: ["calendar.read", "calendar.create_event"],
+            permission: "读取自动，写入受设置控制",
+            riskLevel: "中",
+            discoveryKeywords: ["calendar", "schedule", "agenda", "日程", "行程", "会议", "空闲", "写入日历"],
+            manifestPreview: """
+            {"id":"calendar","type":["context","action"],"tools":["calendar.read","calendar.create_event"],"permissions":{"read":"auto","write":"settings-gated"},"riskLevel":"medium"}
+            """
+        ),
+        .init(
+            id: "weather",
+            name: "天气查询",
+            typeTags: ["context"],
+            summary: "获取 Open-Meteo 当前天气，用于出行和户外决策。",
+            toolNames: ["weather.current", "weather.hourly"],
+            permission: "读取自动",
+            riskLevel: "低",
+            discoveryKeywords: ["weather", "rain", "temperature", "outdoor", "天气", "下雨", "气温", "户外", "跑步"],
+            manifestPreview: """
+            {"id":"weather","type":["context"],"tools":["weather.current","weather.hourly"],"permissions":{"read":"auto"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "focus",
+            name: "焦点计时",
+            typeTags: ["context", "action"],
+            summary: "读取番茄钟状态和专注时长偏好。",
+            toolNames: ["focus.status", "focus.start"],
+            permission: "读取自动，动作由用户触发",
+            riskLevel: "低",
+            discoveryKeywords: ["focus", "pomodoro", "study", "deep work", "专注", "番茄钟", "学习", "冲刺"],
+            manifestPreview: """
+            {"id":"focus","type":["context","action"],"tools":["focus.status","focus.start"],"permissions":{"read":"auto","action":"user-triggered"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "skills",
+            name: "技能手册",
+            typeTags: ["skill"],
+            summary: "注入类似 Codex/Claude Skills 的任务流程。",
+            toolNames: ["skill.study_plan", "skill.assignment_breakdown"],
+            permission: "读取自动",
+            riskLevel: "低",
+            discoveryKeywords: ["skill", "study plan", "assignment", "复习", "作业", "拆解", "规划"],
+            manifestPreview: """
+            {"id":"skills","type":["skill"],"tools":["skill.study_plan","skill.assignment_breakdown"],"permissions":{"read":"auto"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "assignment",
+            name: "作业资料",
+            typeTags: ["context", "skill"],
+            summary: "识别上传或本地文本中的作业要求，提取评分点和交付物。",
+            toolNames: ["assignment.extract_requirements", "assignment.rubric_map"],
+            permission: "读取用户显式提供的文件",
+            riskLevel: "低",
+            discoveryKeywords: ["assignment", "homework", "rubric", "作业", "大作业", "评分", "要求", "提交"],
+            manifestPreview: """
+            {"id":"assignment","type":["context","skill"],"tools":["assignment.extract_requirements","assignment.rubric_map"],"permissions":{"read":"provided-files-only"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "shelf",
+            name: "文件架",
+            typeTags: ["context"],
+            summary: "面向拖入 Notch 的文件做摘要、归类和待办提取。",
+            toolNames: ["shelf.summarize", "shelf.extract_todos"],
+            permission: "读取用户拖入或上传的文件",
+            riskLevel: "低",
+            discoveryKeywords: ["file", "shelf", "summary", "todo", "文件", "上传", "摘要", "待办"],
+            manifestPreview: """
+            {"id":"shelf","type":["context"],"tools":["shelf.summarize","shelf.extract_todos"],"permissions":{"read":"provided-files-only"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "memory",
+            name: "偏好记忆",
+            typeTags: ["context", "action"],
+            summary: "管理短期会话、工作记忆和本地长期记忆检索。",
+            toolNames: ["memory.short_term", "memory.working_state", "memory.retrieve", "memory.save_preference"],
+            permission: "读取自动，长期写入只在用户明确要求记住时发生",
+            riskLevel: "低",
+            discoveryKeywords: ["preference", "habit", "memory", "remember", "偏好", "习惯", "记住", "长期记忆", "工作记忆"],
+            manifestPreview: """
+            {"id":"memory","type":["context","action"],"tools":["memory.short_term","memory.working_state","memory.retrieve","memory.save_preference"],"permissions":{"read":"auto","write":"explicit-memory-request"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "knowledge",
+            name: "本地知识库",
+            typeTags: ["context"],
+            summary: "检索用户导入的local documents、作业要求、论文笔记和 Markdown 文档。",
+            toolNames: ["knowledge.add_document", "knowledge.retrieve"],
+            permission: "只读取用户显式导入的文件",
+            riskLevel: "低",
+            discoveryKeywords: ["knowledge", "rag", "notes", "document", "知识库", "资料库", "local documents", "笔记", "文档"],
+            manifestPreview: """
+            {"id":"knowledge","type":["context"],"tools":["knowledge.add_document","knowledge.retrieve"],"permissions":{"read":"user-imported-only","write":"explicit-import"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "planner",
+            name: "任务规划器",
+            typeTags: ["cognition"],
+            summary: "把复杂目标拆成有顺序、可检查的执行步骤。",
+            toolNames: ["planner.decompose", "planner.dependency_map"],
+            permission: "始终启用，只生成计划",
+            riskLevel: "低",
+            discoveryKeywords: ["plan", "planner", "decompose", "规划", "计划", "拆解", "步骤", "里程碑"],
+            manifestPreview: """
+            {"id":"planner","type":["cognition"],"tools":["planner.decompose","planner.dependency_map"],"permissions":{"read":"always-on","write":"never"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "reasoner",
+            name: "推理模式选择",
+            typeTags: ["cognition"],
+            summary: "根据任务复杂度选择直接回答、工作流、ReAct 或自我修正模式。",
+            toolNames: ["reasoner.mode_select", "reasoner.react_loop", "reasoner.self_correction"],
+            permission: "始终启用，只控制思考流程",
+            riskLevel: "低",
+            discoveryKeywords: ["reason", "react", "cot", "推理", "思考", "自我修正", "复杂任务"],
+            manifestPreview: """
+            {"id":"reasoner","type":["cognition"],"tools":["reasoner.mode_select","reasoner.react_loop","reasoner.self_correction"],"permissions":{"read":"always-on","write":"never"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "reviewer",
+            name: "反思评审器",
+            typeTags: ["guard", "cognition"],
+            summary: "从输出、过程和策略三个层面检查回答质量。",
+            toolNames: ["review.output_check", "review.process_check", "review.strategy_check"],
+            permission: "始终启用，只做质量检查",
+            riskLevel: "低",
+            discoveryKeywords: ["review", "reflect", "quality", "反思", "检查", "评审", "质量"],
+            manifestPreview: """
+            {"id":"reviewer","type":["guard","cognition"],"tools":["review.output_check","review.process_check","review.strategy_check"],"permissions":{"read":"always-on","write":"never"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "recovery",
+            name: "异常恢复器",
+            typeTags: ["guard"],
+            summary: "为工具失败、缺失信息、格式错误和权限不足提供降级策略。",
+            toolNames: ["recovery.retry", "recovery.degrade", "recovery.ask_user"],
+            permission: "始终启用，不自动执行危险动作",
+            riskLevel: "低",
+            discoveryKeywords: ["recovery", "fallback", "error", "失败", "异常", "降级", "恢复", "重试"],
+            manifestPreview: """
+            {"id":"recovery","type":["guard"],"tools":["recovery.retry","recovery.degrade","recovery.ask_user"],"permissions":{"read":"always-on","write":"never"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "safety",
+            name: "安全护栏",
+            typeTags: ["guard"],
+            summary: "检查风险动作、缺失信息和工具失败。",
+            toolNames: ["guard.risk_check", "guard.reflection"],
+            permission: "始终启用",
+            riskLevel: "低",
+            discoveryKeywords: ["risk", "confirm", "safe", "权限", "确认", "安全", "护栏"],
+            manifestPreview: """
+            {"id":"safety","type":["guard"],"tools":["guard.risk_check","guard.reflection"],"permissions":{"read":"always-on","write":"never"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "trace",
+            name: "执行轨迹",
+            typeTags: ["guard", "context"],
+            summary: "记录路由、插件发现、工具上下文、安全检查和执行结果。",
+            toolNames: ["trace.log", "trace.explain"],
+            permission: "始终启用",
+            riskLevel: "低",
+            discoveryKeywords: ["trace", "explain", "debug", "轨迹", "解释", "调试"],
+            manifestPreview: """
+            {"id":"trace","type":["guard","context"],"tools":["trace.log","trace.explain"],"permissions":{"read":"always-on"},"riskLevel":"low"}
+            """
+        ),
+    ]
+
+    let skills: [AgentSkillDescriptor] = [
+        .init(
+            id: "study_plan",
+            name: "学习计划",
+            summary: "把复习、阅读、作业拆成可执行的专注块。",
+            category: "学习",
+            requiredTools: ["calendar.read", "focus.status", "memory.preferences"],
+            riskLevel: "低",
+            triggerKeywords: ["study", "review", "exam", "学习", "复习", "考试"],
+            workflowSteps: ["读取日程空档", "拆分知识点和任务块", "映射番茄钟节奏", "输出当天/本周计划"],
+            frontMatterPreview: """
+            ---
+            name: study-plan
+            required_tools: calendar.read, focus.status, memory.preferences
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "assignment_breakdown",
+            name: "作业拆解",
+            summary: "按评分标准拆交付物、里程碑和当天任务。",
+            category: "学习",
+            requiredTools: ["calendar.read", "focus.status", "skill.assignment_breakdown"],
+            riskLevel: "低",
+            triggerKeywords: ["assignment", "homework", "rubric", "作业", "大作业", "评分"],
+            workflowSteps: ["提取作业要求", "列出评分点", "拆成里程碑", "安排可执行任务", "标出缺失信息"],
+            frontMatterPreview: """
+            ---
+            name: assignment-breakdown
+            required_tools: assignment.extract_requirements, calendar.read, focus.status
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "calendar_aware_planning",
+            name: "日程感知规划",
+            summary: "读取空闲时间，避免冲突，输出绝对时间安排。",
+            category: "桌面",
+            requiredTools: ["calendar.read", "calendar.create_event"],
+            riskLevel: "中",
+            triggerKeywords: ["calendar", "schedule", "meeting", "日历", "日程", "会议", "空闲", "行程"],
+            workflowSteps: ["读取近期日程", "找空闲窗口", "规避冲突", "给出绝对时间", "写入前确认边界"],
+            frontMatterPreview: """
+            ---
+            name: calendar-aware-planning
+            required_tools: calendar.read, calendar.create_event
+            risk: requires-confirmation
+            ---
+            """
+        ),
+        .init(
+            id: "weather_decision",
+            name: "天气决策",
+            summary: "结合天气、时间和日程给出出行/运动建议。",
+            category: "桌面",
+            requiredTools: ["weather.current"],
+            riskLevel: "低",
+            triggerKeywords: ["weather", "outdoor", "run", "天气", "户外", "跑步", "出门"],
+            workflowSteps: ["读取当前天气", "判断天气风险", "给出穿衣/出行建议", "必要时提示缺失信息"],
+            frontMatterPreview: """
+            ---
+            name: weather-decision
+            required_tools: weather.current
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "agent_memory_design",
+            name: "智能体记忆设计",
+            summary: "把短期记忆、工作记忆、长期记忆和 Token 管理组织成可解释架构。",
+            category: "智能体",
+            requiredTools: ["memory.short_term", "memory.working_state", "memory.retrieve", "planner.decompose"],
+            riskLevel: "低",
+            triggerKeywords: ["memory", "agent", "plugin", "skill", "记忆", "智能体", "插件", "架构"],
+            workflowSteps: ["区分三层记忆", "定义写入策略", "设计混合检索", "控制上下文注入", "暴露 trace 解释"],
+            frontMatterPreview: """
+            ---
+            name: agent-memory-design
+            required_tools: memory.short_term, memory.working_state, memory.retrieve
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "file_context_analysis",
+            name: "文件上下文分析",
+            summary: "读取用户显式上传文本，提取摘要、任务、风险和下一步。",
+            category: "文件",
+            requiredTools: ["shelf.summarize", "shelf.extract_todos"],
+            riskLevel: "低",
+            triggerKeywords: ["file", "upload", "文件", "上传", "摘要", "读取"],
+            workflowSteps: ["确认文件来源", "摘要核心内容", "提取待办和实体", "标出缺失信息", "只引用已提供上下文"],
+            frontMatterPreview: """
+            ---
+            name: file-context-analysis
+            required_tools: shelf.summarize, shelf.extract_todos
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "research_planning",
+            name: "研究规划",
+            summary: "把论文、调研或报告主题拆成检索问题、证据表和产出计划。",
+            category: "学术",
+            requiredTools: ["planner.decompose", "memory.retrieve"],
+            riskLevel: "低",
+            triggerKeywords: ["research", "paper", "literature", "论文", "文献", "调研", "研究"],
+            workflowSteps: ["界定研究问题", "拆分检索方向", "规划证据表", "安排写作里程碑", "说明需要外部资料"],
+            frontMatterPreview: """
+            ---
+            name: research-planning
+            required_tools: planner.decompose, memory.retrieve
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "nature_academic_search",
+            name: "Nature 文献检索",
+            summary: "参考本地 nature-academic-search，把多源文献检索、候选筛选和引用导出拆成流程。",
+            category: "学术",
+            source: "local-codex-nature",
+            requiredTools: ["planner.decompose", "memory.retrieve", "external.literature_search"],
+            riskLevel: "低",
+            triggerKeywords: ["literature", "search", "pubmed", "crossref", "arxiv", "文献", "检索", "调研", "综述"],
+            workflowSteps: ["定义检索问题", "拆英文关键词和同义词", "区分 PubMed/CrossRef/arXiv 场景", "建立候选证据表", "标注可信度和缺口"],
+            frontMatterPreview: """
+            ---
+            name: nature-academic-search
+            required_tools: planner.decompose, external.literature_search
+            source: local-codex-skill-summary
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "nature_reader",
+            name: "Nature 论文精读",
+            summary: "参考本地 nature-reader，把论文转成中英对照、图表贴近原文、可追溯的阅读稿。",
+            category: "学术",
+            source: "local-codex-nature",
+            requiredTools: ["shelf.summarize", "memory.retrieve"],
+            riskLevel: "低",
+            triggerKeywords: ["reader", "pdf", "translate paper", "全文翻译", "中英文", "原文对照", "精读", "读论文", "解读论文"],
+            workflowSteps: ["确认论文来源", "保留章节结构", "中英段落对照", "图表靠近首次解释处", "输出 source anchors 和阅读备注"],
+            frontMatterPreview: """
+            ---
+            name: nature-reader
+            required_tools: shelf.summarize, memory.retrieve
+            source: local-codex-skill-summary
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "nature_writing",
+            name: "Nature 科学写作",
+            summary: "参考本地 nature-writing，从证据、贡献和论证顺序重建摘要、引言、结果或讨论。",
+            category: "学术",
+            source: "local-codex-nature",
+            requiredTools: ["planner.decompose", "memory.retrieve"],
+            riskLevel: "低",
+            triggerKeywords: ["manuscript", "abstract", "introduction", "discussion", "写作", "论文摘要", "写摘要", "摘要写作", "引言", "结果", "讨论", "改写论文"],
+            workflowSteps: ["先列作者证据", "搭建论证骨架", "控制创新性和边界", "按章节写作", "标出缺失证据和占位"],
+            frontMatterPreview: """
+            ---
+            name: nature-writing
+            required_tools: planner.decompose, memory.retrieve
+            source: local-codex-skill-summary
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "nature_citation",
+            name: "Nature 严格引用",
+            summary: "参考本地 nature-citation，把文本切分成可引用片段，并保守匹配 Nature/CNS/Cell 等支撑文献。",
+            category: "学术",
+            source: "local-codex-nature",
+            requiredTools: ["planner.decompose", "external.literature_search"],
+            riskLevel: "低",
+            triggerKeywords: ["citation", "reference", "cns", "nature", "cell", "引用", "参考文献", "支撑文献", "补引用", "分段引用"],
+            workflowSteps: ["切分待支撑句子", "翻译成英文检索 claim", "查找候选文献", "判断强/部分/背景支撑", "输出引用建议和风险"],
+            frontMatterPreview: """
+            ---
+            name: nature-citation
+            required_tools: external.literature_search
+            source: local-codex-skill-summary
+            risk: low
+            ---
+            """
+        ),
+    ]
+
+    private init() {}
+
+    func prepare(prompt: String, recentMessages: [AIChatMessage] = []) async -> AgentPreparedRun {
+        let route = routePrompt(prompt)
+        let discoveredPlugins = discoverPlugins(for: route, prompt: prompt)
+        let selectedPlugins = discoveredPlugins
+            .filter(\.selected)
+            .compactMap { match in plugins.first(where: { $0.id == match.id }) }
+        let selectedSkills = skillsForRoute(route, prompt: prompt)
+        let taskUnderstanding = buildTaskUnderstanding(
+            prompt: prompt,
+            route: route,
+            selectedPlugins: selectedPlugins,
+            selectedSkills: selectedSkills
+        )
+        let reasoningProfile = buildReasoningProfile(for: taskUnderstanding, route: route)
+        let planSteps = buildPlanSteps(
+            route: route,
+            selectedPlugins: selectedPlugins,
+            selectedSkills: selectedSkills
+        )
+        var workingMemory: AgentWorkingMemory?
+        var retrievedMemories: [AgentMemoryRecord] = []
+        var storedMemory: AgentMemoryRecord?
+
+        var steps: [AgentTraceStep] = [
+            .init(
+                title: "路由",
+                detail: "\(route.kind.displayName)，置信度 \(String(format: "%.2f", route.confidence))",
+                status: "done"
+            ),
+            .init(
+                title: "渐进式插件发现",
+                detail: discoveredPlugins.prefix(5).map {
+                    "\($0.pluginName) \(Int(($0.score * 100).rounded()))%：\($0.reason)"
+                }.joined(separator: "；"),
+                status: "done"
+            ),
+            .init(
+                title: "装载插件",
+                detail: selectedPlugins.map { "\($0.name)[\($0.category)]" }.joined(separator: "、"),
+                status: "done"
+            ),
+        ]
+
+        var contextBlocks: [String] = []
+        var calendarContext: String?
+        let selectedIDs = Set(selectedPlugins.map(\.id))
+
+        if selectedIDs.contains("memory") {
+            let memoryStore = AgentMemoryStore.shared
+            let shortTermContext = shortTermSummary(from: recentMessages)
+            workingMemory = buildWorkingMemory(
+                prompt: prompt,
+                route: route,
+                selectedPlugins: selectedPlugins,
+                selectedSkills: selectedSkills
+            )
+            storedMemory = memoryStore.storeIfUseful(prompt: prompt, route: route)
+            retrievedMemories = memoryStore.retrieve(prompt: prompt, route: route)
+
+            contextBlocks.append("[memory.short_term]\n\(shortTermContext)")
+            if let workingMemory {
+                contextBlocks.append("[memory.working_state]\n\(workingMemory.contextText)")
+            }
+            contextBlocks.append("[memory.preferences]\n\(preferenceSummary())")
+            contextBlocks.append("[memory.long_term]\n\(longTermMemorySummary(retrievedMemories))")
+
+            steps.append(.init(title: "短期记忆", detail: "保留最近 \(min(recentMessages.count, 6)) 条会话摘要。", status: "done"))
+            if let workingMemory {
+                steps.append(.init(title: "工作记忆", detail: workingMemory.currentGoal, status: "done"))
+            }
+            steps.append(
+                .init(
+                    title: "长期记忆检索",
+                    detail: retrievedMemories.isEmpty ? "无相关长期记忆" : "命中 \(retrievedMemories.count) 条：\(retrievedMemories.prefix(3).map(\.content).joined(separator: "；"))",
+                    status: retrievedMemories.isEmpty ? "skipped" : "done"
+                )
+            )
+            if let storedMemory {
+                steps.append(.init(title: "长期记忆写入", detail: storedMemory.content, status: "done"))
+            }
+        }
+
+        if selectedIDs.contains("knowledge") {
+            let hits = AgentKnowledgeStore.shared.retrieve(query: prompt, limit: 3)
+            let knowledgeContext: String
+            if hits.isEmpty {
+                knowledgeContext = "知识库没有命中相关资料。"
+            } else {
+                knowledgeContext = hits.enumerated().map { index, hit in
+                    """
+                    \(index + 1). \(hit.document.title) score=\(String(format: "%.2f", hit.score)) reason=\(hit.reason)
+                    source: \(hit.document.sourcePath)
+                    summary: \(hit.document.summary)
+                    excerpt: \(String(hit.document.content.prefix(900)))
+                    """
+                }.joined(separator: "\n\n")
+            }
+            contextBlocks.append("[knowledge.retrieve]\n\(knowledgeContext)")
+            steps.append(
+                .init(
+                    title: "工具 knowledge.retrieve",
+                    detail: hits.isEmpty ? "本地知识库无相关命中" : "命中 \(hits.count) 份资料：\(hits.map { $0.document.title }.joined(separator: "、"))",
+                    status: hits.isEmpty ? "skipped" : "done"
+                )
+            )
+        }
+
+        if selectedIDs.contains("calendar") {
+            if Defaults[.aiCalendarContextEnabled] {
+                calendarContext = await CalendarManager.shared.aiScheduleContext()
+                contextBlocks.append(
+                    """
+                    [calendar.read]
+                    \(calendarContext ?? "日历上下文不可用。如果任务依赖日程，请提示用户开启日历权限。")
+                    """
+                )
+                steps.append(
+                    .init(
+                        title: "工具 calendar.read",
+                        detail: calendarContext == nil ? "不可用或权限不足" : "已读取近期日程",
+                        status: calendarContext == nil ? "fallback" : "done"
+                    )
+                )
+            } else {
+                contextBlocks.append("[calendar.read]\nDisabled in Settings > AI.")
+                steps.append(.init(title: "工具 calendar.read", detail: "用户设置已关闭", status: "skipped"))
+            }
+        }
+
+        if selectedIDs.contains("assignment") {
+            let hasProvidedFile = prompt.contains("[file:") || prompt.contains("本地文件上下文")
+            let assignmentContext = hasProvidedFile
+                ? "已检测到用户上传的作业/文本上下文；后续回复需要提取交付物、评分点和缺失信息。"
+                : "未检测到上传的作业要求文件；如任务依赖评分标准，需要请用户上传或粘贴要求。"
+            contextBlocks.append("[assignment.extract_requirements]\n\(assignmentContext)")
+            steps.append(
+                .init(
+                    title: "工具 assignment.extract_requirements",
+                    detail: assignmentContext,
+                    status: hasProvidedFile ? "done" : "fallback"
+                )
+            )
+        }
+
+        if selectedIDs.contains("shelf") {
+            let hasProvidedFile = prompt.contains("[file:") || prompt.contains("本地文件上下文")
+            let shelfContext = hasProvidedFile
+                ? "已读取本轮显式上传文件，可用于摘要、归类和待办提取。"
+                : "文件架上下文仅在用户上传或拖入文件时启用。"
+            contextBlocks.append("[shelf.summarize]\n\(shelfContext)")
+            steps.append(
+                .init(
+                    title: "工具 shelf.summarize",
+                    detail: shelfContext,
+                    status: hasProvidedFile ? "done" : "skipped"
+                )
+            )
+        }
+
+        if selectedIDs.contains("weather") {
+            let weatherContext = await weatherSummary()
+            contextBlocks.append("[weather.current]\n\(weatherContext)")
+            steps.append(.init(title: "工具 weather.current", detail: weatherContext, status: weatherContext.contains("不可用") ? "fallback" : "done"))
+        }
+
+        if selectedIDs.contains("focus") {
+            let focusContext = focusSummary()
+            contextBlocks.append("[focus.status]\n\(focusContext)")
+            steps.append(.init(title: "工具 focus.status", detail: focusContext, status: "done"))
+        }
+
+        if selectedIDs.contains("skills") {
+            let skillContext = skillPlaybook(for: route, selectedSkills: selectedSkills)
+            contextBlocks.append("[skill.playbook]\n\(skillContext)")
+            steps.append(
+                .init(
+                    title: "Skills 选择",
+                    detail: selectedSkills.isEmpty ? playbookName(for: route) : selectedSkills.map(\.name).joined(separator: "、"),
+                    status: "done"
+                )
+            )
+        }
+
+        let safetyNotes = safetyNotes(for: route, contextBlocks: contextBlocks)
+        let recoveryStrategies = buildRecoveryStrategies(
+            route: route,
+            selectedPlugins: selectedPlugins,
+            contextBlocks: contextBlocks
+        )
+        steps.append(
+            .init(
+                title: "Permission Gate",
+                detail: permissionGateSummary(for: selectedPlugins, route: route),
+                status: route.kind == .calendarWrite ? "prepared" : "done"
+            )
+        )
+        steps.append(
+            .init(
+                title: "Reflector / Guard",
+                detail: safetyNotes.joined(separator: " "),
+                status: "done"
+            )
+        )
+        if selectedIDs.contains("trace") {
+            steps.append(.init(title: "Trace Logger", detail: "记录路由、工具发现、上下文和安全检查。", status: "done"))
+        }
+
+        let systemContext = buildSystemContext(
+            route: route,
+            taskUnderstanding: taskUnderstanding,
+            reasoningProfile: reasoningProfile,
+            planSteps: planSteps,
+            recoveryStrategies: recoveryStrategies,
+            plugins: selectedPlugins,
+            skills: selectedSkills,
+            contextBlocks: contextBlocks,
+            safetyNotes: safetyNotes
+        )
+
+        let trace = AgentRunTrace(
+            routeKind: route.kind.rawValue,
+            routeName: route.kind.displayName,
+            routeConfidence: route.confidence,
+            taskUnderstanding: taskUnderstanding,
+            reasoningProfile: reasoningProfile,
+            discoveredPlugins: discoveredPlugins,
+            selectedPlugins: selectedPlugins,
+            selectedSkills: selectedSkills,
+            planSteps: planSteps,
+            workingMemory: workingMemory,
+            retrievedMemories: retrievedMemories,
+            storedMemory: storedMemory,
+            recoveryStrategies: recoveryStrategies,
+            steps: steps,
+            safetyNotes: safetyNotes,
+            status: "已准备",
+            requiresConfirmation: route.kind == .calendarWrite
+        )
+
+        return AgentPreparedRun(
+            trace: trace,
+            systemContext: systemContext,
+            calendarContext: calendarContext,
+            route: route
+        )
+    }
+
+    private func buildTaskUnderstanding(
+        prompt: String,
+        route: AgentRoute,
+        selectedPlugins: [AgentPluginDescriptor],
+        selectedSkills: [AgentSkillDescriptor]
+    ) -> AgentTaskUnderstanding {
+        let lowered = prompt.lowercased()
+        let signals = selectedPlugins.map(\.id) + selectedSkills.map(\.id)
+        let complexity: String
+        if prompt.count > 420 || !selectedSkills.isEmpty || route.kind == .agentArchitecture || route.kind == .researchPlanning {
+            complexity = "high"
+        } else if route.kind == .generalChat {
+            complexity = "low"
+        } else {
+            complexity = "medium"
+        }
+
+        let riskyWords = ["写入", "创建", "删除", "不用问", "直接", "always", "delete", "create"]
+        let riskLevel = route.kind == .calendarWrite || riskyWords.contains(where: lowered.contains) ? "medium" : "low"
+        let needsTools = route.kind != .generalChat || selectedPlugins.contains { !$0.toolNames.isEmpty }
+        let needsMemory = selectedPlugins.contains { $0.id == "memory" } || lowered.contains("记忆") || lowered.contains("remember")
+        let requiresClarification = pendingQuestions(for: prompt, route: route).isEmpty == false
+
+        return AgentTaskUnderstanding(
+            taskType: route.kind.displayName,
+            complexity: complexity,
+            riskLevel: riskLevel,
+            needsTools: needsTools,
+            needsMemory: needsMemory,
+            requiresClarification: requiresClarification,
+            summary: "\(route.kind.displayName)：\(String(prompt.replacingOccurrences(of: "\n", with: " ").prefix(120)))",
+            signals: Array(signals.prefix(10))
+        )
+    }
+
+    private func buildReasoningProfile(
+        for understanding: AgentTaskUnderstanding,
+        route: AgentRoute
+    ) -> AgentReasoningProfile {
+        let mode: String
+        let loop: String
+        let reviewRounds: Int
+
+        switch route.kind {
+        case .generalChat:
+            mode = "direct"
+            loop = "answer -> light_guard"
+            reviewRounds = 1
+        case .calendarWrite:
+            mode = "permissioned_planning"
+            loop = "plan -> permission_gate -> execute_or_explain -> review"
+            reviewRounds = 2
+        case .agentArchitecture, .researchPlanning:
+            mode = "structured_workflow"
+            loop = "understand -> decompose -> retrieve -> synthesize -> review"
+            reviewRounds = 2
+        case .fileProcessing:
+            mode = "grounded_context"
+            loop = "read_provided_context -> extract -> answer -> guard"
+            reviewRounds = 1
+        case .schedulePlanning, .weatherDecision, .focusCoaching, .assignmentPlanning:
+            mode = understanding.complexity == "high" ? "react_workflow" : "tool_grounded"
+            loop = "route -> collect_context -> skill_playbook -> answer -> review"
+            reviewRounds = 1
+        }
+
+        return AgentReasoningProfile(
+            mode: mode,
+            loop: loop,
+            shouldPlan: understanding.complexity != "low",
+            maxReviewRounds: reviewRounds,
+            stopCondition: "回答已覆盖目标、工具边界和缺失信息。"
+        )
+    }
+
+    private func buildPlanSteps(
+        route: AgentRoute,
+        selectedPlugins: [AgentPluginDescriptor],
+        selectedSkills: [AgentSkillDescriptor]
+    ) -> [AgentPlanStep] {
+        var steps: [AgentPlanStep] = [
+            .init(order: 1, title: "理解任务", detail: "识别 \(route.kind.displayName) 并抽取关键实体。", status: "done"),
+            .init(order: 2, title: "发现插件", detail: selectedPlugins.map(\.name).joined(separator: "、"), status: "done"),
+        ]
+
+        if selectedPlugins.contains(where: { $0.id == "memory" }) {
+            steps.append(.init(order: steps.count + 1, title: "装载记忆", detail: "更新短期/工作记忆，并检索相关长期记忆。", status: "done"))
+        }
+
+        if !selectedSkills.isEmpty {
+            steps.append(.init(order: steps.count + 1, title: "应用 Skills", detail: selectedSkills.map(\.name).joined(separator: "、"), status: "done"))
+        }
+
+        steps.append(.init(order: steps.count + 1, title: "生成与检查", detail: "按权限边界回答，并通过安全护栏检查。", status: "prepared"))
+        return steps
+    }
+
+    private func buildRecoveryStrategies(
+        route: AgentRoute,
+        selectedPlugins: [AgentPluginDescriptor],
+        contextBlocks: [String]
+    ) -> [AgentRecoveryStrategy] {
+        var strategies: [AgentRecoveryStrategy] = []
+
+        if selectedPlugins.contains(where: { $0.id == "calendar" }) {
+            strategies.append(
+                .init(
+                    trigger: "日历权限不可用",
+                    strategy: "改为输出人工可复制的绝对时间计划。",
+                    fallback: "提示用户在设置中开启日历读取/写入。",
+                    status: contextBlocks.contains(where: { $0.contains("calendar.read") }) ? "armed" : "standby"
+                )
+            )
+        }
+
+        if selectedPlugins.contains(where: { $0.id == "weather" }) {
+            strategies.append(
+                .init(
+                    trigger: "天气接口失败",
+                    strategy: "声明天气不可用，使用保守出行假设。",
+                    fallback: "建议用户查看实时天气后再做户外安排。",
+                    status: "armed"
+                )
+            )
+        }
+
+        if route.kind == .fileProcessing {
+            strategies.append(
+                .init(
+                    trigger: "文件缺失或不可读",
+                    strategy: "只基于用户可见文本回答，不编造文件内容。",
+                    fallback: "请用户重新上传文本、Markdown、JSON 或 CSV。",
+                    status: "armed"
+                )
+            )
+        }
+
+        strategies.append(
+            .init(
+                trigger: "上下文不足",
+                strategy: "先给可执行假设，再列出需要补充的信息。",
+                fallback: "询问一个最关键的澄清问题。",
+                status: "always-on"
+            )
+        )
+        return strategies
+    }
+
+    private func routePrompt(_ prompt: String) -> AgentRoute {
+        let lowered = prompt.lowercased()
+        let calendarWrite = [
+            "add to calendar", "put on my calendar", "create calendar event",
+            "write to calendar", "schedule it", "写进日历", "写到日历",
+            "加到日历", "添加到日历", "放到日历", "创建日程", "写入日历"
+        ]
+        if calendarWrite.contains(where: lowered.contains) {
+            return .init(kind: .calendarWrite, confidence: 0.93)
+        }
+
+        let fileProcessing = ["[file:", "本地文件上下文", "upload", "uploaded file", "file summary", "上传", "文件", "摘要", "knowledge", "rag", "知识库", "资料库"]
+        if fileProcessing.contains(where: lowered.contains) {
+            return .init(kind: .fileProcessing, confidence: 0.82)
+        }
+
+        let assignment = ["assignment", "homework", "作业", "大作业", "报告", "deadline", "截止", "提交"]
+        if assignment.contains(where: lowered.contains) {
+            return .init(kind: .assignmentPlanning, confidence: 0.86)
+        }
+
+        let weather = ["weather", "rain", "temperature", "wind", "outdoor", "天气", "下雨", "气温", "出门", "户外", "跑步"]
+        if weather.contains(where: lowered.contains) {
+            return .init(kind: .weatherDecision, confidence: 0.84)
+        }
+
+        let focus = ["focus", "pomodoro", "study", "deep work", "专注", "番茄钟", "复习", "学习", "冲刺"]
+        if focus.contains(where: lowered.contains) {
+            return .init(kind: .focusCoaching, confidence: 0.80)
+        }
+
+        let research = ["research", "literature", "paper", "citation", "论文", "文献", "调研", "研究", "引用"]
+        if research.contains(where: lowered.contains) {
+            return .init(kind: .researchPlanning, confidence: 0.76)
+        }
+
+        let agentArchitecture = [
+            "agent", "plugin", "plugins", "skill", "skills", "memory", "mcp",
+            "智能体", "插件", "技能", "记忆", "长期记忆", "工作记忆", "短期记忆", "架构"
+        ]
+        if agentArchitecture.contains(where: lowered.contains) {
+            return .init(kind: .agentArchitecture, confidence: 0.88)
+        }
+
+        let schedule = ["calendar", "schedule", "agenda", "plan", "安排", "计划", "日程", "行程", "空闲", "会议", "available"]
+        if schedule.contains(where: lowered.contains) {
+            return .init(kind: .schedulePlanning, confidence: 0.78)
+        }
+
+        return .init(kind: .generalChat, confidence: 0.58)
+    }
+
+    private func discoverPlugins(for route: AgentRoute, prompt: String) -> [AgentPluginMatch] {
+        let lowered = prompt.lowercased()
+        let routeIDs: [String]
+        switch route.kind {
+        case .calendarWrite:
+            routeIDs = ["calendar", "memory", "skills", "safety", "trace"]
+        case .schedulePlanning:
+            routeIDs = ["calendar", "memory", "skills", "safety", "trace"]
+        case .weatherDecision:
+            let calendarNeeded = Self.weatherCalendarKeywords.contains(where: lowered.contains)
+            routeIDs = calendarNeeded
+                ? ["weather", "calendar", "memory", "safety", "trace"]
+                : ["weather", "memory", "safety", "trace"]
+        case .focusCoaching:
+            routeIDs = ["focus", "calendar", "memory", "skills", "safety", "trace"]
+        case .assignmentPlanning:
+            routeIDs = ["assignment", "knowledge", "calendar", "focus", "memory", "skills", "safety", "trace"]
+        case .agentArchitecture:
+            routeIDs = ["memory", "knowledge", "skills", "planner", "reasoner", "reviewer", "recovery", "safety", "trace"]
+        case .fileProcessing:
+            routeIDs = ["shelf", "assignment", "knowledge", "memory", "skills", "recovery", "safety", "trace"]
+        case .researchPlanning:
+            routeIDs = ["knowledge", "memory", "skills", "planner", "reasoner", "reviewer", "recovery", "safety", "trace"]
+        case .generalChat:
+            routeIDs = ["memory", "safety", "trace"]
+        }
+
+        let hasProvidedFile = lowered.contains("[file:") || lowered.contains("本地文件上下文") || lowered.contains("上传")
+        let asksKnowledge = ["knowledge", "rag", "资料库", "知识库", "local documents", "笔记"].contains { lowered.contains($0) }
+        let hasKnowledgeHit = AgentKnowledgeStore.shared.hasRelevantContent(for: prompt)
+        let selectedIDs = Set(routeIDs + (hasProvidedFile ? ["shelf"] : []) + ((asksKnowledge || hasKnowledgeHit) ? ["knowledge"] : []))
+
+        return plugins.map { plugin in
+            let keywordHits = plugin.discoveryKeywords.filter { lowered.contains($0.lowercased()) }.count
+            let routeBoost = selectedIDs.contains(plugin.id) ? 0.58 : 0
+            let keywordBoost = min(Double(keywordHits) * 0.12, 0.32)
+            let alwaysOnBoost = ["safety", "trace"].contains(plugin.id) ? 0.14 : 0
+            let score = min(routeBoost + keywordBoost + alwaysOnBoost, 0.99)
+            let reason: String
+
+            if selectedIDs.contains(plugin.id), keywordHits > 0 {
+                reason = "路由匹配 + \(keywordHits) 个关键词"
+            } else if selectedIDs.contains(plugin.id) {
+                reason = "路由需要"
+            } else if keywordHits > 0 {
+                reason = "\(keywordHits) 个关键词命中"
+            } else {
+                reason = "暂不相关"
+            }
+
+            return AgentPluginMatch(
+                id: plugin.id,
+                pluginName: plugin.name,
+                score: score,
+                reason: reason,
+                selected: selectedIDs.contains(plugin.id)
+            )
+        }
+        .sorted { lhs, rhs in
+            if lhs.selected != rhs.selected { return lhs.selected && !rhs.selected }
+            return lhs.score > rhs.score
+        }
+    }
+
+    private func skillsForRoute(_ route: AgentRoute, prompt: String) -> [AgentSkillDescriptor] {
+        let lowered = prompt.lowercased()
+        let routeSkillIDs: [String]
+
+        switch route.kind {
+        case .assignmentPlanning:
+            routeSkillIDs = ["assignment_breakdown", "study_plan"]
+        case .calendarWrite, .schedulePlanning:
+            routeSkillIDs = ["calendar_aware_planning"]
+        case .focusCoaching:
+            routeSkillIDs = ["study_plan"]
+        case .weatherDecision:
+            routeSkillIDs = ["weather_decision"]
+        case .agentArchitecture:
+            routeSkillIDs = ["agent_memory_design"]
+        case .fileProcessing:
+            routeSkillIDs = ["file_context_analysis"]
+        case .researchPlanning:
+            routeSkillIDs = ["research_planning"]
+        case .generalChat:
+            routeSkillIDs = []
+        }
+
+        let routeSet = Set(routeSkillIDs)
+        return skills.filter { skill in
+            routeSet.contains(skill.id)
+                || skill.triggerKeywords.contains(where: { lowered.contains($0.lowercased()) })
+        }
+    }
+
+    private func permissionGateSummary(for plugins: [AgentPluginDescriptor], route: AgentRoute) -> String {
+        let writeTools = plugins.flatMap(\.toolNames).filter { $0.contains("create") || $0.contains("start") || $0.contains("save") }
+
+        guard !writeTools.isEmpty else {
+            return "本轮只读上下文为主；无本地写动作。"
+        }
+
+        if route.kind == .calendarWrite {
+            return "检测到写动作候选：\(writeTools.joined(separator: ", "))。日历写入必须满足：用户明确要求 + 设置允许 + 日历权限可用。"
+        }
+
+        return "检测到动作型工具 \(writeTools.joined(separator: ", "))，但当前路由不自动执行，只用于说明能力边界。"
+    }
+
+    private func weatherSummary() async -> String {
+        let manager = WeatherManager.shared
+        await manager.refreshWeather(force: false)
+
+        guard let snapshot = manager.snapshot else {
+            return manager.lastError.map { "天气不可用：\($0)" } ?? "天气不可用。"
+        }
+
+        let current = snapshot.current
+        return "\(snapshot.locationName)：\(Int(current.temperature.rounded()))\(current.unitSymbol)，\(current.condition)，体感 \(Int(current.feelsLike.rounded()))\(current.unitSymbol)，风速 \(Int(current.windSpeed.rounded())) \(current.windUnit)，降水 \(String(format: "%.1f", current.precipitation)) mm。"
+    }
+
+    private func focusSummary() -> String {
+        let manager = PomodoroManager.shared
+        let state = manager.isRunning ? "运行中" : "待开始"
+        return "番茄钟\(state)，阶段 \(manager.phase.rawValue)，剩余 \(manager.formattedRemaining)，默认专注 \(Defaults[.pomodoroFocusMinutes]) 分钟，已完成 \(manager.completedFocusSessions) 个专注段。"
+    }
+
+    private func preferenceSummary() -> String {
+        let city = Defaults[.weatherCity].trimmingCharacters(in: .whitespacesAndNewlines)
+        let cityLabel = city.isEmpty ? defaultWeatherCityName() : city
+        return "日历上下文：\(Defaults[.aiCalendarContextEnabled] ? "开启" : "关闭")；日历写入：\(Defaults[.aiCalendarWriteEnabled] ? "开启" : "关闭")；天气城市：\(cityLabel)；默认专注/休息：\(Defaults[.pomodoroFocusMinutes])/\(Defaults[.pomodoroShortBreakMinutes]) 分钟。"
+    }
+
+    private func shortTermSummary(from messages: [AIChatMessage]) -> String {
+        let recent = messages.suffix(6)
+        guard !recent.isEmpty else {
+            return "当前会话刚开始；无历史消息。"
+        }
+
+        return recent.map { message in
+            let role = message.role == .user ? "user" : "assistant"
+            let content = message.content
+                .replacingOccurrences(of: "\n", with: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return "- \(role): \(String(content.prefix(180)))"
+        }.joined(separator: "\n")
+    }
+
+    private func buildWorkingMemory(
+        prompt: String,
+        route: AgentRoute,
+        selectedPlugins: [AgentPluginDescriptor],
+        selectedSkills: [AgentSkillDescriptor]
+    ) -> AgentWorkingMemory {
+        let goal = "\(route.kind.displayName)：\(String(prompt.replacingOccurrences(of: "\n", with: " ").prefix(90)))"
+        let entities = workingMemoryEntities(
+            from: prompt,
+            selectedPlugins: selectedPlugins,
+            selectedSkills: selectedSkills
+        )
+        let pending = pendingQuestions(for: prompt, route: route)
+
+        return AgentWorkingMemory(
+            currentGoal: goal,
+            taskProgress: "已完成路由、插件发现和上下文准备，等待模型生成回答。",
+            keyEntities: entities,
+            pendingQuestions: pending
+        )
+    }
+
+    private func workingMemoryEntities(
+        from prompt: String,
+        selectedPlugins: [AgentPluginDescriptor],
+        selectedSkills: [AgentSkillDescriptor]
+    ) -> [String] {
+        let lowered = prompt.lowercased()
+        let candidates = [
+            "短期记忆", "工作记忆", "长期记忆", "向量数据库", "Token", "日历", "天气", "作业",
+            "番茄钟", "插件", "Skills", "MCP", "calendar", "weather", "assignment", "memory"
+        ]
+        var entities = candidates.filter { lowered.contains($0.lowercased()) }
+        entities += selectedPlugins.map(\.name)
+        entities += selectedSkills.map(\.name)
+
+        if prompt.contains("[file:") || prompt.contains("本地文件上下文") {
+            entities.append("上传文件")
+        }
+
+        var seen = Set<String>()
+        return entities.filter { seen.insert($0).inserted }.prefix(12).map { $0 }
+    }
+
+    private func pendingQuestions(for prompt: String, route: AgentRoute) -> [String] {
+        var questions: [String] = []
+        let hasProvidedFile = prompt.contains("[file:") || prompt.contains("本地文件上下文")
+
+        if route.kind == .assignmentPlanning && !hasProvidedFile {
+            questions.append("是否需要上传作业要求或评分标准？")
+        }
+        if route.kind == .calendarWrite {
+            questions.append("日历写入是否满足用户明确要求、设置允许和权限可用？")
+        }
+        if route.kind == .weatherDecision && !Defaults[.weatherFeatureEnabled] {
+            questions.append("天气功能当前关闭，是否使用保守假设？")
+        }
+
+        return questions
+    }
+
+    private func longTermMemorySummary(_ memories: [AgentMemoryRecord]) -> String {
+        guard !memories.isEmpty else {
+            return "没有检索到与当前任务相关的长期记忆。"
+        }
+
+        return memories.enumerated().map { index, memory in
+            let scoreText = memory.retrievalScore.map { String(format: "%.2f", $0) } ?? "n/a"
+            let reasonText = memory.retrievalReason ?? "未记录"
+            return "\(index + 1). [\(memory.kind.displayName)] \(memory.content) score=\(scoreText) reason=\(reasonText) keywords=\(memory.keywords.prefix(6).joined(separator: ", "))"
+        }.joined(separator: "\n")
+    }
+
+    private func skillPlaybook(for route: AgentRoute, selectedSkills: [AgentSkillDescriptor]) -> String {
+        if !selectedSkills.isEmpty {
+            return selectedSkills.map { skill in
+                """
+                \(skill.name)：
+                \(skill.workflowSteps.enumerated().map { "\($0.offset + 1). \($0.element)" }.joined(separator: "\n"))
+                """
+            }.joined(separator: "\n\n")
+        }
+
+        switch route.kind {
+        case .assignmentPlanning:
+            return "作业拆解技能：提取交付物，映射评分点，拆成里程碑，预留专注块，并指出缺失信息。"
+        case .calendarWrite, .schedulePlanning:
+            return "日程感知规划技能：寻找空闲窗口，避免冲突，使用绝对时间，并在创建事件前说明取舍。"
+        case .focusCoaching:
+            return "专注辅导技能：把目标拆成番茄钟大小的任务块，包含休息，保持计划现实。"
+        default:
+            return "通用助手技能：简洁回答，并说明使用了哪些本地上下文。"
+        }
+    }
+
+    private func playbookName(for route: AgentRoute) -> String {
+        switch route.kind {
+        case .assignmentPlanning:
+            return "作业拆解"
+        case .calendarWrite, .schedulePlanning:
+            return "日程感知规划"
+        case .focusCoaching:
+            return "专注辅导"
+        default:
+            return "通用助手"
+        }
+    }
+
+    private func safetyNotes(for route: AgentRoute, contextBlocks: [String]) -> [String] {
+        var notes = [
+            "不要编造不可用的本地上下文。",
+            "工具失败或权限不足影响答案时必须说明。",
+        ]
+
+        if route.kind == .calendarWrite {
+            notes.append("只有在用户明确要求写入且设置允许时才创建日历事件。")
+        }
+
+        if contextBlocks.contains(where: { $0.contains("unavailable") || $0.contains("Disabled") }) {
+            notes.append("至少一个工具没有返回可用上下文，需要降级推理。")
+        }
+
+        return notes
+    }
+
+    private func buildSystemContext(
+        route: AgentRoute,
+        taskUnderstanding: AgentTaskUnderstanding,
+        reasoningProfile: AgentReasoningProfile,
+        planSteps: [AgentPlanStep],
+        recoveryStrategies: [AgentRecoveryStrategy],
+        plugins: [AgentPluginDescriptor],
+        skills: [AgentSkillDescriptor],
+        contextBlocks: [String],
+        safetyNotes: [String]
+    ) -> String {
+        let pluginLines = plugins.map {
+            "- \($0.id): type=\($0.category); tools=\($0.toolNames.joined(separator: ", ")); permission=\($0.permission); risk=\($0.riskLevel)"
+        }.joined(separator: "\n")
+        let manifestLines = plugins.map {
+            "- \($0.name): \($0.manifestPreview.replacingOccurrences(of: "\n", with: " "))"
+        }.joined(separator: "\n")
+        let skillLines = skills.isEmpty ? "本轮未装载专用 Skill。" : skills.map { skill in
+            """
+            - \(skill.name): required_tools=\(skill.requiredTools.joined(separator: ", ")); workflow=\(skill.workflowSteps.joined(separator: " -> "))
+            """
+        }.joined(separator: "\n")
+
+        return """
+        Boring Notch Agent 编排上下文：
+        路由：\(route.kind.displayName)，置信度 \(String(format: "%.2f", route.confidence))。
+
+        任务理解：
+        \(taskUnderstanding.contextText)
+
+        推理模式：
+        \(reasoningProfile.contextText)
+
+        计划步骤：
+        \(planSteps.map { "\($0.order). \($0.title)：\($0.detail) [\($0.status)]" }.joined(separator: "\n"))
+
+        已选择插件：
+        \(pluginLines)
+
+        插件 Manifest 摘要：
+        \(manifestLines)
+
+        已选择 Skills：
+        \(skillLines)
+
+        工具上下文：
+        \(contextBlocks.joined(separator: "\n\n"))
+
+        反思与安全护栏：
+        \(safetyNotes.map { "- \($0)" }.joined(separator: "\n"))
+
+        异常恢复策略：
+        \(recoveryStrategies.map { "- \($0.trigger)：\($0.strategy) fallback=\($0.fallback)" }.joined(separator: "\n"))
+
+        回复规则：
+        - 相关时使用已选择的工具上下文；如果上下文显示工具失败，不要声称工具成功。
+        - 如果知识库命中资料，优先基于 knowledge.retrieve 的摘要和 excerpt 回答；没有命中时明确说明未检索到相关资料。
+        - 如果 Skills 已装载，按 workflow 输出过程型计划，不要只给泛泛建议。
+        - 记忆上下文分为短期会话、工作记忆和长期记忆；长期记忆只代表检索命中的稳定信息，不要把普通聊天当成长期事实。
+        - 日程或作业规划要给出具体步骤，并指出冲突或缺失信息。
+        - 对本地风险动作，要清楚说明动作边界。
+        """
+    }
+}
+
+private extension AgentRoute.Kind {
+    var displayName: String {
+        switch self {
+        case .generalChat:
+            return "通用对话"
+        case .schedulePlanning:
+            return "日程规划"
+        case .calendarWrite:
+            return "日历写入"
+        case .weatherDecision:
+            return "天气决策"
+        case .focusCoaching:
+            return "专注辅导"
+        case .assignmentPlanning:
+            return "作业拆解"
+        case .agentArchitecture:
+            return "智能体架构"
+        case .fileProcessing:
+            return "文件处理"
+        case .researchPlanning:
+            return "研究规划"
+        }
+    }
+}
+
+@MainActor
+final class AIChatManager: ObservableObject {
+    static let shared = AIChatManager()
+
+    @Published private(set) var conversations: [AgentChatConversation] = []
+    @Published private(set) var activeConversationID: UUID?
+    @Published private(set) var isSending: Bool = false
+    @Published var lastError: String?
+    @Published private(set) var lastResolvedModelName: String?
+    @Published private(set) var lastAgentTrace: AgentRunTrace?
+
+    private let conversationStoreURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    private init() {
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+
+        let directory = Self.storageDirectory()
+        conversationStoreURL = directory.appendingPathComponent("conversations.json")
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        loadConversations()
+    }
+
+    var activeConversation: AgentChatConversation? {
+        guard let activeConversationID else { return conversations.first }
+        return conversations.first { $0.id == activeConversationID } ?? conversations.first
+    }
+
+    var messages: [AIChatMessage] {
+        activeConversation?.messages ?? []
+    }
+
+    func clearConversation() {
+        mutateActiveConversation { conversation in
+            conversation.messages.removeAll()
+            conversation.updatedAt = Date()
+        }
+        lastError = nil
+        lastResolvedModelName = nil
+        lastAgentTrace = nil
+    }
+
+    func appendLocalAssistantMessage(_ content: String) {
+        appendMessage(AIChatMessage(role: .assistant, content: content))
+    }
+
+    func startNewConversation() {
+        let conversation = AgentChatConversation(title: "新对话")
+        conversations.insert(conversation, at: 0)
+        activeConversationID = conversation.id
+        lastError = nil
+        lastAgentTrace = nil
+        persistConversations()
+    }
+
+    func selectConversation(_ id: UUID) {
+        guard conversations.contains(where: { $0.id == id }) else { return }
+        activeConversationID = id
+        lastError = nil
+        lastAgentTrace = nil
+    }
+
+    func deleteConversation(_ id: UUID) {
+        guard conversations.count > 1 else {
+            clearConversation()
+            return
+        }
+        conversations.removeAll { $0.id == id }
+        if activeConversationID == id {
+            activeConversationID = conversations.first?.id
+            lastError = nil
+            lastAgentTrace = nil
+        }
+        persistConversations()
+    }
+
+    var displayedModelName: String {
+        if let resolved = normalizedModelName(lastResolvedModelName) {
+            return resolved
+        }
+
+        let configured = Defaults[.aiServiceModel].trimmingCharacters(in: .whitespacesAndNewlines)
+        return configured.isEmpty ? "No model configured" : configured
+    }
+
+    var availablePlugins: [AgentPluginDescriptor] {
+        AgentOrchestrator.shared.plugins
+    }
+
+    var availableSkills: [AgentSkillDescriptor] {
+        AgentOrchestrator.shared.skills
+    }
+
+    var longTermMemories: [AgentMemoryRecord] {
+        AgentMemoryStore.shared.recentRecords
+    }
+
+    var longTermMemoryLocation: URL {
+        AgentMemoryStore.shared.storageURL
+    }
+
+    var knowledgeDocuments: [AgentKnowledgeDocument] {
+        AgentKnowledgeStore.shared.documents
+    }
+
+    var knowledgeStorageLocation: URL {
+        AgentKnowledgeStore.shared.storageURL
+    }
+
+    @discardableResult
+    func addKnowledgeDocument(
+        name: String,
+        path: String,
+        content: String,
+        byteCount: Int
+    ) -> AgentKnowledgeDocument? {
+        let document = AgentKnowledgeStore.shared.addDocument(
+            title: name,
+            sourcePath: path,
+            content: content,
+            byteCount: byteCount
+        )
+        if document != nil {
+            objectWillChange.send()
+        }
+        return document
+    }
+
+    func removeKnowledgeDocument(id: UUID) {
+        AgentKnowledgeStore.shared.removeDocument(id: id)
+        objectWillChange.send()
+    }
+
+    func clearKnowledgeBase() {
+        AgentKnowledgeStore.shared.clear()
+        objectWillChange.send()
+    }
+
+    @discardableResult
+    func installStarterKnowledgeBase() -> Int {
+        var importedCount = 0
+        for seed in Self.starterKnowledgeDocuments {
+            let content = seed.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !content.isEmpty else { continue }
+            if AgentKnowledgeStore.shared.addDocument(
+                title: seed.title,
+                sourcePath: seed.sourcePath,
+                content: content,
+                byteCount: content.utf8.count
+            ) != nil {
+                importedCount += 1
+            }
+        }
+        objectWillChange.send()
+        return importedCount
+    }
+
+    @discardableResult
+    func rememberMemory(_ content: String) -> AgentMemoryRecord? {
+        let record = AgentMemoryStore.shared.storeManual(content)
+        if record != nil {
+            objectWillChange.send()
+        }
+        return record
+    }
+
+    @discardableResult
+    func forgetMemory(matching query: String = "") -> Int {
+        let removedCount = AgentMemoryStore.shared.forget(matching: query)
+        if removedCount > 0 {
+            objectWillChange.send()
+        }
+        return removedCount
+    }
+
+    func clearLongTermMemory() {
+        AgentMemoryStore.shared.clear()
+        objectWillChange.send()
+    }
+
+    func revealLongTermMemoryFile() {
+        NSWorkspace.shared.activateFileViewerSelecting([AgentMemoryStore.shared.storageURL])
+    }
+
+    func send(prompt: String, displayPrompt: String? = nil) async {
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPrompt.isEmpty, !isSending else { return }
+
+        appendMessage(AIChatMessage(role: .user, content: displayPrompt ?? trimmedPrompt))
+        lastError = nil
+        isSending = true
+        defer { isSending = false }
+
+        do {
+            var agentRun = await AgentOrchestrator.shared.prepare(prompt: trimmedPrompt, recentMessages: messages)
+            lastAgentTrace = agentRun.trace
+            let reply: AIReply
+
+            if agentRun.route.kind == .calendarWrite {
+                reply = try await requestCalendarWriteReply(
+                    for: trimmedPrompt,
+                    agentRun: agentRun
+                )
+            } else {
+                reply = try await requestReply(
+                    for: trimmedPrompt,
+                    agentRun: agentRun
+                )
+            }
+
+            lastResolvedModelName = reply.resolvedModelName ?? reply.requestedModelName
+            appendMessage(AIChatMessage(role: .assistant, content: reply.content))
+            agentRun.trace.status = "已完成"
+            agentRun.trace.steps.append(
+                .init(
+                    title: "模型回复",
+                    detail: "实际模型：\(reply.resolvedModelName ?? reply.requestedModelName)",
+                    status: "done"
+                )
+            )
+            lastAgentTrace = agentRun.trace
+        } catch {
+            lastError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            if var trace = lastAgentTrace {
+                trace.status = "Failed"
+                trace.steps.append(
+                    .init(
+                        title: "失败",
+                        detail: lastError ?? "Unknown error",
+                        status: "error"
+                    )
+                )
+                lastAgentTrace = trace
+            }
+        }
+    }
+
+    private static func storageDirectory() -> URL {
+        let baseDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? temporaryDirectory
+        return baseDirectory.appendingPathComponent("BoringNotchAgent", isDirectory: true)
+    }
+
+    private func loadConversations() {
+        if let data = try? Data(contentsOf: conversationStoreURL),
+           let decoded = try? decoder.decode([AgentChatConversation].self, from: data),
+           !decoded.isEmpty
+        {
+            conversations = decoded.sorted { $0.updatedAt > $1.updatedAt }
+            activeConversationID = conversations.first?.id
+            return
+        }
+
+        let starter = AgentChatConversation(title: "新对话")
+        conversations = [starter]
+        activeConversationID = starter.id
+        persistConversations()
+    }
+
+    private func persistConversations() {
+        guard let data = try? encoder.encode(conversations) else { return }
+        try? data.write(to: conversationStoreURL, options: .atomic)
+    }
+
+    private func appendMessage(_ message: AIChatMessage) {
+        if conversations.isEmpty {
+            startNewConversation()
+        }
+
+        mutateActiveConversation { conversation in
+            if conversation.messages.isEmpty, message.role == .user {
+                conversation.title = Self.title(from: message.content)
+            }
+            conversation.messages.append(message)
+            conversation.updatedAt = message.createdAt
+        }
+    }
+
+    private func mutateActiveConversation(_ mutate: (inout AgentChatConversation) -> Void) {
+        if conversations.isEmpty {
+            let starter = AgentChatConversation(title: "新对话")
+            conversations = [starter]
+            activeConversationID = starter.id
+        }
+
+        let resolvedID = activeConversationID ?? conversations.first?.id
+        guard let resolvedID,
+              let index = conversations.firstIndex(where: { $0.id == resolvedID })
+        else { return }
+
+        mutate(&conversations[index])
+        conversations.sort { $0.updatedAt > $1.updatedAt }
+        activeConversationID = resolvedID
+        persistConversations()
+    }
+
+    private static func title(from prompt: String) -> String {
+        let withoutFiles = prompt
+            .components(separatedBy: "本地文件上下文：")
+            .first ?? prompt
+        let normalized = withoutFiles
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "用户问题：", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? "新对话" : String(normalized.prefix(18))
+    }
+
+    private static let starterKnowledgeDocuments: [(title: String, sourcePath: String, content: String)] = [
+        (
+            "GitHub 案例：Agent Skills 渐进式加载",
+            "seed://github-agent-skills-progressive-disclosure",
+            """
+            # GitHub 案例：Agent Skills 渐进式加载
+
+            适合Boring Notch Agent 的结论：Skills 不是普通 prompt 集合，而是“按需加载的任务流程包”。一个 Skill 通常由 SKILL.md 作为入口，使用 YAML frontmatter 描述名称、触发描述、权限或工具边界，再用 Markdown 写执行步骤。复杂 Skill 可以把长参考资料、模板、脚本放在同目录，只有任务需要时才读取，避免每轮对话塞满上下文。
+
+            对我们的实现启发：
+            1. 插件负责“能拿到什么上下文/能做什么动作”，Skill 负责“这类任务应该按什么流程做”。
+            2. Skill 的 description 应该写成触发条件，不只是说明文字，例如“当用户要求把作业要求拆成评分点、里程碑和日程计划时使用”。
+            3. 支持文件可以被延迟读取，适合local documents、评分标准模板、论文写作模板。
+            4. 有副作用的技能不要自动运行，例如写日历、发消息、删除文件，应该用确认门控。
+
+            Boring Notch可落地设计：
+            - skills/study-plan/SKILL.md：复习计划流程。
+            - skills/assignment-breakdown/SKILL.md：作业拆解流程。
+            - skills/weather-decision/SKILL.md：天气 + 日程的出行建议流程。
+            - skills/agent-memory-design/SKILL.md：短期/工作/长期记忆说明。
+
+            和 Claude/Codex/Roo 的对应关系：
+            - Codex: openai/skills 仓库提供可安装 Skill catalog。
+            - Claude Code: 个人、项目、插件级 skills 都以 SKILL.md 为入口，description 用于自动加载。
+            - Roo Code: 先索引 frontmatter，命中后再读取完整 SKILL.md，属于典型 progressive disclosure。
+
+            Sources:
+            - https://github.com/openai/skills
+            - https://code.claude.com/docs/en/skills
+            - https://roocodeinc.github.io/Roo-Code/features/skills
+            """
+        ),
+        (
+            "GitHub 案例：Cline/Roo 的插件与 MCP 思路",
+            "seed://github-cline-roo-mcp-plugin-patterns",
+            """
+            # GitHub 案例：Cline/Roo 的插件与 MCP 思路
+
+            适合Boring Notch Agent 的结论：现代 agent host 一般不把所有能力写死在 prompt 里，而是把能力拆成插件、工具、资源和提示模板。Cline 支持通过 SDK 注册工具和生命周期 hooks，也能通过 MCP server 扩展外部数据源和动作；Roo Code 把 MCP 配置分成全局和项目级，并强调工具需要明确配置和审批。
+
+            对我们的实现启发：
+            1. Plugin Registry：每个插件有 id、类型、工具名、权限和风险等级。
+            2. Tool Discovery：先根据用户任务选相关插件，不一次性把所有工具上下文塞给模型。
+            3. Context Plugin 和 Action Plugin 分开：天气、知识库、日历读取属于 context；写日历、启动计时器属于 action。
+            4. Permission Gate：读操作可以自动，写操作必须设置允许并由用户明确请求。
+            5. Trace Logger：记录本轮路由、命中插件、上下文准备和安全检查，方便local展示“智能体不是黑箱”。
+
+            Boring Notch可以对齐的 MCP 分层：
+            - Tools：weather.current、calendar.create_event、memory.save_preference。
+            - Resources：本地知识库文档、local documents、拖入文件、日历上下文。
+            - Prompts：/skills、/knowledge、作业拆解模板、天气决策模板。
+
+            最小可演示架构：
+            User Prompt -> Agent Router -> Plugin Registry -> Tool Discovery -> Context Gathering -> Skill Playbook -> Permission Gate -> LLM Reply -> Trace Logger
+
+            Sources:
+            - https://github.com/cline/cline
+            - https://docs.cline.bot/mcp/mcp-overview
+            - https://roocodeinc.github.io/Roo-Code/features/mcp/using-mcp-in-roo
+            - https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+            - https://modelcontextprotocol.io/docs/concepts/prompts
+            """
+        ),
+        (
+            "GitHub 案例：知识库与记忆的边界",
+            "seed://agent-memory-vs-knowledge-base-boundary",
+            """
+            # GitHub 案例：知识库与记忆的边界
+
+            适合Boring Notch Agent 的结论：知识库不等于长期记忆。知识库存的是用户显式导入的资料，例如local documents、作业要求、论文笔记、项目说明；长期记忆存的是跨会话稳定偏好和事实，例如“我喜欢晚上学习”“默认 45 分钟专注”。两者都可以检索，但写入策略不同。
+
+            三层记忆：
+            - 短期记忆：当前会话最近消息，只影响当前聊天页。
+            - 工作记忆：当前任务目标、进度、实体、待澄清问题，来自本轮 agent trace。
+            - 长期记忆：明确请求“记住”后写入，跨会话可检索。
+
+            知识库策略：
+            - 导入：只接受用户显式选择的文件，避免偷偷读取本地隐私。
+            - 检索：先做关键词和语义词粗检索，再按时间和命中质量排序。
+            - 注入：只把 Top-3 相关片段放进上下文，避免污染回答。
+            - 展示：面板显示资料来源、摘要、关键词和大小，方便用户知道 agent 用了什么。
+
+            演示问法：
+            - “根据知识库里的作业要求，帮我列评分点。”
+            - “我之前导入的智能体资料里，插件和 skill 有什么区别？”
+            - “用知识库内容解释 MCP 的 tools/resources/prompts。”
+
+            和 Skills 的关系：
+            Skill 是流程说明，知识库是资料来源。比如 assignment-breakdown skill 规定怎么拆作业；知识库存储具体 assignment requirements。两者结合才像真正的桌面 agent。
+
+            Sources:
+            - https://code.claude.com/docs/en/skills
+            - https://roocodeinc.github.io/Roo-Code/features/skills
+            - https://modelcontextprotocol.io/docs/concepts/prompts
+            """
+        ),
+        (
+            "GitHub 案例：安全护栏与插件权限",
+            "seed://agent-plugin-safety-permission-model",
+            """
+            # GitHub 案例：安全护栏与插件权限
+
+            适合Boring Notch Agent 的结论：插件系统的难点不是“能调用多少工具”，而是“什么时候不该调用”。Cline、Roo、MCP 文档都把外部工具视为可扩展能力，但同时需要配置、确认、权限和错误处理。对 macOS 桌面应用来说，安全模型尤其重要，因为工具可能影响日历、本地文件、App 启动或用户隐私。
+
+            插件权限建议：
+            - read:auto：天气、只读日历、知识库检索、长期记忆检索。
+            - write:explicit：用户明确说“记住”才写长期记忆。
+            - write:settings-gated：写日历必须设置允许 + 用户明确请求。
+            - action:user-triggered：启动番茄钟、打开 App、分享文件必须可见触发。
+            - deny-by-default：删除文件、上传隐私数据、执行未知脚本默认拒绝。
+
+            Trace 需要记录：
+            1. 为什么选择这个插件。
+            2. 插件权限是什么。
+            3. 工具成功、跳过还是降级。
+            4. 如果信息缺失，模型是否说明了缺口。
+            5. 写操作是否经过用户确认。
+
+            报告可写的亮点：
+            - Progressive tool discovery 降低 prompt 噪声。
+            - Human-in-the-loop 防止危险动作。
+            - Tool permission model 区分只读、写入、动作和拒绝。
+            - Agent trace 提升可解释性。
+            - Knowledge base 只读取用户显式导入资料，符合隐私边界。
+
+            Sources:
+            - https://github.com/cline/cline
+            - https://docs.cline.bot/mcp/mcp-overview
+            - https://roocodeinc.github.io/Roo-Code/features/mcp/using-mcp-in-roo
+            - https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+            """
+        ),
+        (
+            "GitHub 案例：Boring Notch Agent demo 脚本",
+            "seed://boring-notch-agent-demo-script",
+            """
+            # GitHub 案例：Boring Notch Agent demo 脚本
+
+            目标：展示Boring Notch不是普通聊天框，而是一个 macOS 桌面 Agent Host。
+
+            Demo 1：多会话短期记忆
+            1. 新建会话 A，问“帮我记住这轮我们在做天气插件演示”。
+            2. 新建会话 B，问“刚才这个会话说了什么？”。
+            3. 解释：短期记忆按会话隔离，长期记忆只有明确 /remember 或“请记住”才跨会话。
+
+            Demo 2：知识库检索
+            1. 点击知识库，导入 GitHub 示例知识库。
+            2. 问“根据知识库，Skill 和 Plugin 有什么区别？”。
+            3. 展示 trace 中 knowledge.retrieve 命中，说明它不是泛泛回答。
+
+            Demo 3：插件路由
+            1. 问“今天天气怎么样，适合出去跑步吗？”。
+            2. 展示 weather、memory、safety、trace 插件。
+            3. 说明天气插件是 Context Plugin，只读；不会做写操作。
+
+            Demo 4：权限门控
+            1. 问“把明天下午三点的复习写进日历”。
+            2. 展示 calendar action 插件和 Permission Gate。
+            3. 说明写入需要设置允许和用户明确请求。
+
+            Demo 5：Skills
+            1. 输入 /skills。
+            2. 展示 study-plan、assignment-breakdown、weather-decision、Nature 学术类 skill。
+            3. 说明 Skill 是任务流程，Plugin 是工具能力，Knowledge 是资料来源，Memory 是用户状态。
+
+            可以放进报告的一句话：
+            Boring Notch Agent 将 macOS notch utility 升级为桌面 Agent Host：通过插件注册表、渐进式工具发现、Skill 工作流、本地知识库、三层记忆和权限护栏，把聊天界面变成可解释、可扩展、可控的智能体系统。
+            """
+        ),
+    ]
+
+    private func requestReply(for prompt: String, agentRun: AgentPreparedRun) async throws -> AIReply {
+        let config = try resolveServiceConfig()
+        let decoded = try await performChatCompletion(
+            config: config,
+            messages: buildPayloadMessages(
+                requestedModel: config.requestedModel,
+                calendarContext: agentRun.calendarContext,
+                agentContext: agentRun.systemContext
+            ),
+            temperature: 0.7
+        )
+        let resolvedModelName = normalizedModelName(decoded.model) ?? config.requestedModel
+
+        if isModelIdentityQuestion(prompt) {
+            return AIReply(
+                content: localizedModelIdentityReply(
+                    for: prompt,
+                    resolvedModelName: resolvedModelName
+                ),
+                requestedModelName: config.requestedModel,
+                resolvedModelName: resolvedModelName
+            )
+        }
+
+        let content = decoded.choices.first?.message.content.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        guard !content.isEmpty else {
+            throw FeatureError("The AI service returned an empty response.")
+        }
+
+        return AIReply(
+            content: content,
+            requestedModelName: config.requestedModel,
+            resolvedModelName: resolvedModelName
+        )
+    }
+
+    private func requestCalendarWriteReply(for prompt: String, agentRun: AgentPreparedRun) async throws -> AIReply {
+        guard Defaults[.aiCalendarWriteEnabled] else {
+            throw FeatureError("AI calendar writing is disabled in Settings > AI.")
+        }
+
+        guard agentRun.calendarContext != nil else {
+            throw FeatureError("Calendar access is unavailable. Enable it in Settings > Calendar before asking AI to write plans.")
+        }
+
+        let config = try resolveServiceConfig()
+        let decoded = try await performChatCompletion(
+            config: config,
+            messages: buildPayloadMessages(
+                requestedModel: config.requestedModel,
+                calendarContext: agentRun.calendarContext,
+                agentContext: agentRun.systemContext,
+                extraSystemMessages: [calendarWriteInstruction()]
+            ),
+            temperature: 0.2
+        )
+
+        let resolvedModelName = normalizedModelName(decoded.model) ?? config.requestedModel
+        let rawContent = decoded.choices.first?.message.content.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let action = try decodeCalendarAction(from: rawContent)
+
+        let drafts = try action.events.compactMap { try makeCalendarDraft(from: $0) }
+        let createdEvents: [CreatedCalendarEvent]
+
+        if action.createEvents && !drafts.isEmpty {
+            createdEvents = try await CalendarManager.shared.createAIPlannedEvents(drafts)
+        } else {
+            createdEvents = []
+        }
+
+        let content = mergedCalendarWriteReply(baseReply: action.reply, createdEvents: createdEvents)
+        return AIReply(
+            content: content,
+            requestedModelName: config.requestedModel,
+            resolvedModelName: resolvedModelName
+        )
+    }
+
+    private func buildPayloadMessages(
+        requestedModel: String,
+        calendarContext: String? = nil,
+        agentContext: String? = nil,
+        extraSystemMessages: [String] = []
+    ) -> [OpenAIChatRequest.Message] {
+        var payloadMessages: [OpenAIChatRequest.Message] = []
+        let systemPrompt = Defaults[.aiSystemPrompt].trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !systemPrompt.isEmpty {
+            payloadMessages.append(.init(role: "system", content: systemPrompt))
+        }
+
+        payloadMessages.append(
+            .init(
+                role: "system",
+                content: """
+                The requested model name for this chat is "\(requestedModel)".
+                If the user asks which model is responding, answer with that exact model name unless the API metadata for the current response proves otherwise.
+                Do not claim to be GPT-4o or any other different model name.
+                """
+            )
+        )
+
+        if let calendarContext, !calendarContext.isEmpty {
+            payloadMessages.append(
+                .init(
+                    role: "system",
+                    content: """
+                    The user's local time zone is \(TimeZone.current.identifier).
+                    The current local date and time is \(isoTimestamp(Date())).
+                    Use the following calendar context only when it is relevant to the request:
+                    \(calendarContext)
+                    """
+                )
+            )
+        }
+
+        if let agentContext, !agentContext.isEmpty {
+            payloadMessages.append(
+                .init(
+                    role: "system",
+                    content: agentContext
+                )
+            )
+        }
+
+        payloadMessages.append(
+            contentsOf: extraSystemMessages.map { .init(role: "system", content: $0) }
+        )
+
+        let history = messages.suffix(12)
+        payloadMessages.append(
+            contentsOf: history.map {
+                OpenAIChatRequest.Message(role: $0.role.rawValue, content: $0.content)
+            }
+        )
+
+        return payloadMessages
+    }
+
+    private func chatCompletionsURL(from baseURL: String) -> URL? {
+        guard !baseURL.isEmpty else { return nil }
+
+        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sanitized = trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed
+        let lowercased = trimmed.lowercased()
+        let sanitizedLowercased = sanitized.lowercased()
+
+        if lowercased.hasSuffix("/chat/completions") {
+            return URL(string: trimmed)
+        }
+        if sanitizedLowercased.hasSuffix("/v1") {
+            return URL(string: sanitized + "/chat/completions")
+        }
+        return URL(string: sanitized + "/v1/chat/completions")
+    }
+
+    private func normalizedModelName(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func resolveServiceConfig() throws -> AIServiceConfig {
+        let baseURL = Defaults[.aiServiceBaseURL].trimmingCharacters(in: .whitespacesAndNewlines)
+        let apiKey = Defaults[.aiServiceAPIKey].trimmingCharacters(in: .whitespacesAndNewlines)
+        let requestedModel = Defaults[.aiServiceModel].trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard Defaults[.aiChatEnabled] else {
+            throw FeatureError("AI chat is disabled in Settings.")
+        }
+
+        guard !apiKey.isEmpty else {
+            throw FeatureError("Missing API key. Set it in Settings > AI.")
+        }
+
+        guard !requestedModel.isEmpty else {
+            throw FeatureError("Missing model name. Set it in Settings > AI.")
+        }
+
+        guard let endpoint = chatCompletionsURL(from: baseURL) else {
+            throw FeatureError("Invalid AI base URL.")
+        }
+
+        return AIServiceConfig(endpoint: endpoint, apiKey: apiKey, requestedModel: requestedModel)
+    }
+
+    private func performChatCompletion(
+        config: AIServiceConfig,
+        messages: [OpenAIChatRequest.Message],
+        temperature: Double
+    ) async throws -> OpenAIChatResponse {
+        var request = URLRequest(url: config.endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 60
+
+        let payload = OpenAIChatRequest(
+            model: config.requestedModel,
+            messages: messages,
+            temperature: temperature
+        )
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        if let httpResponse = response as? HTTPURLResponse, !(200 ... 299).contains(httpResponse.statusCode) {
+            if let apiError = try? JSONDecoder().decode(OpenAIErrorResponse.self, from: data),
+               let message = apiError.error.message, !message.isEmpty
+            {
+                throw FeatureError(message)
+            }
+            throw FeatureError("AI request failed with status \(httpResponse.statusCode).")
+        }
+
+        return try JSONDecoder().decode(OpenAIChatResponse.self, from: data)
+    }
+
+    private func calendarContextIfRelevant(for prompt: String) async -> String? {
+        guard wantsCalendarContext(for: prompt) else { return nil }
+        return await CalendarManager.shared.aiScheduleContext()
+    }
+
+    private func wantsCalendarContext(for prompt: String) -> Bool {
+        guard Defaults[.aiCalendarContextEnabled] else { return false }
+
+        let lowered = prompt.lowercased()
+        let keywords = [
+            "calendar",
+            "schedule",
+            "agenda",
+            "plan",
+            "安排",
+            "计划",
+            "日程",
+            "日历",
+            "行程",
+            "空闲",
+            "提醒",
+            "会议",
+            "什么时候有空",
+            "when am i free",
+            "available"
+        ]
+        return keywords.contains(where: lowered.contains)
+    }
+
+    private func wantsCalendarWrite(for prompt: String) -> Bool {
+        guard Defaults[.aiCalendarWriteEnabled] else { return false }
+
+        let lowered = prompt.lowercased()
+        let keywords = [
+            "add to calendar",
+            "put on my calendar",
+            "create calendar event",
+            "write to calendar",
+            "schedule it",
+            "写进日历",
+            "写到日历",
+            "加到日历",
+            "添加到日历",
+            "放到日历",
+            "创建日程",
+            "创建日历",
+            "写入日历"
+        ]
+        return keywords.contains(where: lowered.contains)
+    }
+
+    private func calendarWriteInstruction() -> String {
+        """
+        You are creating calendar events for the user.
+        Return only a JSON object with this exact schema:
+        {
+          "reply": "short natural-language confirmation in the user's language",
+          "create_events": true,
+          "events": [
+            {
+              "title": "event title",
+              "start": "ISO-8601 local date-time with timezone offset",
+              "end": "ISO-8601 local date-time with timezone offset",
+              "notes": "optional notes",
+              "location": "optional location"
+            }
+          ]
+        }
+
+        Rules:
+        - Use the user's existing calendar schedule to avoid conflicts.
+        - Use absolute timestamps, never relative phrases.
+        - Keep event titles short and practical.
+        - If the user asked for a study/work plan, split it into sensible time blocks.
+        - If required timing is unclear, make a reasonable plan based on free time in the calendar.
+        - Return JSON only. No markdown fences.
+        """
+    }
+
+    private func decodeCalendarAction(from rawContent: String) throws -> AICalendarWriteAction {
+        guard let jsonString = extractJSONObject(from: rawContent),
+              let data = jsonString.data(using: .utf8)
+        else {
+            throw FeatureError("The AI did not return a usable calendar plan.")
+        }
+
+        do {
+            return try JSONDecoder().decode(AICalendarWriteAction.self, from: data)
+        } catch {
+            throw FeatureError("The AI returned an invalid calendar plan format.")
+        }
+    }
+
+    private func extractJSONObject(from rawContent: String) -> String? {
+        guard let start = rawContent.firstIndex(of: "{"),
+              let end = rawContent.lastIndex(of: "}")
+        else {
+            return nil
+        }
+        return String(rawContent[start...end])
+    }
+
+    private func makeCalendarDraft(from payload: AICalendarEventPayload) throws -> CalendarEventDraft? {
+        let title = payload.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return nil }
+
+        guard let start = parseCalendarDate(payload.start),
+              let end = parseCalendarDate(payload.end)
+        else {
+            throw FeatureError("The AI returned a calendar event with an invalid date.")
+        }
+
+        return CalendarEventDraft(
+            title: title,
+            start: start,
+            end: end,
+            notes: normalizedOptionalText(payload.notes),
+            location: normalizedOptionalText(payload.location)
+        )
+    }
+
+    private func parseCalendarDate(_ rawValue: String) -> Date? {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+
+        let internetFormatter = ISO8601DateFormatter()
+        internetFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let parsed = internetFormatter.date(from: value) {
+            return parsed
+        }
+
+        let fallbackInternetFormatter = ISO8601DateFormatter()
+        fallbackInternetFormatter.formatOptions = [.withInternetDateTime]
+        if let parsed = fallbackInternetFormatter.date(from: value) {
+            return parsed
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+
+        for format in ["yyyy-MM-dd HH:mm", "yyyy-MM-dd HH:mm:ss", "yyyy/MM/dd HH:mm"] {
+            formatter.dateFormat = format
+            if let parsed = formatter.date(from: value) {
+                return parsed
+            }
+        }
+
+        return nil
+    }
+
+    private func normalizedOptionalText(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func mergedCalendarWriteReply(
+        baseReply: String,
+        createdEvents: [CreatedCalendarEvent]
+    ) -> String {
+        let trimmedReply = baseReply.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !createdEvents.isEmpty else {
+            return trimmedReply.isEmpty ? "已生成计划，但没有写入新的日历事件。" : trimmedReply
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "zh_CN")
+        formatter.timeZone = .current
+        formatter.dateFormat = "MM-dd HH:mm"
+
+        let lines = createdEvents.map {
+            "- \($0.title) (\(formatter.string(from: $0.start)) - \(formatter.string(from: $0.end)))"
+        }
+        let creationSummary = "已写入日历：\n" + lines.joined(separator: "\n")
+
+        if trimmedReply.isEmpty {
+            return creationSummary
+        }
+
+        return trimmedReply + "\n\n" + creationSummary
+    }
+
+    private func isoTimestamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = .current
+        return formatter.string(from: date)
+    }
+
+    private func isModelIdentityQuestion(_ prompt: String) -> Bool {
+        let lowered = prompt.lowercased()
+        let keywords = [
+            "what model",
+            "which model",
+            "model are you",
+            "your model",
+            "模型",
+            "什么模型",
+            "哪个模型",
+            "你是什么模型",
+            "真实模型"
+        ]
+        return keywords.contains(where: lowered.contains)
+    }
+
+    private func localizedModelIdentityReply(for prompt: String, resolvedModelName: String) -> String {
+        if prompt.containsChineseCharacters {
+            return "当前接口实际返回的模型是 \(resolvedModelName)。"
+        }
+        return "The current model returned by the API is \(resolvedModelName)."
+    }
+}
+
+private struct WeatherLookupLocation {
+    let displayName: String
+    let latitude: Double
+    let longitude: Double
+}
+
+private final class WeatherLocationProvider: NSObject, CLLocationManagerDelegate {
+    var authorizationDidChange: ((CLAuthorizationStatus) -> Void)?
+
+    private let manager = CLLocationManager()
+    private let geocoder = CLGeocoder()
+
+    private var locationContinuation: CheckedContinuation<CLLocation, Error>?
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyKilometer
+    }
+
+    var authorizationStatus: CLAuthorizationStatus {
+        manager.authorizationStatus
+    }
+
+    func ensureAuthorizationStatus() async -> CLAuthorizationStatus {
+        let status = authorizationStatus
+        guard status == .notDetermined else { return status }
+
+        await MainActor.run {
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+
+        try? await Task.sleep(for: .milliseconds(300))
+
+        await MainActor.run {
+            manager.requestWhenInUseAuthorization()
+        }
+
+        var resolvedStatus = authorizationStatus
+        for _ in 0..<20 {
+            if resolvedStatus != .notDetermined {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(250))
+            resolvedStatus = authorizationStatus
+        }
+
+        if resolvedStatus != .notDetermined {
+            await MainActor.run {
+                NSApp.setActivationPolicy(.accessory)
+            }
+        }
+
+        return resolvedStatus
+    }
+
+    func requestResolvedLocation() async throws -> WeatherLookupLocation {
+        let status = await ensureAuthorizationStatus()
+        let servicesEnabled = CLLocationManager.locationServicesEnabled()
+
+        switch status {
+        case .authorizedAlways, .authorizedWhenInUse:
+            guard servicesEnabled else {
+                throw FeatureError("Location Services are disabled in macOS settings.")
+            }
+            break
+        case .denied:
+            throw FeatureError("Location access is denied. Allow Boring Notch in Privacy & Security > Location Services.")
+        case .restricted:
+            throw FeatureError("Location access is restricted on this Mac.")
+        case .notDetermined:
+            if !servicesEnabled {
+                throw FeatureError("Location Services are disabled in macOS settings.")
+            }
+            throw FeatureError("Location access has not been granted yet.")
+        @unknown default:
+            throw FeatureError("Location access is unavailable.")
+        }
+
+        let location = try await withCheckedThrowingContinuation { continuation in
+            locationContinuation = continuation
+            manager.requestLocation()
+        }
+
+        return WeatherLookupLocation(
+            displayName: await reverseGeocodeDisplayName(for: location) ?? "Current location",
+            latitude: location.coordinate.latitude,
+            longitude: location.coordinate.longitude
+        )
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        authorizationDidChange?(status)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let continuation = locationContinuation else { return }
+        locationContinuation = nil
+
+        if let location = locations.last {
+            continuation.resume(returning: location)
+        } else {
+            continuation.resume(throwing: FeatureError("Current location was unavailable."))
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        guard let continuation = locationContinuation else { return }
+        locationContinuation = nil
+        continuation.resume(throwing: error)
+    }
+
+    private func reverseGeocodeDisplayName(for location: CLLocation) async -> String? {
+        do {
+            let placemarks = try await geocoder.reverseGeocodeLocation(location)
+            guard let placemark = placemarks.first else { return nil }
+            return [placemark.locality, placemark.administrativeArea, placemark.country]
+                .compactMap { component in
+                    guard let component, !component.isEmpty else { return nil }
+                    return component
+                }
+                .joined(separator: ", ")
+        } catch {
+            return nil
+        }
+    }
+}
+
+@MainActor
+final class WeatherManager: ObservableObject {
+    static let shared = WeatherManager()
+
+    @Published private(set) var snapshot: WeatherSnapshot?
+    @Published private(set) var isRefreshing: Bool = false
+    @Published var lastError: String?
+    @Published private(set) var locationServicesEnabled: Bool
+    @Published private(set) var locationAuthorizationStatus: CLAuthorizationStatus
+
+    private var cancellables: Set<AnyCancellable> = []
+    private let locationProvider: WeatherLocationProvider
+
+    private init() {
+        locationProvider = WeatherLocationProvider()
+        locationServicesEnabled = CLLocationManager.locationServicesEnabled()
+        locationAuthorizationStatus = locationProvider.authorizationStatus
+
+        let cityPublisher = Defaults.publisher(.weatherCity).map { _ in () }.eraseToAnyPublisher()
+        let modePublisher = Defaults.publisher(.weatherLocationMode).map { _ in () }.eraseToAnyPublisher()
+        let unitPublisher = Defaults.publisher(.weatherTemperatureUnit).map { _ in () }.eraseToAnyPublisher()
+        let enabledPublisher = Defaults.publisher(.weatherFeatureEnabled).map { _ in () }.eraseToAnyPublisher()
+
+        Publishers.Merge4(cityPublisher, modePublisher, unitPublisher, enabledPublisher)
+            .sink { [weak self] _ in
+                Task { await self?.refreshWeather(force: true) }
+            }
+            .store(in: &cancellables)
+
+        locationProvider.authorizationDidChange = { [weak self] status in
+            Task { @MainActor in
+                guard let self else { return }
+                self.locationAuthorizationStatus = status
+
+                guard Defaults[.weatherFeatureEnabled], Defaults[.weatherLocationMode] == .automatic else { return }
+                await self.refreshWeather(force: true)
+            }
+        }
+
+        Task {
+            await refreshWeather(force: false)
+        }
+    }
+
+    var locationAuthorizationDescription: String {
+        if !locationServicesEnabled {
+            return "Services off"
+        }
+
+        switch locationAuthorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            return "Allowed"
+        case .notDetermined:
+            return "Not requested"
+        case .denied:
+            return "Denied"
+        case .restricted:
+            return "Restricted"
+        @unknown default:
+            return "Unknown"
+        }
+    }
+
+    func requestLocationAuthorization() async {
+        await MainActor.run {
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        refreshLocationAccessState()
+        let status = await locationProvider.ensureAuthorizationStatus()
+        locationAuthorizationStatus = status
+
+        switch status {
+        case .denied, .restricted, .notDetermined:
+            break
+        default:
+            await refreshWeather(force: true)
+        }
+
+        if status != .notDetermined {
+            await MainActor.run {
+                NSApp.setActivationPolicy(.accessory)
+            }
+        }
+    }
+
+    func openLocationSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices") else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    func refreshWeather(force: Bool) async {
+        refreshLocationAccessState()
+
+        guard Defaults[.weatherFeatureEnabled] else {
+            snapshot = nil
+            lastError = nil
+            return
+        }
+
+        guard !isRefreshing else { return }
+
+        if let snapshot, !force, Date().timeIntervalSince(snapshot.updatedAt) < 900 {
+            return
+        }
+
+        isRefreshing = true
+        lastError = nil
+        defer { isRefreshing = false }
+
+        do {
+            let location = try await resolvedLocation()
+            snapshot = try await fetchWeather(for: location)
+        } catch {
+            if snapshot == nil {
+                snapshot = nil
+            }
+            lastError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    func refreshLocationAccessState() {
+        locationServicesEnabled = CLLocationManager.locationServicesEnabled()
+        locationAuthorizationStatus = locationProvider.authorizationStatus
+    }
+
+    private func resolvedLocation() async throws -> WeatherLookupLocation {
+        if Defaults[.weatherLocationMode] == .automatic {
+            return try await locationProvider.requestResolvedLocation()
+        }
+
+        let query = Defaults[.weatherCity].trimmingCharacters(in: .whitespacesAndNewlines)
+        let city = query.isEmpty ? defaultWeatherCityName() : query
+
+        guard !city.isEmpty else {
+            throw FeatureError("请先在设置 > Weather 中填写城市。")
+        }
+
+        return try await geocode(city: city)
+    }
+
+    private func geocode(city: String) async throws -> WeatherLookupLocation {
+        var components = URLComponents(string: "https://geocoding-api.open-meteo.com/v1/search")
+        components?.queryItems = [
+            URLQueryItem(name: "name", value: city),
+            URLQueryItem(name: "count", value: "1"),
+            URLQueryItem(name: "language", value: "en"),
+            URLQueryItem(name: "format", value: "json"),
+        ]
+
+        guard let url = components?.url else {
+            throw FeatureError("天气城市查询地址无效。")
+        }
+
+        let (data, response) = try await URLSession.shared.data(from: url)
+        if let httpResponse = response as? HTTPURLResponse, !(200 ... 299).contains(httpResponse.statusCode) {
+            throw FeatureError("天气城市查询失败，状态码 \(httpResponse.statusCode)。")
+        }
+
+        let decoded = try JSONDecoder().decode(GeocodingResponse.self, from: data)
+        guard let firstMatch = decoded.results?.first else {
+            throw FeatureError("没有找到“\(city)”的天气结果。")
+        }
+
+        return .init(
+            displayName: firstMatch.displayName,
+            latitude: firstMatch.latitude,
+            longitude: firstMatch.longitude
+        )
+    }
+
+    private func fetchWeather(for location: WeatherLookupLocation) async throws -> WeatherSnapshot {
+        var components = URLComponents(string: "https://api.open-meteo.com/v1/forecast")
+        let unit = Defaults[.weatherTemperatureUnit]
+        components?.queryItems = [
+            URLQueryItem(name: "latitude", value: String(location.latitude)),
+            URLQueryItem(name: "longitude", value: String(location.longitude)),
+            URLQueryItem(
+                name: "current",
+                value: "temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,weather_code,wind_speed_10m,is_day"
+            ),
+            URLQueryItem(name: "hourly", value: "temperature_2m,weather_code,precipitation_probability,is_day"),
+            URLQueryItem(name: "daily", value: "temperature_2m_max,temperature_2m_min"),
+            URLQueryItem(name: "forecast_days", value: "1"),
+            URLQueryItem(name: "timezone", value: "auto"),
+            URLQueryItem(name: "temperature_unit", value: unit.apiValue),
+            URLQueryItem(name: "wind_speed_unit", value: unit.windSpeedAPIValue),
+        ]
+
+        guard let url = components?.url else {
+            throw FeatureError("天气预报地址无效。")
+        }
+
+        let (data, response) = try await URLSession.shared.data(from: url)
+        if let httpResponse = response as? HTTPURLResponse, !(200 ... 299).contains(httpResponse.statusCode) {
+            throw FeatureError("天气获取失败，状态码 \(httpResponse.statusCode)。")
+        }
+
+        let decoded = try JSONDecoder().decode(OpenMeteoForecastResponse.self, from: data)
+        let currentDescriptor = WeatherDescriptor.from(code: decoded.current.weatherCode, isDay: decoded.current.isDay == 1)
+        let hourlySlice = hourlyEntries(from: decoded.hourly, currentTime: decoded.current.time, unit: unit)
+
+        return WeatherSnapshot(
+            locationName: location.displayName,
+            updatedAt: Date(),
+            current: .init(
+                temperature: decoded.current.temperature,
+                feelsLike: decoded.current.apparentTemperature,
+                humidity: decoded.current.relativeHumidity,
+                precipitation: decoded.current.precipitation,
+                windSpeed: decoded.current.windSpeed,
+                condition: currentDescriptor.title,
+                symbolName: currentDescriptor.symbolName,
+                unitSymbol: unit.symbol,
+                windUnit: unit.windSpeedLabel,
+                highTemperature: decoded.daily?.temperatureMax.first,
+                lowTemperature: decoded.daily?.temperatureMin.first
+            ),
+            hourly: hourlySlice
+        )
+    }
+
+    private func hourlyEntries(
+        from hourly: OpenMeteoForecastResponse.Hourly,
+        currentTime: String,
+        unit: WeatherTemperatureUnit
+    ) -> [WeatherSnapshot.HourlyEntry] {
+        guard !hourly.time.isEmpty else { return [] }
+
+        let startIndex = hourly.time.firstIndex(of: currentTime) ?? 0
+        let endIndex = min(startIndex + 5, hourly.time.count)
+
+        return (startIndex ..< endIndex).compactMap { index in
+            guard index < hourly.temperature.count, index < hourly.weatherCode.count else { return nil }
+            let isDay = hourly.isDay.flatMap { index < $0.count ? $0[index] : nil } ?? 1
+            let descriptor = WeatherDescriptor.from(code: hourly.weatherCode[index], isDay: isDay == 1)
+            return WeatherSnapshot.HourlyEntry(
+                timeLabel: formattedHourLabel(from: hourly.time[index]),
+                temperature: hourly.temperature[index],
+                symbolName: descriptor.symbolName,
+                unitSymbol: unit.symbol,
+                precipitationProbability: hourly.precipitationProbability.flatMap { index < $0.count ? $0[index] : nil }
+            )
+        }
+    }
+
+    private func formattedHourLabel(from value: String) -> String {
+        let raw = value.replacingOccurrences(of: "T", with: " ")
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+
+        guard let date = formatter.date(from: raw) else {
+            return String(value.suffix(5))
+        }
+
+        let display = DateFormatter()
+        display.locale = Locale.current
+        display.dateFormat = "HH:mm"
+        return display.string(from: date)
+    }
+}
+
+enum PomodoroPhase: String, CaseIterable, Identifiable {
+    case focus = "Focus"
+    case shortBreak = "Short Break"
+    case longBreak = "Long Break"
+
+    var id: String { rawValue }
+
+    var symbolName: String {
+        switch self {
+        case .focus:
+            return "brain.head.profile"
+        case .shortBreak:
+            return "cup.and.saucer.fill"
+        case .longBreak:
+            return "bed.double.fill"
+        }
+    }
+
+    var shortLabel: String {
+        switch self {
+        case .focus:
+            return "Focus"
+        case .shortBreak:
+            return "Short"
+        case .longBreak:
+            return "Long"
+        }
+    }
+}
+
+@MainActor
+final class PomodoroManager: ObservableObject {
+    static let shared = PomodoroManager()
+
+    @Published private(set) var phase: PomodoroPhase = .focus
+    @Published private(set) var remainingSeconds: Int
+    @Published private(set) var isRunning: Bool = false
+    @Published private(set) var completedFocusSessions: Int = 0
+
+    private var timerTask: Task<Void, Never>?
+    private var targetDate: Date?
+    private var cancellables: Set<AnyCancellable> = []
+
+    private init() {
+        remainingSeconds = Self.duration(for: .focus)
+
+        Publishers.MergeMany([
+            Defaults.publisher(.pomodoroEnabled).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.pomodoroFocusMinutes).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.pomodoroShortBreakMinutes).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.pomodoroLongBreakMinutes).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.pomodoroLongBreakInterval).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.pomodoroAutoStartNextPhase).map { _ in () }.eraseToAnyPublisher(),
+        ])
+        .sink { [weak self] _ in
+            self?.handleConfigurationChange()
+        }
+        .store(in: &cancellables)
+    }
+
+    deinit {
+        timerTask?.cancel()
+    }
+
+    var formattedRemaining: String {
+        String(format: "%02d:%02d", remainingSeconds / 60, remainingSeconds % 60)
+    }
+
+    var progress: Double {
+        let total = max(phaseTotalSeconds, 1)
+        return 1 - min(max(Double(remainingSeconds) / Double(total), 0), 1)
+    }
+
+    var phaseTotalSeconds: Int {
+        Self.duration(for: phase)
+    }
+
+    var nextPhaseTitle: String {
+        nextPhase(after: phase, completedFocusCount: phase == .focus ? completedFocusSessions + 1 : completedFocusSessions).rawValue
+    }
+
+    var currentCycleIndexLabel: String {
+        let interval = max(2, Defaults[.pomodoroLongBreakInterval])
+        let completedInCycle = completedFocusSessions % interval
+
+        if phase == .focus {
+            return "\(completedInCycle + 1)/\(interval)"
+        }
+
+        if completedFocusSessions > 0 && completedInCycle == 0 {
+            return "\(interval)/\(interval)"
+        }
+
+        return "\(max(completedInCycle, 1))/\(interval)"
+    }
+
+    func toggleRunning() {
+        isRunning ? pause() : start()
+    }
+
+    func start() {
+        guard Defaults[.pomodoroEnabled] else { return }
+        guard !isRunning else { return }
+
+        if remainingSeconds <= 0 {
+            remainingSeconds = phaseTotalSeconds
+        }
+
+        isRunning = true
+        targetDate = Date().addingTimeInterval(Double(remainingSeconds))
+        scheduleTickTask()
+    }
+
+    func pause() {
+        guard isRunning else { return }
+        syncRemainingToNow()
+        stopTimer(clearRemaining: false)
+    }
+
+    func resetCurrentPhase() {
+        stopTimer(clearRemaining: true)
+    }
+
+    func resetCycle() {
+        completedFocusSessions = 0
+        phase = .focus
+        stopTimer(clearRemaining: true)
+    }
+
+    func skipPhase() {
+        advanceToNextPhase(completedCurrentPhase: false, continueRunning: isRunning)
+    }
+
+    func selectPhase(_ newPhase: PomodoroPhase) {
+        guard phase != newPhase else { return }
+        phase = newPhase
+        stopTimer(clearRemaining: true)
+    }
+
+    private func handleConfigurationChange() {
+        guard Defaults[.pomodoroEnabled] else {
+            resetCycle()
+            return
+        }
+
+        if !isRunning {
+            remainingSeconds = phaseTotalSeconds
+        }
+    }
+
+    private func scheduleTickTask() {
+        timerTask?.cancel()
+        timerTask = Task { [weak self] in
+            while let self, !Task.isCancelled {
+                await self.tick()
+                try? await Task.sleep(for: .seconds(1))
+            }
+        }
+    }
+
+    private func tick() async {
+        guard isRunning, let targetDate else { return }
+
+        let nextRemaining = max(0, Int(ceil(targetDate.timeIntervalSinceNow)))
+        if nextRemaining != remainingSeconds {
+            remainingSeconds = nextRemaining
+        }
+
+        if nextRemaining <= 0 {
+            completeCurrentPhase()
+        }
+    }
+
+    private func completeCurrentPhase() {
+        NSSound.beep()
+        advanceToNextPhase(
+            completedCurrentPhase: true,
+            continueRunning: Defaults[.pomodoroAutoStartNextPhase]
+        )
+    }
+
+    private func advanceToNextPhase(completedCurrentPhase: Bool, continueRunning: Bool) {
+        let previousPhase = phase
+        stopTimer(clearRemaining: false)
+
+        if completedCurrentPhase && previousPhase == .focus {
+            completedFocusSessions += 1
+        }
+
+        phase = nextPhase(
+            after: previousPhase,
+            completedFocusCount: completedFocusSessions
+        )
+        remainingSeconds = phaseTotalSeconds
+
+        if continueRunning {
+            start()
+        }
+    }
+
+    private func nextPhase(after phase: PomodoroPhase, completedFocusCount: Int) -> PomodoroPhase {
+        switch phase {
+        case .focus:
+            let interval = max(2, Defaults[.pomodoroLongBreakInterval])
+            if completedFocusCount > 0 && completedFocusCount % interval == 0 {
+                return .longBreak
+            }
+            return .shortBreak
+        case .shortBreak, .longBreak:
+            return .focus
+        }
+    }
+
+    private func syncRemainingToNow() {
+        guard let targetDate else { return }
+        remainingSeconds = max(0, Int(ceil(targetDate.timeIntervalSinceNow)))
+    }
+
+    private func stopTimer(clearRemaining: Bool) {
+        isRunning = false
+        targetDate = nil
+        timerTask?.cancel()
+        timerTask = nil
+
+        if clearRemaining {
+            remainingSeconds = phaseTotalSeconds
+        }
+    }
+
+    private static func duration(for phase: PomodoroPhase) -> Int {
+        let minutes: Int
+
+        switch phase {
+        case .focus:
+            minutes = max(1, Defaults[.pomodoroFocusMinutes])
+        case .shortBreak:
+            minutes = max(1, Defaults[.pomodoroShortBreakMinutes])
+        case .longBreak:
+            minutes = max(1, Defaults[.pomodoroLongBreakMinutes])
+        }
+
+        return minutes * 60
+    }
+}
+
+struct WeatherSnapshot {
+    struct CurrentConditions {
+        let temperature: Double
+        let feelsLike: Double
+        let humidity: Int
+        let precipitation: Double
+        let windSpeed: Double
+        let condition: String
+        let symbolName: String
+        let unitSymbol: String
+        let windUnit: String
+        let highTemperature: Double?
+        let lowTemperature: Double?
+    }
+
+    struct HourlyEntry: Identifiable {
+        let id = UUID()
+        let timeLabel: String
+        let temperature: Double
+        let symbolName: String
+        let unitSymbol: String
+        let precipitationProbability: Int?
+    }
+
+    let locationName: String
+    let updatedAt: Date
+    let current: CurrentConditions
+    let hourly: [HourlyEntry]
+}
+
+enum WeatherDescriptor {
+    case clear
+    case clearNight
+    case partlyCloudy
+    case partlyCloudyNight
+    case cloudy
+    case fog
+    case drizzle
+    case rain
+    case snow
+    case thunder
+
+    var title: String {
+        switch self {
+        case .clear: return "晴"
+        case .clearNight: return "晴朗夜间"
+        case .partlyCloudy: return "少云"
+        case .partlyCloudyNight: return "少云夜间"
+        case .cloudy: return "多云"
+        case .fog: return "雾"
+        case .drizzle: return "小雨"
+        case .rain: return "雨"
+        case .snow: return "雪"
+        case .thunder: return "雷暴"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .clear: return "sun.max.fill"
+        case .clearNight: return "moon.stars.fill"
+        case .partlyCloudy: return "cloud.sun.fill"
+        case .partlyCloudyNight: return "cloud.moon.fill"
+        case .cloudy: return "cloud.fill"
+        case .fog: return "cloud.fog.fill"
+        case .drizzle: return "cloud.drizzle.fill"
+        case .rain: return "cloud.rain.fill"
+        case .snow: return "cloud.snow.fill"
+        case .thunder: return "cloud.bolt.rain.fill"
+        }
+    }
+
+    static func from(code: Int, isDay: Bool) -> WeatherDescriptor {
+        switch code {
+        case 0:
+            return isDay ? .clear : .clearNight
+        case 1, 2:
+            return isDay ? .partlyCloudy : .partlyCloudyNight
+        case 3:
+            return .cloudy
+        case 45, 48:
+            return .fog
+        case 51, 53, 55, 56, 57:
+            return .drizzle
+        case 61, 63, 65, 66, 67, 80, 81, 82:
+            return .rain
+        case 71, 73, 75, 77, 85, 86:
+            return .snow
+        case 95, 96, 99:
+            return .thunder
+        default:
+            return .cloudy
+        }
+    }
+}
+
+private struct OpenAIChatRequest: Encodable {
+    struct Message: Encodable {
+        let role: String
+        let content: String
+    }
+
+    let model: String
+    let messages: [Message]
+    let temperature: Double
+}
+
+private struct OpenAIChatResponse: Decodable {
+    struct Choice: Decodable {
+        let message: Message
+    }
+
+    struct Message: Decodable {
+        let content: String
+
+        enum CodingKeys: String, CodingKey {
+            case content
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if let plainText = try? container.decode(String.self, forKey: .content) {
+                content = plainText
+                return
+            }
+
+            if let array = try? container.decode([ContentPart].self, forKey: .content) {
+                content = array.compactMap(\.text).joined(separator: "\n")
+                return
+            }
+
+            content = ""
+        }
+    }
+
+    struct ContentPart: Decodable {
+        let text: String?
+    }
+
+    let choices: [Choice]
+    let model: String?
+}
+
+private struct AIReply {
+    let content: String
+    let requestedModelName: String
+    let resolvedModelName: String?
+}
+
+private struct AIServiceConfig {
+    let endpoint: URL
+    let apiKey: String
+    let requestedModel: String
+}
+
+private struct AICalendarWriteAction: Decodable {
+    let reply: String
+    let createEvents: Bool
+    let events: [AICalendarEventPayload]
+
+    enum CodingKeys: String, CodingKey {
+        case reply
+        case createEvents = "create_events"
+        case events
+    }
+}
+
+private struct AICalendarEventPayload: Decodable {
+    let title: String
+    let start: String
+    let end: String
+    let notes: String?
+    let location: String?
+}
+
+private struct OpenAIErrorResponse: Decodable {
+    struct ErrorPayload: Decodable {
+        let message: String?
+    }
+
+    let error: ErrorPayload
+}
+
+private struct GeocodingResponse: Decodable {
+    struct ResultItem: Decodable {
+        let name: String
+        let latitude: Double
+        let longitude: Double
+        let country: String?
+        let admin1: String?
+
+        var displayName: String {
+            [name, admin1, country]
+                .compactMap { component in
+                    guard let component, !component.isEmpty else { return nil }
+                    return component
+                }
+                .joined(separator: ", ")
+        }
+    }
+
+    let results: [ResultItem]?
+}
+
+private extension String {
+    var containsChineseCharacters: Bool {
+        unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x4E00 ... 0x9FFF, 0x3400 ... 0x4DBF, 0x20000 ... 0x2A6DF:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}
+
+private struct OpenMeteoForecastResponse: Decodable {
+    struct Current: Decodable {
+        let time: String
+        let temperature: Double
+        let relativeHumidity: Int
+        let apparentTemperature: Double
+        let precipitation: Double
+        let weatherCode: Int
+        let windSpeed: Double
+        let isDay: Int
+
+        enum CodingKeys: String, CodingKey {
+            case time
+            case temperature = "temperature_2m"
+            case relativeHumidity = "relative_humidity_2m"
+            case apparentTemperature = "apparent_temperature"
+            case precipitation
+            case weatherCode = "weather_code"
+            case windSpeed = "wind_speed_10m"
+            case isDay = "is_day"
+        }
+    }
+
+    struct Hourly: Decodable {
+        let time: [String]
+        let temperature: [Double]
+        let weatherCode: [Int]
+        let precipitationProbability: [Int]?
+        let isDay: [Int]?
+
+        enum CodingKeys: String, CodingKey {
+            case time
+            case temperature = "temperature_2m"
+            case weatherCode = "weather_code"
+            case precipitationProbability = "precipitation_probability"
+            case isDay = "is_day"
+        }
+    }
+
+    struct Daily: Decodable {
+        let temperatureMax: [Double]
+        let temperatureMin: [Double]
+
+        enum CodingKeys: String, CodingKey {
+            case temperatureMax = "temperature_2m_max"
+            case temperatureMin = "temperature_2m_min"
+        }
+    }
+
+    let current: Current
+    let hourly: Hourly
+    let daily: Daily?
+}
+
+private struct FeatureError: LocalizedError {
+    let errorDescription: String?
+
+    init(_ message: String) {
+        errorDescription = message
+    }
+}

--- a/boringNotch/managers/AIWeatherManagers.swift
+++ b/boringNotch/managers/AIWeatherManagers.swift
@@ -10,6 +10,154 @@ import Combine
 import CoreLocation
 import Defaults
 import Foundation
+import LocalAuthentication
+import Security
+
+private struct AICredentialStoreError: LocalizedError {
+    let errorDescription: String?
+
+    init(_ message: String) {
+        errorDescription = message
+    }
+}
+
+enum AIProviderCredentialStore {
+    private static let service = "\(Bundle.main.bundleIdentifier ?? "theboringteam.boringnotch").ai-provider-v2"
+    private static let account = "openai-compatible-api-key"
+    private static let accessCoordinator = CredentialAccessCoordinator()
+
+    private actor CredentialAccessCoordinator {
+        private var cachedAPIKey: String?
+        private var loadTask: Task<String, Never>?
+
+        func loadAPIKey() async -> String {
+            if let cachedAPIKey {
+                return cachedAPIKey
+            }
+            if let loadTask {
+                return await loadTask.value
+            }
+
+            let task = Task.detached(priority: .userInitiated) {
+                AIProviderCredentialStore.loadAPIKeySynchronously()
+            }
+            loadTask = task
+            let value = await task.value
+            cachedAPIKey = value
+            loadTask = nil
+            return value
+        }
+
+        func saveAPIKey(_ rawValue: String) async throws {
+            let normalizedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            try await Task.detached(priority: .userInitiated) {
+                try AIProviderCredentialStore.saveAPIKeySynchronously(normalizedValue)
+            }.value
+            cachedAPIKey = normalizedValue
+            loadTask = nil
+        }
+    }
+
+    static func loadAPIKey() async -> String {
+        await accessCoordinator.loadAPIKey()
+    }
+
+    static func saveAPIKey(_ rawValue: String) async throws {
+        try await accessCoordinator.saveAPIKey(rawValue)
+    }
+
+    private static func loadAPIKeySynchronously() -> String {
+        if let value = try? readKeychainValue(), !value.isEmpty {
+            return value
+        }
+
+        let legacyValue = Defaults[.aiServiceAPIKey]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !legacyValue.isEmpty else { return "" }
+
+        if (try? saveAPIKeySynchronously(legacyValue)) != nil {
+            Defaults[.aiServiceAPIKey] = ""
+        }
+        return legacyValue
+    }
+
+    private static func saveAPIKeySynchronously(_ rawValue: String) throws {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let query = baseQuery
+
+        if value.isEmpty {
+            var deleteQuery = query
+            deleteQuery[kSecUseAuthenticationContext] = nonInteractiveContext()
+            let status = SecItemDelete(deleteQuery as CFDictionary)
+            guard status == errSecSuccess || status == errSecItemNotFound else {
+                throw credentialError(status)
+            }
+            Defaults[.aiServiceAPIKey] = ""
+            return
+        }
+
+        let attributes: [CFString: Any] = [
+            kSecValueData: Data(value.utf8),
+            kSecAttrLabel: "Boring Notch AI API Key",
+        ]
+        var updateQuery = query
+        updateQuery[kSecUseAuthenticationContext] = nonInteractiveContext()
+        var status = SecItemUpdate(updateQuery as CFDictionary, attributes as CFDictionary)
+        if status == errSecItemNotFound {
+            var item = query
+            for (key, value) in attributes {
+                item[key] = value
+            }
+            status = SecItemAdd(item as CFDictionary, nil)
+        }
+
+        guard status == errSecSuccess else {
+            throw credentialError(status)
+        }
+        Defaults[.aiServiceAPIKey] = ""
+    }
+
+    private static var baseQuery: [CFString: Any] {
+        [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+        ]
+    }
+
+    private static func readKeychainValue() throws -> String {
+        var query = baseQuery
+        query[kSecReturnData] = true
+        query[kSecMatchLimit] = kSecMatchLimitOne
+        query[kSecUseAuthenticationContext] = nonInteractiveContext()
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound {
+            return ""
+        }
+        guard status == errSecSuccess else {
+            throw credentialError(status)
+        }
+        guard let data = result as? Data,
+              let value = String(data: data, encoding: .utf8)
+        else {
+            throw credentialError(errSecDecode)
+        }
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func nonInteractiveContext() -> LAContext {
+        let context = LAContext()
+        context.interactionNotAllowed = true
+        return context
+    }
+
+    private static func credentialError(_ status: OSStatus) -> AICredentialStoreError {
+        let message = SecCopyErrorMessageString(status, nil) as String?
+        return AICredentialStoreError("Unable to access macOS Keychain: \(message ?? "error \(status)")")
+    }
+}
 
 struct AIChatMessage: Identifiable, Equatable, Codable {
     enum Role: String, Codable {
@@ -2499,7 +2647,7 @@ final class AIChatManager: ObservableObject {
     ]
 
     private func requestReply(for prompt: String, agentRun: AgentPreparedRun) async throws -> AIReply {
-        let config = try resolveServiceConfig()
+        let config = try await resolveServiceConfig()
         let decoded = try await performChatCompletion(
             config: config,
             messages: buildPayloadMessages(
@@ -2544,7 +2692,7 @@ final class AIChatManager: ObservableObject {
             throw FeatureError("Calendar access is unavailable. Enable it in Settings > Calendar before asking AI to write plans.")
         }
 
-        let config = try resolveServiceConfig()
+        let config = try await resolveServiceConfig()
         let decoded = try await performChatCompletion(
             config: config,
             messages: buildPayloadMessages(
@@ -2661,9 +2809,9 @@ final class AIChatManager: ObservableObject {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    private func resolveServiceConfig() throws -> AIServiceConfig {
+    private func resolveServiceConfig() async throws -> AIServiceConfig {
         let baseURL = Defaults[.aiServiceBaseURL].trimmingCharacters(in: .whitespacesAndNewlines)
-        let apiKey = Defaults[.aiServiceAPIKey].trimmingCharacters(in: .whitespacesAndNewlines)
+        let apiKey = await AIProviderCredentialStore.loadAPIKey()
         let requestedModel = Defaults[.aiServiceModel].trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard Defaults[.aiChatEnabled] else {

--- a/boringNotch/managers/CalendarManager.swift
+++ b/boringNotch/managers/CalendarManager.swift
@@ -201,4 +201,98 @@ class CalendarManager: ObservableObject {
             to: Calendar.current.date(byAdding: .day, value: 1, to: currentWeekStartDate)!,
             calendars: selectedCalendars.map { $0.id })
     }
+
+    func ensureCalendarAccessIfNeeded() async -> Bool {
+        let status = EKEventStore.authorizationStatus(for: .event)
+        calendarAuthorizationStatus = status
+
+        if status == .notDetermined {
+            await checkCalendarAuthorization()
+        } else if status == .fullAccess {
+            await reloadCalendarAndReminderLists()
+        }
+
+        return calendarAuthorizationStatus == .fullAccess
+    }
+
+    func aiScheduleContext(daysAhead: Int = 7, limit: Int = 18) async -> String? {
+        guard Defaults[.aiCalendarContextEnabled] else { return nil }
+        guard await ensureCalendarAccessIfNeeded() else { return nil }
+
+        await reloadCalendarAndReminderLists()
+        updateSelectedCalendars()
+
+        let start = Date()
+        let end = Calendar.current.date(byAdding: .day, value: daysAhead, to: start) ?? start
+        let calendarIDs = selectedCalendars.map { $0.id }
+        let fetchedEvents = await calendarService.events(from: start, to: end, calendars: calendarIDs)
+
+        let relevantEvents = fetchedEvents
+            .filter { event in
+                if event.type.isReminder,
+                   case let .reminder(completed) = event.type,
+                   completed && Defaults[.hideCompletedReminders]
+                {
+                    return false
+                }
+                return true
+            }
+            .prefix(limit)
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "zh_CN")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+
+        let lines = relevantEvents.map { event in
+            let timeRange: String
+            if event.isAllDay {
+                timeRange = "\(formatter.string(from: event.start)) (all day)"
+            } else {
+                timeRange = "\(formatter.string(from: event.start)) - \(formatter.string(from: event.end))"
+            }
+
+            let typeLabel: String
+            switch event.type {
+            case .birthday:
+                typeLabel = "birthday"
+            case .reminder:
+                typeLabel = "reminder"
+            case .event:
+                typeLabel = "event"
+            }
+
+            return "- [\(typeLabel)] \(timeRange) | \(event.title) | calendar: \(event.calendar.title)"
+        }
+
+        if lines.isEmpty {
+            return "No scheduled calendar events were found in the next \(daysAhead) days."
+        }
+
+        return """
+        Calendar events in the next \(daysAhead) days:
+        \(lines.joined(separator: "\n"))
+        """
+    }
+
+    func createAIPlannedEvents(_ drafts: [CalendarEventDraft]) async throws -> [CreatedCalendarEvent] {
+        guard Defaults[.aiCalendarWriteEnabled] else {
+            throw CalendarWriteError.accessDenied
+        }
+
+        guard await ensureCalendarAccessIfNeeded() else {
+            throw CalendarWriteError.accessDenied
+        }
+
+        await reloadCalendarAndReminderLists()
+        updateSelectedCalendars()
+
+        let preferredEventCalendarIDs = selectedCalendars
+            .filter { !$0.isReminder && !$0.isSubscribed }
+            .map(\.id)
+
+        let created = try await calendarService.createEvents(drafts, preferredCalendarIDs: preferredEventCalendarIDs)
+        await updateEvents()
+        return created
+    }
 }

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -30,6 +30,7 @@ class BoringViewModel: NSObject, ObservableObject {
     @Published var edgeAutoOpenActive: Bool = false
     @Published var isHoveringCalendar: Bool = false
     @Published var isBatteryPopoverActive: Bool = false
+    @Published var preventAutoClose: Bool = false
 
     @Published var screenUUID: String?
 
@@ -198,13 +199,48 @@ class BoringViewModel: NSObject, ObservableObject {
     func open() -> Bool {
         guard !coordinator.firstLaunch else { return false }
 
-        self.notchSize = openNotchSize
+        let targetSize = openNotchSizeForView(coordinator.currentView, screenUUID: screenUUID)
+        if notchState == .open
+            && abs(notchSize.width - targetSize.width) < 1
+            && abs(notchSize.height - targetSize.height) < 1
+        {
+            return false
+        }
+
+        self.notchSize = targetSize
         self.notchState = .open
+        notifyPanelSizeChanged()
         
         // Force music information update when notch is opened
         MusicManager.shared.forceUpdate()
 
         return true
+    }
+
+    func updateOpenSizeForCurrentView() {
+        guard notchState == .open else { return }
+        self.notchSize = openNotchSizeForView(coordinator.currentView, screenUUID: screenUUID)
+        notifyPanelSizeChanged()
+    }
+
+    func resizeAssistantPanel(to requestedSize: CGSize, persist: Bool = true) {
+        let nextSize = clampedAIChatPanelSize(
+            width: requestedSize.width,
+            height: requestedSize.height,
+            screenUUID: screenUUID
+        )
+        let widthChanged = abs(nextSize.width - notchSize.width) >= 4
+        let heightChanged = abs(nextSize.height - notchSize.height) >= 4
+
+        if persist {
+            Defaults[.aiChatPanelWidth] = nextSize.width
+            Defaults[.aiChatPanelHeight] = nextSize.height
+        }
+
+        guard notchState == .open, coordinator.currentView == .assistant else { return }
+        guard persist || widthChanged || heightChanged else { return }
+        self.notchSize = nextSize
+        notifyPanelSizeChanged()
     }
 
     func close() {
@@ -215,6 +251,7 @@ class BoringViewModel: NSObject, ObservableObject {
         self.notchSize = getClosedNotchSize(screenUUID: self.screenUUID)
         self.closedNotchSize = self.notchSize
         self.notchState = .closed
+        notifyPanelSizeChanged()
         self.isBatteryPopoverActive = false
         if self.coordinator.shouldShowSneakPeek(on: self.screenUUID) {
             self.coordinator.toggleSneakPeek(status: false, type: .music, targetScreenUUID: self.screenUUID)
@@ -228,6 +265,10 @@ class BoringViewModel: NSObject, ObservableObject {
         } else if !coordinator.openLastTabByDefault {
             coordinator.currentView = .home
         }
+    }
+
+    private func notifyPanelSizeChanged() {
+        NotificationCenter.default.post(name: .notchPanelSizeChanged, object: screenUUID)
     }
 
     func closeHello() {

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -19,6 +19,20 @@ let appVersion = "\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as
 let temporaryDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
 let spacing: CGFloat = 16
 
+func defaultWeatherCityName() -> String {
+    let fallback = TimeZone.current.identifier
+        .split(separator: "/")
+        .last
+        .map(String.init)?
+        .replacingOccurrences(of: "_", with: " ")
+
+    if let fallback, !fallback.isEmpty {
+        return fallback
+    }
+
+    return "San Francisco"
+}
+
 enum CalendarSelectionState: Codable, Defaults.Serializable {
     case all
     case selected(Set<String>)
@@ -122,6 +136,7 @@ extension Notification.Name {
     
     // MARK: - UI
     static let accentColorChanged = Notification.Name("AccentColorChanged")
+    static let notchPanelSizeChanged = Notification.Name("notchPanelSizeChanged")
 }
 
 // Media controller types for selection in settings
@@ -182,6 +197,56 @@ enum OptionKeyAction: String, CaseIterable, Identifiable, Defaults.Serializable 
             return NSLocalizedString("option_key_no_action", comment: "Option (⌥) key behavior: No action")
         }
     }
+}
+
+enum WeatherTemperatureUnit: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case celsius = "Celsius"
+    case fahrenheit = "Fahrenheit"
+
+    var id: String { self.rawValue }
+
+    var apiValue: String {
+        switch self {
+        case .celsius:
+            return "celsius"
+        case .fahrenheit:
+            return "fahrenheit"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .celsius:
+            return "°C"
+        case .fahrenheit:
+            return "°F"
+        }
+    }
+
+    var windSpeedAPIValue: String {
+        switch self {
+        case .celsius:
+            return "kmh"
+        case .fahrenheit:
+            return "mph"
+        }
+    }
+
+    var windSpeedLabel: String {
+        switch self {
+        case .celsius:
+            return "km/h"
+        case .fahrenheit:
+            return "mph"
+        }
+    }
+}
+
+enum WeatherLocationMode: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case automatic = "Automatic location"
+    case manualCity = "Manual city"
+
+    var id: String { self.rawValue }
 }
 
 // Source/provider for OSD control (user-facing: "Source")
@@ -253,6 +318,34 @@ extension Defaults.Keys {
         default: SliderColorEnum.white
     )
     static let playerColorTinting = Key<Bool>("playerColorTinting", default: true)
+    static let aiChatEnabled = Key<Bool>("aiChatEnabled", default: true)
+    static let aiServiceBaseURL = Key<String>("aiServiceBaseURL", default: "https://api.openai.com")
+    static let aiServiceModel = Key<String>("aiServiceModel", default: "gpt-4o-mini")
+    static let aiServiceAPIKey = Key<String>("aiServiceAPIKey", default: "")
+    static let aiSystemPrompt = Key<String>(
+        "aiSystemPrompt",
+        default: "You are a concise assistant inside a macOS notch utility."
+    )
+    static let aiCalendarContextEnabled = Key<Bool>("aiCalendarContextEnabled", default: true)
+    static let aiCalendarWriteEnabled = Key<Bool>("aiCalendarWriteEnabled", default: true)
+    static let aiChatPanelWidth = Key<CGFloat>("aiChatPanelWidth", default: aiChatPanelDefaultSize.width)
+    static let aiChatPanelHeight = Key<CGFloat>("aiChatPanelHeight", default: aiChatPanelDefaultSize.height)
+    static let weatherFeatureEnabled = Key<Bool>("weatherFeatureEnabled", default: true)
+    static let weatherLocationMode = Key<WeatherLocationMode>(
+        "weatherLocationMode",
+        default: .automatic
+    )
+    static let weatherCity = Key<String>("weatherCity", default: defaultWeatherCityName())
+    static let weatherTemperatureUnit = Key<WeatherTemperatureUnit>(
+        "weatherTemperatureUnit",
+        default: .celsius
+    )
+    static let pomodoroEnabled = Key<Bool>("pomodoroEnabled", default: true)
+    static let pomodoroFocusMinutes = Key<Int>("pomodoroFocusMinutes", default: 25)
+    static let pomodoroShortBreakMinutes = Key<Int>("pomodoroShortBreakMinutes", default: 5)
+    static let pomodoroLongBreakMinutes = Key<Int>("pomodoroLongBreakMinutes", default: 15)
+    static let pomodoroLongBreakInterval = Key<Int>("pomodoroLongBreakInterval", default: 4)
+    static let pomodoroAutoStartNextPhase = Key<Bool>("pomodoroAutoStartNextPhase", default: false)
     
     // MARK: Gestures
     static let enableGestures = Key<Bool>("enableGestures", default: true)

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -321,6 +321,7 @@ extension Defaults.Keys {
     static let aiChatEnabled = Key<Bool>("aiChatEnabled", default: true)
     static let aiServiceBaseURL = Key<String>("aiServiceBaseURL", default: "https://api.openai.com")
     static let aiServiceModel = Key<String>("aiServiceModel", default: "gpt-4o-mini")
+    // Legacy migration source only. New credentials are stored in macOS Keychain.
     static let aiServiceAPIKey = Key<String>("aiServiceAPIKey", default: "")
     static let aiSystemPrompt = Key<String>(
         "aiSystemPrompt",

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -318,7 +318,7 @@ extension Defaults.Keys {
         default: SliderColorEnum.white
     )
     static let playerColorTinting = Key<Bool>("playerColorTinting", default: true)
-    static let aiChatEnabled = Key<Bool>("aiChatEnabled", default: true)
+    static let aiChatEnabled = Key<Bool>("aiChatEnabled", default: false)
     static let aiServiceBaseURL = Key<String>("aiServiceBaseURL", default: "https://api.openai.com")
     static let aiServiceModel = Key<String>("aiServiceModel", default: "gpt-4o-mini")
     // Legacy migration source only. New credentials are stored in macOS Keychain.
@@ -327,11 +327,11 @@ extension Defaults.Keys {
         "aiSystemPrompt",
         default: "You are a concise assistant inside a macOS notch utility."
     )
-    static let aiCalendarContextEnabled = Key<Bool>("aiCalendarContextEnabled", default: true)
-    static let aiCalendarWriteEnabled = Key<Bool>("aiCalendarWriteEnabled", default: true)
+    static let aiCalendarContextEnabled = Key<Bool>("aiCalendarContextEnabled", default: false)
+    static let aiCalendarWriteEnabled = Key<Bool>("aiCalendarWriteEnabled", default: false)
     static let aiChatPanelWidth = Key<CGFloat>("aiChatPanelWidth", default: aiChatPanelDefaultSize.width)
     static let aiChatPanelHeight = Key<CGFloat>("aiChatPanelHeight", default: aiChatPanelDefaultSize.height)
-    static let weatherFeatureEnabled = Key<Bool>("weatherFeatureEnabled", default: true)
+    static let weatherFeatureEnabled = Key<Bool>("weatherFeatureEnabled", default: false)
     static let weatherLocationMode = Key<WeatherLocationMode>(
         "weatherLocationMode",
         default: .automatic
@@ -341,7 +341,7 @@ extension Defaults.Keys {
         "weatherTemperatureUnit",
         default: .celsius
     )
-    static let pomodoroEnabled = Key<Bool>("pomodoroEnabled", default: true)
+    static let pomodoroEnabled = Key<Bool>("pomodoroEnabled", default: false)
     static let pomodoroFocusMinutes = Key<Int>("pomodoroFocusMinutes", default: 25)
     static let pomodoroShortBreakMinutes = Key<Int>("pomodoroShortBreakMinutes", default: 5)
     static let pomodoroLongBreakMinutes = Key<Int>("pomodoroLongBreakMinutes", default: 15)

--- a/boringNotch/sizing/matters.swift
+++ b/boringNotch/sizing/matters.swift
@@ -15,6 +15,9 @@ let batterySneakSize: CGSize = .init(width: 160, height: 1)
 let shadowPadding: CGFloat = 20
 let openNotchSize: CGSize = .init(width: 640, height: 190)
 let windowSize: CGSize = .init(width: openNotchSize.width, height: openNotchSize.height + shadowPadding)
+let aiChatPanelDefaultSize: CGSize = .init(width: 980, height: 620)
+let aiChatPanelMinSize: CGSize = .init(width: 760, height: 360)
+let aiChatPanelMaxSize: CGSize = .init(width: 1_680, height: 900)
 let cornerRadiusInsets: (opened: (top: CGFloat, bottom: CGFloat), closed: (top: CGFloat, bottom: CGFloat)) = (opened: (top: 19, bottom: 24), closed: (top: 6, bottom: 14))
 
 // Horizontal gap between closed-state live-activity content (album art / waveform)
@@ -39,6 +42,30 @@ enum MusicPlayerImageSizes {
     }
     
     return nil
+}
+
+@MainActor func clampedAIChatPanelSize(
+    width: CGFloat = Defaults[.aiChatPanelWidth],
+    height: CGFloat = Defaults[.aiChatPanelHeight],
+    screenUUID: String? = nil
+) -> CGSize {
+    let screen = screenUUID.flatMap { NSScreen.screen(withUUID: $0) } ?? NSScreen.main
+    let visibleFrame = screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? .init(x: 0, y: 0, width: 1_440, height: 900)
+    let maxWidth = min(aiChatPanelMaxSize.width, max(aiChatPanelMinSize.width, visibleFrame.width - 80))
+    let maxHeight = min(aiChatPanelMaxSize.height, max(aiChatPanelMinSize.height, visibleFrame.height - 80))
+
+    return .init(
+        width: min(max(width, aiChatPanelMinSize.width), maxWidth),
+        height: min(max(height, aiChatPanelMinSize.height), maxHeight)
+    )
+}
+
+@MainActor func openNotchSizeForView(_ view: NotchViews, screenUUID: String? = nil) -> CGSize {
+    view == .assistant ? clampedAIChatPanelSize(screenUUID: screenUUID) : openNotchSize
+}
+
+@MainActor func hostingWindowSize(for notchSize: CGSize) -> CGSize {
+    .init(width: notchSize.width, height: notchSize.height + shadowPadding)
 }
 
 @MainActor func getRealNotchHeight() -> CGFloat {


### PR DESCRIPTION
## Summary

This PR adds a configurable productivity suite to Boring Notch:

- an OpenAI-compatible AI agent panel;
- an Open-Meteo weather dashboard;
- a local Pomodoro timer;
- persistent, user-resizable notch panel dimensions.

All new modules are disabled by default and can be enabled independently from Settings.

## Motivation

Boring Notch already provides an always-available macOS surface. These additions let users handle short, contextual tasks without opening a separate full-screen application, while keeping local actions visible and permission-gated.

## What changed

### AI agent

- Adds an optional chat tab with multiple conversations and persisted local history.
- Supports OpenAI-compatible chat-completions endpoints and configurable models.
- Includes a built-in plugin registry, task-oriented skills, lightweight local knowledge retrieval, memory controls, file import, and an execution trace.
- Reads calendar context only when enabled and relevant to the prompt.
- Creates calendar events only when calendar writing is enabled and the user explicitly requests the action.

### Credential handling

- Stores the provider API key in macOS Keychain instead of `UserDefaults`.
- Migrates an existing legacy preference value to Keychain and clears the old value after a successful migration.
- Performs Keychain reads and writes away from the main actor so opening Settings does not block the UI.
- Prevents unexpected authentication prompts and surfaces Keychain errors in the settings view.

### Weather

- Adds current conditions and an hourly forecast using Open-Meteo.
- Supports automatic Core Location lookup or a manually configured city.
- Provides metric/imperial temperature preferences and clear loading, permission, and error states.

### Pomodoro

- Adds focus, short-break, and long-break phases.
- Supports configurable durations, long-break intervals, auto-start behavior, and persisted progress.

### Window behavior

- Adds persisted width and height settings for the AI panel.
- Supports direct edge and corner resizing while keeping the notch anchored.
- Keeps the existing Home and Shelf behavior unchanged when the new modules are disabled.

## Privacy and safety

- No API keys, account data, conversation history, calendar data, or local documents are committed.
- Provider credentials are stored in macOS Keychain.
- Calendar read/write access and location-dependent weather are separately controlled by settings and macOS permissions.
- Calendar writes require both an enabled setting and an explicit user request.
- The plugin registry is built in; this PR does not execute arbitrary third-party plugin code.

## Validation

- Rebased onto the current `dev` branch (`50edc10`).
- Universal macOS Debug build succeeded for `arm64` and `x86_64` with Xcode.
- `plutil -lint boringNotch/Info.plist boringNotch/boringNotch.entitlements`
- `git diff --check origin/dev...HEAD`
- Scanned the complete PR diff for local filesystem paths and common credential formats; no matches were found.

## Screenshots / demo

A runnable universal preview of the broader fork is available in the [DanShen 2.7.3 preview release](https://github.com/YL-SSSSu/boring.notch/releases/tag/v2.7.3-danshen.1).

This remains a draft while focused screenshots or a short recording are prepared for the final review pass.
