### PR TITLE
Add Kaset as a media source

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		1153BD932D986E4300979FB0 /* AppleMusicController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BD922D986E4300979FB0 /* AppleMusicController.swift */; };
 		1153BD982D9881F900979FB0 /* AppleScriptHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BD972D9881F900979FB0 /* AppleScriptHelper.swift */; };
 		1153BD9A2D98824300979FB0 /* SpotifyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BD992D98824300979FB0 /* SpotifyController.swift */; };
+		1153BDFF2DAA000000979FB0 /* KasetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BDFE2DAA000000979FB0 /* KasetController.swift */; };
 		1153BD9C2D98853B00979FB0 /* NowPlayingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BD9B2D98853B00979FB0 /* NowPlayingController.swift */; };
 		1153BDA72D99B22200979FB0 /* YouTubeMusicController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1153BDA62D99B22200979FB0 /* YouTubeMusicController.swift */; };
 		115C12EC2ED3D003009754CA /* OpenNotchOSD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115C12EB2ED3D003009754CA /* OpenNotchOSD.swift */; };
@@ -222,6 +223,7 @@
 		1153BD922D986E4300979FB0 /* AppleMusicController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMusicController.swift; sourceTree = "<group>"; };
 		1153BD972D9881F900979FB0 /* AppleScriptHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptHelper.swift; sourceTree = "<group>"; };
 		1153BD992D98824300979FB0 /* SpotifyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyController.swift; sourceTree = "<group>"; };
+		1153BDFE2DAA000000979FB0 /* KasetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KasetController.swift; sourceTree = "<group>"; };
 		1153BD9B2D98853B00979FB0 /* NowPlayingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingController.swift; sourceTree = "<group>"; };
 		1153BDA62D99B22200979FB0 /* YouTubeMusicController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeMusicController.swift; sourceTree = "<group>"; };
 		115C12EB2ED3D003009754CA /* OpenNotchOSD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenNotchOSD.swift; sourceTree = "<group>"; };
@@ -460,6 +462,7 @@
 				1153BD8D2D986B1F00979FB0 /* MediaControllerProtocol.swift */,
 				1153BD922D986E4300979FB0 /* AppleMusicController.swift */,
 				1153BD992D98824300979FB0 /* SpotifyController.swift */,
+				1153BDFE2DAA000000979FB0 /* KasetController.swift */,
 				1153BD9B2D98853B00979FB0 /* NowPlayingController.swift */,
 			);
 			path = MediaControllers;
@@ -1021,6 +1024,7 @@
 				1153BDA72D99B22200979FB0 /* YouTubeMusicController.swift in Sources */,
 				1163988F2DF5CC870052E6AF /* CalendarModel.swift in Sources */,
 				1153BD9A2D98824300979FB0 /* SpotifyController.swift in Sources */,
+				1153BDFF2DAA000000979FB0 /* KasetController.swift in Sources */,
 				118EBE292E946B3F00D54B5A /* ShareServiceFinder.swift in Sources */,
 				B1C974342C642B6D0000E707 /* MarqueeTextView.swift in Sources */,
 				14288DE82C6E01C800B9F80C /* ProgressIndicator.swift in Sources */,

