### PR TITLE
Add charging wattage to the battery popover

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -315,6 +315,7 @@ struct ContentView: View {
                                     isInLowPowerMode: batteryModel.isInLowPowerMode,
                                     isPluggedIn: batteryModel.isPluggedIn,
                                     levelBattery: batteryModel.levelBattery,
+                                    maxAdapterWatts: batteryModel.maxAdapterWatts,
                                     isForNotification: true
                                 )
                             }

--- a/boringNotch/components/Live activities/BoringBattery.swift
+++ b/boringNotch/components/Live activities/BoringBattery.swift
@@ -94,6 +94,7 @@ struct BatteryMenuView: View {
     var timeToFullCharge: Int
     var timeToDischarge: Int
     var isInLowPowerMode: Bool
+    var maxAdapterWatts: Int = 0
     var onDismiss: () -> Void
 
     @Environment(\.openURL) private var openURL
@@ -112,6 +113,20 @@ struct BatteryMenuView: View {
         formatter.unitsStyle = .abbreviated
         formatter.zeroFormattingBehavior = .dropAll
         return formatter.string(from: TimeInterval(timeToFullCharge * 60)) ?? ""
+    }
+
+    // Power status row ("Charging"/"Plugged In") with ": 140W" appended when the
+    // adapter wattage is known and enabled. Watts is a separate Text so the
+    // localized status key stays intact.
+    private func powerStatusLabel(_ title: LocalizedStringKey, icon: String) -> some View {
+        let suffix = (Defaults[.showChargingWattage] && maxAdapterWatts > 0) ? ": \(maxAdapterWatts)W" : ""
+        return Label {
+            Text(title) + Text(suffix)
+        } icon: {
+            Image(systemName: icon)
+        }
+        .font(.subheadline)
+        .fontWeight(.regular)
     }
 
     var body: some View {
@@ -143,14 +158,10 @@ struct BatteryMenuView: View {
                         .fontWeight(.regular)
                 }
                 if isCharging {
-                    Label("Charging", systemImage: "bolt.fill")
-                        .font(.subheadline)
-                        .fontWeight(.regular)
+                    powerStatusLabel("Charging", icon: "bolt.fill")
                 }
                 if isPluggedIn && !isCharging {
-                    Label("Plugged In", systemImage: "powerplug.fill")
-                        .font(.subheadline)
-                        .fontWeight(.regular)
+                    powerStatusLabel("Plugged In", icon: "powerplug.fill")
                 }
                 if isCharging && timeToFullCharge > 0 {
                     Label("Time to Full Charge: \(formattedTimeToFullCharge)", systemImage: "clock")
@@ -213,6 +224,7 @@ struct BoringBatteryView: View {
     var maxCapacity: Float?
     var timeToFullCharge: Int = 0
     var timeToDischarge: Int = 0
+    var maxAdapterWatts: Int = 0
     @State var isForNotification: Bool = false
     
     @State private var showPopupMenu: Bool = false
@@ -257,7 +269,8 @@ struct BoringBatteryView: View {
                 timeToFullCharge: timeToFullCharge,
                 timeToDischarge: timeToDischarge,
                 isInLowPowerMode: isInLowPowerMode,
-                onDismiss: { 
+                maxAdapterWatts: maxAdapterWatts,
+                onDismiss: {
                     showPopupMenu = false
                 }
             )
@@ -301,6 +314,7 @@ struct BoringBatteryView: View {
         maxCapacity: 100,
         timeToFullCharge: 10,
         timeToDischarge: 10,
+        maxAdapterWatts: 140,
         isForNotification: false
     ).frame(width: 200, height: 200)
 }

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -92,6 +92,7 @@ struct BoringHeader: View {
                                 maxCapacity: batteryModel.maxCapacity,
                                 timeToFullCharge: batteryModel.timeToFullCharge,
                                 timeToDischarge: batteryModel.timeToDischarge,
+                                maxAdapterWatts: batteryModel.maxAdapterWatts,
                                 isForNotification: false
                             )
                         }

--- a/boringNotch/components/Settings/Views/BatterySettingsView.swift
+++ b/boringNotch/components/Settings/Views/BatterySettingsView.swift
@@ -28,6 +28,9 @@ struct Charge: View {
                 Defaults.Toggle(key: .showPowerStatusIcons) {
                     Text("Show power status icons")
                 }
+                Defaults.Toggle(key: .showChargingWattage) {
+                    Text("Show charging wattage")
+                }
             } header: {
                 Text("Battery Information")
             }

--- a/boringNotch/managers/BatteryActivityManager.swift
+++ b/boringNotch/managers/BatteryActivityManager.swift
@@ -55,6 +55,7 @@ class BatteryActivityManager {
         case timeToFullChargeChanged(time: Int)
         case timeToDischargeChanged(time: Int)
         case maxCapacityChanged(capacity: Float?)
+        case adapterWattageChanged(watts: Int)
         case error(description: String)
     }
 
@@ -175,6 +176,12 @@ class BatteryActivityManager {
                 current: batteryInfo.maxCapacity,
                 eventGenerator: { .maxCapacityChanged(capacity: $0) }
             )
+
+            checkAndNotify(
+                previous: previousInfo.maxAdapterWatts,
+                current: batteryInfo.maxAdapterWatts,
+                eventGenerator: { .adapterWattageChanged(watts: $0) }
+            )
         } else {
             // First time notification
             enqueueNotification(.powerSourceChanged(isPluggedIn: batteryInfo.isPluggedIn))
@@ -184,6 +191,7 @@ class BatteryActivityManager {
             enqueueNotification(.timeToFullChargeChanged(time: batteryInfo.timeToFullCharge))
             enqueueNotification(.timeToDischargeChanged(time: batteryInfo.timeToDischarge))
             enqueueNotification(.maxCapacityChanged(capacity: batteryInfo.maxCapacity))
+            enqueueNotification(.adapterWattageChanged(watts: batteryInfo.maxAdapterWatts))
         }
 
         // Update previous battery info
@@ -282,6 +290,12 @@ class BatteryActivityManager {
                 batteryInfo.timeToDischarge = timeToDischarge
             }
 
+            // Rated adapter wattage; nil on battery or unreported, stays 0
+            if let adapterDetails = IOPSCopyExternalPowerAdapterDetails()?.takeRetainedValue() as? [String: Any],
+               let watts = adapterDetails[kIOPSPowerAdapterWattsKey as String] as? Int {
+                batteryInfo.maxAdapterWatts = watts
+            }
+
             return batteryInfo
             
         } catch BatteryError.powerSourceUnavailable {
@@ -378,4 +392,5 @@ struct BatteryInfo {
     var isInLowPowerMode: Bool
     var timeToFullCharge: Int
     var timeToDischarge: Int
+    var maxAdapterWatts: Int = 0
 }

--- a/boringNotch/models/BatteryStatusViewModel.swift
+++ b/boringNotch/models/BatteryStatusViewModel.swift
@@ -21,6 +21,7 @@ class BatteryStatusViewModel: ObservableObject {
     @Published private(set) var isInitial: Bool = false
     @Published private(set) var timeToFullCharge: Int = 0
     @Published private(set) var timeToDischarge: Int = 0
+    @Published private(set) var maxAdapterWatts: Int = 0
     @Published private(set) var lastStatus: LastStatus = .plugged(false)
 
     enum LastStatus: Equatable {
@@ -129,6 +130,12 @@ class BatteryStatusViewModel: ObservableObject {
                 self.maxCapacity = capacity
             }
 
+        case .adapterWattageChanged(let watts):
+            print("🔌 Power adapter: \(watts)W")
+            withAnimation {
+                self.maxAdapterWatts = watts
+            }
+
         case .error(let description):
             print("⚠️ Error: \(description)")
         }
@@ -145,6 +152,7 @@ class BatteryStatusViewModel: ObservableObject {
             self.timeToFullCharge = batteryInfo.timeToFullCharge
             self.timeToDischarge = batteryInfo.timeToDischarge
             self.maxCapacity = batteryInfo.maxCapacity
+            self.maxAdapterWatts = batteryInfo.maxAdapterWatts
             self.lastStatus = .plugged(batteryInfo.isPluggedIn)
         }
     }

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -282,6 +282,7 @@ extension Defaults.Keys {
     static let showBatteryIndicator = Key<Bool>("showBatteryIndicator", default: true)
     static let showBatteryPercentage = Key<Bool>("showBatteryPercentage", default: true)
     static let showPowerStatusIcons = Key<Bool>("showPowerStatusIcons", default: true)
+    static let showChargingWattage = Key<Bool>("showChargingWattage", default: true)
     
     // MARK: Downloads
     static let enableDownloadListener = Key<Bool>("enableDownloadListener", default: true)


### PR DESCRIPTION
### What

Adds option to show the connected power adapter's rated wattage to the battery popover, inline on the status line — e.g. **"Charging: 140W"** / **"Plugged In: 140W"**.
This makes it easy to tell at a glance whether a weak brick or cable is limiting charging (e.g. grabbing a 30W charger instead of the 140W one).

<img width="284" height="209" alt="Screenshot 2026-06-30 at 11 52 05 PM" src="https://github.com/user-attachments/assets/5eea2f21-fa51-484e-bd82-5a50fda22312" />

<img width="713" height="616" alt="Screenshot 2026-06-30 at 11 50 23 PM" src="https://github.com/user-attachments/assets/da73f881-896a-41d0-b14f-e3175fcf6f7c" />

### How

- Reads the adapter's rated watts via the public `IOPSCopyExternalPowerAdapterDetails()`
  (`kIOPSPowerAdapterWattsKey`), threaded through the existing  `BatteryInfo` / `BatteryEvent` flow like the other battery fields.
- The watts are appended as a separate `Text`, so the localized "Charging" / "Plugged In" strings stay intact for Crowdin.
- New **"Show charging wattage"** toggle in Battery settings (default on), matching the existing per-element battery display toggles.
- Shows only when plugged in and a wattage is reported; hidden on battery.


### Testing

Verified the popover shows the correct wattage on multiple 140W/65W/20W adapters, updates live on plug/unplug, and
hides on battery. The settings toggle shows/hides the row.