--- a/boringNotch/MediaControllers/KasetController.swift
+++ b/boringNotch/MediaControllers/KasetController.swift
@@ -1,0 +1,218 @@
+//
+//  KasetController.swift
+//  boringNotch
+//
+//  AppleScript-based controller for Kaset (https://github.com/sozercan/kaset),
+//  a native macOS YouTube Music client. Modeled on AppleMusicController /
+//  SpotifyController: it reads and controls Kaset through its AppleScript suite
+//  (`get player info`, transport commands, `like track`). Favourite is supported
+//  because Kaset exposes per-track like state, just like Apple Music's `favorited`.
+//
+//  Kaset's bundle id and AppleScript dictionary are fixed, so no configuration is
+//  required. State is refreshed on a short poll and, when available, on Kaset's
+//  `com.sertacozercan.Kaset.playerInfo` distributed notification.
+//
+
+import Combine
+import Foundation
+import SwiftUI
+
+class KasetController: MediaControllerProtocol {
+    // MARK: - Properties
+    @Published private var playbackState = PlaybackState(
+        bundleIdentifier: KasetController.bundleIdentifier
+    )
+
+    var playbackStatePublisher: AnyPublisher<PlaybackState, Never> {
+        $playbackState.eraseToAnyPublisher()
+    }
+
+    var supportsVolumeControl: Bool { true }
+    var supportsFavorite: Bool { true }
+
+    private static let bundleIdentifier = "com.sertacozercan.Kaset"
+    private static let changeNotification = NSNotification.Name("com.sertacozercan.Kaset.playerInfo")
+    private static let pollInterval: TimeInterval = 2.0
+
+    private var notificationTask: Task<Void, Never>?
+    private var pollTimer: Timer?
+    private var artworkFetchTask: Task<Void, Never>?
+    private var lastArtworkURL: String?
+
+    // MARK: - Initialization
+    init() {
+        setupPlaybackStateChangeObserver()
+        startPolling()
+        Task {
+            if isActive() {
+                await updatePlaybackInfo()
+            }
+        }
+    }
+
+    deinit {
+        notificationTask?.cancel()
+        artworkFetchTask?.cancel()
+        pollTimer?.invalidate()
+    }
+
+    private func setupPlaybackStateChangeObserver() {
+        notificationTask = Task { @Sendable [weak self] in
+            let notifications = DistributedNotificationCenter.default().notifications(
+                named: KasetController.changeNotification
+            )
+            for await _ in notifications {
+                await self?.updatePlaybackInfo()
+            }
+        }
+    }
+
+    private func startPolling() {
+        pollTimer?.invalidate()
+        // Kaset is sandboxed; its distributed notification may not be delivered on
+        // every system, so poll as a reliable baseline (the notification just makes
+        // updates snappier when it does arrive).
+        pollTimer = Timer.scheduledTimer(withTimeInterval: KasetController.pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                // Call unconditionally: updatePlaybackInfo handles the inactive case
+                // (it clears state), so this is how we notice Kaset quitting.
+                await self.updatePlaybackInfo()
+            }
+        }
+    }
+
+    // MARK: - Protocol Implementation
+    func play() async { await executeCommand("play") }
+    func pause() async { await executeCommand("pause") }
+    func togglePlay() async { await executeCommand("playpause") }
+    func nextTrack() async { await executeCommand("next track") }
+    func previousTrack() async { await executeCommand("previous track") }
+
+    func seek(to time: Double) async {
+        await executeCommand("seek \(time)")
+        await refreshSoon()
+    }
+
+    func toggleShuffle() async {
+        await executeCommand("toggle shuffle")
+        await refreshSoon()
+    }
+
+    func toggleRepeat() async {
+        await executeCommand("cycle repeat")
+        await refreshSoon()
+    }
+
+    func setVolume(_ level: Double) async {
+        let percentage = Int((max(0.0, min(1.0, level)) * 100).rounded())
+        await executeCommand("set volume \(percentage)")
+        await refreshSoon()
+    }
+
+    @MainActor
+    func setFavorite(_ favorite: Bool) async {
+        // Kaset's `like track` toggles; only send it when the state actually flips.
+        // @MainActor-isolated so this `isFavorite` read shares the isolation domain
+        // that writes playbackState (applyPlayerInfo), avoiding a data race.
+        guard favorite != playbackState.isFavorite else { return }
+        await executeCommand("like track")
+        await refreshSoon()
+    }
+
+    func isActive() -> Bool {
+        NSWorkspace.shared.runningApplications.contains {
+            $0.bundleIdentifier == KasetController.bundleIdentifier
+        }
+    }
+
+    func updatePlaybackInfo() async {
+        guard isActive() else {
+            // Kaset isn't running; clear any stale track so the notch doesn't keep
+            // showing a phantom Kaset song after the app quits.
+            await resetPlaybackState()
+            return
+        }
+        guard let descriptor = try? await AppleScriptHelper.execute(
+                  "tell application \"Kaset\" to get player info"
+              ),
+              let json = descriptor.stringValue,
+              let data = json.data(using: .utf8),
+              let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else { return }
+        await applyPlayerInfo(object)
+    }
+
+    // MARK: - Private Methods
+
+    // Main-actor isolated so the poll timer and the distributed-notification
+    // observer (which run on different executors) can't mutate state concurrently.
+    @MainActor
+    private func applyPlayerInfo(_ object: [String: Any]) {
+        var state = playbackState
+
+        let track = object["currentTrack"] as? [String: Any]
+        state.isPlaying = (object["isPlaying"] as? Bool) ?? false
+        state.title = (track?["name"] as? String) ?? "Not Playing"
+        state.artist = (track?["artist"] as? String) ?? ""
+        state.album = (track?["album"] as? String) ?? ""
+        state.currentTime = Self.double(object["position"]) ?? 0
+        state.duration = Self.double(object["duration"]) ?? Self.double(track?["duration"]) ?? 0
+        state.isShuffled = (object["shuffling"] as? Bool) ?? false
+        state.repeatMode = Self.repeatMode(object["repeating"] as? String)
+        if let volume = Self.double(object["volume"]) { state.volume = volume / 100.0 }
+        state.isFavorite = (object["likeStatus"] as? String) == "liked"
+        state.lastUpdated = Date()
+
+        if state != playbackState {
+            playbackState = state
+        }
+
+        fetchArtworkIfNeeded(urlString: track?["artworkURL"] as? String)
+    }
+
+    @MainActor
+    private func fetchArtworkIfNeeded(urlString: String?) {
+        guard let urlString, !urlString.isEmpty, urlString != lastArtworkURL,
+              let url = URL(string: urlString) else { return }
+        lastArtworkURL = urlString
+        artworkFetchTask?.cancel()
+        artworkFetchTask = Task { [weak self] in
+            guard let data = try? await ImageService.shared.fetchImageData(from: url) else { return }
+            await MainActor.run { [weak self] in
+                self?.playbackState.artwork = data
+            }
+        }
+    }
+
+    @MainActor
+    private func resetPlaybackState() {
+        artworkFetchTask?.cancel()
+        lastArtworkURL = nil
+        let cleared = PlaybackState(bundleIdentifier: KasetController.bundleIdentifier, isPlaying: false)
+        if cleared != playbackState {
+            playbackState = cleared
+        }
+    }
+
+    private func executeCommand(_ command: String) async {
+        try? await AppleScriptHelper.executeVoid("tell application \"Kaset\" to \(command)")
+    }
+
+    private func refreshSoon() async {
+        try? await Task.sleep(for: .milliseconds(150))
+        await updatePlaybackInfo()
+    }
+
+    private static func double(_ value: Any?) -> Double? {
+        (value as? NSNumber)?.doubleValue
+    }
+
+    private static func repeatMode(_ value: String?) -> RepeatMode {
+        switch value {
+        case "all": .all
+        case "one": .one
+        default: .off
+        }
+    }
+}

--- a/boringNotch/MediaControllers/KasetController.swift
+++ b/boringNotch/MediaControllers/KasetController.swift
@@ -16,6 +16,7 @@
 import AppKit
 import Combine
 import Foundation
+import ImageIO
 import SwiftUI
 
 class KasetController: MediaControllerProtocol {
@@ -38,7 +39,9 @@ class KasetController: MediaControllerProtocol {
     private var notificationTask: Task<Void, Never>?
     private var pollTimer: Timer?
     private var artworkFetchTask: Task<Void, Never>?
-    private var lastArtworkURL: String?
+    /// Identity (videoId, else artworkURL) of the track whose cover is loaded or in flight — so
+    /// repeated polls don't refetch. Reset on track change / failure so the cover can (re)load.
+    private var lastArtworkKey: String?
 
     // MARK: - Initialization
     init() {
@@ -182,44 +185,94 @@ class KasetController: MediaControllerProtocol {
             // (forever if the fetch fails). Clearing lets it settle immediately (app icon shows
             // until the real cover loads); fetchArtworkIfNeeded repopulates below.
             state.artwork = nil
-            lastArtworkURL = nil
+            lastArtworkKey = nil
         }
 
         if state != playbackState {
             playbackState = state
         }
 
-        fetchArtworkIfNeeded(urlString: track?["artworkURL"] as? String)
+        fetchArtworkIfNeeded(
+            artworkURL: track?["artworkURL"] as? String,
+            videoId: track?["videoId"] as? String
+        )
     }
 
     @MainActor
-    private func fetchArtworkIfNeeded(urlString: String?) {
-        guard let urlString, !urlString.isEmpty, urlString != lastArtworkURL,
-              let url = URL(string: urlString) else { return }
-        // Mark this URL as in-flight so repeated polls don't restart a healthy fetch.
-        lastArtworkURL = urlString
+    private func fetchArtworkIfNeeded(artworkURL: String?, videoId: String?) {
+        // Kaset's `get player info` usually reports a useless artworkURL (the YouTube Music
+        // homepage), but always gives a videoId. Derive the cover from YouTube's thumbnail
+        // endpoint in that case; prefer a real image artworkURL when Kaset does provide one.
+        let key = videoId ?? artworkURL
+        guard let key, !key.isEmpty, key != lastArtworkKey else { return }
+        let candidates = Self.artworkCandidateURLs(artworkURL: artworkURL, videoId: videoId)
+        guard !candidates.isEmpty else { return }
+        // Mark in-flight so repeated polls don't restart a healthy fetch.
+        lastArtworkKey = key
         artworkFetchTask?.cancel()
         artworkFetchTask = Task { [weak self] in
-            let data = try? await ImageService.shared.fetchImageData(from: url)
-            if Task.isCancelled { return }
+            for url in candidates {
+                if Task.isCancelled { return }
+                guard let data = try? await ImageService.shared.fetchImageData(from: url),
+                      let square = Self.squareJPEGData(from: data) else { continue }
+                if Task.isCancelled { return }
+                await MainActor.run { [weak self] in
+                    guard let self, self.lastArtworkKey == key else { return }
+                    self.playbackState.artwork = square
+                }
+                return
+            }
+            // No candidate produced a valid image — forget the key so the next poll retries
+            // instead of sticking on the app-icon fallback.
             await MainActor.run { [weak self] in
-                guard let self, self.lastArtworkURL == urlString else { return }
-                if let data, NSImage(data: data) != nil {
-                    self.playbackState.artwork = data
-                } else {
-                    // Fetch failed, or the bytes weren't an image (Kaset occasionally reports a
-                    // bogus artworkURL, e.g. the YouTube Music homepage, which returns HTML).
-                    // Forget the URL so the next poll retries instead of sticking on a blank cover.
-                    self.lastArtworkURL = nil
+                guard let self, self.lastArtworkKey == key else { return }
+                self.lastArtworkKey = nil
+            }
+        }
+    }
+
+    /// Ordered cover URLs to try: a genuine image artworkURL first (Kaset rarely provides one),
+    /// then YouTube thumbnails derived from the videoId. The homepage/app-internal URL Kaset
+    /// usually reports is filtered out.
+    private static func artworkCandidateURLs(artworkURL: String?, videoId: String?) -> [URL] {
+        var urls: [URL] = []
+        if let artworkURL, !artworkURL.isEmpty,
+           let url = URL(string: artworkURL),
+           let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https",
+           let host = url.host, host != "music.youtube.com" {
+            urls.append(url)
+        }
+        if let videoId, !videoId.isEmpty {
+            for name in ["maxresdefault", "hqdefault"] {
+                if let url = URL(string: "https://i.ytimg.com/vi/\(videoId)/\(name).jpg") {
+                    urls.append(url)
                 }
             }
         }
+        return urls
+    }
+
+    /// Decode `data`, center-crop to a square, and re-encode as JPEG. Returns nil if the bytes
+    /// aren't a decodable image (doubles as validation). YouTube thumbnails are 16:9/4:3; the
+    /// notch shows cover art with `.fit`, so a square keeps it from rendering as a wide strip.
+    private static func squareJPEGData(from data: Data) -> Data? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else { return nil }
+        let width = cgImage.width, height = cgImage.height
+        guard width > 0, height > 0 else { return nil }
+        let side = min(width, height)
+        let cropRect = CGRect(
+            x: (width - side) / 2, y: (height - side) / 2, width: side, height: side
+        )
+        guard let cropped = cgImage.cropping(to: cropRect) else { return nil }
+        let rep = NSBitmapImageRep(cgImage: cropped)
+        return rep.representation(using: .jpeg, properties: [.compressionFactor: 0.9])
     }
 
     @MainActor
     private func resetPlaybackState() {
         artworkFetchTask?.cancel()
-        lastArtworkURL = nil
+        lastArtworkKey = nil
         let cleared = PlaybackState(bundleIdentifier: KasetController.bundleIdentifier, isPlaying: false)
         if cleared != playbackState {
             playbackState = cleared

--- a/boringNotch/MediaControllers/KasetController.swift
+++ b/boringNotch/MediaControllers/KasetController.swift
@@ -13,6 +13,7 @@
 //  `com.sertacozercan.Kaset.playerInfo` distributed notification.
 //
 
+import AppKit
 import Combine
 import Foundation
 import SwiftUI
@@ -152,10 +153,20 @@ class KasetController: MediaControllerProtocol {
         var state = playbackState
 
         let track = object["currentTrack"] as? [String: Any]
+        let newTitle = (track?["name"] as? String) ?? "Not Playing"
+        let newArtist = (track?["artist"] as? String) ?? ""
+        let newAlbum = (track?["album"] as? String) ?? ""
+        // A new track is starting if any identity field changed. `state` is copied from the
+        // previous `playbackState`, so without this we'd carry the OLD track's cover into the
+        // new track's published state.
+        let trackChanged = newTitle != playbackState.title
+            || newArtist != playbackState.artist
+            || newAlbum != playbackState.album
+
         state.isPlaying = (object["isPlaying"] as? Bool) ?? false
-        state.title = (track?["name"] as? String) ?? "Not Playing"
-        state.artist = (track?["artist"] as? String) ?? ""
-        state.album = (track?["album"] as? String) ?? ""
+        state.title = newTitle
+        state.artist = newArtist
+        state.album = newAlbum
         state.currentTime = Self.double(object["position"]) ?? 0
         state.duration = Self.double(object["duration"]) ?? Self.double(track?["duration"]) ?? 0
         state.isShuffled = (object["shuffling"] as? Bool) ?? false
@@ -163,6 +174,16 @@ class KasetController: MediaControllerProtocol {
         if let volume = Self.double(object["volume"]) { state.volume = volume / 100.0 }
         state.isFavorite = (object["likeStatus"] as? String) == "liked"
         state.lastUpdated = Date()
+
+        if trackChanged {
+            // Don't publish the previous track's cover under the new track. MusicManager gates
+            // its "content changed" bookkeeping on the artwork, so a stale non-nil cover makes it
+            // re-fire the sneak peek and flip animation on every 2s poll until fresh art arrives
+            // (forever if the fetch fails). Clearing lets it settle immediately (app icon shows
+            // until the real cover loads); fetchArtworkIfNeeded repopulates below.
+            state.artwork = nil
+            lastArtworkURL = nil
+        }
 
         if state != playbackState {
             playbackState = state
@@ -175,12 +196,22 @@ class KasetController: MediaControllerProtocol {
     private func fetchArtworkIfNeeded(urlString: String?) {
         guard let urlString, !urlString.isEmpty, urlString != lastArtworkURL,
               let url = URL(string: urlString) else { return }
+        // Mark this URL as in-flight so repeated polls don't restart a healthy fetch.
         lastArtworkURL = urlString
         artworkFetchTask?.cancel()
         artworkFetchTask = Task { [weak self] in
-            guard let data = try? await ImageService.shared.fetchImageData(from: url) else { return }
+            let data = try? await ImageService.shared.fetchImageData(from: url)
+            if Task.isCancelled { return }
             await MainActor.run { [weak self] in
-                self?.playbackState.artwork = data
+                guard let self, self.lastArtworkURL == urlString else { return }
+                if let data, NSImage(data: data) != nil {
+                    self.playbackState.artwork = data
+                } else {
+                    // Fetch failed, or the bytes weren't an image (Kaset occasionally reports a
+                    // bogus artworkURL, e.g. the YouTube Music homepage, which returns HTML).
+                    // Forget the URL so the next poll retries instead of sticking on a blank cover.
+                    self.lastArtworkURL = nil
+                }
             }
         }
     }

--- a/boringNotch/boringNotch.entitlements
+++ b/boringNotch/boringNotch.entitlements
@@ -26,6 +26,7 @@
 	<array>
 		<string>com.spotify.client</string>
 		<string>com.apple.Music</string>
+		<string>com.sertacozercan.Kaset</string>
 	</array>
 	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
 	<array>

--- a/boringNotch/components/Onboarding/MusicControllerSelectionView.swift
+++ b/boringNotch/components/Onboarding/MusicControllerSelectionView.swift
@@ -130,6 +130,8 @@ extension MediaControllerType {
             return "Connects directly to the Apple Music app."
         case .youtubeMusic:
             return "Requires a third-party client with API plugin enabled."
+        case .kaset:
+            return "Connects to the Kaset app (native YouTube Music client) via AppleScript."
         }
     }
 }

--- a/boringNotch/helpers/AppleScriptHelper.swift
+++ b/boringNotch/helpers/AppleScriptHelper.swift
@@ -8,10 +8,25 @@
 import Foundation
 
 class AppleScriptHelper {
+    /// `NSAppleScript.executeAndReturnError` is a *blocking* call, and an Apple Event to an
+    /// unresponsive app can block for up to the Apple Event timeout (~2 min). The previous
+    /// implementation ran it via `Task.detached`, i.e. on Swift's *shared cooperative thread pool*
+    /// (~one thread per core). A hung target app (e.g. Kaset with a broken API) polled every couple
+    /// of seconds then piled up blocked calls and starved that pool, wedging app-wide async work and
+    /// freezing the notch.
+    ///
+    /// Running it on a dedicated *serial* queue isolates the blocking from the cooperative pool: a
+    /// hung app blocks only this one queue (its data just goes stale) and never freezes the UI, and
+    /// serial execution caps it at a single blocked thread even under repeated polling.
+    private static let queue = DispatchQueue(
+        label: "com.theboringteam.boringnotch.applescript",
+        qos: .userInitiated
+    )
+
     @discardableResult
     class func execute(_ scriptText: String) async throws -> NSAppleEventDescriptor? {
         try await withCheckedThrowingContinuation { continuation in
-            Task.detached(priority: .userInitiated) {
+            queue.async {
                 let script = NSAppleScript(source: scriptText)
                 var error: NSDictionary?
                 if let descriptor = script?.executeAndReturnError(&error) {
@@ -24,7 +39,7 @@ class AppleScriptHelper {
             }
         }
     }
-    
+
     class func executeVoid(_ scriptText: String) async throws {
         _ = try await execute(scriptText)
     }

--- a/boringNotch/managers/AudioCaptureManager.swift
+++ b/boringNotch/managers/AudioCaptureManager.swift
@@ -39,6 +39,13 @@ final class AudioCaptureManager: ObservableObject {
         kAudioHardwareBadObjectError,
         kAudioHardwareUnknownPropertyError
     ]
+    /// Sources that render their audio in a separate WebKit helper process (com.apple.WebKit.GPU),
+    /// not in their own process. A process tap on their main app therefore captures silence, which
+    /// would show as a flat waveform. Skip real-time capture for these so the visualizer keeps its
+    /// synthetic animation instead. (Kaset is a WKWebView YouTube Music client.)
+    private static let audioUncapturableBundleIdentifiers: Set<String> = [
+        "com.sertacozercan.Kaset"
+    ]
 
     @Published private(set) var isCapturing: Bool = false
 
@@ -189,6 +196,19 @@ final class AudioCaptureManager: ObservableObject {
               enabled, isPlaying,
               let resolvedDisplayBundleID = displayBundleID,
               !resolvedDisplayBundleID.isEmpty else {
+            stopCaptureAsync()
+            return
+        }
+        // If every candidate source renders its audio out-of-process (e.g. a WKWebView app),
+        // there's nothing on its own process to tap — don't switch the visualizer to a flat
+        // real-time waveform; leave capture off so it keeps the synthetic animation.
+        let candidateCaptureBundleIDs = captureBundleIDs.isEmpty
+            ? [resolvedDisplayBundleID]
+            : captureBundleIDs
+        let hasCapturableSource = candidateCaptureBundleIDs.contains {
+            !Self.audioUncapturableBundleIdentifiers.contains($0)
+        }
+        guard hasCapturableSource else {
             stopCaptureAsync()
             return
         }

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -135,6 +135,8 @@ class MusicManager: ObservableObject {
             newController = SpotifyController()
         case .youtubeMusic:
             newController = YouTubeMusicController()
+        case .kaset:
+            newController = KasetController()
         }
 
         // Set up state observation for the new controller

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -130,7 +130,8 @@ enum MediaControllerType: String, CaseIterable, Identifiable, Defaults.Serializa
     case appleMusic
     case spotify
     case youtubeMusic
-    
+    case kaset
+
     var id: String { self.rawValue }
 
     var localizedString: String {
@@ -143,6 +144,8 @@ enum MediaControllerType: String, CaseIterable, Identifiable, Defaults.Serializa
             return "Spotify"
         case .youtubeMusic:
             return "YouTube Music"
+        case .kaset:
+            return "Kaset"
         }
     }
 }


### PR DESCRIPTION
### What
Adds **Kaset** ([sozercan/kaset](https://github.com/sozercan/kaset)) — a native macOS YouTube Music client — as a selectable music source. boring.notch can now display and control Kaset playback (play/pause, next/previous, seek, volume, shuffle, repeat) and toggle the like/heart, the same way it integrates Apple Music and Spotify.

### Why
Closes #1167. Kaset users had no way to surface or control playback from the notch. Kaset exposes a full AppleScript suite plus a `com.sertacozercan.Kaset.playerInfo` distributed notification, so it can be supported cleanly with a dedicated controller.

### How
- New `KasetController` (modeled on `AppleMusicController`/`SpotifyController`), reading state from Kaset's `get player info` JSON and driving transport/like via its AppleScript commands. State refreshes on a short poll plus Kaset's distributed notification.
- Registered the source in `MediaControllerType`, `MusicManager.createController`, the onboarding + Settings pickers, and added the `com.sertacozercan.Kaset` apple-events entitlement exception.
- All `@Published` state mutation is `@MainActor`-isolated, emissions are change-gated via `PlaybackState: Equatable`, and the displayed track is cleared when Kaset isn't running.

### Testing
- ✅ Builds clean (`xcodebuild -scheme boringNotch -configuration Debug build` → **BUILD SUCCEEDED**).
- ✅ Every command, JSON key, and string token verified against Kaset's `Kaset.sdef` and `ScriptCommands.swift` (transport + `seek`; `position`/`duration`/`volume` numeric types; `repeating`/`likeStatus` token casing; bundle id `com.sertacozercan.Kaset`).
- Manually exercised with Kaset running: metadata + artwork, play/pause/next/previous, seek, volume, shuffle/repeat, like toggle, and clear-on-quit.

### Screenshots / recording
<img width="1662" height="1080" alt="2026-06-30 22-15-19" src="https://github.com/user-attachments/assets/45645bef-2ef4-4b0a-b018-0c77c3b7f23d" />


