### PR TITLE
[codex] Add notch productivity assistant suite

### DIFF
--- a/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
@@ -11,6 +11,25 @@ import IOKit
 import CoreGraphics
 
 class BoringNotchXPCHelper: NSObject, BoringNotchXPCHelperProtocol {
+
+    private struct BluetoothBatteryPartPayload: Codable {
+        let kind: String
+        let percentage: Int
+        let isCharging: Bool
+    }
+
+    private struct BluetoothBatteryDevicePayload: Codable {
+        let name: String
+        let category: String
+        let parts: [BluetoothBatteryPartPayload]
+    }
+
+    private struct RawAccessoryBattery {
+        let name: String
+        let groupKey: String
+        let category: String
+        let part: BluetoothBatteryPartPayload
+    }
     
     @objc func isAccessibilityAuthorized(with reply: @escaping (Bool) -> Void) {
         reply(AXIsProcessTrusted())
@@ -137,6 +156,200 @@ class BoringNotchXPCHelper: NSObject, BoringNotchXPCHelperProtocol {
             return
         }
         reply(false)
+    }
+
+    @objc func bluetoothAccessoryBatteryData(with reply: @escaping (NSData?) -> Void) {
+        DispatchQueue.global(qos: .utility).async {
+            let pmsetEntries = self.readAccessoryPowerSources()
+            let hidEntries = self.readBluetoothHIDBatteries()
+            let devices = self.groupBluetoothBatteries(pmsetEntries + hidEntries)
+            guard let data = try? JSONEncoder().encode(devices) else {
+                reply(nil)
+                return
+            }
+            reply(data as NSData)
+        }
+    }
+
+    private func readAccessoryPowerSources() -> [RawAccessoryBattery] {
+        let process = Process()
+        let outputPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
+        process.arguments = ["-g", "accps", "-xml"]
+        process.standardOutput = outputPipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0,
+                  let output = String(data: data, encoding: .utf8)
+            else {
+                return []
+            }
+            return parseAccessoryPowerSourcePlists(output)
+        } catch {
+            return []
+        }
+    }
+
+    private func parseAccessoryPowerSourcePlists(_ output: String) -> [RawAccessoryBattery] {
+        let marker = "<?xml"
+        return output.components(separatedBy: marker).compactMap { chunk in
+            let trimmed = chunk.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty,
+                  let data = (marker + chunk).data(using: .utf8),
+                  let dictionary = try? PropertyListSerialization.propertyList(
+                    from: data,
+                    options: [],
+                    format: nil
+                  ) as? [String: Any],
+                  dictionary["Type"] as? String == "Accessory Source",
+                  dictionary["Is Present"] as? Bool != false,
+                  let name = dictionary["Name"] as? String,
+                  !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  let percentage = normalizedPercentage(dictionary["Current Capacity"])
+            else {
+                return nil
+            }
+
+            let transport = (dictionary["Transport Type"] as? String ?? "").lowercased()
+            guard transport.contains("bluetooth") else { return nil }
+
+            let partName = dictionary["Part Identifier"] as? String ?? "Main"
+            let groupIdentifier = dictionary["Group Identifier"] as? String
+            let groupKey = groupIdentifier?.isEmpty == false
+                ? "accessory:\(groupIdentifier!)"
+                : "name:\(normalizedDeviceName(name).lowercased())"
+            let category = inferredDeviceCategory(
+                name: name,
+                reportedCategory: dictionary["Accessory Category"] as? String
+            )
+
+            return RawAccessoryBattery(
+                name: normalizedDeviceName(name),
+                groupKey: groupKey,
+                category: category,
+                part: .init(
+                    kind: normalizedPartKind(partName),
+                    percentage: percentage,
+                    isCharging: dictionary["Is Charging"] as? Bool ?? false
+                )
+            )
+        }
+    }
+
+    private func readBluetoothHIDBatteries() -> [RawAccessoryBattery] {
+        guard let matching = IOServiceMatching("AppleDeviceManagementHIDEventService") else {
+            return []
+        }
+
+        var iterator: io_iterator_t = 0
+        guard IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator) == kIOReturnSuccess else {
+            return []
+        }
+        defer { IOObjectRelease(iterator) }
+
+        var results: [RawAccessoryBattery] = []
+        while case let service = IOIteratorNext(iterator), service != 0 {
+            defer { IOObjectRelease(service) }
+            var properties: Unmanaged<CFMutableDictionary>?
+            guard IORegistryEntryCreateCFProperties(service, &properties, kCFAllocatorDefault, 0) == kIOReturnSuccess,
+                  let dictionary = properties?.takeRetainedValue() as? [String: Any],
+                  dictionary["BluetoothDevice"] as? Bool == true,
+                  let name = dictionary["Product"] as? String,
+                  let percentage = normalizedPercentage(dictionary["BatteryPercent"])
+            else {
+                continue
+            }
+
+            let normalizedName = normalizedDeviceName(name)
+            results.append(
+                .init(
+                    name: normalizedName,
+                    groupKey: "hid:\(normalizedName.lowercased())",
+                    category: inferredDeviceCategory(name: normalizedName, reportedCategory: nil),
+                    part: .init(kind: "main", percentage: percentage, isCharging: false)
+                )
+            )
+        }
+        return results
+    }
+
+    private func groupBluetoothBatteries(_ entries: [RawAccessoryBattery]) -> [BluetoothBatteryDevicePayload] {
+        let grouped = Dictionary(grouping: entries, by: \.groupKey)
+        return grouped.values.compactMap { entries in
+            guard let first = entries.first else { return nil }
+            let preferredName = entries.first(where: { $0.part.kind != "case" })?.name ?? first.name
+            let preferredCategory = entries.first(where: { $0.category != "other" })?.category ?? first.category
+
+            var partsByKind: [String: BluetoothBatteryPartPayload] = [:]
+            for entry in entries {
+                partsByKind[entry.part.kind] = entry.part
+            }
+            if partsByKind["left"] != nil || partsByKind["right"] != nil {
+                partsByKind.removeValue(forKey: "combined")
+                partsByKind.removeValue(forKey: "main")
+            }
+
+            let order = ["left", "right", "case", "main", "combined"]
+            let parts = partsByKind.values.sorted { lhs, rhs in
+                (order.firstIndex(of: lhs.kind) ?? order.count)
+                    < (order.firstIndex(of: rhs.kind) ?? order.count)
+            }
+            guard !parts.isEmpty else { return nil }
+            return .init(name: preferredName, category: preferredCategory, parts: parts)
+        }
+        .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    private func normalizedPercentage(_ value: Any?) -> Int? {
+        let percentage: Int
+        switch value {
+        case let value as Int:
+            percentage = value
+        case let value as NSNumber:
+            percentage = value.intValue
+        case let value as Double:
+            percentage = value <= 1 ? Int((value * 100).rounded()) : Int(value.rounded())
+        case let value as String:
+            percentage = Int(value.replacingOccurrences(of: "%", with: "")) ?? -1
+        default:
+            return nil
+        }
+        guard (0 ... 100).contains(percentage) else { return nil }
+        return percentage
+    }
+
+    private func normalizedPartKind(_ rawValue: String) -> String {
+        let value = rawValue.lowercased()
+        if value.contains("left") || value == "l" { return "left" }
+        if value.contains("right") || value == "r" { return "right" }
+        if value.contains("case") || value.contains("盒") { return "case" }
+        if value.contains("combined") { return "combined" }
+        return "main"
+    }
+
+    private func normalizedDeviceName(_ rawValue: String) -> String {
+        var value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        for suffix in ["充电盒", " Charging Case", " charging case"] where value.hasSuffix(suffix) {
+            value.removeLast(suffix.count)
+        }
+        return value.isEmpty ? "Bluetooth device" : value
+    }
+
+    private func inferredDeviceCategory(name: String, reportedCategory: String?) -> String {
+        let value = "\(name) \(reportedCategory ?? "")".lowercased()
+        if value.contains("airpods") || value.contains("headphone") || value.contains("headset")
+            || value.contains("earbud") || value.contains("audio") || value.contains("耳机")
+        {
+            return "headphones"
+        }
+        if value.contains("keyboard") || value.contains("键盘") { return "keyboard" }
+        if value.contains("trackpad") || value.contains("触控板") { return "trackpad" }
+        if value.contains("mouse") || value.contains("鼠标") { return "mouse" }
+        return "other"
     }
 
     // MARK: - Private helpers for DisplayServices / IOKit access

--- a/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
@@ -20,6 +20,9 @@ import Foundation
     func isScreenBrightnessAvailable(with reply: @escaping (Bool) -> Void)
     func currentScreenBrightness(with reply: @escaping (NSNumber?) -> Void)
     func setScreenBrightness(_ value: Float, with reply: @escaping (Bool) -> Void)
+    // System-reported Bluetooth accessory battery levels. The payload excludes
+    // device addresses, serial numbers, and accessory identifiers.
+    func bluetoothAccessoryBatteryData(with reply: @escaping (NSData?) -> Void)
 }
 
 /*

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -25,6 +25,11 @@
 		111BEA5F2ED07A340079DD4E /* MacroVisionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 111BEA5E2ED07A340079DD4E /* MacroVisionKit */; };
 		111BEA612ED09B1B0079DD4E /* NSScreen+UUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111BEA602ED09B1B0079DD4E /* NSScreen+UUID.swift */; };
 		111BEA6F2ED166E20079DD4E /* MacroVisionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 111BEA6E2ED166E20079DD4E /* MacroVisionKit */; };
+		C0D600012F00000100000001 /* AIWeatherManagers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D600022F00000100000001 /* AIWeatherManagers.swift */; };
+		C0D600032F00000100000001 /* AIWeatherViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D600042F00000100000001 /* AIWeatherViews.swift */; };
+		C0D600052F00000200000001 /* PomodoroDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D600062F00000200000001 /* PomodoroDashboardView.swift */; };
+		C0D600072F00000300000001 /* WeatherDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D600082F00000300000001 /* WeatherDashboardView.swift */; };
+		C0D600092F00000400000001 /* NotchPanelAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6000A2F00000400000001 /* NotchPanelAnimation.swift */; };
 		112B0EB82E30DD0F00562D6C /* MediaRemoteAdapterTestClient in Resources */ = {isa = PBXBuildFile; fileRef = 112B0EB52E30DD0F00562D6C /* MediaRemoteAdapterTestClient */; };
 		112B0EB92E30DD0F00562D6C /* mediaremote-adapter.pl in Resources */ = {isa = PBXBuildFile; fileRef = 112B0EB32E30DD0F00562D6C /* mediaremote-adapter.pl */; };
 		112B0EBB2E30DD5000562D6C /* MediaRemoteAdapter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 112B0EBA2E30DD5000562D6C /* MediaRemoteAdapter.framework */; };
@@ -93,7 +98,6 @@
 		14CEF41A2C5CAED400855D72 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14CEF4192C5CAED400855D72 /* Assets.xcassets */; };
 		14CEF41D2C5CAED400855D72 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14CEF41C2C5CAED400855D72 /* Preview Assets.xcassets */; };
 		14D0321A2C68F32E0096E6A1 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 14D032192C68F32E0096E6A1 /* LaunchAtLogin */; };
-		14D0321D2C68F3350096E6A1 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 14D0321C2C68F3350096E6A1 /* Sparkle */; };
 		14D570B92C5E98A20011E668 /* drop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570B82C5E98A20011E668 /* drop.swift */; };
 		14D570BC2C5E98EB0011E668 /* generic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570BB2C5E98EB0011E668 /* generic.swift */; };
 		14D570C02C5EA5870011E668 /* AnimatedFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570BF2C5EA5870011E668 /* AnimatedFace.swift */; };
@@ -113,12 +117,10 @@
 		9A0887322C7A693000C160EA /* TabButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0887312C7A693000C160EA /* TabButton.swift */; };
 		9A0887352C7AFF8E00C160EA /* TabSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0887342C7AFF8E00C160EA /* TabSelectionView.swift */; };
 		9A987A0D2C73CA66005CA465 /* ShelfView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A987A032C73CA66005CA465 /* ShelfView.swift */; };
-		9A987A102C73CA8D005CA465 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 9A987A0F2C73CA8D005CA465 /* Collections */; };
 		9AB0C6BD2C73C9CB00F7CD30 /* NotchHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */; };
 		B10348D92C74E56000475897 /* ConditionalModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10348D82C74E56000475897 /* ConditionalModifier.swift */; };
 		B10F84A32C6C9596009F3026 /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10F84A22C6C9596009F3026 /* TestView.swift */; };
 		B141C2412CA5F53F00AC8CC8 /* SparkleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B141C2402CA5F53E00AC8CC8 /* SparkleView.swift */; };
-		B1628B922CC260C0003D8DF3 /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = B1628B912CC260C0003D8DF3 /* SwiftUIIntrospect */; };
 		B17266DF2C64DFA00031BA0D /* BundleInfos.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17266DE2C64DFA00031BA0D /* BundleInfos.swift */; };
 		B17266E12C6532560031BA0D /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B17266E02C6532560031BA0D /* Localizable.xcstrings */; };
 		B17266E32C65F7FB0031BA0D /* WhatsNewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17266E22C65F7FB0031BA0D /* WhatsNewView.swift */; };
@@ -195,6 +197,11 @@
 		1113ABCF2E80E6BB00EC13B2 /* ThumbnailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailService.swift; sourceTree = "<group>"; };
 		111BE9942ECF2DEF0079DD4E /* DragDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragDetector.swift; sourceTree = "<group>"; };
 		111BEA602ED09B1B0079DD4E /* NSScreen+UUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScreen+UUID.swift"; sourceTree = "<group>"; };
+		C0D600022F00000100000001 /* AIWeatherManagers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIWeatherManagers.swift; sourceTree = "<group>"; };
+		C0D600042F00000100000001 /* AIWeatherViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIWeatherViews.swift; sourceTree = "<group>"; };
+		C0D600062F00000200000001 /* PomodoroDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroDashboardView.swift; sourceTree = "<group>"; };
+		C0D600082F00000300000001 /* WeatherDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherDashboardView.swift; sourceTree = "<group>"; };
+		C0D6000A2F00000400000001 /* NotchPanelAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchPanelAnimation.swift; sourceTree = "<group>"; };
 		112B0EB32E30DD0F00562D6C /* mediaremote-adapter.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "mediaremote-adapter.pl"; sourceTree = "<group>"; };
 		112B0EB52E30DD0F00562D6C /* MediaRemoteAdapterTestClient */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = MediaRemoteAdapterTestClient; sourceTree = "<group>"; };
 		112B0EBA2E30DD5000562D6C /* MediaRemoteAdapter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaRemoteAdapter.framework; path = "mediaremote-adapter/MediaRemoteAdapter.framework"; sourceTree = "<group>"; };
@@ -339,10 +346,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				111BEA5F2ED07A340079DD4E /* MacroVisionKit in Frameworks */,
-				9A987A102C73CA8D005CA465 /* Collections in Frameworks */,
 				1194E8852EA57D23009C82D6 /* SkyLightWindow in Frameworks */,
 				112B0EBB2E30DD5000562D6C /* MediaRemoteAdapter.framework in Frameworks */,
-				14D0321D2C68F3350096E6A1 /* Sparkle in Frameworks */,
 				111BEA6F2ED166E20079DD4E /* MacroVisionKit in Frameworks */,
 				11F748732EC9DA9300F841DB /* Lottie in Frameworks */,
 				14D0321A2C68F32E0096E6A1 /* LaunchAtLogin in Frameworks */,
@@ -350,7 +355,6 @@
 				B18654392C6F4990000B926A /* KeyboardShortcuts in Frameworks */,
 				B19016222CC15B3D00E3F12E /* Defaults in Frameworks */,
 				111BE95D2ECD71E10079DD4E /* AsyncXPCConnection in Frameworks */,
-				B1628B922CC260C0003D8DF3 /* SwiftUIIntrospect in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -510,6 +514,7 @@
 		147163B52C5D804B0068B555 /* managers */ = {
 			isa = PBXGroup;
 			children = (
+				C0D600022F00000100000001 /* AIWeatherManagers.swift */,
 				11D58EA12E760AE100FA8377 /* ImageService.swift */,
 				F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */,
 				112FB7342CCF16F70015238C /* NotchSpaceManager.swift */,
@@ -611,6 +616,7 @@
 			children = (
 				14D570B82C5E98A20011E668 /* drop.swift */,
 				14A7E5872C64A89C008C1BE9 /* HelloAnimation.swift */,
+				C0D6000A2F00000400000001 /* NotchPanelAnimation.swift */,
 			);
 			path = animations;
 			sourceTree = "<group>";
@@ -704,6 +710,9 @@
 		B186542F2C6F455E000B926A /* Notch */ = {
 			isa = PBXGroup;
 			children = (
+				C0D600042F00000100000001 /* AIWeatherViews.swift */,
+				C0D600062F00000200000001 /* PomodoroDashboardView.swift */,
+				C0D600082F00000300000001 /* WeatherDashboardView.swift */,
 				1194E8862EA6DDA7009C82D6 /* BoringNotchSkyLightWindow.swift */,
 				1160F8D72DD98230006FBB94 /* NotchShape.swift */,
 				9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */,
@@ -803,11 +812,8 @@
 			name = boringNotch;
 			packageProductDependencies = (
 				14D032192C68F32E0096E6A1 /* LaunchAtLogin */,
-				14D0321C2C68F3350096E6A1 /* Sparkle */,
 				B18654382C6F4990000B926A /* KeyboardShortcuts */,
-				9A987A0F2C73CA8D005CA465 /* Collections */,
 				B19016212CC15B3D00E3F12E /* Defaults */,
-				B1628B912CC260C0003D8DF3 /* SwiftUIIntrospect */,
 				1194E8842EA57D23009C82D6 /* SkyLightWindow */,
 				11F748722EC9DA9300F841DB /* Lottie */,
 				111BE95C2ECD71E10079DD4E /* AsyncXPCConnection */,
@@ -849,12 +855,8 @@
 			mainGroup = 14CEF4092C5CAED200855D72;
 			packageReferences = (
 				14D032182C68F32E0096E6A1 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */,
-				14D0321B2C68F3350096E6A1 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				B18654372C6F4990000B926A /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
-				9A987A0E2C73CA8D005CA465 /* XCRemoteSwiftPackageReference "swift-collections" */,
-				9A987A112C73CAA1005CA465 /* XCRemoteSwiftPackageReference "Pow" */,
 				B19016202CC15B3D00E3F12E /* XCRemoteSwiftPackageReference "Defaults" */,
-				B1628B902CC260C0003D8DF3 /* XCRemoteSwiftPackageReference "swiftui-introspect" */,
 				1194E8832EA57D23009C82D6 /* XCRemoteSwiftPackageReference "SkyLightWindow" */,
 				11F748712EC9DA9300F841DB /* XCRemoteSwiftPackageReference "lottie-spm" */,
 				111BE95B2ECD71E10079DD4E /* XCRemoteSwiftPackageReference "AsyncXPCConnection" */,
@@ -905,6 +907,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C0D600012F00000100000001 /* AIWeatherManagers.swift in Sources */,
+				C0D600032F00000100000001 /* AIWeatherViews.swift in Sources */,
+				C0D600052F00000200000001 /* PomodoroDashboardView.swift in Sources */,
+				C0D600072F00000300000001 /* WeatherDashboardView.swift in Sources */,
+				C0D600092F00000400000001 /* NotchPanelAnimation.swift in Sources */,
 				115C12EC2ED3D003009754CA /* OpenNotchHUD.swift in Sources */,
 				14C08BB92C8DE4B1000F8AA0 /* BoringCalendar.swift in Sources */,
 				5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */,
@@ -1234,15 +1241,16 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = boringNotch/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = TheBoringNotch;
+				INFOPLIST_KEY_CFBundleDisplayName = "蛋神";
+				INFOPLIST_KEY_CFBundleName = "蛋神";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSBackgroundOnly = NO;
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSAppleEventsUsageDescription = "This app uses AppleEvents to control music";
-				INFOPLIST_KEY_NSCalendarsUsageDescription = "This app uses the calendar to display your calendar events";
-				INFOPLIST_KEY_NSCameraUsageDescription = "This app uses the camera to display a live camera view";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "蛋神需要使用 AppleEvents 来控制音乐播放。";
+				INFOPLIST_KEY_NSCalendarsUsageDescription = "蛋神需要读取日历来显示你的日程事件。";
+				INFOPLIST_KEY_NSCameraUsageDescription = "蛋神需要使用摄像头来显示实时镜子预览。";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSRemindersUsageDescription = "This app uses Reminders to display your scheduled reminder in the calendar";
+				INFOPLIST_KEY_NSRemindersUsageDescription = "蛋神需要读取提醒事项来显示你的待办提醒。";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -1287,15 +1295,16 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = boringNotch/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = TheBoringNotch;
+				INFOPLIST_KEY_CFBundleDisplayName = "蛋神";
+				INFOPLIST_KEY_CFBundleName = "蛋神";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSBackgroundOnly = NO;
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSAppleEventsUsageDescription = "This app uses AppleEvents to control music";
-				INFOPLIST_KEY_NSCalendarsUsageDescription = "This app uses the calendar to display your calendar events";
-				INFOPLIST_KEY_NSCameraUsageDescription = "This app uses the camera to display a live camera view";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "蛋神需要使用 AppleEvents 来控制音乐播放。";
+				INFOPLIST_KEY_NSCalendarsUsageDescription = "蛋神需要读取日历来显示你的日程事件。";
+				INFOPLIST_KEY_NSCameraUsageDescription = "蛋神需要使用摄像头来显示实时镜子预览。";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSRemindersUsageDescription = "This app uses Reminders to display your scheduled reminder in the calendar";
+				INFOPLIST_KEY_NSRemindersUsageDescription = "蛋神需要读取提醒事项来显示你的待办提醒。";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -1388,38 +1397,6 @@
 				minimumVersion = 1.1.0;
 			};
 		};
-		14D0321B2C68F3350096E6A1 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/sparkle-project/Sparkle";
-			requirement = {
-				kind = exactVersion;
-				version = 2.9.1;
-			};
-		};
-		9A987A0E2C73CA8D005CA465 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/apple/swift-collections.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.1.2;
-			};
-		};
-		9A987A112C73CAA1005CA465 /* XCRemoteSwiftPackageReference "Pow" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/EmergeTools/Pow";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.4;
-			};
-		};
-		B1628B902CC260C0003D8DF3 /* XCRemoteSwiftPackageReference "swiftui-introspect" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/siteline/swiftui-introspect";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.3.0;
-			};
-		};
 		B18654372C6F4990000B926A /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
@@ -1471,21 +1448,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 14D032182C68F32E0096E6A1 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */;
 			productName = LaunchAtLogin;
-		};
-		14D0321C2C68F3350096E6A1 /* Sparkle */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 14D0321B2C68F3350096E6A1 /* XCRemoteSwiftPackageReference "Sparkle" */;
-			productName = Sparkle;
-		};
-		9A987A0F2C73CA8D005CA465 /* Collections */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9A987A0E2C73CA8D005CA465 /* XCRemoteSwiftPackageReference "swift-collections" */;
-			productName = Collections;
-		};
-		B1628B912CC260C0003D8DF3 /* SwiftUIIntrospect */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B1628B902CC260C0003D8DF3 /* XCRemoteSwiftPackageReference "swiftui-introspect" */;
-			productName = SwiftUIIntrospect;
 		};
 		B18654382C6F4990000B926A /* KeyboardShortcuts */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -1241,16 +1241,16 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = boringNotch/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "蛋神";
-				INFOPLIST_KEY_CFBundleName = "蛋神";
+				INFOPLIST_KEY_CFBundleDisplayName = "Boring Notch";
+				INFOPLIST_KEY_CFBundleName = "Boring Notch";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSBackgroundOnly = NO;
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSAppleEventsUsageDescription = "蛋神需要使用 AppleEvents 来控制音乐播放。";
-				INFOPLIST_KEY_NSCalendarsUsageDescription = "蛋神需要读取日历来显示你的日程事件。";
-				INFOPLIST_KEY_NSCameraUsageDescription = "蛋神需要使用摄像头来显示实时镜子预览。";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Boring Notch需要使用 AppleEvents 来控制音乐播放。";
+				INFOPLIST_KEY_NSCalendarsUsageDescription = "Boring Notch需要读取日历来显示你的日程事件。";
+				INFOPLIST_KEY_NSCameraUsageDescription = "Boring Notch需要使用摄像头来显示实时镜子预览。";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSRemindersUsageDescription = "蛋神需要读取提醒事项来显示你的待办提醒。";
+				INFOPLIST_KEY_NSRemindersUsageDescription = "Boring Notch需要读取提醒事项来显示你的待办提醒。";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -1295,16 +1295,16 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = boringNotch/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "蛋神";
-				INFOPLIST_KEY_CFBundleName = "蛋神";
+				INFOPLIST_KEY_CFBundleDisplayName = "Boring Notch";
+				INFOPLIST_KEY_CFBundleName = "Boring Notch";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSBackgroundOnly = NO;
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSAppleEventsUsageDescription = "蛋神需要使用 AppleEvents 来控制音乐播放。";
-				INFOPLIST_KEY_NSCalendarsUsageDescription = "蛋神需要读取日历来显示你的日程事件。";
-				INFOPLIST_KEY_NSCameraUsageDescription = "蛋神需要使用摄像头来显示实时镜子预览。";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Boring Notch需要使用 AppleEvents 来控制音乐播放。";
+				INFOPLIST_KEY_NSCalendarsUsageDescription = "Boring Notch需要读取日历来显示你的日程事件。";
+				INFOPLIST_KEY_NSCameraUsageDescription = "Boring Notch需要使用摄像头来显示实时镜子预览。";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSRemindersUsageDescription = "蛋神需要读取提醒事项来显示你的待办提醒。";
+				INFOPLIST_KEY_NSRemindersUsageDescription = "Boring Notch需要读取提醒事项来显示你的待办提醒。";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		C0D600052F00000200000001 /* PomodoroDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D600062F00000200000001 /* PomodoroDashboardView.swift */; };
 		C0D600072F00000300000001 /* WeatherDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D600082F00000300000001 /* WeatherDashboardView.swift */; };
 		C0D600092F00000400000001 /* NotchPanelAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6000A2F00000400000001 /* NotchPanelAnimation.swift */; };
+		C0D6000B2F00000500000001 /* ScreenMediaBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D6000C2F00000500000001 /* ScreenMediaBar.swift */; };
 		112B0EB82E30DD0F00562D6C /* MediaRemoteAdapterTestClient in Resources */ = {isa = PBXBuildFile; fileRef = 112B0EB52E30DD0F00562D6C /* MediaRemoteAdapterTestClient */; };
 		112B0EB92E30DD0F00562D6C /* mediaremote-adapter.pl in Resources */ = {isa = PBXBuildFile; fileRef = 112B0EB32E30DD0F00562D6C /* mediaremote-adapter.pl */; };
 		112B0EBB2E30DD5000562D6C /* MediaRemoteAdapter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 112B0EBA2E30DD5000562D6C /* MediaRemoteAdapter.framework */; };
@@ -202,6 +203,7 @@
 		C0D600062F00000200000001 /* PomodoroDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroDashboardView.swift; sourceTree = "<group>"; };
 		C0D600082F00000300000001 /* WeatherDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherDashboardView.swift; sourceTree = "<group>"; };
 		C0D6000A2F00000400000001 /* NotchPanelAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchPanelAnimation.swift; sourceTree = "<group>"; };
+		C0D6000C2F00000500000001 /* ScreenMediaBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenMediaBar.swift; sourceTree = "<group>"; };
 		112B0EB32E30DD0F00562D6C /* mediaremote-adapter.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "mediaremote-adapter.pl"; sourceTree = "<group>"; };
 		112B0EB52E30DD0F00562D6C /* MediaRemoteAdapterTestClient */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = MediaRemoteAdapterTestClient; sourceTree = "<group>"; };
 		112B0EBA2E30DD5000562D6C /* MediaRemoteAdapter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaRemoteAdapter.framework; path = "mediaremote-adapter/MediaRemoteAdapter.framework"; sourceTree = "<group>"; };
@@ -713,6 +715,7 @@
 				C0D600042F00000100000001 /* AIWeatherViews.swift */,
 				C0D600062F00000200000001 /* PomodoroDashboardView.swift */,
 				C0D600082F00000300000001 /* WeatherDashboardView.swift */,
+				C0D6000C2F00000500000001 /* ScreenMediaBar.swift */,
 				1194E8862EA6DDA7009C82D6 /* BoringNotchSkyLightWindow.swift */,
 				1160F8D72DD98230006FBB94 /* NotchShape.swift */,
 				9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */,
@@ -912,6 +915,7 @@
 				C0D600052F00000200000001 /* PomodoroDashboardView.swift in Sources */,
 				C0D600072F00000300000001 /* WeatherDashboardView.swift in Sources */,
 				C0D600092F00000400000001 /* NotchPanelAnimation.swift in Sources */,
+				C0D6000B2F00000500000001 /* ScreenMediaBar.swift in Sources */,
 				115C12EC2ED3D003009754CA /* OpenNotchHUD.swift in Sources */,
 				14C08BB92C8DE4B1000F8AA0 /* BoringCalendar.swift in Sources */,
 				5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */,
@@ -1241,16 +1245,16 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = boringNotch/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Boring Notch";
-				INFOPLIST_KEY_CFBundleName = "Boring Notch";
+				INFOPLIST_KEY_CFBundleDisplayName = "蛋神";
+				INFOPLIST_KEY_CFBundleName = "蛋神";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSBackgroundOnly = NO;
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Boring Notch需要使用 AppleEvents 来控制音乐播放。";
-				INFOPLIST_KEY_NSCalendarsUsageDescription = "Boring Notch需要读取日历来显示你的日程事件。";
-				INFOPLIST_KEY_NSCameraUsageDescription = "Boring Notch需要使用摄像头来显示实时镜子预览。";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "蛋神需要使用 AppleEvents 来控制音乐播放。";
+				INFOPLIST_KEY_NSCalendarsUsageDescription = "蛋神需要读取日历来显示你的日程事件。";
+				INFOPLIST_KEY_NSCameraUsageDescription = "蛋神需要使用摄像头来显示实时镜子预览。";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSRemindersUsageDescription = "Boring Notch需要读取提醒事项来显示你的待办提醒。";
+				INFOPLIST_KEY_NSRemindersUsageDescription = "蛋神需要读取提醒事项来显示你的待办提醒。";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -1295,16 +1299,16 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = boringNotch/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Boring Notch";
-				INFOPLIST_KEY_CFBundleName = "Boring Notch";
+				INFOPLIST_KEY_CFBundleDisplayName = "蛋神";
+				INFOPLIST_KEY_CFBundleName = "蛋神";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSBackgroundOnly = NO;
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Boring Notch需要使用 AppleEvents 来控制音乐播放。";
-				INFOPLIST_KEY_NSCalendarsUsageDescription = "Boring Notch需要读取日历来显示你的日程事件。";
-				INFOPLIST_KEY_NSCameraUsageDescription = "Boring Notch需要使用摄像头来显示实时镜子预览。";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "蛋神需要使用 AppleEvents 来控制音乐播放。";
+				INFOPLIST_KEY_NSCalendarsUsageDescription = "蛋神需要读取日历来显示你的日程事件。";
+				INFOPLIST_KEY_NSCameraUsageDescription = "蛋神需要使用摄像头来显示实时镜子预览。";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSRemindersUsageDescription = "Boring Notch需要读取提醒事项来显示你的待办提醒。";
+				INFOPLIST_KEY_NSRemindersUsageDescription = "蛋神需要读取提醒事项来显示你的待办提醒。";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/boringNotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/boringNotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "ab961f5de25797b1a82bd0f8c39b561332a3dfe10de0a118e1252262fbd45864",
   "pins" : [
     {
       "identity" : "asyncxpcconnection",
@@ -56,15 +55,6 @@
       }
     },
     {
-      "identity" : "pow",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/EmergeTools/Pow",
-      "state" : {
-        "revision" : "a504eb6d144bcf49f4f33029a2795345cb39e6b4",
-        "version" : "1.0.5"
-      }
-    },
-    {
       "identity" : "skylightwindow",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lakr233/SkyLightWindow",
@@ -74,39 +64,12 @@
       }
     },
     {
-      "identity" : "sparkle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sparkle-project/Sparkle",
-      "state" : {
-        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
-        "version" : "2.9.1"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
         "version" : "602.0.0"
-      }
-    },
-    {
-      "identity" : "swiftui-introspect",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/swiftui-introspect",
-      "state" : {
-        "revision" : "807f73ce09a9b9723f12385e592b4e0aaebd3336",
-        "version" : "1.3.0"
       }
     }
   ],

--- a/boringNotch/BoringViewCoordinator.swift
+++ b/boringNotch/BoringViewCoordinator.swift
@@ -122,18 +122,21 @@ class BoringViewCoordinator: ObservableObject {
         }
         
         selectedScreenUUID = preferredScreenUUID ?? NSScreen.main?.displayUUID ?? ""
-        // Observe changes to accessibility authorization and react accordingly
+        // Start the interceptor as soon as both required system permissions are available.
         accessibilityObserver = NotificationCenter.default.addObserver(
-            forName: Notification.Name.accessibilityAuthorizationChanged,
+            forName: Notification.Name.hudPermissionStatusChanged,
             object: nil,
             queue: .main
-        ) { _ in
+        ) { notification in
             Task { @MainActor in
-                if Defaults[.hudReplacement] {
+                let authorized = notification.userInfo?["authorized"] as? Bool ?? false
+                if authorized, Defaults[.hudReplacement] {
                     await MediaKeyInterceptor.shared.start(promptIfNeeded: false)
                 }
             }
         }
+
+        XPCHelperClient.shared.startMonitoringAccessibilityAuthorization()
 
         // Observe changes to hudReplacement
         hudReplacementCancellable = Defaults.publisher(.hudReplacement)
@@ -146,14 +149,7 @@ class BoringViewCoordinator: ObservableObject {
 
                     if change.newValue {
                         self.hudEnableTask = Task { @MainActor in
-                            let granted = await XPCHelperClient.shared.ensureAccessibilityAuthorization(promptIfNeeded: true)
-                            if Task.isCancelled { return }
-
-                            if granted {
-                                await MediaKeyInterceptor.shared.start()
-                            } else {
-                                Defaults[.hudReplacement] = false
-                            }
+                            await MediaKeyInterceptor.shared.start(promptIfNeeded: false)
                         }
                     } else {
                         MediaKeyInterceptor.shared.stop()
@@ -165,12 +161,7 @@ class BoringViewCoordinator: ObservableObject {
             helloAnimationRunning = firstLaunch
 
             if Defaults[.hudReplacement] {
-                let authorized = await XPCHelperClient.shared.isAccessibilityAuthorized()
-                if !authorized {
-                    Defaults[.hudReplacement] = false
-                } else {
-                    await MediaKeyInterceptor.shared.start(promptIfNeeded: false)
-                }
+                await MediaKeyInterceptor.shared.start(promptIfNeeded: false)
             }
         }
     }

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -11,7 +11,6 @@ import Combine
 import Defaults
 import KeyboardShortcuts
 import SwiftUI
-import SwiftUIIntrospect
 
 @MainActor
 struct ContentView: View {
@@ -25,6 +24,7 @@ struct ContentView: View {
     @ObservedObject var volumeManager = VolumeManager.shared
     @State private var hoverTask: Task<Void, Never>?
     @State private var isHovering: Bool = false
+    @State private var hoverOpenedAt: Date?
     @State private var anyDropDebounceTask: Task<Void, Never>?
 
     @State private var gestureProgress: CGFloat = .zero
@@ -36,12 +36,16 @@ struct ContentView: View {
     @Default(.useMusicVisualizer) var useMusicVisualizer
 
     @Default(.showNotHumanFace) var showNotHumanFace
+    @Default(.aiChatPanelWidth) var aiChatPanelWidth
+    @Default(.aiChatPanelHeight) var aiChatPanelHeight
 
     // Shared interactive spring for movement/resizing to avoid conflicting animations
-    private let animationSpring = Animation.interactiveSpring(response: 0.38, dampingFraction: 0.8, blendDuration: 0)
+    private let animationSpring = NotchPanelAnimation.spring
 
     private let extendedHoverPadding: CGFloat = 30
     private let zeroHeightHoverPadding: CGFloat = 10
+    private let hoverExitDelay: UInt64 = 140_000_000
+    private let hoverExitDelayAfterOpen: UInt64 = 420_000_000
 
     private var topCornerRadius: CGFloat {
        ((vm.notchState == .open) && Defaults[.cornerRadiusScaling])
@@ -80,6 +84,10 @@ struct ContentView: View {
         return chinWidth
     }
 
+    private var shouldKeepOpenForInteraction: Bool {
+        vm.preventAutoClose || coordinator.currentView == .assistant
+    }
+
     var body: some View {
         // Calculate scale based on gesture progress only
         let gestureScale: CGFloat = {
@@ -87,6 +95,7 @@ struct ContentView: View {
             let scaleFactor = 1.0 + gestureProgress * 0.01
             return max(0.6, scaleFactor)
         }()
+        let contentWindowSize = hostingWindowSize(for: vm.notchSize)
         
         ZStack(alignment: .top) {
             VStack(spacing: 0) {
@@ -100,6 +109,7 @@ struct ContentView: View {
                         : cornerRadiusInsets.closed.bottom
                     )
                     .padding([.horizontal, .bottom], vm.notchState == .open ? 12 : 0)
+                    .frame(width: vm.notchSize.width, alignment: .top)
                     .background(.black)
                     .clipShape(currentNotchShape)
                     .overlay(alignment: .top) {
@@ -120,11 +130,8 @@ struct ContentView: View {
                 mainLayout
                     .frame(height: vm.notchState == .open ? vm.notchSize.height : nil)
                     .conditionalModifier(true) { view in
-                        let openAnimation = Animation.spring(response: 0.42, dampingFraction: 0.8, blendDuration: 0)
-                        let closeAnimation = Animation.spring(response: 0.45, dampingFraction: 1.0, blendDuration: 0)
-                        
                         return view
-                            .animation(vm.notchState == .open ? openAnimation : closeAnimation, value: vm.notchState)
+                            .animation(NotchPanelAnimation.spring, value: vm.notchState)
                             .animation(.smooth, value: gestureProgress)
                     }
                     .contentShape(Rectangle())
@@ -132,28 +139,31 @@ struct ContentView: View {
                         handleHover(hovering)
                     }
                     .onTapGesture {
+                        guard vm.notchState == .closed else { return }
                         doOpen()
                     }
-                    .conditionalModifier(Defaults[.enableGestures]) { view in
+                    .conditionalModifier(Defaults[.enableGestures] && vm.notchState == .closed) { view in
                         view
                             .panGesture(direction: .down) { translation, phase in
                                 handleDownGesture(translation: translation, phase: phase)
                             }
                     }
-                    .conditionalModifier(Defaults[.closeGestureEnabled] && Defaults[.enableGestures]) { view in
+                    .conditionalModifier(
+                        Defaults[.closeGestureEnabled] && Defaults[.enableGestures] && vm.notchState == .open
+                    ) { view in
                         view
                             .panGesture(direction: .up) { translation, phase in
                                 handleUpGesture(translation: translation, phase: phase)
                             }
                     }
                     .onReceive(NotificationCenter.default.publisher(for: .sharingDidFinish)) { _ in
-                        if vm.notchState == .open && !isHovering && !vm.isBatteryPopoverActive {
+                        if vm.notchState == .open && !isHovering && !vm.isBatteryPopoverActive && !shouldKeepOpenForInteraction {
                             hoverTask?.cancel()
                             hoverTask = Task {
                                 try? await Task.sleep(for: .milliseconds(100))
                                 guard !Task.isCancelled else { return }
                                 await MainActor.run {
-                                    if self.vm.notchState == .open && !self.isHovering && !self.vm.isBatteryPopoverActive && !SharingStateManager.shared.preventNotchClose {
+                                    if self.vm.notchState == .open && !self.isHovering && !self.vm.isBatteryPopoverActive && !self.shouldKeepOpenForInteraction && !SharingStateManager.shared.preventNotchClose {
                                         self.vm.close()
                                     }
                                 }
@@ -168,13 +178,13 @@ struct ContentView: View {
                         }
                     }
                     .onChange(of: vm.isBatteryPopoverActive) {
-                        if !vm.isBatteryPopoverActive && !isHovering && vm.notchState == .open && !SharingStateManager.shared.preventNotchClose {
+                        if !vm.isBatteryPopoverActive && !isHovering && vm.notchState == .open && !shouldKeepOpenForInteraction && !SharingStateManager.shared.preventNotchClose {
                             hoverTask?.cancel()
                             hoverTask = Task {
                                 try? await Task.sleep(for: .milliseconds(100))
                                 guard !Task.isCancelled else { return }
                                 await MainActor.run {
-                                    if !self.vm.isBatteryPopoverActive && !self.isHovering && self.vm.notchState == .open && !SharingStateManager.shared.preventNotchClose {
+                                    if !self.vm.isBatteryPopoverActive && !self.isHovering && self.vm.notchState == .open && !self.shouldKeepOpenForInteraction && !SharingStateManager.shared.preventNotchClose {
                                         self.vm.close()
                                     }
                                 }
@@ -203,7 +213,7 @@ struct ContentView: View {
             }
         }
         .padding(.bottom, 8)
-        .frame(maxWidth: windowSize.width, maxHeight: windowSize.height, alignment: .top)
+        .frame(width: contentWindowSize.width, height: contentWindowSize.height, alignment: .top)
         .compositingGroup()
         .scaleEffect(
             x: gestureScale,
@@ -238,6 +248,23 @@ struct ContentView: View {
                 if !SharingStateManager.shared.preventNotchClose {
                     vm.close()
                 }
+            }
+        }
+        .onChange(of: coordinator.currentView) { _, _ in
+            withAnimation(animationSpring) {
+                vm.updateOpenSizeForCurrentView()
+            }
+        }
+        .onChange(of: aiChatPanelWidth) { _, _ in
+            guard !vm.isResizingAssistantPanel else { return }
+            withAnimation(animationSpring) {
+                vm.updateOpenSizeForCurrentView()
+            }
+        }
+        .onChange(of: aiChatPanelHeight) { _, _ in
+            guard !vm.isResizingAssistantPanel else { return }
+            withAnimation(animationSpring) {
+                vm.updateOpenSizeForCurrentView()
             }
         }
     }
@@ -294,7 +321,7 @@ struct ContentView: View {
                           BoringFaceAnimation()
                        } else if vm.notchState == .open {
                            BoringHeader()
-                               .frame(height: max(24, vm.effectiveClosedNotchHeight))
+                               .frame(height: max(32, vm.effectiveClosedNotchHeight))
                                .opacity(gestureProgress != 0 ? 1.0 - min(abs(gestureProgress) * 0.1, 0.3) : 1.0)
                        } else {
                            Rectangle().fill(.clear).frame(width: vm.closedNotchSize.width - 20, height: vm.effectiveClosedNotchHeight)
@@ -344,18 +371,24 @@ struct ContentView: View {
               .zIndex(2)
             if vm.notchState == .open {
                 VStack {
-                    switch coordinator.currentView {
-                    case .home:
-                        NotchHomeView(albumArtNamespace: albumArtNamespace)
-                    case .shelf:
-                        ShelfView()
+                    Group {
+                        switch coordinator.currentView {
+                        case .home:
+                            NotchHomeView(albumArtNamespace: albumArtNamespace)
+                        case .shelf:
+                            ShelfView()
+                        case .assistant:
+                            AIChatView()
+                        case .weather:
+                            WeatherDashboardView()
+                        case .pomodoro:
+                            PomodoroDashboardView()
+                        }
                     }
+                    .id(coordinator.currentView)
                 }
-                .transition(
-                    .scale(scale: 0.8, anchor: .top)
-                    .combined(with: .opacity)
-                    .animation(.smooth(duration: 0.35))
-                )
+                .transition(NotchPanelAnimation.contentTransition)
+                .animation(animationSpring, value: coordinator.currentView)
                 .zIndex(1)
                 .allowsHitTesting(vm.notchState == .open)
                 .opacity(gestureProgress != 0 ? 1.0 - min(abs(gestureProgress) * 0.1, 0.3) : 1.0)
@@ -503,6 +536,8 @@ struct ContentView: View {
     }
 
     private func doOpen() {
+        guard vm.notchState == .closed else { return }
+        hoverOpenedAt = Date()
         withAnimation(animationSpring) {
             vm.open()
         }
@@ -515,6 +550,13 @@ struct ContentView: View {
         hoverTask?.cancel()
         
         if hovering {
+            guard !vm.isHoverAutoOpenSuppressed() else {
+                withAnimation(animationSpring) {
+                    isHovering = false
+                }
+                return
+            }
+
             withAnimation(animationSpring) {
                 isHovering = true
             }
@@ -532,6 +574,13 @@ struct ContentView: View {
                 guard !Task.isCancelled else { return }
                 
                 await MainActor.run {
+                    guard !self.vm.isHoverAutoOpenSuppressed() else {
+                        withAnimation(animationSpring) {
+                            self.isHovering = false
+                        }
+                        return
+                    }
+
                     guard self.vm.notchState == .closed,
                           self.isHovering,
                           !self.coordinator.sneakPeek.show else { return }
@@ -541,20 +590,40 @@ struct ContentView: View {
             }
         } else {
             hoverTask = Task {
-                try? await Task.sleep(for: .milliseconds(100))
+                let delay = recentlyOpenedFromHover ? hoverExitDelayAfterOpen : hoverExitDelay
+                try? await Task.sleep(nanoseconds: delay)
                 guard !Task.isCancelled else { return }
                 
                 await MainActor.run {
+                    guard !self.vm.isHoverAutoOpenSuppressed() else {
+                        withAnimation(animationSpring) {
+                            self.isHovering = false
+                        }
+                        return
+                    }
+
+                    if self.vm.isMouseHovering() {
+                        withAnimation(animationSpring) {
+                            self.isHovering = true
+                        }
+                        return
+                    }
+
                     withAnimation(animationSpring) {
                         self.isHovering = false
                     }
                     
-                    if self.vm.notchState == .open && !self.vm.isBatteryPopoverActive && !SharingStateManager.shared.preventNotchClose {
+                    if self.vm.notchState == .open && !self.vm.isBatteryPopoverActive && !self.shouldKeepOpenForInteraction && !SharingStateManager.shared.preventNotchClose {
                         self.vm.close()
                     }
                 }
             }
         }
+    }
+
+    private var recentlyOpenedFromHover: Bool {
+        guard let hoverOpenedAt else { return false }
+        return Date().timeIntervalSince(hoverOpenedAt) < 0.45
     }
 
     // MARK: - Gesture Handling

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -229,7 +229,7 @@ struct ContentView: View {
 
             if isTargeted {
                 if vm.notchState == .closed {
-                    coordinator.currentView = .shelf
+                    vm.selectOpenView(.shelf)
                     doOpen()
                 }
                 return
@@ -251,21 +251,15 @@ struct ContentView: View {
             }
         }
         .onChange(of: coordinator.currentView) { _, _ in
-            withAnimation(animationSpring) {
-                vm.updateOpenSizeForCurrentView()
-            }
+            vm.updateOpenSizeForCurrentView()
         }
         .onChange(of: aiChatPanelWidth) { _, _ in
             guard !vm.isResizingAssistantPanel else { return }
-            withAnimation(animationSpring) {
-                vm.updateOpenSizeForCurrentView()
-            }
+            vm.updateOpenSizeForCurrentView()
         }
         .onChange(of: aiChatPanelHeight) { _, _ in
             guard !vm.isResizingAssistantPanel else { return }
-            withAnimation(animationSpring) {
-                vm.updateOpenSizeForCurrentView()
-            }
+            vm.updateOpenSizeForCurrentView()
         }
     }
 
@@ -386,9 +380,9 @@ struct ContentView: View {
                         }
                     }
                     .id(coordinator.currentView)
+                    .transition(.identity)
                 }
                 .transition(NotchPanelAnimation.contentTransition)
-                .animation(animationSpring, value: coordinator.currentView)
                 .zIndex(1)
                 .allowsHitTesting(vm.notchState == .open)
                 .opacity(gestureProgress != 0 ? 1.0 - min(abs(gestureProgress) * 0.1, 0.3) : 1.0)

--- a/boringNotch/Info.plist
+++ b/boringNotch/Info.plist
@@ -7,6 +7,10 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSLocationUsageDescription</key>
+	<string>Boring Notch需要使用你的位置来显示本地天气。</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Boring Notch需要使用你的位置来显示本地天气。</string>
 	<key>SUEnableDownloaderService</key>
 	<true/>
 	<key>SUEnableInstallerLauncherService</key>

--- a/boringNotch/Info.plist
+++ b/boringNotch/Info.plist
@@ -2,15 +2,23 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleName</key>
+	<string>蛋神</string>
+	<key>LSMultipleInstancesProhibited</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
 	<key>NSLocationUsageDescription</key>
-	<string>Boring Notch需要使用你的位置来显示本地天气。</string>
+	<string>蛋神需要使用你的位置来显示本地天气。</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Boring Notch需要使用你的位置来显示本地天气。</string>
+	<string>蛋神需要使用你的位置来显示本地天气。</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>蛋神需要读取和创建日程，以回答安排问题并执行你明确要求的日历操作。</string>
+	<key>NSRemindersFullAccessUsageDescription</key>
+	<string>蛋神需要读取提醒事项，以在日程视图和智能体回答中显示待办。</string>
 	<key>SUEnableDownloaderService</key>
 	<true/>
 	<key>SUEnableInstallerLauncherService</key>

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -101,6 +101,182 @@
         }
       }
     },
+    "Battery levels appear in the Quick Launch Home card. This choice is kept when the card is hidden." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Battery levels appear in the Quick Launch Home card. This choice is kept when the card is hidden."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蓝牙设备电量显示在主页面的“快捷启动”卡片中；隐藏该卡片时仍会保留此选择。"
+          }
+        }
+      }
+    },
+    "Bluetooth Devices" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bluetooth Devices"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蓝牙设备"
+          }
+        }
+      }
+    },
+    "Choose up to six apps for the Quick Launch Home card. Connected-device batteries are configured in Bluetooth Devices." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose up to six apps for the Quick Launch Home card. Connected-device batteries are configured in Bluetooth Devices."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最多为主页面的“快捷启动”卡片选择 6 个 App。已连接设备的电量请在“蓝牙设备”中设置。"
+          }
+        }
+      }
+    },
+    "Devices to Display" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Devices to Display"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示设备"
+          }
+        }
+      }
+    },
+    "Home Display" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home Display"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主页面显示"
+          }
+        }
+      }
+    },
+    "No connected device with battery data has been detected yet." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No connected device with battery data has been detected yet."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂未检测到可提供电量信息的已连接设备。"
+          }
+        }
+      }
+    },
+    "Only devices connected to this Mac with a system-reported battery level are listed. Names and visibility choices stay on this Mac; Bluetooth addresses and serial numbers are not stored." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only devices connected to this Mac with a system-reported battery level are listed. Names and visibility choices stay on this Mac; Bluetooth addresses and serial numbers are not stored."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅列出已连接到这台 Mac 且系统可读取电量的设备。设备名称和显示选择只保存在本机；不会存储蓝牙地址或序列号。"
+          }
+        }
+      }
+    },
+    "Previously Detected" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previously Detected"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "之前检测到"
+          }
+        }
+      }
+    },
+    "Refresh Devices" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh Devices"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新设备"
+          }
+        }
+      }
+    },
+    "Show All" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show All"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部显示"
+          }
+        }
+      }
+    },
+    "Show connected-device batteries" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show connected-device batteries"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示已连接设备电量"
+          }
+        }
+      }
+    },
     " – %lld" : {
       "localizations" : {
         "ar" : {
@@ -11909,6 +12085,38 @@
         }
       }
     },
+    "Keep screen media bar on top" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep screen media bar on top"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "屏幕媒体条始终置顶"
+          }
+        }
+      }
+    },
+    "Keep settings and Agent windows on top" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep settings and Agent windows on top"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置与智能体窗口始终置顶"
+          }
+        }
+      }
+    },
     "Layout Preview" : {
       "localizations" : {
         "ar" : {
@@ -17710,6 +17918,22 @@
         }
       }
     },
+    "Reset screen media bar position" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset screen media bar position"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置屏幕媒体条位置"
+          }
+        }
+      }
+    },
     "Reset to Defaults" : {
       "localizations" : {
         "ar" : {
@@ -20008,6 +20232,38 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "显示电源状态通知"
+          }
+        }
+      }
+    },
+    "Show lyrics in screen media bar" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show lyrics in screen media bar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在屏幕媒体条中显示歌词"
+          }
+        }
+      }
+    },
+    "Show screen media bar" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show screen media bar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示屏幕媒体条"
           }
         }
       }

--- a/boringNotch/Providers/CalendarServiceProviding.swift
+++ b/boringNotch/Providers/CalendarServiceProviding.swift
@@ -14,6 +14,7 @@ protocol CalendarServiceProviding {
     func requestAccess(to type: EKEntityType) async throws -> Bool
     func calendars() async -> [CalendarModel]
     func events(from start: Date, to end: Date, calendars: [String]) async -> [EventModel]
+    func createEvents(_ drafts: [CalendarEventDraft], preferredCalendarIDs: [String]) async throws -> [CreatedCalendarEvent]
 }
 
 class CalendarService: CalendarServiceProviding {
@@ -114,6 +115,83 @@ class CalendarService: CalendarServiceProviding {
             try store.save(reminder, commit: true)
         } catch {
             print("Failed to update reminder completion: \(error)")
+        }
+    }
+
+    func createEvents(_ drafts: [CalendarEventDraft], preferredCalendarIDs: [String]) async throws -> [CreatedCalendarEvent] {
+        guard hasAccess(to: .event) else {
+            throw CalendarWriteError.accessDenied
+        }
+
+        guard let targetCalendar = writableCalendar(preferredCalendarIDs: preferredCalendarIDs) else {
+            throw CalendarWriteError.noWritableCalendar
+        }
+
+        var createdEvents: [CreatedCalendarEvent] = []
+        for draft in drafts {
+            let event = EKEvent(eventStore: store)
+            event.calendar = targetCalendar
+            event.title = draft.title
+            event.startDate = draft.start
+            event.endDate = max(draft.end, draft.start.addingTimeInterval(60 * 30))
+            event.notes = draft.notes
+            event.location = draft.location
+
+            try store.save(event, span: .thisEvent, commit: false)
+            createdEvents.append(
+                CreatedCalendarEvent(
+                    title: draft.title,
+                    start: event.startDate,
+                    end: event.endDate,
+                    calendarTitle: targetCalendar.title
+                )
+            )
+        }
+
+        try store.commit()
+        return createdEvents
+    }
+
+    private func writableCalendar(preferredCalendarIDs: [String]) -> EKCalendar? {
+        let eventCalendars = store.calendars(for: .event).filter(\.allowsContentModifications)
+
+        if let selected = eventCalendars.first(where: { preferredCalendarIDs.contains($0.calendarIdentifier) }) {
+            return selected
+        }
+
+        if let defaultCalendar = store.defaultCalendarForNewEvents, defaultCalendar.allowsContentModifications {
+            return defaultCalendar
+        }
+
+        return eventCalendars.first
+    }
+}
+
+struct CalendarEventDraft: Equatable {
+    let title: String
+    let start: Date
+    let end: Date
+    let notes: String?
+    let location: String?
+}
+
+struct CreatedCalendarEvent: Equatable {
+    let title: String
+    let start: Date
+    let end: Date
+    let calendarTitle: String
+}
+
+enum CalendarWriteError: LocalizedError {
+    case accessDenied
+    case noWritableCalendar
+
+    var errorDescription: String? {
+        switch self {
+        case .accessDenied:
+            return "Calendar access is not available. Enable it in Settings > Calendar."
+        case .noWritableCalendar:
+            return "No writable calendar is available for new events."
         }
     }
 }

--- a/boringNotch/Providers/CalendarServiceProviding.swift
+++ b/boringNotch/Providers/CalendarServiceProviding.swift
@@ -10,6 +10,7 @@
 import Foundation
 @preconcurrency import EventKit
 
+@MainActor
 protocol CalendarServiceProviding {
     func requestAccess(to type: EKEntityType) async throws -> Bool
     func calendars() async -> [CalendarModel]
@@ -17,10 +18,11 @@ protocol CalendarServiceProviding {
     func createEvents(_ drafts: [CalendarEventDraft], preferredCalendarIDs: [String]) async throws -> [CreatedCalendarEvent]
 }
 
-class CalendarService: CalendarServiceProviding {
+@MainActor
+final class CalendarService: CalendarServiceProviding {
+    private let agentCalendarTitle = "蛋神"
     private let store = EKEventStore()
     
-    @MainActor
     func requestAccess(to type: EKEntityType) async throws -> Bool {
         if #available(macOS 14.0, *) {
             switch type {
@@ -46,6 +48,7 @@ class CalendarService: CalendarServiceProviding {
     }
     
     func calendars() async -> [CalendarModel] {
+        store.refreshSourcesIfNecessary()
         var calendars: [EKCalendar] = []
         
         for type in [EKEntityType.event, .reminder] where hasAccess(to: type) {
@@ -56,18 +59,12 @@ class CalendarService: CalendarServiceProviding {
     }
     
     func events(from start: Date, to end: Date, calendars ids: [String]) async -> [EventModel] {
-        let allCalendars = await self.calendars()
-        let filteredCalendars = allCalendars.filter { ids.isEmpty || ids.contains($0.id) }
-        let ekCalendars = filteredCalendars.compactMap { calendarModel in
-            store.calendars(for: .event).first { $0.calendarIdentifier == calendarModel.id } ??
-            store.calendars(for: .reminder).first { $0.calendarIdentifier == calendarModel.id }
-        }
-        
+        store.refreshSourcesIfNecessary()
         var events: [EventModel] = []
         
         // Fetch regular events
         if hasAccess(to: .event) {
-            let eventCalendars = ekCalendars.filter { store.calendars(for: .event).contains($0) }
+            let eventCalendars = resolvedCalendars(for: .event, ids: ids)
             let predicate = store.predicateForEvents(withStart: start, end: end, calendars: eventCalendars)
             let ekEvents = store.events(matching: predicate)
             events.append(contentsOf: ekEvents.compactMap { EventModel(from: $0) })
@@ -75,14 +72,22 @@ class CalendarService: CalendarServiceProviding {
         
         // Fetch reminders
         if hasAccess(to: .reminder) {
-            let reminderCalendars = ekCalendars.filter { store.calendars(for: .reminder).contains($0) }
+            let reminderCalendars = resolvedCalendars(for: .reminder, ids: ids)
             events.append(contentsOf: await fetchReminders(from: start, to: end, calendars: reminderCalendars))
         }
         
         return events.sorted { $0.start < $1.start }
     }
     
-    private func fetchReminders(from start: Date, to end: Date, calendars: [EKCalendar]) async -> [EventModel] {
+    private func resolvedCalendars(for type: EKEntityType, ids: [String]) -> [EKCalendar]? {
+        guard !ids.isEmpty else {
+            return nil
+        }
+
+        return store.calendars(for: type).filter { ids.contains($0.calendarIdentifier) }
+    }
+
+    private func fetchReminders(from start: Date, to end: Date, calendars: [EKCalendar]?) async -> [EventModel] {
         return await withCheckedContinuation { continuation in
             // Create predicate for reminders with due dates in the specified range
             let predicate = store.predicateForReminders(in: calendars)
@@ -119,51 +124,158 @@ class CalendarService: CalendarServiceProviding {
     }
 
     func createEvents(_ drafts: [CalendarEventDraft], preferredCalendarIDs: [String]) async throws -> [CreatedCalendarEvent] {
+        guard !drafts.isEmpty else {
+            return []
+        }
+
         guard hasAccess(to: .event) else {
             throw CalendarWriteError.accessDenied
         }
 
-        guard let targetCalendar = writableCalendar(preferredCalendarIDs: preferredCalendarIDs) else {
+        guard let targetCalendar = try writableCalendar(preferredCalendarIDs: preferredCalendarIDs) else {
             throw CalendarWriteError.noWritableCalendar
         }
 
-        var createdEvents: [CreatedCalendarEvent] = []
-        for draft in drafts {
-            let event = EKEvent(eventStore: store)
-            event.calendar = targetCalendar
-            event.title = draft.title
-            event.startDate = draft.start
-            event.endDate = max(draft.end, draft.start.addingTimeInterval(60 * 30))
-            event.notes = draft.notes
-            event.location = draft.location
+        var eventIdentifiers: [String] = []
 
-            try store.save(event, span: .thisEvent, commit: false)
-            createdEvents.append(
-                CreatedCalendarEvent(
+        do {
+            for draft in drafts {
+                let normalizedEnd = max(draft.end, draft.start.addingTimeInterval(60 * 5))
+                if let existing = matchingEvent(
                     title: draft.title,
-                    start: event.startDate,
-                    end: event.endDate,
-                    calendarTitle: targetCalendar.title
-                )
+                    start: draft.start,
+                    end: normalizedEnd,
+                    calendar: targetCalendar
+                ) {
+                    eventIdentifiers.append(existing.eventIdentifier)
+                    continue
+                }
+
+                let event = EKEvent(eventStore: store)
+                event.calendar = targetCalendar
+                event.title = draft.title
+                event.startDate = draft.start
+                event.endDate = normalizedEnd
+                event.notes = draft.notes
+                event.location = draft.location
+                if let alarmOffsetMinutes = draft.alarmOffsetMinutes {
+                    event.addAlarm(EKAlarm(relativeOffset: TimeInterval(alarmOffsetMinutes * 60)))
+                }
+
+                try store.save(event, span: .thisEvent, commit: false)
+                guard let identifier = event.eventIdentifier, !identifier.isEmpty else {
+                    throw CalendarWriteError.verificationFailed
+                }
+                eventIdentifiers.append(identifier)
+            }
+
+            try store.commit()
+        } catch {
+            store.reset()
+            throw error
+        }
+
+        store.refreshSourcesIfNecessary()
+        return try eventIdentifiers.map { identifier in
+            guard let persistedEvent = store.event(withIdentifier: identifier),
+                  persistedEvent.calendar.title == agentCalendarTitle
+            else {
+                throw CalendarWriteError.verificationFailed
+            }
+
+            return CreatedCalendarEvent(
+                identifier: persistedEvent.calendarItemIdentifier,
+                title: persistedEvent.title ?? "AI 日程",
+                start: persistedEvent.startDate,
+                end: persistedEvent.endDate,
+                calendarTitle: persistedEvent.calendar.title
             )
         }
-
-        try store.commit()
-        return createdEvents
     }
 
-    private func writableCalendar(preferredCalendarIDs: [String]) -> EKCalendar? {
+    #if DEBUG
+    func removeEventsForRuntimeTest(calendarItemIdentifiers: [String]) throws -> Int {
+        var removedCount = 0
+
+        for identifier in calendarItemIdentifiers {
+            guard let event = store.calendarItem(withIdentifier: identifier) as? EKEvent else {
+                continue
+            }
+            try store.remove(event, span: .thisEvent, commit: false)
+            removedCount += 1
+        }
+
+        if removedCount > 0 {
+            try store.commit()
+            store.refreshSourcesIfNecessary()
+        }
+        return removedCount
+    }
+    #endif
+
+    private func matchingEvent(
+        title: String,
+        start: Date,
+        end: Date,
+        calendar: EKCalendar
+    ) -> EKEvent? {
+        let tolerance: TimeInterval = 1
+        let predicate = store.predicateForEvents(
+            withStart: start.addingTimeInterval(-60),
+            end: end.addingTimeInterval(60),
+            calendars: [calendar]
+        )
+
+        return store.events(matching: predicate).first { event in
+            event.title == title
+                && abs(event.startDate.timeIntervalSince(start)) <= tolerance
+                && abs(event.endDate.timeIntervalSince(end)) <= tolerance
+        }
+    }
+
+    private func writableCalendar(preferredCalendarIDs: [String]) throws -> EKCalendar? {
+        _ = preferredCalendarIDs
         let eventCalendars = store.calendars(for: .event).filter(\.allowsContentModifications)
 
-        if let selected = eventCalendars.first(where: { preferredCalendarIDs.contains($0.calendarIdentifier) }) {
-            return selected
+        if let agentCalendar = eventCalendars.first(where: { $0.title == agentCalendarTitle }) {
+            return agentCalendar
         }
 
-        if let defaultCalendar = store.defaultCalendarForNewEvents, defaultCalendar.allowsContentModifications {
-            return defaultCalendar
+        return try createAgentCalendarIfPossible()
+    }
+
+    private func createAgentCalendarIfPossible() throws -> EKCalendar? {
+        for source in calendarCreationSources() {
+            let calendar = EKCalendar(for: .event, eventStore: store)
+            calendar.title = agentCalendarTitle
+            calendar.source = source
+
+            do {
+                try store.saveCalendar(calendar, commit: true)
+                return calendar
+            } catch {
+                continue
+            }
         }
 
-        return eventCalendars.first
+        return nil
+    }
+
+    private func calendarCreationSources() -> [EKSource] {
+        var candidates: [EKSource] = []
+
+        if let defaultSource = store.defaultCalendarForNewEvents?.source {
+            candidates.append(defaultSource)
+        }
+
+        candidates.append(contentsOf: store.sources.filter { $0.sourceType == .local })
+        candidates.append(contentsOf: store.sources.filter { $0.sourceType == .calDAV || $0.sourceType == .exchange })
+
+        var unique: [EKSource] = []
+        for source in candidates where !unique.contains(where: { $0.sourceIdentifier == source.sourceIdentifier }) {
+            unique.append(source)
+        }
+        return unique
     }
 }
 
@@ -173,9 +285,11 @@ struct CalendarEventDraft: Equatable {
     let end: Date
     let notes: String?
     let location: String?
+    let alarmOffsetMinutes: Int?
 }
 
 struct CreatedCalendarEvent: Equatable {
+    let identifier: String
     let title: String
     let start: Date
     let end: Date
@@ -185,13 +299,16 @@ struct CreatedCalendarEvent: Equatable {
 enum CalendarWriteError: LocalizedError {
     case accessDenied
     case noWritableCalendar
+    case verificationFailed
 
     var errorDescription: String? {
         switch self {
         case .accessDenied:
             return "Calendar access is not available. Enable it in Settings > Calendar."
         case .noWritableCalendar:
-            return "No writable calendar is available for new events."
+            return "无法创建或找到可写入的“蛋神”日历。"
+        case .verificationFailed:
+            return "日程写入后未能从系统日历回读验证，请稍后重试。"
         }
     }
 }

--- a/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
+++ b/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
@@ -20,5 +20,5 @@ import Foundation
     func isScreenBrightnessAvailable(with reply: @escaping (Bool) -> Void)
     func currentScreenBrightness(with reply: @escaping (NSNumber?) -> Void)
     func setScreenBrightness(_ value: Float, with reply: @escaping (Bool) -> Void)
+    func bluetoothAccessoryBatteryData(with reply: @escaping (NSData?) -> Void)
 }
-

--- a/boringNotch/XPCHelperClient/XPCHelperClient.swift
+++ b/boringNotch/XPCHelperClient/XPCHelperClient.swift
@@ -1,6 +1,16 @@
 import Foundation
 import Cocoa
+import ApplicationServices
 import AsyncXPCConnection
+
+struct HUDPermissionStatus: Equatable, Sendable {
+    let accessibilityAuthorized: Bool
+    let inputMonitoringAuthorized: Bool
+
+    var isAuthorized: Bool {
+        accessibilityAuthorized
+    }
+}
 
 final class XPCHelperClient: NSObject {
     nonisolated static let shared = XPCHelperClient()
@@ -10,6 +20,7 @@ final class XPCHelperClient: NSObject {
     private var remoteService: RemoteXPCService<BoringNotchXPCHelperProtocol>?
     private var connection: NSXPCConnection?
     private var lastKnownAuthorization: Bool?
+    private var lastKnownHUDPermissionStatus: HUDPermissionStatus?
     private var monitoringTask: Task<Void, Never>?
     
     deinit {
@@ -69,6 +80,27 @@ final class XPCHelperClient: NSObject {
         )
     }
 
+    @MainActor
+    private func notifyHUDPermissionChange(_ status: HUDPermissionStatus) {
+        notifyAuthorizationChange(status.accessibilityAuthorized)
+        guard lastKnownHUDPermissionStatus != status else { return }
+        lastKnownHUDPermissionStatus = status
+        NSLog(
+            "[HUD] permissions accessibility=%@ inputMonitoring=%@",
+            status.accessibilityAuthorized.description,
+            status.inputMonitoringAuthorized.description
+        )
+        NotificationCenter.default.post(
+            name: .hudPermissionStatusChanged,
+            object: nil,
+            userInfo: [
+                "accessibilityAuthorized": status.accessibilityAuthorized,
+                "inputMonitoringAuthorized": status.inputMonitoringAuthorized,
+                "authorized": status.isAuthorized
+            ]
+        )
+    }
+
     // MARK: - Monitoring
     nonisolated func startMonitoringAccessibilityAuthorization(every interval: TimeInterval = 3.0) {
         // Ensure only one monitor exists
@@ -76,8 +108,7 @@ final class XPCHelperClient: NSObject {
         monitoringTask = Task.detached { [weak self] in
             guard let self = self else { return }
             while !Task.isCancelled {
-                // Call the helper method periodically which will notify on change
-                _ = await self.isAccessibilityAuthorized()
+                _ = await self.hudPermissionStatus()
                 do {
                     try await Task.sleep(for: .seconds(interval))
                 } catch { break }
@@ -96,54 +127,81 @@ final class XPCHelperClient: NSObject {
     }
     
     // MARK: - Accessibility
+
+    // The media-key event tap lives in the main app. Accessibility trust is
+    // process-specific, so checking the XPC helper here reports the wrong app.
+    private nonisolated func mainAppAccessibilityAuthorized(prompt: Bool) -> Bool {
+        if AXIsProcessTrusted() || CGPreflightPostEventAccess() {
+            return true
+        }
+        guard prompt else { return false }
+
+        let options = [
+            kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true
+        ] as CFDictionary
+        _ = AXIsProcessTrustedWithOptions(options)
+        _ = CGRequestPostEventAccess()
+        return AXIsProcessTrusted() || CGPreflightPostEventAccess()
+    }
+
+    private nonisolated func mainAppInputMonitoringAuthorized() -> Bool {
+        CGPreflightListenEventAccess()
+    }
     
     nonisolated func requestAccessibilityAuthorization() {
+        let authorized = mainAppAccessibilityAuthorized(prompt: true)
         Task {
-            let service = await MainActor.run {
-                ensureRemoteService()
-            }
-            try? await service.withService { service in
-                service.requestAccessibilityAuthorization()
+            _ = await hudPermissionStatus()
+            await MainActor.run {
+                notifyAuthorizationChange(authorized)
             }
         }
     }
     
     nonisolated func isAccessibilityAuthorized() async -> Bool {
-        do {
-            let service = await MainActor.run {
-                ensureRemoteService()
-            }
-            let result: Bool = try await service.withContinuation { service, continuation in
-                service.isAccessibilityAuthorized { authorized in
-                    continuation.resume(returning: authorized)
-                }
-            }
-            await MainActor.run {
-                notifyAuthorizationChange(result)
-            }
-            return result
-        } catch {
-            return false
+        let authorized = mainAppAccessibilityAuthorized(prompt: false)
+        await MainActor.run {
+            notifyAuthorizationChange(authorized)
         }
+        return authorized
     }
     
     nonisolated func ensureAccessibilityAuthorization(promptIfNeeded: Bool) async -> Bool {
-        do {
-            let service = await MainActor.run {
-                ensureRemoteService()
-            }
-            let result: Bool = try await service.withContinuation { service, continuation in
-                service.ensureAccessibilityAuthorization(promptIfNeeded) { authorized in
-                    continuation.resume(returning: authorized)
-                }
-            }
-            await MainActor.run {
-                notifyAuthorizationChange(result)
-            }
-            return result
-        } catch {
-            return false
+        let authorized = mainAppAccessibilityAuthorized(prompt: promptIfNeeded)
+        await MainActor.run {
+            notifyAuthorizationChange(authorized)
         }
+        return authorized
+    }
+
+    nonisolated func isInputMonitoringAuthorized() async -> Bool {
+        let authorized = mainAppInputMonitoringAuthorized()
+        _ = await hudPermissionStatus()
+        return authorized
+    }
+
+    nonisolated func requestInputMonitoringAuthorization() async -> Bool {
+        let authorized = CGRequestListenEventAccess()
+        _ = await hudPermissionStatus()
+        return authorized
+    }
+
+    nonisolated func hudPermissionStatus() async -> HUDPermissionStatus {
+        let status = HUDPermissionStatus(
+            accessibilityAuthorized: mainAppAccessibilityAuthorized(prompt: false),
+            inputMonitoringAuthorized: mainAppInputMonitoringAuthorized()
+        )
+        await MainActor.run {
+            notifyHUDPermissionChange(status)
+        }
+        return status
+    }
+
+    nonisolated func requestHUDPermissions() async -> HUDPermissionStatus {
+        if !mainAppAccessibilityAuthorized(prompt: false) {
+            _ = mainAppAccessibilityAuthorized(prompt: true)
+        }
+        return await hudPermissionStatus()
     }
     
     // MARK: - Keyboard Brightness
@@ -241,10 +299,26 @@ final class XPCHelperClient: NSObject {
             return false
         }
     }
+
+    nonisolated func bluetoothAccessoryBatteryData() async -> Data? {
+        do {
+            let service = await MainActor.run {
+                ensureRemoteService()
+            }
+            let result: NSData? = try await service.withContinuation { service, continuation in
+                service.bluetoothAccessoryBatteryData { data in
+                    continuation.resume(returning: data)
+                }
+            }
+            return result as Data?
+        } catch {
+            return nil
+        }
+    }
 }
 
 extension Notification.Name {
     static let accessibilityAuthorizationChanged = Notification.Name("accessibilityAuthorizationChanged")
+    static let hudPermissionStatusChanged = Notification.Name("hudPermissionStatusChanged")
+    static let mediaKeyInterceptorStateChanged = Notification.Name("mediaKeyInterceptorStateChanged")
 }
-
-

--- a/boringNotch/animations/NotchPanelAnimation.swift
+++ b/boringNotch/animations/NotchPanelAnimation.swift
@@ -1,0 +1,17 @@
+//
+//  NotchPanelAnimation.swift
+//  boringNotch
+//
+//  Created by Codex on 2026-06-30.
+//
+
+import Foundation
+import SwiftUI
+
+enum NotchPanelAnimation {
+    static let spring = Animation.interactiveSpring(response: 0.52, dampingFraction: 0.9, blendDuration: 0)
+    static let contentTransition = AnyTransition.asymmetric(
+        insertion: .scale(scale: 0.82, anchor: .top).combined(with: .opacity),
+        removal: .scale(scale: 0.92, anchor: .top).combined(with: .opacity)
+    )
+}

--- a/boringNotch/boringNotch.entitlements
+++ b/boringNotch/boringNotch.entitlements
@@ -20,6 +20,8 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
 	<key>com.apple.security.temporary-exception.apple-events</key>
 	<array>
 		<string>com.spotify.client</string>

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -9,7 +9,6 @@ import AVFoundation
 import Combine
 import Defaults
 import KeyboardShortcuts
-import Sparkle
 import SwiftUI
 
 @main
@@ -18,30 +17,20 @@ struct DynamicNotchApp: App {
     @Default(.menubarIcon) var showMenuBarIcon
     @Environment(\.openWindow) var openWindow
 
-    let updaterController: SPUStandardUpdaterController
-
-    init() {
-        updaterController = SPUStandardUpdaterController(
-            startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
-
-        // Initialize the settings window controller with the updater controller
-        SettingsWindowController.shared.setUpdaterController(updaterController)
-    }
-
     var body: some Scene {
-        MenuBarExtra("boring.notch", systemImage: "sparkle", isInserted: $showMenuBarIcon) {
-            Button("Settings") {
+        MenuBarExtra("Boring Notch", systemImage: "sparkle", isInserted: $showMenuBarIcon) {
+            Button("设置") {
                 DispatchQueue.main.async {
                     SettingsWindowController.shared.showWindow()
                 }
             }
             .keyboardShortcut(KeyEquivalent(","), modifiers: .command)
-            CheckForUpdatesView(updater: updaterController.updater)
+            CheckForUpdatesView()
             Divider()
-            Button("Restart Boring Notch") {
+            Button("重启Boring Notch") {
                 ApplicationRelauncher.restart()
             }
-            Button("Quit", role: .destructive) {
+            Button("退出", role: .destructive) {
                 NSApplication.shared.terminate(self)
             }
             .keyboardShortcut(KeyEquivalent("Q"), modifiers: .command)
@@ -67,6 +56,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var isScreenLocked: Bool = false
     private var windowScreenDidChangeObserver: Any?
     private var dragDetectors: [String: DragDetector] = [:] // UUID -> DragDetector
+    private var pendingFrameRefreshTask: Task<Void, Never>?
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return false
@@ -232,7 +222,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func createBoringNotchWindow(for screen: NSScreen, with viewModel: BoringViewModel) -> NSWindow {
-        let rect = NSRect(x: 0, y: 0, width: windowSize.width, height: windowSize.height)
+        let initialSize = hostingWindowSize(for: viewModel.notchSize)
+        let rect = NSRect(x: 0, y: 0, width: initialSize.width, height: initialSize.height)
         let styleMask: NSWindow.StyleMask = [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow]
         
         let window = BoringNotchSkyLightWindow(contentRect: rect, styleMask: styleMask, backing: .buffered, defer: false)
@@ -265,18 +256,75 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @MainActor
-    private func positionWindow(_ window: NSWindow, on screen: NSScreen, changeAlpha: Bool = false) {
+    private func positionWindow(
+        _ window: NSWindow,
+        on screen: NSScreen,
+        notchSize: CGSize,
+        changeAlpha: Bool = false
+    ) {
         if changeAlpha {
             window.alphaValue = 0
         }
 
         let screenFrame = screen.frame
-        window.setFrameOrigin(
-            NSPoint(
-                x: screenFrame.origin.x + (screenFrame.width / 2) - window.frame.width / 2,
-                y: screenFrame.origin.y + screenFrame.height - window.frame.height
-            ))
+        let targetSize = hostingWindowSize(for: notchSize)
+        let targetFrame = NSRect(
+            x: screenFrame.origin.x + (screenFrame.width / 2) - targetSize.width / 2,
+            y: screenFrame.origin.y + screenFrame.height - targetSize.height,
+            width: targetSize.width,
+            height: targetSize.height
+        )
+        window.setFrame(targetFrame, display: true)
         window.alphaValue = 1
+    }
+
+    @MainActor
+    private func refreshWindowFrames(changeAlpha: Bool = false) {
+        if Defaults[.showOnAllDisplays] {
+            for (uuid, window) in windows {
+                guard
+                    let screen = NSScreen.screen(withUUID: uuid),
+                    let viewModel = viewModels[uuid]
+                else { continue }
+
+                positionWindow(
+                    window,
+                    on: screen,
+                    notchSize: viewModel.notchSize,
+                    changeAlpha: changeAlpha
+                )
+            }
+        } else if let window {
+            let screen = window.screen
+                ?? NSScreen.screen(withUUID: coordinator.selectedScreenUUID)
+                ?? NSScreen.main
+
+            if let screen {
+                positionWindow(
+                    window,
+                    on: screen,
+                    notchSize: vm.notchSize,
+                    changeAlpha: changeAlpha
+                )
+            }
+        }
+    }
+
+    @MainActor
+    private func scheduleWindowFrameRefresh() {
+        let isResizingAssistantPanel = vm.isResizingAssistantPanel || viewModels.values.contains { $0.isResizingAssistantPanel }
+        guard isResizingAssistantPanel else {
+            pendingFrameRefreshTask?.cancel()
+            refreshWindowFrames()
+            return
+        }
+
+        pendingFrameRefreshTask?.cancel()
+        pendingFrameRefreshTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(24))
+            guard !Task.isCancelled else { return }
+            refreshWindowFrames()
+        }
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -303,6 +351,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor in
                 self?.adjustWindowPosition()
                 self?.setupDragDetectors()
+            }
+        }
+
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name.notchPanelSizeChanged, object: nil, queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.scheduleWindowFrameRefresh()
             }
         }
 
@@ -501,11 +557,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
 
                 if let window = windows[uuid], let viewModel = viewModels[uuid] {
-                    positionWindow(window, on: screen, changeAlpha: changeAlpha)
-
                     if viewModel.notchState == .closed {
                         viewModel.close()
+                    } else {
+                        viewModel.updateOpenSizeForCurrentView()
                     }
+
+                    positionWindow(window, on: screen, notchSize: viewModel.notchSize, changeAlpha: changeAlpha)
                 }
             }
         } else {
@@ -526,18 +584,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             vm.screenUUID = selectedScreen.displayUUID
-            vm.notchSize = getClosedNotchSize(screenUUID: selectedScreen.displayUUID)
+            if vm.notchState == .closed {
+                vm.close()
+            } else {
+                vm.updateOpenSizeForCurrentView()
+            }
 
             if window == nil {
                 window = createBoringNotchWindow(for: selectedScreen, with: vm)
             }
 
             if let window = window {
-                positionWindow(window, on: selectedScreen, changeAlpha: changeAlpha)
-
-                if vm.notchState == .closed {
-                    vm.close()
-                }
+                positionWindow(window, on: selectedScreen, notchSize: vm.notchSize, changeAlpha: changeAlpha)
             }
         }
     }
@@ -600,6 +658,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 extension Notification.Name {
     static let selectedScreenChanged = Notification.Name("SelectedScreenChanged")
     static let notchHeightChanged = Notification.Name("NotchHeightChanged")
+    static let notchPanelSizeChanged = Notification.Name("notchPanelSizeChanged")
     static let showOnAllDisplaysChanged = Notification.Name("showOnAllDisplaysChanged")
     static let automaticallySwitchDisplayChanged = Notification.Name("automaticallySwitchDisplayChanged")
     static let expandedDragDetectionChanged = Notification.Name("expandedDragDetectionChanged")

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -7,6 +7,7 @@
 
 import AVFoundation
 import Combine
+import Darwin
 import Defaults
 import KeyboardShortcuts
 import SwiftUI
@@ -18,7 +19,7 @@ struct DynamicNotchApp: App {
     @Environment(\.openWindow) var openWindow
 
     var body: some Scene {
-        MenuBarExtra("Boring Notch", systemImage: "sparkle", isInserted: $showMenuBarIcon) {
+        MenuBarExtra("蛋神", systemImage: "sparkle", isInserted: $showMenuBarIcon) {
             Button("设置") {
                 DispatchQueue.main.async {
                     SettingsWindowController.shared.showWindow()
@@ -27,7 +28,7 @@ struct DynamicNotchApp: App {
             .keyboardShortcut(KeyEquivalent(","), modifiers: .command)
             CheckForUpdatesView()
             Divider()
-            Button("重启Boring Notch") {
+            Button("重启蛋神") {
                 ApplicationRelauncher.restart()
             }
             Button("退出", role: .destructive) {
@@ -57,6 +58,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var windowScreenDidChangeObserver: Any?
     private var dragDetectors: [String: DragDetector] = [:] // UUID -> DragDetector
     private var pendingFrameRefreshTask: Task<Void, Never>?
+    private var singleInstanceLockDescriptor: Int32 = -1
+    private var isSecondaryInstance = false
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        guard acquireSingleInstanceLock() else {
+            isSecondaryInstance = true
+            activateExistingInstance()
+            DispatchQueue.main.async {
+                NSApplication.shared.terminate(nil)
+            }
+            return
+        }
+    }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return false
@@ -73,9 +87,44 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             screenUnlockedObserver = nil
         }
         MusicManager.shared.destroy()
+        ScreenMediaBarController.shared.stop()
         cleanupDragDetectors()
         cleanupWindows()
         XPCHelperClient.shared.stopMonitoringAccessibilityAuthorization()
+        releaseSingleInstanceLock()
+    }
+
+    private func acquireSingleInstanceLock() -> Bool {
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "theboringteam.boringnotch"
+        let lockURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(bundleIdentifier).instance.lock")
+        let descriptor = lockURL.path.withCString {
+            Darwin.open($0, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        }
+        guard descriptor >= 0 else { return true }
+
+        guard Darwin.lockf(descriptor, F_TLOCK, 0) == 0 else {
+            Darwin.close(descriptor)
+            return false
+        }
+
+        singleInstanceLockDescriptor = descriptor
+        return true
+    }
+
+    private func releaseSingleInstanceLock() {
+        guard singleInstanceLockDescriptor >= 0 else { return }
+        Darwin.lockf(singleInstanceLockDescriptor, F_ULOCK, 0)
+        Darwin.close(singleInstanceLockDescriptor)
+        singleInstanceLockDescriptor = -1
+    }
+
+    private func activateExistingInstance() {
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return }
+        let currentPID = ProcessInfo.processInfo.processIdentifier
+        NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+            .first(where: { $0.processIdentifier != currentPID && !$0.isTerminated })?
+            .activate(options: [])
     }
 
     @MainActor
@@ -315,19 +364,69 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let isResizingAssistantPanel = vm.isResizingAssistantPanel || viewModels.values.contains { $0.isResizingAssistantPanel }
         guard isResizingAssistantPanel else {
             pendingFrameRefreshTask?.cancel()
+            pendingFrameRefreshTask = nil
             refreshWindowFrames()
             return
         }
 
-        pendingFrameRefreshTask?.cancel()
+        guard pendingFrameRefreshTask == nil else { return }
         pendingFrameRefreshTask = Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(24))
-            guard !Task.isCancelled else { return }
+            try? await Task.sleep(for: .milliseconds(16))
+            guard !Task.isCancelled else {
+                pendingFrameRefreshTask = nil
+                return
+            }
             refreshWindowFrames()
+            pendingFrameRefreshTask = nil
         }
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        guard !isSecondaryInstance else { return }
+        _ = AIProviderCredentialStore.apiKey
+
+        #if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("--bluetooth-battery-self-test") {
+            Task { @MainActor in
+                let payload = await XPCHelperClient.shared.bluetoothAccessoryBatteryData()
+                let devices = payload.flatMap {
+                    try? JSONDecoder().decode([BluetoothAccessoryBatteryDevice].self, from: $0)
+                }
+                let parts = devices?.flatMap(\.parts) ?? []
+                let result: [String: Any] = [
+                    "payloadReceived": payload != nil,
+                    "deviceCount": devices?.count ?? 0,
+                    "partCount": parts.count,
+                    "percentagesValid": parts.allSatisfy { (0 ... 100).contains($0.percentage) },
+                ]
+                if let data = try? JSONSerialization.data(
+                    withJSONObject: result,
+                    options: [.sortedKeys]
+                ) {
+                    FileHandle.standardOutput.write(data)
+                    FileHandle.standardOutput.write(Data([0x0A]))
+                }
+                NSApplication.shared.terminate(nil)
+            }
+            return
+        }
+
+        if ProcessInfo.processInfo.arguments.contains("--calendar-self-test") {
+            Task { @MainActor in
+                let result = await CalendarManager.shared.runCalendarRuntimeSelfTest()
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.sortedKeys]
+                if let data = try? encoder.encode(result) {
+                    FileHandle.standardOutput.write(data)
+                    FileHandle.standardOutput.write(Data([0x0A]))
+                }
+                NSApplication.shared.terminate(nil)
+            }
+            return
+        }
+        #endif
+
+        _ = ScreenMediaBarController.shared
 
         NotificationCenter.default.addObserver(
             self,
@@ -355,9 +454,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         NotificationCenter.default.addObserver(
-            forName: Notification.Name.notchPanelSizeChanged, object: nil, queue: nil
+            forName: Notification.Name.notchPanelSizeChanged, object: nil, queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in
+            MainActor.assumeIsolated {
                 self?.scheduleWindowFrameRefresh()
             }
         }

--- a/boringNotch/components/Calendar/BoringCalendar.swift
+++ b/boringNotch/components/Calendar/BoringCalendar.swift
@@ -10,12 +10,12 @@ import SwiftUI
 
 struct Config: Equatable {
     //    var count: Int = 10  // 3 days past + today + 7 days future
-    var past: Int = 7
-    var future: Int = 14
+    var past: Int = 2
+    var future: Int = 6
     var steps: Int = 1  // Each step is one day
     var spacing: CGFloat = 0
     var showsText: Bool = true
-    var offset: Int = 2  // Number of dates to the left of the selected date
+    var offset: Int = 1  // Number of dates to the left of the selected date
 }
 
 struct WheelPicker: View {
@@ -184,32 +184,29 @@ struct CalendarView: View {
     @State private var selectedDate = Date()
 
     var body: some View {
-        VStack(spacing: 0) {
-            HStack(alignment: .top, spacing: 8) {
-                VStack(alignment: .leading) {
-                    Text(selectedDate.formatted(.dateTime.month(.abbreviated)))
-                        .font(.title3)
-                        .fontWeight(.semibold)
-                        .foregroundColor(.white)
-                    Text(selectedDate.formatted(.dateTime.year()))
-                        .font(.title3)
-                        .fontWeight(.light)
-                        .foregroundColor(Color(white: 0.65))
-                }
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(selectedDate.formatted(.dateTime.month(.abbreviated)))
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white)
+                Text(selectedDate.formatted(.dateTime.year()))
+                    .font(.subheadline)
+                    .foregroundColor(Color(white: 0.65))
+            }
 
-                ZStack(alignment: .top) {
-                    WheelPicker(selectedDate: $selectedDate, config: Config())
-                    HStack(alignment: .top) {
-                        LinearGradient(
-                            colors: [Color.black, .clear], startPoint: .leading, endPoint: .trailing
-                        )
-                        .frame(width: 20)
-                        Spacer()
-                        LinearGradient(
-                            colors: [.clear, Color.black], startPoint: .leading, endPoint: .trailing
-                        )
-                        .frame(width: 20)
-                    }
+            ZStack(alignment: .top) {
+                WheelPicker(selectedDate: $selectedDate, config: Config())
+                HStack(alignment: .top) {
+                    LinearGradient(
+                        colors: [Color.black, .clear], startPoint: .leading, endPoint: .trailing
+                    )
+                    .frame(width: 16)
+                    Spacer()
+                    LinearGradient(
+                        colors: [.clear, Color.black], startPoint: .leading, endPoint: .trailing
+                    )
+                    .frame(width: 16)
                 }
             }
 
@@ -223,8 +220,8 @@ struct CalendarView: View {
                 EventListView(events: calendarManager.events)
             }
         }
+        .frame(maxWidth: .infinity, minHeight: 190, maxHeight: 190, alignment: .topLeading)
         .listRowBackground(Color.clear)
-        .frame(height: 120)
         .onChange(of: selectedDate) {
             Task {
                 await calendarManager.updateCurrentDate(selectedDate)
@@ -249,7 +246,7 @@ struct EmptyEventsView: View {
     let selectedDate: Date
     
     var body: some View {
-        VStack {
+        VStack(alignment: .leading, spacing: 6) {
             Image(systemName: "calendar.badge.checkmark")
                 .font(.title)
                 .foregroundColor(Color(white: 0.65))
@@ -260,6 +257,7 @@ struct EmptyEventsView: View {
                 .font(.caption)
                 .foregroundColor(Color(white: 0.65))
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/boringNotch/components/Calendar/BoringCalendar.swift
+++ b/boringNotch/components/Calendar/BoringCalendar.swift
@@ -229,13 +229,13 @@ struct CalendarView: View {
         }
         .onChange(of: vm.notchState) { _, _ in
             Task {
-                await calendarManager.updateCurrentDate(Date.now)
+                await calendarManager.refreshVisibleCalendar(for: Date.now)
                 selectedDate = Date.now
             }
         }
         .onAppear {
             Task {
-                await calendarManager.updateCurrentDate(Date.now)
+                await calendarManager.refreshVisibleCalendar(for: Date.now)
                 selectedDate = Date.now
             }
         }

--- a/boringNotch/components/Notch/AIWeatherViews.swift
+++ b/boringNotch/components/Notch/AIWeatherViews.swift
@@ -46,7 +46,63 @@ private let agentPanelAnimation = NotchPanelAnimation.spring
 private func prepareAgentOpenPanel(_ panel: NSOpenPanel) {
     NSApp.setActivationPolicy(.regular)
     NSApp.activate(ignoringOtherApps: true)
+    panel.hidesOnDeactivate = false
+    panel.isFloatingPanel = true
     panel.level = agentOpenPanelLevel
+    panel.collectionBehavior = [
+        .canJoinAllSpaces,
+        .fullScreenAuxiliary,
+        .transient,
+    ]
+}
+
+private func agentPanelHostWindow() -> NSWindow? {
+    if let keyWindow = NSApp.keyWindow, isAgentPanelHostWindow(keyWindow) {
+        return keyWindow
+    }
+
+    return NSApp.windows.first { window in
+        window.isVisible && isAgentPanelHostWindow(window)
+    }
+}
+
+private func isAgentPanelHostWindow(_ window: NSWindow) -> Bool {
+    window is BoringNotchWindow || window is BoringNotchSkyLightWindow
+}
+
+private func runAgentOpenPanel(_ panel: NSOpenPanel, completion: @escaping ([URL]) -> Void) {
+    prepareAgentOpenPanel(panel)
+
+    let finish: (NSApplication.ModalResponse) -> Void = { response in
+        DispatchQueue.main.async {
+            completion(response == .OK ? panel.urls : [])
+        }
+    }
+
+    if let hostWindow = agentPanelHostWindow() {
+        panel.level = NSWindow.Level(
+            rawValue: max(agentOpenPanelLevel.rawValue, hostWindow.level.rawValue + 4)
+        )
+        hostWindow.makeKeyAndOrderFront(nil)
+        hostWindow.orderFrontRegardless()
+
+        panel.beginSheetModal(for: hostWindow) { response in
+            finish(response)
+        }
+
+        DispatchQueue.main.async {
+            panel.level = NSWindow.Level(
+                rawValue: max(agentOpenPanelLevel.rawValue, hostWindow.level.rawValue + 4)
+            )
+            panel.orderFrontRegardless()
+            panel.makeKey()
+        }
+        return
+    }
+
+    panel.orderFrontRegardless()
+    panel.makeKeyAndOrderFront(nil)
+    finish(panel.runModal())
 }
 
 private struct AgentSlashCommand: Identifiable {
@@ -627,14 +683,19 @@ struct AIChatView: View {
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
         panel.allowedContentTypes = agentAllowedImportTypes()
-        prepareAgentOpenPanel(panel)
 
-        guard panel.runModal() == .OK else { return }
+        runAgentOpenPanel(panel) { urls in
+            importSelectedFiles(urls, mode: mode)
+        }
+    }
+
+    private func importSelectedFiles(_ urls: [URL], mode: AgentFileImportMode) {
+        guard !urls.isEmpty else { return }
 
         var importedKnowledgeTitles: [String] = []
         let maxFiles = mode == .knowledge ? 8 : 4
 
-        for url in panel.urls.prefix(maxFiles) {
+        for url in urls.prefix(maxFiles) {
             do {
                 let file = try readAgentImportableFile(at: url)
 
@@ -1079,12 +1140,17 @@ private struct AgentInventoryPanel: View {
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
         panel.allowedContentTypes = agentAllowedImportTypes()
-        prepareAgentOpenPanel(panel)
 
-        guard panel.runModal() == .OK else { return }
+        runAgentOpenPanel(panel) { urls in
+            importKnowledgeFiles(urls)
+        }
+    }
+
+    private func importKnowledgeFiles(_ urls: [URL]) {
+        guard !urls.isEmpty else { return }
 
         var imported: [String] = []
-        for url in panel.urls.prefix(8) {
+        for url in urls.prefix(8) {
             do {
                 let file = try readAgentImportableFile(at: url)
                 if let document = manager.addKnowledgeDocument(

--- a/boringNotch/components/Notch/AIWeatherViews.swift
+++ b/boringNotch/components/Notch/AIWeatherViews.swift
@@ -114,6 +114,7 @@ private struct AgentSlashCommand: Identifiable {
 
 struct AIChatView: View {
     @Default(.aiChatEnabled) private var aiChatEnabled
+    @Default(.aiShowAgentTrace) private var aiShowAgentTrace
 
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject private var manager = AIChatManager.shared
@@ -136,7 +137,8 @@ struct AIChatView: View {
         .init(id: "/kb", title: "知识库", subtitle: "同 /knowledge，可输入 add 或 seed", symbolName: "books.vertical"),
         .init(id: "/remember", title: "记住", subtitle: "把一句稳定偏好写入长期记忆", symbolName: "plus.circle"),
         .init(id: "/forget", title: "遗忘", subtitle: "按关键词删除长期记忆，留空则清空", symbolName: "minus.circle"),
-        .init(id: "/file", title: "上传文件", subtitle: "把本地文本文件作为下一条消息上下文", symbolName: "paperclip"),
+        .init(id: "/file", title: "上传文件", subtitle: "支持文本、PDF 文本抽取和图片 OCR", symbolName: "paperclip"),
+        .init(id: "/web", title: "联网检索", subtitle: "搜索公开网页或 GitHub 仓库", symbolName: "globe"),
         .init(id: "/clear", title: "清空", subtitle: "清除当前会话消息和轨迹", symbolName: "trash"),
         .init(id: "/help", title: "帮助", subtitle: "生成命令、插件和 Skills 说明", symbolName: "questionmark.circle"),
     ]
@@ -164,7 +166,7 @@ struct AIChatView: View {
                         isComposerFocused = true
                     }
                 }
-                if let trace = manager.lastAgentTrace {
+                if aiShowAgentTrace, let trace = manager.lastAgentTrace {
                     AgentTracePanel(trace: trace, isExpanded: $showsTrace)
                         .layoutPriority(0)
                 }
@@ -628,6 +630,9 @@ struct AIChatView: View {
         case "/file":
             draft = ""
             openFilePicker(mode: .attach)
+        case "/web":
+            draft = argument.isEmpty ? "请联网检索：" : "请联网检索：\(argument)"
+            sendDraft()
         case "/knowledge", "/kb":
             if ["add", "import", "导入", "添加"].contains(argument.lowercased()) {
                 draft = ""
@@ -1075,7 +1080,7 @@ private struct AgentInventoryPanel: View {
             }
 
             if manager.knowledgeDocuments.isEmpty {
-                Text("还没有导入资料。使用 /knowledge add，或点击下面的“导入资料”按钮导入文本、Markdown、JSON、CSV 或 PDF。")
+                Text("还没有导入资料。使用 /knowledge add，或点击下面的“导入资料”按钮导入文本、Markdown、JSON、CSV、可抽取文本的 PDF 或带文字的图片。")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .padding(8)

--- a/boringNotch/components/Notch/AIWeatherViews.swift
+++ b/boringNotch/components/Notch/AIWeatherViews.swift
@@ -1,0 +1,1647 @@
+//
+//  AIWeatherViews.swift
+//  boringNotch
+//
+//  Created by Codex on 2026-06-06.
+//
+
+import AppKit
+import Defaults
+import SwiftUI
+import UniformTypeIdentifiers
+
+private struct AgentAttachedFile: Identifiable, Equatable {
+    let id = UUID()
+    let name: String
+    let path: String
+    let content: String
+    let byteCount: Int
+}
+
+private enum AgentInspectorMode: String, Identifiable {
+    case plugins
+    case skills
+    case memory
+    case knowledge
+
+    var id: String { rawValue }
+}
+
+private enum AgentFileImportMode {
+    case attach
+    case knowledge
+}
+
+private enum AgentResizeAxis: Equatable {
+    case horizontal
+    case vertical
+    case both
+}
+
+private let agentResizeHorizontalSensitivity: CGFloat = 0.68
+private let agentResizeVerticalSensitivity: CGFloat = 0.72
+private let agentOpenPanelLevel = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue + 6)
+private let agentPanelAnimation = NotchPanelAnimation.spring
+
+private func prepareAgentOpenPanel(_ panel: NSOpenPanel) {
+    NSApp.setActivationPolicy(.regular)
+    NSApp.activate(ignoringOtherApps: true)
+    panel.level = agentOpenPanelLevel
+}
+
+private struct AgentSlashCommand: Identifiable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let symbolName: String
+}
+
+struct AIChatView: View {
+    @Default(.aiChatEnabled) private var aiChatEnabled
+
+    @EnvironmentObject var vm: BoringViewModel
+    @ObservedObject private var manager = AIChatManager.shared
+    @State private var draft: String = ""
+    @State private var showsTrace: Bool = false
+    @State private var inspectorMode: AgentInspectorMode?
+    @State private var attachedFiles: [AgentAttachedFile] = []
+    @State private var fileError: String?
+    @State private var resizeStartSize: CGSize?
+    @State private var activeResizeAxis: AgentResizeAxis?
+    @FocusState private var isComposerFocused: Bool
+
+    private let slashCommands: [AgentSlashCommand] = [
+        .init(id: "/new", title: "新对话", subtitle: "创建一个独立会话页", symbolName: "plus.bubble"),
+        .init(id: "/chats", title: "会话", subtitle: "查看并切换多个对话页", symbolName: "rectangle.3.group.bubble"),
+        .init(id: "/plugins", title: "插件", subtitle: "查看可用工具、权限和风险等级", symbolName: "puzzlepiece.extension"),
+        .init(id: "/skills", title: "Skills", subtitle: "查看任务技能手册", symbolName: "sparkles"),
+        .init(id: "/memory", title: "记忆", subtitle: "查看工作记忆和长期记忆", symbolName: "brain.head.profile"),
+        .init(id: "/knowledge", title: "知识库", subtitle: "查看资料；add 导入文件；seed 导入 GitHub 示例", symbolName: "books.vertical"),
+        .init(id: "/kb", title: "知识库", subtitle: "同 /knowledge，可输入 add 或 seed", symbolName: "books.vertical"),
+        .init(id: "/remember", title: "记住", subtitle: "把一句稳定偏好写入长期记忆", symbolName: "plus.circle"),
+        .init(id: "/forget", title: "遗忘", subtitle: "按关键词删除长期记忆，留空则清空", symbolName: "minus.circle"),
+        .init(id: "/file", title: "上传文件", subtitle: "把本地文本文件作为下一条消息上下文", symbolName: "paperclip"),
+        .init(id: "/clear", title: "清空", subtitle: "清除当前会话消息和轨迹", symbolName: "trash"),
+        .init(id: "/help", title: "帮助", subtitle: "生成命令、插件和 Skills 说明", symbolName: "questionmark.circle"),
+    ]
+
+    var body: some View {
+        VStack(spacing: 10) {
+            header
+
+            if !aiChatEnabled {
+                featureDisabledState(
+                    title: "AI 已关闭",
+                    subtitle: "请在 设置 > AI 中启用智能体。"
+                )
+            } else if Defaults[.aiServiceAPIKey].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                featureDisabledState(
+                    title: "缺少 API Key",
+                    subtitle: "请在 设置 > AI 中填写 Base URL、模型和 API Key。"
+                )
+            } else {
+                conversationTabs
+                messagesPanel
+                if let inspectorMode {
+                    AgentInventoryPanel(mode: inspectorMode) {
+                        self.inspectorMode = nil
+                        isComposerFocused = true
+                    }
+                }
+                if let trace = manager.lastAgentTrace {
+                    AgentTracePanel(trace: trace, isExpanded: $showsTrace)
+                        .layoutPriority(0)
+                }
+                composer
+                    .layoutPriority(2)
+            }
+        }
+        .padding(.horizontal, 4)
+        .padding(.bottom, 4)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .overlay(resizeHandles)
+        .onExitCommand {
+            if inspectorMode != nil {
+                inspectorMode = nil
+                isComposerFocused = true
+            }
+        }
+        .onAppear {
+            vm.preventAutoClose = true
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(150))
+                isComposerFocused = true
+            }
+        }
+        .onDisappear {
+            vm.preventAutoClose = false
+            isComposerFocused = false
+
+            if SettingsWindowController.shared.window?.isVisible != true {
+                NSApp.setActivationPolicy(.accessory)
+            }
+        }
+        .onChange(of: manager.isSending) { _, isSending in
+            if isSending {
+                showsTrace = false
+            }
+        }
+        .onChange(of: manager.lastAgentTrace?.id) { _, _ in
+            showsTrace = false
+        }
+    }
+
+    private var resizeHandles: some View {
+        ZStack {
+            HStack {
+                Spacer()
+                resizeEdge(axis: .horizontal, width: 12, height: nil)
+            }
+
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer(minLength: 40)
+                    resizeEdge(axis: .vertical, width: nil, height: 12)
+                    Spacer(minLength: 40)
+                }
+            }
+
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    resizeCorner
+                }
+            }
+        }
+        .allowsHitTesting(true)
+        .zIndex(20)
+    }
+
+    private func resizeEdge(axis: AgentResizeAxis, width: CGFloat?, height: CGFloat?) -> some View {
+        Rectangle()
+            .fill(activeResizeAxis == axis ? Color.effectiveAccent.opacity(0.28) : Color.white.opacity(0.001))
+            .frame(width: width, height: height)
+            .contentShape(Rectangle())
+            .gesture(resizeGesture(axis: axis))
+            .help(axis == .horizontal ? "拖拽调整宽度" : "拖拽调整高度")
+    }
+
+    private var resizeCorner: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Rectangle()
+                .fill(Color.white.opacity(0.001))
+                .frame(width: 34, height: 34)
+            Image(systemName: "arrow.down.right.and.arrow.up.left")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(activeResizeAxis == .both ? Color.effectiveAccent : Color.white.opacity(0.38))
+                .padding(7)
+        }
+        .contentShape(Rectangle())
+        .gesture(resizeGesture(axis: .both))
+        .help("拖拽调整宽高")
+    }
+
+    private func resizeGesture(axis: AgentResizeAxis) -> some Gesture {
+        DragGesture(minimumDistance: 6, coordinateSpace: .global)
+            .onChanged { value in
+                let startSize = resizeStartSize ?? vm.notchSize
+                resizeStartSize = startSize
+                activeResizeAxis = axis
+
+                var nextWidth = startSize.width
+                var nextHeight = startSize.height
+
+                switch axis {
+                case .horizontal:
+                    nextWidth = startSize.width + value.translation.width * agentResizeHorizontalSensitivity
+                case .vertical:
+                    nextHeight = startSize.height + value.translation.height * agentResizeVerticalSensitivity
+                case .both:
+                    nextWidth = startSize.width + value.translation.width * agentResizeHorizontalSensitivity
+                    nextHeight = startSize.height + value.translation.height * agentResizeVerticalSensitivity
+                }
+
+                vm.resizeAssistantPanel(
+                    to: CGSize(
+                        width: nextWidth,
+                        height: nextHeight
+                    ),
+                    persist: false
+                )
+            }
+            .onEnded { _ in
+                vm.finishAssistantPanelResize()
+                resizeStartSize = nil
+                activeResizeAxis = nil
+            }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Boring Notch Agent")
+                    .font(.headline)
+                Text(manager.displayedModelName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            if manager.isSending {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Button {
+                manager.clearConversation()
+            } label: {
+                Image(systemName: "trash")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("清空当前会话")
+
+            Button {
+                collapseAssistantPanel()
+            } label: {
+                Text(">>")
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+                    .rotationEffect(.degrees(-90))
+                    .frame(width: 24, height: 24)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("收回 AI 面板")
+        }
+    }
+
+    private func collapseAssistantPanel() {
+        showsTrace = false
+        inspectorMode = nil
+        isComposerFocused = false
+        vm.suppressHoverAutoOpen()
+
+        withAnimation(agentPanelAnimation) {
+            vm.close()
+        }
+    }
+
+    private var conversationTabs: some View {
+        HStack(spacing: 6) {
+            Button {
+                manager.startNewConversation()
+                isComposerFocused = true
+            } label: {
+                Image(systemName: "plus.bubble")
+                    .font(.system(size: 13, weight: .semibold))
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.effectiveAccent)
+            .help("新建对话")
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(manager.conversations) { conversation in
+                        ConversationTabButton(
+                            conversation: conversation,
+                            isActive: manager.activeConversationID == conversation.id,
+                            canDelete: manager.conversations.count > 1,
+                            onSelect: {
+                                manager.selectConversation(conversation.id)
+                                isComposerFocused = true
+                            },
+                            onDelete: {
+                                manager.deleteConversation(conversation.id)
+                            }
+                        )
+                    }
+                }
+            }
+
+            Button {
+                inspectorMode = inspectorMode == .knowledge ? nil : .knowledge
+            } label: {
+                Image(systemName: "books.vertical")
+                    .font(.system(size: 13, weight: .semibold))
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(inspectorMode == .knowledge ? Color.effectiveAccent : .secondary)
+            .help("知识库")
+        }
+        .frame(height: 30)
+    }
+
+    private var messagesPanel: some View {
+        ScrollViewReader { proxy in
+            ScrollView(showsIndicators: false) {
+                LazyVStack(spacing: 8) {
+                    if manager.messages.isEmpty {
+                        emptyConversationState
+                    } else {
+                        ForEach(manager.messages) { message in
+                            ChatBubble(message: message)
+                                .id(message.id)
+                        }
+                    }
+
+                    if let lastError = manager.lastError {
+                        Label(lastError, systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.white.opacity(0.04))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .onChange(of: manager.messages.count) { _, _ in
+                if let lastID = manager.messages.last?.id {
+                    withAnimation(.smooth(duration: 0.2)) {
+                        proxy.scrollTo(lastID, anchor: .bottom)
+                    }
+                }
+            }
+        }
+        .layoutPriority(1)
+    }
+
+    private var emptyConversationState: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("输入任务，或使用 / 调出命令。")
+                .font(.subheadline.weight(.semibold))
+            Text("上方可以切换多个会话页；知识库资料会跨会话检索，当前对话只保留自己的短期记忆。")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+    }
+
+    private var composer: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if shouldShowSlashMenu {
+                SlashCommandMenu(
+                    commands: filteredSlashCommands,
+                    onSelect: runSlashCommand
+                )
+            }
+
+            if !attachedFiles.isEmpty || fileError != nil {
+                attachmentStrip
+            }
+
+            HStack(spacing: 8) {
+                Button {
+                    openFilePicker(mode: .attach)
+                } label: {
+                    Image(systemName: "paperclip")
+                        .font(.system(size: 15, weight: .semibold))
+                        .frame(width: 26, height: 26)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("上传文件作为上下文")
+
+                TextField("输入问题，或输入 / 查看命令...", text: $draft)
+                    .textFieldStyle(.plain)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                    .background(Color.white.opacity(0.06))
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .focused($isComposerFocused)
+                    .onSubmit(sendDraft)
+
+                Button(action: sendDraft) {
+                    Image(systemName: manager.isSending ? "ellipsis.circle.fill" : "arrow.up.circle.fill")
+                        .font(.system(size: 24))
+                        .foregroundColor(canSend ? .effectiveAccent : .secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSend)
+            }
+            .padding(.trailing, 24)
+        }
+    }
+
+    private var shouldShowSlashMenu: Bool {
+        isComposerFocused && draft.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("/")
+    }
+
+    private var filteredSlashCommands: [AgentSlashCommand] {
+        let query = draft.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard query.count > 1 else { return slashCommands }
+        return slashCommands.filter { command in
+            command.id.lowercased().contains(query)
+                || command.title.lowercased().contains(query)
+                || command.subtitle.lowercased().contains(query)
+        }
+    }
+
+    private var attachmentStrip: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if !attachedFiles.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(attachedFiles) { file in
+                            HStack(spacing: 6) {
+                                Image(systemName: "doc.text")
+                                    .font(.caption)
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text(file.name)
+                                        .font(.caption2.weight(.semibold))
+                                        .lineLimit(1)
+                                    Text("\(file.byteCount / 1024 + 1) KB")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Button {
+                                    attachedFiles.removeAll { $0.id == file.id }
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .font(.caption)
+                                }
+                                .buttonStyle(.plain)
+                                .foregroundStyle(.secondary)
+                            }
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 5)
+                            .background(Color.white.opacity(0.05))
+                            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        }
+                    }
+                }
+            }
+
+            if let fileError {
+                Label(fileError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private var canSend: Bool {
+        aiChatEnabled
+            && !manager.isSending
+            && !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func sendDraft() {
+        let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else { return }
+
+        if prompt.hasPrefix("/") {
+            runSlashCommand(matching: prompt)
+            return
+        }
+
+        let finalPrompt = promptWithAttachedFiles(prompt)
+        let displayPrompt = displayPromptWithAttachedFiles(prompt)
+        draft = ""
+        attachedFiles.removeAll()
+        showsTrace = false
+        Task {
+            await manager.send(prompt: finalPrompt, displayPrompt: displayPrompt)
+        }
+    }
+
+    private func runSlashCommand(matching rawValue: String) {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowered = trimmed.lowercased()
+        let command = slashCommands.first { lowered.hasPrefix($0.id) } ?? filteredSlashCommands.first
+        if let command {
+            runSlashCommand(command, rawValue: trimmed)
+        }
+    }
+
+    private func runSlashCommand(_ command: AgentSlashCommand) {
+        runSlashCommand(command, rawValue: command.id)
+    }
+
+    private func runSlashCommand(_ command: AgentSlashCommand, rawValue: String) {
+        let argument = slashArgument(from: rawValue, commandID: command.id)
+        switch command.id {
+        case "/plugins":
+            inspectorMode = inspectorMode == .plugins ? nil : .plugins
+            draft = ""
+        case "/skills":
+            inspectorMode = inspectorMode == .skills ? nil : .skills
+            draft = ""
+        case "/memory":
+            if argument == "clear" {
+                manager.clearLongTermMemory()
+                manager.appendLocalAssistantMessage("已清空长期记忆。")
+            } else if ["reveal", "open", "file"].contains(argument.lowercased()) {
+                manager.revealLongTermMemoryFile()
+                manager.appendLocalAssistantMessage("已在 Finder 中定位长期记忆文件。")
+            } else {
+                inspectorMode = inspectorMode == .memory ? nil : .memory
+            }
+            draft = ""
+        case "/remember":
+            if argument.isEmpty {
+                draft = "/remember "
+                isComposerFocused = true
+            } else if let record = manager.rememberMemory(argument) {
+                inspectorMode = .memory
+                draft = ""
+                manager.appendLocalAssistantMessage("已写入长期记忆：[\(record.kind.displayName)] \(record.content)")
+            }
+        case "/forget":
+            let removedCount = manager.forgetMemory(matching: argument)
+            inspectorMode = .memory
+            draft = ""
+            if argument.isEmpty {
+                manager.appendLocalAssistantMessage("已清空长期记忆，共删除 \(removedCount) 条。")
+            } else {
+                manager.appendLocalAssistantMessage("已删除 \(removedCount) 条匹配“\(argument)”的长期记忆。")
+            }
+        case "/file":
+            draft = ""
+            openFilePicker(mode: .attach)
+        case "/knowledge", "/kb":
+            if ["add", "import", "导入", "添加"].contains(argument.lowercased()) {
+                draft = ""
+                openFilePicker(mode: .knowledge)
+            } else if ["seed", "demo", "github", "示例", "样例"].contains(argument.lowercased()) {
+                let count = manager.installStarterKnowledgeBase()
+                inspectorMode = .knowledge
+                draft = ""
+                manager.appendLocalAssistantMessage("已导入 \(count) 份 GitHub/官方文档启发的示例知识库。")
+            } else if ["clear", "清空"].contains(argument.lowercased()) {
+                manager.clearKnowledgeBase()
+                inspectorMode = .knowledge
+                draft = ""
+                manager.appendLocalAssistantMessage("已清空本地知识库。")
+            } else {
+                inspectorMode = inspectorMode == .knowledge ? nil : .knowledge
+                draft = ""
+            }
+        case "/new":
+            draft = ""
+            attachedFiles.removeAll()
+            inspectorMode = nil
+            manager.startNewConversation()
+        case "/chats":
+            draft = ""
+            attachedFiles.removeAll()
+            inspectorMode = nil
+            isComposerFocused = true
+        case "/clear":
+            draft = ""
+            attachedFiles.removeAll()
+            inspectorMode = nil
+            manager.clearConversation()
+        case "/help":
+            draft = "请用中文说明你支持的 / 命令、插件和 Skills，并举 3 个示例任务。"
+            sendDraft()
+        default:
+            break
+        }
+    }
+
+    private func slashArgument(from rawValue: String, commandID: String) -> String {
+        guard rawValue.lowercased().hasPrefix(commandID) else { return "" }
+        return rawValue
+            .dropFirst(commandID.count)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func openFilePicker(mode: AgentFileImportMode) {
+        fileError = nil
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = agentAllowedImportTypes()
+        prepareAgentOpenPanel(panel)
+
+        guard panel.runModal() == .OK else { return }
+
+        var importedKnowledgeTitles: [String] = []
+        let maxFiles = mode == .knowledge ? 8 : 4
+
+        for url in panel.urls.prefix(maxFiles) {
+            do {
+                let file = try readAgentImportableFile(at: url)
+
+                switch mode {
+                case .attach:
+                    attachedFiles.append(
+                        AgentAttachedFile(
+                            name: url.lastPathComponent,
+                            path: url.path,
+                            content: file.content,
+                            byteCount: file.byteCount
+                        )
+                    )
+                case .knowledge:
+                    if let document = manager.addKnowledgeDocument(
+                        name: url.lastPathComponent,
+                        path: url.path,
+                        content: file.content,
+                        byteCount: file.byteCount
+                    ) {
+                        importedKnowledgeTitles.append(document.title)
+                    }
+                }
+            } catch {
+                fileError = "\(url.lastPathComponent) 读取失败：\(error.localizedDescription)"
+            }
+        }
+
+        if mode == .knowledge {
+            inspectorMode = .knowledge
+            if !importedKnowledgeTitles.isEmpty {
+                manager.appendLocalAssistantMessage("已导入知识库：\(importedKnowledgeTitles.joined(separator: "、"))")
+            }
+        }
+    }
+
+    private func promptWithAttachedFiles(_ prompt: String) -> String {
+        guard !attachedFiles.isEmpty else { return prompt }
+
+        let fileBlocks = attachedFiles.map { file in
+            """
+            [file: \(file.name)]
+            path: \(file.path)
+            content:
+            \(file.content)
+            """
+        }.joined(separator: "\n\n")
+
+        return """
+        用户问题：
+        \(prompt)
+
+        本地文件上下文：
+        \(fileBlocks)
+        """
+    }
+
+    private func displayPromptWithAttachedFiles(_ prompt: String) -> String {
+        guard !attachedFiles.isEmpty else { return prompt }
+        return "\(prompt)\n\n已附加文件：\(attachedFiles.map(\.name).joined(separator: "、"))"
+    }
+
+    private func featureDisabledState(title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Button("打开设置") {
+                SettingsWindowController.shared.showWindow()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(12)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct SlashCommandMenu: View {
+    let commands: [AgentSlashCommand]
+    let onSelect: (AgentSlashCommand) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(commands) { command in
+                Button {
+                    onSelect(command)
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: command.symbolName)
+                            .font(.system(size: 13, weight: .semibold))
+                            .frame(width: 18)
+                            .foregroundStyle(Color.effectiveAccent)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("\(command.id)  \(command.title)")
+                                .font(.caption.weight(.semibold))
+                            Text(command.subtitle)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(6)
+        .background(Color.white.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct ConversationTabButton: View {
+    let conversation: AgentChatConversation
+    let isActive: Bool
+    let canDelete: Bool
+    let onSelect: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: isActive ? "bubble.left.and.bubble.right.fill" : "bubble.left")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(isActive ? Color.effectiveAccent : .secondary)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(conversation.title)
+                    .font(.caption2.weight(.semibold))
+                    .lineLimit(1)
+                Text("\(conversation.messages.count) 条")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            if canDelete {
+                Button(action: onDelete) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("删除会话")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(isActive ? Color.effectiveAccent.opacity(0.18) : Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onSelect)
+        .frame(maxWidth: 170)
+    }
+}
+
+private struct AgentInventoryPanel: View {
+    let mode: AgentInspectorMode
+    let onClose: () -> Void
+    @ObservedObject private var manager = AIChatManager.shared
+    @Default(.aiKnowledgeRetrievalEnabled) private var aiKnowledgeRetrievalEnabled
+    @Default(.aiKnowledgeRetrievalLimit) private var aiKnowledgeRetrievalLimit
+    @State private var selectedSkillCategory: String = "全部"
+    @State private var knowledgeImportError: String?
+    private let columns = [GridItem(.adaptive(minimum: 250, maximum: 360), spacing: 6)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label(panelTitle, systemImage: panelIcon)
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Text(panelCount)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Button(action: onClose) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.cancelAction)
+                .help("关闭面板")
+            }
+
+            ScrollView(showsIndicators: true) {
+                switch mode {
+                case .plugins:
+                    LazyVGrid(columns: columns, spacing: 6) {
+                        ForEach(manager.availablePlugins) { plugin in
+                            PluginInventoryCard(plugin: plugin)
+                        }
+                    }
+                case .skills:
+                    VStack(alignment: .leading, spacing: 8) {
+                        skillCategoryPicker
+                        LazyVGrid(columns: columns, spacing: 6) {
+                            ForEach(filteredSkills) { skill in
+                                SkillInventoryCard(skill: skill)
+                            }
+                        }
+                    }
+                case .memory:
+                    memoryPanel
+                case .knowledge:
+                    knowledgePanel
+                }
+            }
+            .frame(maxHeight: 360)
+        }
+        .padding(10)
+        .background(Color.white.opacity(0.045))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .onAppear {
+            if mode == .knowledge {
+                manager.refreshKnowledgeDocuments()
+            }
+        }
+    }
+
+    private var skillCategoryPicker: some View {
+        HStack(spacing: 6) {
+            ForEach(skillCategories, id: \.self) { category in
+                Button {
+                    selectedSkillCategory = category
+                } label: {
+                    Text(category)
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            selectedSkillCategory == category
+                            ? Color.effectiveAccent.opacity(0.26)
+                            : Color.white.opacity(0.05)
+                        )
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var skillCategories: [String] {
+        let categories = manager.availableSkills.map(\.category)
+        return ["全部"] + Array(Set(categories)).sorted()
+    }
+
+    private var filteredSkills: [AgentSkillDescriptor] {
+        guard selectedSkillCategory != "全部" else {
+            return manager.availableSkills
+        }
+        return manager.availableSkills.filter { $0.category == selectedSkillCategory }
+    }
+
+    private var panelTitle: String {
+        switch mode {
+        case .plugins: return "插件总览"
+        case .skills: return "Skills 总览"
+        case .memory: return "记忆系统"
+        case .knowledge: return "本地知识库"
+        }
+    }
+
+    private var panelIcon: String {
+        switch mode {
+        case .plugins: return "puzzlepiece.extension"
+        case .skills: return "sparkles"
+        case .memory: return "brain.head.profile"
+        case .knowledge: return "books.vertical"
+        }
+    }
+
+    private var panelCount: String {
+        switch mode {
+        case .plugins: return "\(manager.availablePlugins.count) 个插件"
+        case .skills: return "\(filteredSkills.count)/\(manager.availableSkills.count) 个技能"
+        case .memory: return "\(manager.longTermMemories.count) 条长期记忆"
+        case .knowledge: return "\(manager.knowledgeDocuments.count) 份资料"
+        }
+    }
+
+    private var memoryPanel: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            LazyVGrid(columns: columns, spacing: 6) {
+                MemoryLayerCard(
+                    title: "短期记忆",
+                    value: "\(min(manager.messages.count, 6)) 条",
+                    detail: "最近会话窗口，直接进入上下文",
+                    symbolName: "text.bubble"
+                )
+                MemoryLayerCard(
+                    title: "工作记忆",
+                    value: manager.lastAgentTrace?.workingMemory == nil ? "待生成" : "已生成",
+                    detail: "当前目标、进度、实体和待澄清问题",
+                    symbolName: "list.clipboard"
+                )
+                MemoryLayerCard(
+                    title: "长期记忆",
+                    value: "\(manager.longTermMemories.count) 条",
+                    detail: "显式写入，本地检索后按需注入",
+                    symbolName: "externaldrive"
+                )
+            }
+
+            if let workingMemory = manager.lastAgentTrace?.workingMemory {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("工作记忆")
+                        .font(.caption2.weight(.semibold))
+                    Text(workingMemory.contextText)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(8)
+                .background(Color.white.opacity(0.04))
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+
+            if manager.longTermMemories.isEmpty {
+                Text("还没有长期记忆。只有当用户明确说“记住/以后/我的偏好”等稳定信息时才会写入。")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.white.opacity(0.04))
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            } else {
+                ForEach(manager.longTermMemories.prefix(5)) { memory in
+                    MemoryInventoryCard(memory: memory)
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button("定位记忆文件") {
+                    manager.revealLongTermMemoryFile()
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+
+                Button("清空长期记忆") {
+                    manager.clearLongTermMemory()
+                    manager.appendLocalAssistantMessage("已清空长期记忆。")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var knowledgePanel: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            LazyVGrid(columns: columns, spacing: 6) {
+                MemoryLayerCard(
+                    title: "资料数量",
+                    value: "\(manager.knowledgeDocuments.count) 份",
+                    detail: "跨会话检索，不属于某一个聊天页",
+                    symbolName: "books.vertical"
+                )
+                MemoryLayerCard(
+                    title: "检索方式",
+                    value: aiKnowledgeRetrievalEnabled ? "Hybrid" : "关闭",
+                    detail: "关键词 + 语义词 + 时间权重 Top-\(aiKnowledgeRetrievalLimit) 注入",
+                    symbolName: "magnifyingglass"
+                )
+                MemoryLayerCard(
+                    title: "存储",
+                    value: "JSON",
+                    detail: manager.knowledgeStorageLocation.lastPathComponent,
+                    symbolName: "externaldrive"
+                )
+            }
+
+            if manager.knowledgeDocuments.isEmpty {
+                Text("还没有导入资料。使用 /knowledge add，或点击下面的“导入资料”按钮导入文本、Markdown、JSON、CSV 或 PDF。")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.white.opacity(0.04))
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            } else {
+                ForEach(manager.knowledgeDocuments.prefix(8)) { document in
+                    KnowledgeInventoryCard(document: document) {
+                        manager.removeKnowledgeDocument(id: document.id)
+                    }
+                }
+            }
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 82), spacing: 8)], alignment: .leading, spacing: 6) {
+                Button("导入 GitHub 示例") {
+                    let count = manager.installStarterKnowledgeBase()
+                    manager.appendLocalAssistantMessage("已导入 \(count) 份 GitHub/官方文档启发的示例知识库。")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+
+                Button("导入资料") {
+                    openKnowledgeImporter()
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+
+                Button("刷新") {
+                    manager.refreshKnowledgeDocuments()
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+
+                Button("定位文件") {
+                    manager.revealKnowledgeBaseFile()
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+
+                Button("清空知识库") {
+                    manager.clearKnowledgeBase()
+                    manager.appendLocalAssistantMessage("已清空本地知识库。")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .foregroundStyle(.red)
+            }
+
+            if let knowledgeImportError {
+                Label(knowledgeImportError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private func openKnowledgeImporter() {
+        knowledgeImportError = nil
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = agentAllowedImportTypes()
+        prepareAgentOpenPanel(panel)
+
+        guard panel.runModal() == .OK else { return }
+
+        var imported: [String] = []
+        for url in panel.urls.prefix(8) {
+            do {
+                let file = try readAgentImportableFile(at: url)
+                if let document = manager.addKnowledgeDocument(
+                    name: url.lastPathComponent,
+                    path: url.path,
+                    content: file.content,
+                    byteCount: file.byteCount
+                ) {
+                    imported.append(document.title)
+                }
+            } catch {
+                knowledgeImportError = "\(url.lastPathComponent) 读取失败：\(error.localizedDescription)"
+            }
+        }
+
+        if !imported.isEmpty {
+            manager.appendLocalAssistantMessage("已导入知识库：\(imported.joined(separator: "、"))")
+        }
+    }
+}
+
+private struct MemoryLayerCard: View {
+    let title: String
+    let value: String
+    let detail: String
+    let symbolName: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 5) {
+                Image(systemName: symbolName)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Color.effectiveAccent)
+                Text(title)
+                    .font(.caption2.weight(.semibold))
+                Spacer()
+                Text(value)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+            Text(detail)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct MemoryInventoryCard: View {
+    let memory: AgentMemoryRecord
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(memory.kind.displayName)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Color.effectiveAccent)
+                Spacer()
+                Text(memory.updatedAt, style: .relative)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Text(memory.content)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+            HStack(spacing: 6) {
+                Text("重要 \(Int((memory.importance * 100).rounded()))%")
+                Text("置信 \(Int((memory.confidence * 100).rounded()))%")
+                Text("访问 \(memory.accessCount)")
+                if let score = memory.retrievalScore {
+                    Text("命中 \(Int((score * 100).rounded()))%")
+                }
+            }
+            .font(.caption2.monospaced())
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            if let reason = memory.retrievalReason {
+                Text(reason)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Text(memory.keywords.prefix(8).joined(separator: ", "))
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct KnowledgeInventoryCard: View {
+    let document: AgentKnowledgeDocument
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(document.title)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                Spacer()
+                Text(document.updatedAt, style: .relative)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Button(action: onDelete) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("移出知识库")
+            }
+            Text(document.summary.isEmpty ? "无摘要" : document.summary)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+            Text(document.sourcePath)
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            HStack(spacing: 6) {
+                Text("\(document.byteCount / 1024 + 1) KB")
+                Text(document.keywords.prefix(6).joined(separator: ", "))
+            }
+            .font(.caption2.monospaced())
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct PluginInventoryCard: View {
+    let plugin: AgentPluginDescriptor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(plugin.name)
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Text(plugin.riskLevel)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(plugin.riskLevel == "中" ? .orange : .green)
+            }
+            Text(plugin.summary)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            HStack(spacing: 4) {
+                ForEach(plugin.typeTags, id: \.self) { tag in
+                    Text(tag)
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(Color.effectiveAccent.opacity(0.12))
+                        .clipShape(Capsule())
+                }
+            }
+            Text(plugin.toolNames.joined(separator: ", "))
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Text(plugin.permission)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct SkillInventoryCard: View {
+    let skill: AgentSkillDescriptor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(skill.name)
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Text(skill.riskLevel)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(skill.riskLevel == "中" ? .orange : .green)
+            }
+            Text(skill.summary)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                Text(skill.category)
+                    .font(.caption2.weight(.semibold))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.effectiveAccent.opacity(0.16))
+                    .clipShape(Capsule())
+                Text(skill.source == "built-in" ? "内置" : skill.source)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Text(skill.workflowSteps.joined(separator: " -> "))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            Text(skill.requiredTools.joined(separator: ", "))
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct AgentTracePanel: View {
+    let trace: AgentRunTrace
+    @Binding var isExpanded: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                withAnimation(.smooth(duration: 0.18)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption2.weight(.semibold))
+                        .frame(width: 10)
+                    Text("智能体轨迹")
+                        .font(.caption.weight(.semibold))
+                    statusPill(trace.status)
+                    metricChip("路由", "\(Int((trace.routeConfidence * 100).rounded()))%")
+                    metricChip("工具", "\(trace.selectedToolNames.count)")
+                    Spacer()
+                    Text(trace.routeName)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded, trace.routeKind == "general_chat" {
+                compactGeneralTrace
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            } else if isExpanded {
+                ScrollView(showsIndicators: true) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(spacing: 6) {
+                            metricChip("Skills", "\(trace.selectedSkills.count)")
+                            metricChip("记忆", "\(trace.retrievedMemories.count)")
+                            if trace.requiresConfirmation {
+                                metricChip("风险", "写入")
+                            }
+                        }
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("任务理解")
+                                .font(.caption2.weight(.semibold))
+                            Text("\(trace.taskUnderstanding.taskType) / \(trace.taskUnderstanding.complexity) / \(trace.reasoningProfile.mode)")
+                                .font(.caption2.monospaced())
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+
+                        if !trace.discoveredPlugins.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Tool Discovery")
+                                    .font(.caption2.weight(.semibold))
+                                ForEach(trace.discoveredPlugins.prefix(4)) { match in
+                                    discoveryRow(match)
+                                }
+                            }
+                        }
+
+                        if !trace.selectedPlugins.isEmpty {
+                            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 6) {
+                                ForEach(trace.selectedPlugins) { plugin in
+                                    pluginChip(plugin)
+                                }
+                            }
+                        }
+
+                        if !trace.selectedSkills.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Skills")
+                                    .font(.caption2.weight(.semibold))
+                                ForEach(trace.selectedSkills) { skill in
+                                    skillChip(skill)
+                                }
+                            }
+                        }
+
+                        if let workingMemory = trace.workingMemory {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Working Memory")
+                                    .font(.caption2.weight(.semibold))
+                                Text(workingMemory.contextText)
+                                    .font(.caption2.monospaced())
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(5)
+                            }
+                        }
+
+                        if !trace.retrievedMemories.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Long-Term Memory")
+                                    .font(.caption2.weight(.semibold))
+                                ForEach(trace.retrievedMemories.prefix(3)) { memory in
+                                    Text("[\(memory.kind.displayName)] \(memory.content) \(memory.retrievalReason ?? "")")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(2)
+                                }
+                            }
+                        }
+
+                        if !trace.planSteps.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Plan")
+                                    .font(.caption2.weight(.semibold))
+                                ForEach(trace.planSteps.prefix(4)) { step in
+                                    Text("\(step.order). \(step.title)：\(step.status)")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                        }
+
+                        if !trace.recoveryStrategies.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Recovery")
+                                    .font(.caption2.weight(.semibold))
+                                ForEach(trace.recoveryStrategies.prefix(2)) { strategy in
+                                    Text("\(strategy.trigger) -> \(strategy.strategy)")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                        }
+
+                        VStack(alignment: .leading, spacing: 5) {
+                            ForEach(trace.steps.suffix(5)) { step in
+                                HStack(alignment: .top, spacing: 6) {
+                                    Circle()
+                                        .fill(statusColor(step.status))
+                                        .frame(width: 6, height: 6)
+                                        .padding(.top, 5)
+                                    VStack(alignment: .leading, spacing: 1) {
+                                        Text(step.title)
+                                            .font(.caption2.weight(.semibold))
+                                        Text(step.detail)
+                                            .font(.caption2)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(2)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding(.trailing, 6)
+                }
+                .frame(maxHeight: 210)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(10)
+        .background(Color.white.opacity(0.045))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private var compactGeneralTrace: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("普通对话：轻量轨迹")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            ForEach(trace.steps.suffix(3)) { step in
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(statusColor(step.status))
+                        .frame(width: 6, height: 6)
+                    Text(step.title)
+                        .font(.caption2.weight(.semibold))
+                    Text(step.detail)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+    }
+
+    private func statusPill(_ status: String) -> some View {
+        Text(status)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(statusColor(status))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(statusColor(status).opacity(0.14))
+            .clipShape(Capsule())
+    }
+
+    private func metricChip(_ title: String, _ value: String) -> some View {
+        HStack(spacing: 4) {
+            Text(title)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .fontWeight(.semibold)
+        }
+        .font(.caption2)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 4)
+        .background(Color.white.opacity(0.05))
+        .clipShape(Capsule())
+    }
+
+    private func pluginChip(_ plugin: AgentPluginDescriptor) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 4) {
+                Text(plugin.name)
+                    .font(.caption2.weight(.semibold))
+                    .lineLimit(1)
+                Spacer(minLength: 4)
+                Text(plugin.riskLevel)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Text(plugin.category)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(Color.effectiveAccent)
+                .lineLimit(1)
+            Text(plugin.toolNames.joined(separator: ", "))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 6)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+    }
+
+    private func discoveryRow(_ match: AgentPluginMatch) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: match.selected ? "checkmark.circle.fill" : "circle")
+                .font(.caption2)
+                .foregroundStyle(match.selected ? Color.effectiveAccent : .secondary)
+            Text(match.pluginName)
+                .font(.caption2.weight(.semibold))
+                .lineLimit(1)
+            Text("\(Int((match.score * 100).rounded()))%")
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+            Text(match.reason)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func skillChip(_ skill: AgentSkillDescriptor) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(skill.name)
+                .font(.caption2.weight(.semibold))
+            Text(skill.workflowSteps.joined(separator: " -> "))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 6)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+    }
+
+    private func statusColor(_ status: String) -> Color {
+        switch status.lowercased() {
+        case "done", "completed", "已完成":
+            return .green
+        case "prepared", "已准备":
+            return Color.effectiveAccent
+        case "fallback", "skipped":
+            return .orange
+        case "error", "failed":
+            return .red
+        default:
+            return .secondary
+        }
+    }
+}
+
+private struct ChatBubble: View {
+    let message: AIChatMessage
+
+    var body: some View {
+        HStack {
+            if message.role == .user { Spacer(minLength: 36) }
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(message.role == .user ? "你" : "助手")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                MarkdownMessageText(content: message.content)
+                    .font(.caption)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                message.role == .user
+                    ? Color.effectiveAccentBackground
+                    : Color.white.opacity(0.06)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .frame(maxWidth: 360, alignment: message.role == .user ? .trailing : .leading)
+
+            if message.role == .assistant { Spacer(minLength: 36) }
+        }
+        .frame(maxWidth: .infinity, alignment: message.role == .user ? .trailing : .leading)
+        .padding(.horizontal, 10)
+    }
+}
+
+private struct MarkdownMessageText: View {
+    let content: String
+
+    var body: some View {
+        Text(attributedContent)
+    }
+
+    private var attributedContent: AttributedString {
+        (try? AttributedString(markdown: content)) ?? AttributedString(content)
+    }
+}

--- a/boringNotch/components/Notch/AIWeatherViews.swift
+++ b/boringNotch/components/Notch/AIWeatherViews.swift
@@ -25,6 +25,162 @@ private enum AgentInspectorMode: String, Identifiable {
     case knowledge
 
     var id: String { rawValue }
+
+    var windowTitle: String {
+        switch self {
+        case .plugins: return "蛋神 · 插件总览"
+        case .skills: return "蛋神 · Skills 总览"
+        case .memory: return "蛋神 · 记忆系统"
+        case .knowledge: return "蛋神 · 本地知识库"
+        }
+    }
+
+    var savedPanelSize: CGSize {
+        switch self {
+        case .plugins:
+            return .init(width: Defaults[.aiPluginPanelWidth], height: Defaults[.aiPluginPanelHeight])
+        case .skills:
+            return .init(width: Defaults[.aiSkillsPanelWidth], height: Defaults[.aiSkillsPanelHeight])
+        case .memory:
+            return .init(width: Defaults[.aiMemoryPanelWidth], height: Defaults[.aiMemoryPanelHeight])
+        case .knowledge:
+            return .init(width: Defaults[.aiKnowledgePanelWidth], height: Defaults[.aiKnowledgePanelHeight])
+        }
+    }
+
+    func savePanelSize(_ size: CGSize) {
+        switch self {
+        case .plugins:
+            Defaults[.aiPluginPanelWidth] = size.width
+            Defaults[.aiPluginPanelHeight] = size.height
+        case .skills:
+            Defaults[.aiSkillsPanelWidth] = size.width
+            Defaults[.aiSkillsPanelHeight] = size.height
+        case .memory:
+            Defaults[.aiMemoryPanelWidth] = size.width
+            Defaults[.aiMemoryPanelHeight] = size.height
+        case .knowledge:
+            Defaults[.aiKnowledgePanelWidth] = size.width
+            Defaults[.aiKnowledgePanelHeight] = size.height
+        }
+    }
+}
+
+@MainActor
+private final class AgentInspectorWindowController: NSObject, NSWindowDelegate {
+    static let shared = AgentInspectorWindowController()
+
+    private var inspectorWindow: NSWindow?
+    private var currentMode: AgentInspectorMode?
+
+    var isVisible: Bool {
+        inspectorWindow?.isVisible == true
+    }
+
+    func show(mode: AgentInspectorMode) {
+        if currentMode != mode {
+            persistCurrentSize()
+        }
+        currentMode = mode
+
+        let isNewWindow = inspectorWindow == nil
+        let targetSize = resolvedContentSize(mode.savedPanelSize)
+        let window = inspectorWindow ?? makeWindow()
+
+        window.title = mode.windowTitle
+        window.contentView = NSHostingView(
+            rootView: AgentInventoryPanel(mode: mode)
+                .id(mode)
+                .onExitCommand { [weak self] in
+                    self?.close()
+                }
+        )
+        window.setContentSize(targetSize)
+
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
+        AppWindowPresentationCoordinator.shared.present(window)
+
+        if isNewWindow {
+            window.center()
+        }
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    func close() {
+        persistCurrentSize()
+        inspectorWindow?.close()
+    }
+
+    private func makeWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: CGSize(width: 760, height: 460)),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier("DanShenAgentInspectorWindow")
+        window.contentMinSize = NSSize(width: 520, height: 340)
+        window.collectionBehavior = [.managed, .participatesInCycle, .fullScreenAuxiliary]
+        window.hidesOnDeactivate = false
+        window.isExcludedFromWindowsMenu = false
+        window.isReleasedWhenClosed = false
+        window.tabbingMode = .disallowed
+        window.animationBehavior = .documentWindow
+        window.appearance = NSAppearance(named: .darkAqua)
+        window.backgroundColor = .windowBackgroundColor
+        window.level = .normal
+        window.delegate = self
+        inspectorWindow = window
+        return window
+    }
+
+    private func resolvedContentSize(_ requested: CGSize) -> CGSize {
+        let visibleSize = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame.size
+            ?? CGSize(width: 1440, height: 900)
+        let maximum = CGSize(
+            width: max(520, visibleSize.width - 80),
+            height: max(340, visibleSize.height - 80)
+        )
+        return CGSize(
+            width: min(max(requested.width, 520), maximum.width),
+            height: min(max(requested.height, 340), maximum.height)
+        )
+    }
+
+    private func persistCurrentSize() {
+        guard let currentMode, let inspectorWindow else { return }
+        currentMode.savePanelSize(inspectorWindow.contentLayoutRect.size)
+    }
+
+    func windowDidResize(_ notification: Notification) {
+        persistCurrentSize()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        persistCurrentSize()
+        if let inspectorWindow {
+            AppWindowPresentationCoordinator.shared.dismiss(inspectorWindow)
+        }
+        AppWindowPresentationCoordinator.shared.relinquishApplicationFocusIfPossible()
+    }
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        NSApp.setActivationPolicy(.regular)
+        if let inspectorWindow {
+            AppWindowPresentationCoordinator.shared.present(inspectorWindow)
+        }
+    }
+
+    func windowDidMiniaturize(_ notification: Notification) {
+        AppWindowPresentationCoordinator.shared.refresh()
+    }
+
+    func windowDidDeminiaturize(_ notification: Notification) {
+        if let inspectorWindow {
+            AppWindowPresentationCoordinator.shared.present(inspectorWindow)
+        }
+    }
 }
 
 private enum AgentFileImportMode {
@@ -38,22 +194,18 @@ private enum AgentResizeAxis: Equatable {
     case both
 }
 
-private let agentResizeHorizontalSensitivity: CGFloat = 0.68
-private let agentResizeVerticalSensitivity: CGFloat = 0.72
-private let agentOpenPanelLevel = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue + 6)
+private let agentResizeHorizontalSensitivity: CGFloat = 0.52
+private let agentResizeVerticalSensitivity: CGFloat = 0.56
 private let agentPanelAnimation = NotchPanelAnimation.spring
 
+@MainActor
 private func prepareAgentOpenPanel(_ panel: NSOpenPanel) {
     NSApp.setActivationPolicy(.regular)
     NSApp.activate(ignoringOtherApps: true)
     panel.hidesOnDeactivate = false
-    panel.isFloatingPanel = true
-    panel.level = agentOpenPanelLevel
-    panel.collectionBehavior = [
-        .canJoinAllSpaces,
-        .fullScreenAuxiliary,
-        .transient,
-    ]
+    panel.isFloatingPanel = false
+    panel.level = .normal
+    panel.collectionBehavior = [.managed, .participatesInCycle, .fullScreenAuxiliary]
 }
 
 private func agentPanelHostWindow() -> NSWindow? {
@@ -67,42 +219,38 @@ private func agentPanelHostWindow() -> NSWindow? {
 }
 
 private func isAgentPanelHostWindow(_ window: NSWindow) -> Bool {
-    window is BoringNotchWindow || window is BoringNotchSkyLightWindow
+    window is BoringNotchWindow
+        || window is BoringNotchSkyLightWindow
+        || window.identifier?.rawValue == "DanShenAgentInspectorWindow"
 }
 
-private func runAgentOpenPanel(_ panel: NSOpenPanel, completion: @escaping ([URL]) -> Void) {
+@MainActor
+func runAgentOpenPanel(_ panel: NSOpenPanel, completion: @escaping ([URL]) -> Void) {
     prepareAgentOpenPanel(panel)
+    AppWindowPresentationCoordinator.shared.present(panel)
 
     let finish: (NSApplication.ModalResponse) -> Void = { response in
         DispatchQueue.main.async {
+            AppWindowPresentationCoordinator.shared.dismiss(panel)
+            AppWindowPresentationCoordinator.shared.relinquishApplicationFocusIfPossible()
             completion(response == .OK ? panel.urls : [])
         }
     }
 
-    if let hostWindow = agentPanelHostWindow() {
-        panel.level = NSWindow.Level(
-            rawValue: max(agentOpenPanelLevel.rawValue, hostWindow.level.rawValue + 4)
-        )
+    if let hostWindow = agentPanelHostWindow(),
+       !(hostWindow is BoringNotchWindow),
+       !(hostWindow is BoringNotchSkyLightWindow) {
         hostWindow.makeKeyAndOrderFront(nil)
-        hostWindow.orderFrontRegardless()
 
         panel.beginSheetModal(for: hostWindow) { response in
             finish(response)
         }
-
-        DispatchQueue.main.async {
-            panel.level = NSWindow.Level(
-                rawValue: max(agentOpenPanelLevel.rawValue, hostWindow.level.rawValue + 4)
-            )
-            panel.orderFrontRegardless()
-            panel.makeKey()
-        }
         return
     }
 
-    panel.orderFrontRegardless()
-    panel.makeKeyAndOrderFront(nil)
-    finish(panel.runModal())
+    panel.begin { response in
+        finish(response)
+    }
 }
 
 private struct AgentSlashCommand: Identifiable {
@@ -120,7 +268,6 @@ struct AIChatView: View {
     @ObservedObject private var manager = AIChatManager.shared
     @State private var draft: String = ""
     @State private var showsTrace: Bool = false
-    @State private var inspectorMode: AgentInspectorMode?
     @State private var attachedFiles: [AgentAttachedFile] = []
     @State private var fileError: String?
     @State private var resizeStartSize: CGSize?
@@ -133,11 +280,11 @@ struct AIChatView: View {
         .init(id: "/plugins", title: "插件", subtitle: "查看可用工具、权限和风险等级", symbolName: "puzzlepiece.extension"),
         .init(id: "/skills", title: "Skills", subtitle: "查看任务技能手册", symbolName: "sparkles"),
         .init(id: "/memory", title: "记忆", subtitle: "查看工作记忆和长期记忆", symbolName: "brain.head.profile"),
-        .init(id: "/knowledge", title: "知识库", subtitle: "查看资料；add 导入文件；seed 导入 GitHub 示例", symbolName: "books.vertical"),
-        .init(id: "/kb", title: "知识库", subtitle: "同 /knowledge，可输入 add 或 seed", symbolName: "books.vertical"),
+        .init(id: "/knowledge", title: "知识库", subtitle: "显示资料数量；add 导入文件；seed 导入 GitHub 示例", symbolName: "books.vertical"),
+        .init(id: "/kb", title: "知识库", subtitle: "同 /knowledge，可输入 add、seed 或 clear", symbolName: "books.vertical"),
         .init(id: "/remember", title: "记住", subtitle: "把一句稳定偏好写入长期记忆", symbolName: "plus.circle"),
         .init(id: "/forget", title: "遗忘", subtitle: "按关键词删除长期记忆，留空则清空", symbolName: "minus.circle"),
-        .init(id: "/file", title: "上传文件", subtitle: "支持文本、PDF 文本抽取和图片 OCR", symbolName: "paperclip"),
+        .init(id: "/file", title: "上传文件", subtitle: "支持文本、PDF（含扫描件 OCR）和图片 OCR", symbolName: "paperclip"),
         .init(id: "/web", title: "联网检索", subtitle: "搜索公开网页或 GitHub 仓库", symbolName: "globe"),
         .init(id: "/clear", title: "清空", subtitle: "清除当前会话消息和轨迹", symbolName: "trash"),
         .init(id: "/help", title: "帮助", subtitle: "生成命令、插件和 Skills 说明", symbolName: "questionmark.circle"),
@@ -152,7 +299,7 @@ struct AIChatView: View {
                     title: "AI 已关闭",
                     subtitle: "请在 设置 > AI 中启用智能体。"
                 )
-            } else if Defaults[.aiServiceAPIKey].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            } else if !manager.hasConfiguredAPIKey {
                 featureDisabledState(
                     title: "缺少 API Key",
                     subtitle: "请在 设置 > AI 中填写 Base URL、模型和 API Key。"
@@ -160,12 +307,6 @@ struct AIChatView: View {
             } else {
                 conversationTabs
                 messagesPanel
-                if let inspectorMode {
-                    AgentInventoryPanel(mode: inspectorMode) {
-                        self.inspectorMode = nil
-                        isComposerFocused = true
-                    }
-                }
                 if aiShowAgentTrace, let trace = manager.lastAgentTrace {
                     AgentTracePanel(trace: trace, isExpanded: $showsTrace)
                         .layoutPriority(0)
@@ -178,16 +319,11 @@ struct AIChatView: View {
         .padding(.bottom, 4)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .overlay(resizeHandles)
-        .onExitCommand {
-            if inspectorMode != nil {
-                inspectorMode = nil
-                isComposerFocused = true
-            }
-        }
         .onAppear {
             vm.preventAutoClose = true
             NSApp.setActivationPolicy(.regular)
             NSApp.activate(ignoringOtherApps: true)
+            manager.refreshPersistentState()
 
             Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(150))
@@ -198,7 +334,8 @@ struct AIChatView: View {
             vm.preventAutoClose = false
             isComposerFocused = false
 
-            if SettingsWindowController.shared.window?.isVisible != true {
+            if SettingsWindowController.shared.window?.isVisible != true,
+               !AgentInspectorWindowController.shared.isVisible {
                 NSApp.setActivationPolicy(.accessory)
             }
         }
@@ -209,6 +346,9 @@ struct AIChatView: View {
         }
         .onChange(of: manager.lastAgentTrace?.id) { _, _ in
             showsTrace = false
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            manager.refreshPersistentState()
         }
     }
 
@@ -302,7 +442,7 @@ struct AIChatView: View {
     private var header: some View {
         HStack(spacing: 10) {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Boring Notch Agent")
+                Text("蛋神 Agent")
                     .font(.headline)
                 Text(manager.displayedModelName)
                     .font(.caption)
@@ -344,7 +484,6 @@ struct AIChatView: View {
 
     private func collapseAssistantPanel() {
         showsTrace = false
-        inspectorMode = nil
         isComposerFocused = false
         vm.suppressHoverAutoOpen()
 
@@ -356,6 +495,8 @@ struct AIChatView: View {
     private var conversationTabs: some View {
         HStack(spacing: 6) {
             Button {
+                attachedFiles.removeAll()
+                fileError = nil
                 manager.startNewConversation()
                 isComposerFocused = true
             } label: {
@@ -375,6 +516,8 @@ struct AIChatView: View {
                             isActive: manager.activeConversationID == conversation.id,
                             canDelete: manager.conversations.count > 1,
                             onSelect: {
+                                attachedFiles.removeAll()
+                                fileError = nil
                                 manager.selectConversation(conversation.id)
                                 isComposerFocused = true
                             },
@@ -387,14 +530,14 @@ struct AIChatView: View {
             }
 
             Button {
-                inspectorMode = inspectorMode == .knowledge ? nil : .knowledge
+                AgentInspectorWindowController.shared.show(mode: .knowledge)
             } label: {
                 Image(systemName: "books.vertical")
                     .font(.system(size: 13, weight: .semibold))
                     .frame(width: 24, height: 24)
             }
             .buttonStyle(.plain)
-            .foregroundStyle(inspectorMode == .knowledge ? Color.effectiveAccent : .secondary)
+            .foregroundStyle(.secondary)
             .help("知识库")
         }
         .frame(height: 30)
@@ -417,6 +560,13 @@ struct AIChatView: View {
                         Label(lastError, systemImage: "exclamationmark.triangle.fill")
                             .font(.caption)
                             .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    if let persistenceError = manager.persistenceError {
+                        Label(persistenceError, systemImage: "externaldrive.badge.exclamationmark")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
@@ -450,13 +600,6 @@ struct AIChatView: View {
 
     private var composer: some View {
         VStack(alignment: .leading, spacing: 8) {
-            if shouldShowSlashMenu {
-                SlashCommandMenu(
-                    commands: filteredSlashCommands,
-                    onSelect: runSlashCommand
-                )
-            }
-
             if !attachedFiles.isEmpty || fileError != nil {
                 attachmentStrip
             }
@@ -492,6 +635,24 @@ struct AIChatView: View {
             }
             .padding(.trailing, 24)
         }
+        .overlay(alignment: .top) {
+            if shouldShowSlashMenu {
+                SlashCommandMenu(
+                    commands: filteredSlashCommands,
+                    onSelect: { command in
+                        runSlashCommand(command, rawValue: draft)
+                    }
+                )
+                .padding(.trailing, 24)
+                .offset(
+                    y: -SlashCommandMenu.preferredHeight(
+                        for: filteredSlashCommands.count
+                    ) - 8
+                )
+                .transition(.opacity)
+            }
+        }
+        .zIndex(30)
     }
 
     private var shouldShowSlashMenu: Bool {
@@ -499,8 +660,12 @@ struct AIChatView: View {
     }
 
     private var filteredSlashCommands: [AgentSlashCommand] {
-        let query = draft.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard query.count > 1 else { return slashCommands }
+        let rawQuery = draft.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard rawQuery.count > 1 else { return slashCommands }
+        let query = rawQuery.split(whereSeparator: { $0.isWhitespace }).first.map(String.init) ?? rawQuery
+        if let exactCommand = slashCommands.first(where: { $0.id == query }) {
+            return [exactCommand]
+        }
         return slashCommands.filter { command in
             command.id.lowercased().contains(query)
                 || command.title.lowercased().contains(query)
@@ -579,7 +744,8 @@ struct AIChatView: View {
     private func runSlashCommand(matching rawValue: String) {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         let lowered = trimmed.lowercased()
-        let command = slashCommands.first { lowered.hasPrefix($0.id) } ?? filteredSlashCommands.first
+        let commandToken = lowered.split(whereSeparator: { $0.isWhitespace }).first.map(String.init)
+        let command = slashCommands.first { $0.id == commandToken } ?? filteredSlashCommands.first
         if let command {
             runSlashCommand(command, rawValue: trimmed)
         }
@@ -593,10 +759,10 @@ struct AIChatView: View {
         let argument = slashArgument(from: rawValue, commandID: command.id)
         switch command.id {
         case "/plugins":
-            inspectorMode = inspectorMode == .plugins ? nil : .plugins
+            AgentInspectorWindowController.shared.show(mode: .plugins)
             draft = ""
         case "/skills":
-            inspectorMode = inspectorMode == .skills ? nil : .skills
+            AgentInspectorWindowController.shared.show(mode: .skills)
             draft = ""
         case "/memory":
             if argument == "clear" {
@@ -606,7 +772,7 @@ struct AIChatView: View {
                 manager.revealLongTermMemoryFile()
                 manager.appendLocalAssistantMessage("已在 Finder 中定位长期记忆文件。")
             } else {
-                inspectorMode = inspectorMode == .memory ? nil : .memory
+                AgentInspectorWindowController.shared.show(mode: .memory)
             }
             draft = ""
         case "/remember":
@@ -614,13 +780,13 @@ struct AIChatView: View {
                 draft = "/remember "
                 isComposerFocused = true
             } else if let record = manager.rememberMemory(argument) {
-                inspectorMode = .memory
+                AgentInspectorWindowController.shared.show(mode: .memory)
                 draft = ""
                 manager.appendLocalAssistantMessage("已写入长期记忆：[\(record.kind.displayName)] \(record.content)")
             }
         case "/forget":
             let removedCount = manager.forgetMemory(matching: argument)
-            inspectorMode = .memory
+            AgentInspectorWindowController.shared.show(mode: .memory)
             draft = ""
             if argument.isEmpty {
                 manager.appendLocalAssistantMessage("已清空长期记忆，共删除 \(removedCount) 条。")
@@ -639,32 +805,30 @@ struct AIChatView: View {
                 openFilePicker(mode: .knowledge)
             } else if ["seed", "demo", "github", "示例", "样例"].contains(argument.lowercased()) {
                 let count = manager.installStarterKnowledgeBase()
-                inspectorMode = .knowledge
+                AgentInspectorWindowController.shared.show(mode: .knowledge)
                 draft = ""
                 manager.appendLocalAssistantMessage("已导入 \(count) 份 GitHub/官方文档启发的示例知识库。")
             } else if ["clear", "清空"].contains(argument.lowercased()) {
                 manager.clearKnowledgeBase()
-                inspectorMode = .knowledge
+                AgentInspectorWindowController.shared.show(mode: .knowledge)
                 draft = ""
                 manager.appendLocalAssistantMessage("已清空本地知识库。")
             } else {
-                inspectorMode = inspectorMode == .knowledge ? nil : .knowledge
+                AgentInspectorWindowController.shared.show(mode: .knowledge)
                 draft = ""
+                manager.refreshKnowledgeDocuments()
             }
         case "/new":
             draft = ""
             attachedFiles.removeAll()
-            inspectorMode = nil
             manager.startNewConversation()
         case "/chats":
             draft = ""
             attachedFiles.removeAll()
-            inspectorMode = nil
             isComposerFocused = true
         case "/clear":
             draft = ""
             attachedFiles.removeAll()
-            inspectorMode = nil
             manager.clearConversation()
         case "/help":
             draft = "请用中文说明你支持的 / 命令、插件和 Skills，并举 3 个示例任务。"
@@ -690,11 +854,14 @@ struct AIChatView: View {
         panel.allowedContentTypes = agentAllowedImportTypes()
 
         runAgentOpenPanel(panel) { urls in
-            importSelectedFiles(urls, mode: mode)
+            Task { @MainActor in
+                await importSelectedFiles(urls, mode: mode)
+            }
         }
     }
 
-    private func importSelectedFiles(_ urls: [URL], mode: AgentFileImportMode) {
+    @MainActor
+    private func importSelectedFiles(_ urls: [URL], mode: AgentFileImportMode) async {
         guard !urls.isEmpty else { return }
 
         var importedKnowledgeTitles: [String] = []
@@ -702,7 +869,9 @@ struct AIChatView: View {
 
         for url in urls.prefix(maxFiles) {
             do {
-                let file = try readAgentImportableFile(at: url)
+                let file = try await Task.detached(priority: .userInitiated) {
+                    try readAgentImportableFile(at: url)
+                }.value
 
                 switch mode {
                 case .attach:
@@ -730,11 +899,20 @@ struct AIChatView: View {
         }
 
         if mode == .knowledge {
-            inspectorMode = .knowledge
+            AgentInspectorWindowController.shared.show(mode: .knowledge)
             if !importedKnowledgeTitles.isEmpty {
                 manager.appendLocalAssistantMessage("已导入知识库：\(importedKnowledgeTitles.joined(separator: "、"))")
             }
         }
+    }
+
+    private func appendKnowledgeStatusMessage() {
+        manager.refreshKnowledgeDocuments()
+        let enabledText = Defaults[.aiKnowledgeRetrievalEnabled] ? "已开启" : "已关闭"
+        let limit = Defaults[.aiKnowledgeRetrievalLimit]
+        manager.appendLocalAssistantMessage(
+            "本地知识库当前有 \(manager.knowledgeDocuments.count) 份资料，自动检索\(enabledText)，每次最多注入 Top-\(limit)。使用 /knowledge add 导入资料，/knowledge seed 导入示例，/knowledge clear 清空。"
+        )
     }
 
     private func promptWithAttachedFiles(_ prompt: String) -> String {
@@ -788,36 +966,66 @@ private struct SlashCommandMenu: View {
     let commands: [AgentSlashCommand]
     let onSelect: (AgentSlashCommand) -> Void
 
+    private static let rowHeight: CGFloat = 42
+    private static let verticalPadding: CGFloat = 10
+    private static let maximumHeight: CGFloat = 262
+
+    static func preferredHeight(for commandCount: Int) -> CGFloat {
+        let visibleRows = max(commandCount, 1)
+        return min(
+            CGFloat(visibleRows) * rowHeight + verticalPadding,
+            maximumHeight
+        )
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            ForEach(commands) { command in
-                Button {
-                    onSelect(command)
-                } label: {
-                    HStack(spacing: 8) {
-                        Image(systemName: command.symbolName)
-                            .font(.system(size: 13, weight: .semibold))
-                            .frame(width: 18)
-                            .foregroundStyle(Color.effectiveAccent)
-                        VStack(alignment: .leading, spacing: 1) {
-                            Text("\(command.id)  \(command.title)")
-                                .font(.caption.weight(.semibold))
-                            Text(command.subtitle)
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
+        ScrollView(.vertical) {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if commands.isEmpty {
+                    Label("没有匹配的命令", systemImage: "magnifyingglass")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, minHeight: Self.rowHeight, alignment: .leading)
+                        .padding(.horizontal, 10)
+                } else {
+                    ForEach(commands) { command in
+                        Button {
+                            onSelect(command)
+                        } label: {
+                            HStack(spacing: 8) {
+                                Image(systemName: command.symbolName)
+                                    .font(.system(size: 13, weight: .semibold))
+                                    .frame(width: 18)
+                                    .foregroundStyle(Color.effectiveAccent)
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text("\(command.id)  \(command.title)")
+                                        .font(.caption.weight(.semibold))
+                                    Text(command.subtitle)
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                                Spacer(minLength: 0)
+                            }
+                            .padding(.horizontal, 10)
+                            .frame(height: Self.rowHeight)
+                            .contentShape(Rectangle())
                         }
-                        Spacer()
+                        .buttonStyle(.plain)
                     }
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
             }
         }
-        .padding(6)
-        .background(Color.white.opacity(0.06))
+        .scrollIndicators(.visible)
+        .padding(.vertical, Self.verticalPadding / 2)
+        .frame(height: Self.preferredHeight(for: commands.count))
+        .background(Color(nsColor: .windowBackgroundColor).opacity(0.98))
         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.45), radius: 12, y: 5)
     }
 }
 
@@ -864,12 +1072,18 @@ private struct ConversationTabButton: View {
 
 private struct AgentInventoryPanel: View {
     let mode: AgentInspectorMode
-    let onClose: () -> Void
     @ObservedObject private var manager = AIChatManager.shared
     @Default(.aiKnowledgeRetrievalEnabled) private var aiKnowledgeRetrievalEnabled
     @Default(.aiKnowledgeRetrievalLimit) private var aiKnowledgeRetrievalLimit
     @State private var selectedSkillCategory: String = "全部"
     @State private var knowledgeImportError: String?
+    @State private var selectedMemoryKind: String = "all"
+    @State private var memorySearchText: String = ""
+    @State private var editingMemoryID: UUID?
+    @State private var memoryDraft: String = ""
+    @State private var memoryDraftKind: AgentMemoryRecord.Kind = .fact
+    @State private var memoryFeedback: String?
+    @State private var showsClearMemoryConfirmation = false
     private let columns = [GridItem(.adaptive(minimum: 250, maximum: 360), spacing: 6)]
 
     var body: some View {
@@ -881,14 +1095,6 @@ private struct AgentInventoryPanel: View {
                 Text(panelCount)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
-                Button(action: onClose) {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-                .keyboardShortcut(.cancelAction)
-                .help("关闭面板")
             }
 
             ScrollView(showsIndicators: true) {
@@ -914,15 +1120,13 @@ private struct AgentInventoryPanel: View {
                     knowledgePanel
                 }
             }
-            .frame(maxHeight: 360)
+            .frame(maxHeight: .infinity)
         }
-        .padding(10)
-        .background(Color.white.opacity(0.045))
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .padding(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Color(nsColor: .windowBackgroundColor))
         .onAppear {
-            if mode == .knowledge {
-                manager.refreshKnowledgeDocuments()
-            }
+            manager.refreshPersistentState()
         }
     }
 
@@ -1024,8 +1228,53 @@ private struct AgentInventoryPanel: View {
                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             }
 
-            if manager.longTermMemories.isEmpty {
-                Text("还没有长期记忆。只有当用户明确说“记住/以后/我的偏好”等稳定信息时才会写入。")
+            HStack(spacing: 8) {
+                HStack(spacing: 6) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.secondary)
+                    TextField("搜索记忆内容或关键词", text: $memorySearchText)
+                        .textFieldStyle(.plain)
+                }
+                .padding(.horizontal, 8)
+                .frame(height: 28)
+                .background(Color.white.opacity(0.06))
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+                Button {
+                    beginCreatingMemory()
+                } label: {
+                    Label("新增", systemImage: "plus")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            Picker("记忆类型", selection: $selectedMemoryKind) {
+                Text("全部").tag("all")
+                ForEach(AgentMemoryRecord.Kind.allCases, id: \.rawValue) { kind in
+                    Text(kind.displayName).tag(kind.rawValue)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            if editingMemoryID != nil {
+                memoryEditor
+            }
+
+            HStack {
+                Text("长期记忆")
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Text("显示 \(filteredMemories.count) / \(manager.longTermMemories.count) 条")
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+
+            if filteredMemories.isEmpty {
+                Text(manager.longTermMemories.isEmpty
+                     ? "还没有长期记忆。点击“新增”，或用 /remember 写入稳定信息。"
+                     : "没有符合当前搜索和类型筛选的记忆。")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .padding(8)
@@ -1033,9 +1282,28 @@ private struct AgentInventoryPanel: View {
                     .background(Color.white.opacity(0.04))
                     .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             } else {
-                ForEach(manager.longTermMemories.prefix(5)) { memory in
-                    MemoryInventoryCard(memory: memory)
+                LazyVStack(spacing: 6) {
+                    ForEach(filteredMemories) { memory in
+                        MemoryInventoryCard(
+                            memory: memory,
+                            onEdit: { beginEditingMemory(memory) },
+                            onDelete: {
+                                if manager.deleteMemory(id: memory.id) {
+                                    if editingMemoryID == memory.id {
+                                        cancelMemoryEditing()
+                                    }
+                                    memoryFeedback = "已删除这条长期记忆。"
+                                }
+                            }
+                        )
+                    }
                 }
+            }
+
+            if let memoryFeedback {
+                Text(memoryFeedback)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
             }
 
             HStack(spacing: 10) {
@@ -1046,13 +1314,118 @@ private struct AgentInventoryPanel: View {
                 .controlSize(.small)
 
                 Button("清空长期记忆") {
-                    manager.clearLongTermMemory()
-                    manager.appendLocalAssistantMessage("已清空长期记忆。")
+                    showsClearMemoryConfirmation = true
                 }
                 .buttonStyle(.borderless)
                 .controlSize(.small)
                 .foregroundStyle(.red)
             }
+        }
+        .alert("清空全部长期记忆？", isPresented: $showsClearMemoryConfirmation) {
+            Button("取消", role: .cancel) {}
+            Button("清空", role: .destructive) {
+                manager.clearLongTermMemory()
+                cancelMemoryEditing()
+                memoryFeedback = "已清空全部长期记忆。"
+            }
+        } message: {
+            Text("此操作会删除本地保存的全部长期记忆，无法撤销。")
+        }
+    }
+
+    private var filteredMemories: [AgentMemoryRecord] {
+        let query = memorySearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return manager.longTermMemories.filter { memory in
+            let kindMatches = selectedMemoryKind == "all" || memory.kind.rawValue == selectedMemoryKind
+            let queryMatches = query.isEmpty
+                || memory.content.localizedCaseInsensitiveContains(query)
+                || memory.keywords.contains(where: { $0.localizedCaseInsensitiveContains(query) })
+            return kindMatches && queryMatches
+        }
+    }
+
+    private var memoryEditor: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label(editingMemoryID == AgentMemoryEditor.newRecordID ? "新增长期记忆" : "编辑长期记忆",
+                      systemImage: "square.and.pencil")
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Button(action: cancelMemoryEditing) {
+                    Image(systemName: "xmark")
+                }
+                .buttonStyle(.plain)
+                .help("取消编辑")
+            }
+
+            Picker("类型", selection: $memoryDraftKind) {
+                ForEach(AgentMemoryRecord.Kind.allCases, id: \.rawValue) { kind in
+                    Text(kind.displayName).tag(kind)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            TextEditor(text: $memoryDraft)
+                .font(.caption)
+                .scrollContentBackground(.hidden)
+                .padding(6)
+                .frame(minHeight: 72, maxHeight: 110)
+                .background(Color.white.opacity(0.06))
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+            HStack {
+                Text("保存后将参与跨会话检索。")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("取消", action: cancelMemoryEditing)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                Button("保存", action: saveMemoryDraft)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(memoryDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(9)
+        .background(Color.effectiveAccent.opacity(0.10))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private func beginCreatingMemory() {
+        editingMemoryID = AgentMemoryEditor.newRecordID
+        memoryDraft = ""
+        memoryDraftKind = .fact
+        memoryFeedback = nil
+    }
+
+    private func beginEditingMemory(_ memory: AgentMemoryRecord) {
+        editingMemoryID = memory.id
+        memoryDraft = memory.content
+        memoryDraftKind = memory.kind
+        memoryFeedback = nil
+    }
+
+    private func cancelMemoryEditing() {
+        editingMemoryID = nil
+        memoryDraft = ""
+        memoryDraftKind = .fact
+    }
+
+    private func saveMemoryDraft() {
+        let content = memoryDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !content.isEmpty, let editingMemoryID else { return }
+
+        let saved: Bool
+        if editingMemoryID == AgentMemoryEditor.newRecordID {
+            saved = manager.createMemory(content, kind: memoryDraftKind) != nil
+        } else {
+            saved = manager.updateMemory(id: editingMemoryID, content: content, kind: memoryDraftKind)
+        }
+        memoryFeedback = saved ? "长期记忆已保存。" : "保存失败，请检查本地存储权限。"
+        if saved {
+            cancelMemoryEditing()
         }
     }
 
@@ -1080,7 +1453,7 @@ private struct AgentInventoryPanel: View {
             }
 
             if manager.knowledgeDocuments.isEmpty {
-                Text("还没有导入资料。使用 /knowledge add，或点击下面的“导入资料”按钮导入文本、Markdown、JSON、CSV、可抽取文本的 PDF 或带文字的图片。")
+                Text("还没有导入资料。使用 /knowledge add，或点击下面的“导入资料”按钮导入文本、Markdown、JSON、CSV、PDF（含扫描件 OCR）或带文字的图片。")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .padding(8)
@@ -1088,7 +1461,7 @@ private struct AgentInventoryPanel: View {
                     .background(Color.white.opacity(0.04))
                     .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             } else {
-                ForEach(manager.knowledgeDocuments.prefix(8)) { document in
+                ForEach(manager.knowledgeDocuments) { document in
                     KnowledgeInventoryCard(document: document) {
                         manager.removeKnowledgeDocument(id: document.id)
                     }
@@ -1135,6 +1508,12 @@ private struct AgentInventoryPanel: View {
                     .font(.caption2)
                     .foregroundStyle(.orange)
             }
+
+            if let persistenceError = manager.persistenceError {
+                Label(persistenceError, systemImage: "externaldrive.badge.exclamationmark")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
         }
     }
 
@@ -1147,17 +1526,22 @@ private struct AgentInventoryPanel: View {
         panel.allowedContentTypes = agentAllowedImportTypes()
 
         runAgentOpenPanel(panel) { urls in
-            importKnowledgeFiles(urls)
+            Task { @MainActor in
+                await importKnowledgeFiles(urls)
+            }
         }
     }
 
-    private func importKnowledgeFiles(_ urls: [URL]) {
+    @MainActor
+    private func importKnowledgeFiles(_ urls: [URL]) async {
         guard !urls.isEmpty else { return }
 
         var imported: [String] = []
         for url in urls.prefix(8) {
             do {
-                let file = try readAgentImportableFile(at: url)
+                let file = try await Task.detached(priority: .userInitiated) {
+                    try readAgentImportableFile(at: url)
+                }.value
                 if let document = manager.addKnowledgeDocument(
                     name: url.lastPathComponent,
                     path: url.path,
@@ -1208,8 +1592,15 @@ private struct MemoryLayerCard: View {
     }
 }
 
+private enum AgentMemoryEditor {
+    static let newRecordID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+}
+
 private struct MemoryInventoryCard: View {
     let memory: AgentMemoryRecord
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+    @State private var showsDeleteConfirmation = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -1221,6 +1612,22 @@ private struct MemoryInventoryCard: View {
                 Text(memory.updatedAt, style: .relative)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
+                Button(action: onEdit) {
+                    Image(systemName: "pencil")
+                        .font(.caption2.weight(.semibold))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("编辑记忆")
+                Button {
+                    showsDeleteConfirmation = true
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.caption2.weight(.semibold))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.red)
+                .help("删除记忆")
             }
             Text(memory.content)
                 .font(.caption2)
@@ -1252,6 +1659,12 @@ private struct MemoryInventoryCard: View {
         .padding(8)
         .background(Color.white.opacity(0.04))
         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .alert("删除这条长期记忆？", isPresented: $showsDeleteConfirmation) {
+            Button("取消", role: .cancel) {}
+            Button("删除", role: .destructive, action: onDelete)
+        } message: {
+            Text(memory.content)
+        }
     }
 }
 
@@ -1696,7 +2109,10 @@ private struct ChatBubble: View {
                     : Color.white.opacity(0.06)
             )
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .frame(maxWidth: 360, alignment: message.role == .user ? .trailing : .leading)
+            .frame(
+                maxWidth: message.role == .user ? 420 : 640,
+                alignment: message.role == .user ? .trailing : .leading
+            )
 
             if message.role == .assistant { Spacer(minLength: 36) }
         }
@@ -1709,10 +2125,187 @@ private struct MarkdownMessageText: View {
     let content: String
 
     var body: some View {
-        Text(attributedContent)
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                blockView(block)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var attributedContent: AttributedString {
-        (try? AttributedString(markdown: content)) ?? AttributedString(content)
+    @ViewBuilder
+    private func blockView(_ block: MarkdownBlock) -> some View {
+        switch block {
+        case .heading(let level, let text):
+            Text(inlineMarkdown(text))
+                .font(level <= 2 ? .subheadline.weight(.semibold) : .caption.weight(.semibold))
+        case .paragraph(let text):
+            Text(inlineMarkdown(text))
+        case .bullet(let text):
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text("•")
+                    .foregroundStyle(Color.effectiveAccent)
+                Text(inlineMarkdown(text))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        case .numbered(let marker, let text):
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(marker)
+                    .font(.caption.monospacedDigit().weight(.semibold))
+                    .foregroundStyle(Color.effectiveAccent)
+                    .frame(minWidth: 18, alignment: .trailing)
+                Text(inlineMarkdown(text))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        case .quote(let text):
+            HStack(alignment: .top, spacing: 7) {
+                Rectangle()
+                    .fill(Color.effectiveAccent.opacity(0.65))
+                    .frame(width: 2)
+                Text(inlineMarkdown(text))
+                    .foregroundStyle(.secondary)
+            }
+        case .code(let text):
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(text)
+                    .font(.caption2.monospaced())
+                    .textSelection(.enabled)
+                    .padding(7)
+            }
+            .background(Color.black.opacity(0.24))
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        }
+    }
+
+    private var blocks: [MarkdownBlock] {
+        MarkdownBlock.parse(content)
+    }
+
+    private func inlineMarkdown(_ text: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace,
+            failurePolicy: .returnPartiallyParsedIfPossible
+        )
+        return (try? AttributedString(markdown: text, options: options)) ?? AttributedString(text)
+    }
+}
+
+private enum MarkdownBlock {
+    case heading(level: Int, text: String)
+    case paragraph(String)
+    case bullet(String)
+    case numbered(marker: String, text: String)
+    case quote(String)
+    case code(String)
+
+    static func parse(_ source: String) -> [MarkdownBlock] {
+        let lines = source
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .components(separatedBy: "\n")
+        var result: [MarkdownBlock] = []
+        var paragraphLines: [String] = []
+        var codeLines: [String] = []
+        var isInCodeFence = false
+
+        func flushParagraph() {
+            let text = paragraphLines.joined(separator: "\n")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                result.append(.paragraph(text))
+            }
+            paragraphLines.removeAll(keepingCapacity: true)
+        }
+
+        func flushCode() {
+            let text = codeLines.joined(separator: "\n")
+                .trimmingCharacters(in: .newlines)
+            if !text.isEmpty {
+                result.append(.code(text))
+            }
+            codeLines.removeAll(keepingCapacity: true)
+        }
+
+        for rawLine in lines {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+
+            if line.hasPrefix("```") {
+                flushParagraph()
+                if isInCodeFence {
+                    flushCode()
+                }
+                isInCodeFence.toggle()
+                continue
+            }
+
+            if isInCodeFence {
+                codeLines.append(rawLine)
+                continue
+            }
+
+            guard !line.isEmpty else {
+                flushParagraph()
+                continue
+            }
+
+            let headingLevel = line.prefix { $0 == "#" }.count
+            if headingLevel > 0,
+               headingLevel <= 6,
+               line.dropFirst(headingLevel).first == " "
+            {
+                flushParagraph()
+                result.append(.heading(
+                    level: headingLevel,
+                    text: String(line.dropFirst(headingLevel)).trimmingCharacters(in: .whitespaces)
+                ))
+                continue
+            }
+
+            if line.hasPrefix("- ") || line.hasPrefix("* ") {
+                flushParagraph()
+                result.append(.bullet(String(line.dropFirst(2))))
+                continue
+            }
+
+            if let markerRange = line.range(of: #"^\d+[\.)]\s+"#, options: .regularExpression) {
+                flushParagraph()
+                let marker = String(line[..<markerRange.upperBound]).trimmingCharacters(in: .whitespaces)
+                result.append(.numbered(
+                    marker: marker,
+                    text: String(line[markerRange.upperBound...])
+                ))
+                continue
+            }
+
+            if line.hasPrefix("> ") {
+                flushParagraph()
+                result.append(.quote(String(line.dropFirst(2))))
+                continue
+            }
+
+            if line.contains("|") && line.filter({ $0 == "|" }).count >= 2 {
+                let cells = line
+                    .split(separator: "|", omittingEmptySubsequences: true)
+                    .map { $0.trimmingCharacters(in: .whitespaces) }
+                let isSeparator = !cells.isEmpty && cells.allSatisfy { cell in
+                    cell.replacingOccurrences(of: "-", with: "")
+                        .replacingOccurrences(of: ":", with: "")
+                        .isEmpty
+                }
+                if !isSeparator {
+                    flushParagraph()
+                    result.append(.bullet(cells.joined(separator: " · ")))
+                }
+                continue
+            }
+
+            paragraphLines.append(rawLine)
+        }
+
+        if isInCodeFence {
+            flushCode()
+        } else {
+            flushParagraph()
+        }
+        return result.isEmpty ? [.paragraph(source)] : result
     }
 }

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -12,14 +12,12 @@ struct BoringHeader: View {
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var coordinator = BoringViewCoordinator.shared
-    @StateObject var tvm = ShelfStateViewModel.shared
+
     var body: some View {
         HStack(spacing: 0) {
             HStack {
-                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
+                if vm.notchState == .open {
                     TabSelectionView()
-                } else if vm.notchState == .open {
-                    EmptyView()
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -98,6 +96,8 @@ struct BoringHeader: View {
             .blur(radius: vm.notchState == .closed ? 20 : 0)
             .zIndex(2)
         }
+        .padding(.horizontal, 12)
+        .padding(.top, 4)
         .foregroundColor(.gray)
         .environmentObject(vm)
     }

--- a/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
@@ -58,6 +58,7 @@ class BoringNotchSkyLightWindow: NSPanel {
         titlebarAppearsTransparent = true
         backgroundColor = .clear
         isMovable = false
+        becomesKeyOnlyIfNeeded = true
         level = .mainMenu + 3
         hasShadow = false
         isReleasedWhenClosed = false
@@ -109,6 +110,6 @@ class BoringNotchSkyLightWindow: NSPanel {
     
     private var observers: Set<AnyCancellable> = []
     
-    override var canBecomeKey: Bool { false }
-    override var canBecomeMain: Bool { false }
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
 }

--- a/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
@@ -59,7 +59,7 @@ class BoringNotchSkyLightWindow: NSPanel {
         backgroundColor = .clear
         isMovable = false
         becomesKeyOnlyIfNeeded = true
-        level = .mainMenu + 3
+        level = AppWindowPresentationCoordinator.defaultNotchLevel
         hasShadow = false
         isReleasedWhenClosed = false
         

--- a/boringNotch/components/Notch/BoringNotchWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchWindow.swift
@@ -27,6 +27,7 @@ class BoringNotchWindow: NSPanel {
         titlebarAppearsTransparent = true
         backgroundColor = .clear
         isMovable = false
+        becomesKeyOnlyIfNeeded = true
         
         collectionBehavior = [
             .fullScreenAuxiliary,
@@ -41,10 +42,10 @@ class BoringNotchWindow: NSPanel {
     }
     
     override var canBecomeKey: Bool {
-        false
+        true
     }
     
     override var canBecomeMain: Bool {
-        false
+        true
     }
 }

--- a/boringNotch/components/Notch/BoringNotchWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchWindow.swift
@@ -6,6 +6,93 @@
 //
 
 import Cocoa
+import Combine
+import Defaults
+
+@MainActor
+final class AppWindowPresentationCoordinator {
+    static let shared = AppWindowPresentationCoordinator()
+    static let defaultNotchLevel = NSWindow.Level(
+        rawValue: NSWindow.Level.mainMenu.rawValue + 3
+    )
+
+    private let presentedWindows = NSHashTable<NSWindow>.weakObjects()
+    private var cancellables = Set<AnyCancellable>()
+
+    private init() {
+        Defaults.publisher(.auxiliaryWindowsAlwaysOnTop)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.applyPresentationPolicy()
+            }
+            .store(in: &cancellables)
+    }
+
+    var hasPresentedWindows: Bool {
+        presentedWindows.allObjects.contains {
+            $0.isVisible && !$0.isMiniaturized
+        }
+    }
+
+    func present(_ window: NSWindow) {
+        if !presentedWindows.allObjects.contains(where: { $0 === window }) {
+            presentedWindows.add(window)
+        }
+        configureAuxiliaryWindow(window)
+        setNotchWindowsYielding(true)
+    }
+
+    func dismiss(_ window: NSWindow) {
+        presentedWindows.remove(window)
+        applyPresentationPolicy()
+    }
+
+    func refresh() {
+        applyPresentationPolicy()
+    }
+
+    func relinquishApplicationFocusIfPossible() {
+        let isAssistantVisible = BoringViewCoordinator.shared.currentView == .assistant
+            && NSApp.windows.contains {
+                ($0 is BoringNotchWindow || $0 is BoringNotchSkyLightWindow) && $0.isVisible
+            }
+        guard !hasPresentedWindows, !isAssistantVisible else { return }
+        NSApp.setActivationPolicy(.accessory)
+    }
+
+    private func applyPresentationPolicy() {
+        for window in presentedWindows.allObjects {
+            configureAuxiliaryWindow(window)
+        }
+
+        let hasVisibleWindow = presentedWindows.allObjects.contains {
+            $0.isVisible && !$0.isMiniaturized
+        }
+        setNotchWindowsYielding(hasVisibleWindow)
+    }
+
+    private func configureAuxiliaryWindow(_ window: NSWindow) {
+        let staysOnTop = Defaults[.auxiliaryWindowsAlwaysOnTop]
+        window.level = staysOnTop ? .floating : .normal
+        window.collectionBehavior = [.managed, .participatesInCycle, .fullScreenAuxiliary]
+        if let panel = window as? NSPanel {
+            panel.isFloatingPanel = staysOnTop
+        }
+    }
+
+    private func setNotchWindowsYielding(_ shouldYield: Bool) {
+        for window in NSApp.windows where isNotchWindow(window) {
+            window.level = shouldYield ? .normal : Self.defaultNotchLevel
+            if shouldYield, window.isVisible {
+                window.orderBack(nil)
+            }
+        }
+    }
+
+    private func isNotchWindow(_ window: NSWindow) -> Bool {
+        window is BoringNotchWindow || window is BoringNotchSkyLightWindow
+    }
+}
 
 class BoringNotchWindow: NSPanel {
     override init(
@@ -37,7 +124,7 @@ class BoringNotchWindow: NSPanel {
         ]
         
         isReleasedWhenClosed = false
-        level = .mainMenu + 3
+        level = AppWindowPresentationCoordinator.defaultNotchLevel
         hasShadow = false
     }
     

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -10,6 +10,8 @@ import Combine
 import Defaults
 import SwiftUI
 
+private let homeWidgetCardHeight: CGFloat = 214
+
 // MARK: - Music Player Components
 
 struct MusicPlayerView: View {
@@ -420,6 +422,7 @@ struct NotchHomeView: View {
     @Default(.quickLaunchApps) private var quickLaunchApps
     @Default(.quickLaunchEnabled) private var quickLaunchEnabled
     @Default(.weatherFeatureEnabled) private var weatherFeatureEnabled
+    @Default(.homeWidgetSlots) private var homeWidgetSlots
 
     var body: some View {
         Group {
@@ -451,29 +454,58 @@ struct NotchHomeView: View {
     }
 
     private var shouldShowUtilityRow: Bool {
-        weatherFeatureEnabled || pomodoroEnabled || quickLaunchEnabled || Defaults[.showCalendar]
+        homeSlots.contains { $0 != .hidden }
+    }
+
+    private var homeSlots: [HomeWidgetKind] {
+        normalizedHomeWidgetSlots(homeWidgetSlots)
     }
 
     private var utilityRow: some View {
         HStack(alignment: .top, spacing: 12) {
-            if weatherFeatureEnabled {
-                HomeWeatherCard()
-            }
-
-            if pomodoroEnabled {
-                HomePomodoroCard()
-            }
-
-            if quickLaunchEnabled {
-                QuickLaunchHomeCard(apps: quickLaunchApps)
-            }
-
-            if Defaults[.showCalendar] {
-                HomeCalendarPanel()
-                    .environmentObject(vm)
+            ForEach(Array(homeSlots.enumerated()), id: \.offset) { index, widget in
+                homeWidget(for: widget, slotNumber: index + 1)
+                    .frame(maxWidth: .infinity)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func homeWidget(for widget: HomeWidgetKind, slotNumber: Int) -> some View {
+        switch widget {
+        case .weather:
+            if weatherFeatureEnabled {
+                HomeWeatherCard()
+            } else {
+                HomeDisabledWidgetCard(title: "天气", subtitle: "Weather", message: "在 Weather 设置中开启。")
+            }
+        case .pomodoro:
+            if pomodoroEnabled {
+                HomePomodoroCard()
+            } else {
+                HomeDisabledWidgetCard(title: "Pomodoro", subtitle: "Focus", message: "在 Pomodoro 设置中开启。")
+            }
+        case .quickLaunch:
+            if quickLaunchEnabled {
+                QuickLaunchHomeCard(apps: quickLaunchApps)
+            } else {
+                HomeDisabledWidgetCard(title: "Quick launch", subtitle: "Apps", message: "在 Appearance 设置中开启。")
+            }
+        case .calendar:
+            if Defaults[.showCalendar] {
+                HomeCalendarPanel()
+                    .environmentObject(vm)
+            } else {
+                HomeDisabledWidgetCard(title: "日历", subtitle: "Calendar", message: "在 Calendar 设置中开启。")
+            }
+        case .media:
+            HomeMediaCard()
+        case .hidden:
+            Color.clear
+                .frame(maxWidth: .infinity, minHeight: homeWidgetCardHeight, maxHeight: homeWidgetCardHeight)
+                .accessibilityHidden(true)
+        }
     }
 
     private var footerRow: some View {
@@ -497,10 +529,37 @@ private struct HomeCalendarPanel: View {
             .onHover { isHovering in
                 vm.isHoveringCalendar = isHovering
             }
-            .frame(minHeight: 214, alignment: .topLeading)
+            .frame(height: homeWidgetCardHeight, alignment: .topLeading)
             .padding(12)
             .background(Color.white.opacity(0.04))
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .clipped()
+    }
+}
+
+private struct HomeDisabledWidgetCard: View {
+    let title: String
+    let subtitle: String
+    let message: String
+
+    var body: some View {
+        HomeWidgetCard(title: title, subtitle: subtitle) {
+            VStack(alignment: .leading, spacing: 10) {
+                Image(systemName: "eye.slash")
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 44, height: 44)
+                    .background(Color.white.opacity(0.05))
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer(minLength: 0)
+            }
+        }
     }
 }
 
@@ -852,6 +911,130 @@ private struct QuickLaunchHomeCard: View {
     }
 }
 
+private struct HomeMediaCard: View {
+    @ObservedObject private var musicManager = MusicManager.shared
+    @State private var sliderValue: Double = 0
+    @State private var dragging = false
+    @State private var lastDragged = Date.distantPast
+
+    var body: some View {
+        HomeWidgetCard(
+            title: "Media",
+            subtitle: musicManager.isPlaying ? "Playing" : "Controls"
+        ) {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .center, spacing: 10) {
+                    mediaArtwork
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(musicManager.songTitle.isEmpty ? "Not playing" : musicManager.songTitle)
+                            .font(.headline)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                        Text(musicManager.artistName.isEmpty ? activeSourceLabel : musicManager.artistName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                    }
+
+                    Spacer(minLength: 0)
+                }
+
+                TimelineView(.animation(minimumInterval: musicManager.playbackRate > 0 ? 0.1 : nil)) { timeline in
+                    MusicSliderView(
+                        sliderValue: $sliderValue,
+                        duration: $musicManager.songDuration,
+                        lastDragged: $lastDragged,
+                        color: musicManager.avgColor,
+                        dragging: $dragging,
+                        currentDate: timeline.date,
+                        timestampDate: musicManager.timestampDate,
+                        elapsedTime: musicManager.elapsedTime,
+                        playbackRate: musicManager.playbackRate,
+                        isPlaying: musicManager.isPlaying
+                    ) { newValue in
+                        MusicManager.shared.seek(to: newValue)
+                    }
+                }
+                .frame(height: 26)
+
+                HStack(spacing: 8) {
+                    mediaButton("backward.fill") {
+                        MusicManager.shared.previousTrack()
+                    }
+                    mediaButton(musicManager.isPlaying ? "pause.fill" : "play.fill", prominent: true) {
+                        MusicManager.shared.togglePlay()
+                    }
+                    mediaButton("forward.fill") {
+                        MusicManager.shared.nextTrack()
+                    }
+                    mediaButton("music.note") {
+                        MusicManager.shared.openMusicApp()
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+
+                if Defaults[.enableLyrics], musicManager.isPlaying {
+                    Text(currentLyricLine)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+    }
+
+    private var mediaArtwork: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Image(nsImage: musicManager.albumArt)
+                .resizable()
+                .aspectRatio(1, contentMode: .fill)
+                .frame(width: 52, height: 52)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .overlay {
+                    if !musicManager.isPlaying {
+                        Color.black.opacity(0.42)
+                    }
+                }
+
+            if !musicManager.usingAppIconForArtwork {
+                AppIcon(for: musicManager.bundleIdentifier ?? "com.apple.Music")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 18, height: 18)
+                    .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+                    .offset(x: 4, y: 4)
+            }
+        }
+        .frame(width: 52, height: 52)
+    }
+
+    private var activeSourceLabel: String {
+        Defaults[.mediaController].rawValue
+    }
+
+    private var currentLyricLine: String {
+        let trimmed = musicManager.currentLyrics.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Lyrics enabled" : trimmed.replacingOccurrences(of: "\n", with: " ")
+    }
+
+    private func mediaButton(
+        _ systemImage: String,
+        prominent: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: prominent ? 16 : 13, weight: .semibold))
+                .frame(width: prominent ? 44 : 36, height: 32)
+                .background(Color.white.opacity(prominent ? 0.12 : 0.06))
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
 private struct HomeWidgetCard<Content: View>: View {
     let title: String
     let subtitle: String
@@ -877,10 +1060,11 @@ private struct HomeWidgetCard<Content: View>: View {
 
             content
         }
-        .frame(maxWidth: .infinity, minHeight: 214, alignment: .topLeading)
+        .frame(maxWidth: .infinity, minHeight: homeWidgetCardHeight, maxHeight: homeWidgetCardHeight, alignment: .topLeading)
         .padding(12)
         .background(Color.white.opacity(0.04))
         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .clipped()
     }
 }
 

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -111,8 +111,6 @@ struct AlbumArtView: View {
 
 struct MusicControlsView: View {
     @ObservedObject var musicManager = MusicManager.shared
-        @EnvironmentObject var vm: BoringViewModel
-        @ObservedObject var webcamManager = WebcamManager.shared
     @State private var sliderValue: Double = 0
     @State private var dragging: Bool = false
     @State private var lastDragged: Date = .distantPast
@@ -227,14 +225,7 @@ struct MusicControlsView: View {
             MusicControlButton.maxSlotCount
         )
         let padded = slotConfig.padded(to: sanitizedLimit, filler: .none)
-        let result = Array(padded.prefix(sanitizedLimit))
-        // If calendar and camera are both visible alongside music, hide the edge slots
-        let shouldHideEdges = Defaults[.showCalendar] && Defaults[.showMirror] && webcamManager.cameraAvailable && vm.isCameraExpanded
-        if shouldHideEdges && result.count >= 5 {
-            return Array(result.dropFirst().dropLast())
-        }
-
-        return result
+        return Array(padded.prefix(sanitizedLimit))
     }
 
     @ViewBuilder
@@ -425,6 +416,11 @@ struct NotchHomeView: View {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     let albumArtNamespace: Namespace.ID
 
+    @Default(.pomodoroEnabled) private var pomodoroEnabled
+    @Default(.quickLaunchApps) private var quickLaunchApps
+    @Default(.quickLaunchEnabled) private var quickLaunchEnabled
+    @Default(.weatherFeatureEnabled) private var weatherFeatureEnabled
+
     var body: some View {
         Group {
             if !coordinator.firstLaunch {
@@ -440,30 +436,505 @@ struct NotchHomeView: View {
     }
 
     private var mainContent: some View {
-        HStack(alignment: .top, spacing: (shouldShowCamera && Defaults[.showCalendar]) ? 10 : 15) {
-            MusicPlayerView(albumArtNamespace: albumArtNamespace)
-
-            if Defaults[.showCalendar] {
-                CalendarView()
-                    .frame(width: shouldShowCamera ? 170 : 215)
-                    .onHover { isHovering in
-                        vm.isHoveringCalendar = isHovering
-                    }
-                    .environmentObject(vm)
-                    .transition(.opacity)
+        VStack(alignment: .leading, spacing: 14) {
+            if shouldShowUtilityRow {
+                utilityRow
             }
 
             if shouldShowCamera {
-                CameraPreviewView(webcamManager: webcamManager)
-                    .scaledToFit()
-                    .opacity(vm.notchState == .closed ? 0 : 1)
-                    .blur(radius: vm.notchState == .closed ? 20 : 0)
-                    .animation(.interactiveSpring(response: 0.32, dampingFraction: 0.76, blendDuration: 0), value: shouldShowCamera)
+                footerRow
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .transition(.asymmetric(insertion: .opacity.combined(with: .move(edge: .top)), removal: .opacity))
         .blur(radius: vm.notchState == .closed ? 30 : 0)
     }
+
+    private var shouldShowUtilityRow: Bool {
+        weatherFeatureEnabled || pomodoroEnabled || quickLaunchEnabled || Defaults[.showCalendar]
+    }
+
+    private var utilityRow: some View {
+        HStack(alignment: .top, spacing: 12) {
+            if weatherFeatureEnabled {
+                HomeWeatherCard()
+            }
+
+            if pomodoroEnabled {
+                HomePomodoroCard()
+            }
+
+            if quickLaunchEnabled {
+                QuickLaunchHomeCard(apps: quickLaunchApps)
+            }
+
+            if Defaults[.showCalendar] {
+                HomeCalendarPanel()
+                    .environmentObject(vm)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var footerRow: some View {
+        HStack(alignment: .top, spacing: 12) {
+            if shouldShowCamera {
+                HomeCameraPanel(webcamManager: webcamManager)
+                    .frame(width: 176)
+                    .environmentObject(vm)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+}
+
+private struct HomeCalendarPanel: View {
+    @EnvironmentObject var vm: BoringViewModel
+
+    var body: some View {
+        CalendarView()
+            .frame(maxWidth: .infinity)
+            .onHover { isHovering in
+                vm.isHoveringCalendar = isHovering
+            }
+            .frame(minHeight: 214, alignment: .topLeading)
+            .padding(12)
+            .background(Color.white.opacity(0.04))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct HomeCameraPanel: View {
+    @EnvironmentObject var vm: BoringViewModel
+    let webcamManager: WebcamManager
+
+    var body: some View {
+        CameraPreviewView(webcamManager: webcamManager)
+            .scaledToFit()
+            .padding(8)
+            .background(Color.white.opacity(0.04))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .opacity(vm.notchState == .closed ? 0 : 1)
+            .blur(radius: vm.notchState == .closed ? 20 : 0)
+            .animation(
+                .interactiveSpring(response: 0.32, dampingFraction: 0.76, blendDuration: 0),
+                value: webcamManager.cameraAvailable
+            )
+    }
+}
+
+private struct HomeWeatherCard: View {
+    @Default(.weatherCity) private var weatherCity
+    @Default(.weatherLocationMode) private var weatherLocationMode
+
+    @ObservedObject private var manager = WeatherManager.shared
+
+    var body: some View {
+        HomeWidgetCard(
+            title: "天气",
+            subtitle: subtitle
+        ) {
+            if let snapshot = manager.snapshot {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(alignment: .center, spacing: 10) {
+                        HomeWeatherIcon(symbolName: snapshot.current.symbolName, size: 38)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                                Text("\(Int(snapshot.current.temperature.rounded()))\(snapshot.current.unitSymbol)")
+                                    .font(.system(size: 26, weight: .semibold, design: .rounded))
+                                Text(snapshot.current.condition)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+
+                            if let high = snapshot.current.highTemperature, let low = snapshot.current.lowTemperature {
+                                Text("最高 \(Int(high.rounded()))\(snapshot.current.unitSymbol)  最低 \(Int(low.rounded()))\(snapshot.current.unitSymbol)")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                        }
+
+                        Spacer(minLength: 0)
+                    }
+
+                    if !snapshot.hourly.isEmpty {
+                        HStack(spacing: 6) {
+                            ForEach(snapshot.hourly.prefix(3)) { entry in
+                                HomeWeatherHour(entry: entry)
+                                    .frame(maxWidth: .infinity)
+                            }
+                        }
+                    }
+
+                    HStack(spacing: 8) {
+                        compactMetric("体感", "\(Int(snapshot.current.feelsLike.rounded()))\(snapshot.current.unitSymbol)")
+                        compactMetric("湿度", "\(snapshot.current.humidity)%")
+                        compactMetric("风速", "\(Int(snapshot.current.windSpeed.rounded())) \(snapshot.current.windUnit)")
+                    }
+
+                    HStack(spacing: 8) {
+                        actionButton("刷新", systemImage: "arrow.clockwise") {
+                            Task {
+                                await manager.refreshWeather(force: true)
+                            }
+                        }
+
+                        if manager.locationAuthorizationStatus == .denied || manager.locationAuthorizationStatus == .restricted {
+                            actionButton("设置", systemImage: "location.slash") {
+                                manager.openLocationSettings()
+                            }
+                        }
+                    }
+                }
+            } else if manager.isRefreshing {
+                VStack(alignment: .leading, spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("正在获取最新天气...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(manager.lastError ?? "天气暂时不可用。")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    HStack(spacing: 8) {
+                        if weatherLocationMode == .automatic && manager.locationAuthorizationStatus == .notDetermined {
+                            actionButton("允许定位", systemImage: "location") {
+                                Task {
+                                    await manager.requestLocationAuthorization()
+                                }
+                            }
+                        } else if !manager.locationServicesEnabled {
+                            actionButton("设置", systemImage: "location.slash") {
+                                manager.openLocationSettings()
+                            }
+                        } else if weatherLocationMode == .automatic &&
+                            (manager.locationAuthorizationStatus == .denied || manager.locationAuthorizationStatus == .restricted)
+                        {
+                            actionButton("设置", systemImage: "location.slash") {
+                                manager.openLocationSettings()
+                            }
+                        } else {
+                            actionButton("刷新", systemImage: "arrow.clockwise") {
+                                Task {
+                                    await manager.refreshWeather(force: true)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            manager.refreshLocationAccessState()
+        }
+    }
+
+    private var subtitle: String {
+        if let locationName = manager.snapshot?.locationName, !locationName.isEmpty {
+            return shortLocationName(from: locationName)
+        }
+
+        if weatherLocationMode == .automatic {
+            return "当前位置"
+        }
+
+        let trimmedCity = weatherCity.trimmingCharacters(in: .whitespacesAndNewlines)
+        return shortLocationName(from: trimmedCity.isEmpty ? defaultWeatherCityName() : trimmedCity)
+    }
+
+    private func shortLocationName(from locationName: String) -> String {
+        locationName
+            .split(separator: ",")
+            .first
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .flatMap { $0.isEmpty ? nil : $0 }
+            ?? locationName
+    }
+}
+
+private struct HomeWeatherHour: View {
+    let entry: WeatherSnapshot.HourlyEntry
+
+    var body: some View {
+        VStack(spacing: 5) {
+            Text(entry.timeLabel)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+            HomeWeatherIcon(symbolName: entry.symbolName, size: 24, cornerRadius: 6)
+            Text("\(Int(entry.temperature.rounded()))\(entry.unitSymbol)")
+                .font(.caption2.weight(.semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .monospacedDigit()
+        }
+        .frame(maxWidth: .infinity, minHeight: 54)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 6)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct HomeWeatherIcon: View {
+    let symbolName: String
+    let size: CGFloat
+    var cornerRadius: CGFloat = 9
+
+    var body: some View {
+        let palette = homeWeatherSymbolPalette(for: symbolName)
+
+        Image(systemName: symbolName)
+            .symbolRenderingMode(.palette)
+            .font(.system(size: size * 0.58, weight: .semibold))
+            .foregroundStyle(palette.primary, palette.secondary)
+            .frame(width: size, height: size)
+            .background(
+                LinearGradient(
+                    colors: [
+                        palette.primary.opacity(0.22),
+                        palette.secondary.opacity(0.10)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    }
+}
+
+private func homeWeatherSymbolPalette(for symbolName: String) -> (primary: Color, secondary: Color) {
+    if symbolName.contains("sun") {
+        return (.yellow, .orange)
+    }
+    if symbolName.contains("moon") {
+        return (.indigo, .cyan)
+    }
+    if symbolName.contains("bolt") {
+        return (.yellow, .purple)
+    }
+    if symbolName.contains("snow") {
+        return (.cyan, .blue)
+    }
+    if symbolName.contains("rain") || symbolName.contains("drizzle") {
+        return (.cyan, .blue)
+    }
+    if symbolName.contains("fog") {
+        return (.gray, .white.opacity(0.8))
+    }
+    return (.gray, .blue)
+}
+
+private struct HomePomodoroCard: View {
+    @ObservedObject private var manager = PomodoroManager.shared
+
+    var body: some View {
+        HomeWidgetCard(
+            title: "Pomodoro",
+            subtitle: manager.phase.rawValue
+        ) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(manager.formattedRemaining)
+                    .font(.system(size: 26, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+
+                ProgressView(value: manager.progress)
+                    .progressViewStyle(.linear)
+                    .tint(accentColor(for: manager.phase))
+
+                HStack(spacing: 8) {
+                    compactMetric("Next", manager.nextPhaseTitle)
+                    compactMetric("Session", manager.currentCycleIndexLabel)
+                    compactMetric("Done", "\(manager.completedFocusSessions)")
+                }
+
+                HStack(spacing: 8) {
+                    actionButton(
+                        manager.isRunning ? "Pause" : "Start",
+                        systemImage: manager.isRunning ? "pause.fill" : "play.fill",
+                        prominent: true,
+                        tint: accentColor(for: manager.phase)
+                    ) {
+                        manager.toggleRunning()
+                    }
+
+                    iconOnlyAction("forward.fill", help: "Skip phase") {
+                        manager.skipPhase()
+                    }
+
+                    iconOnlyAction("arrow.counterclockwise", help: "Reset phase") {
+                        manager.resetCurrentPhase()
+                    }
+                }
+            }
+        }
+    }
+
+    private func accentColor(for phase: PomodoroPhase) -> Color {
+        switch phase {
+        case .focus:
+            return .effectiveAccent
+        case .shortBreak:
+            return .green
+        case .longBreak:
+            return .orange
+        }
+    }
+}
+
+private struct QuickLaunchHomeCard: View {
+    @ObservedObject private var manager = QuickLaunchManager.shared
+
+    let apps: [QuickLaunchAppItem]
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 3)
+
+    var body: some View {
+        HomeWidgetCard(
+            title: "Quick launch",
+            subtitle: "Apps"
+        ) {
+            if apps.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Add apps in Settings > General.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    actionButton("Open settings", systemImage: "slider.horizontal.3") {
+                        SettingsWindowController.shared.showWindow()
+                    }
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 10) {
+                    LazyVGrid(columns: columns, spacing: 8) {
+                        ForEach(Array(apps.prefix(6))) { item in
+                            Button {
+                                manager.open(item)
+                            } label: {
+                                VStack(spacing: 6) {
+                                    AppIcon(for: item)
+                                        .resizable()
+                                        .frame(width: 30, height: 30)
+                                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                                    Text(item.displayName)
+                                        .font(.caption2)
+                                        .lineLimit(1)
+                                        .frame(maxWidth: .infinity)
+                                }
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 8)
+                                .frame(maxWidth: .infinity)
+                                .background(Color.white.opacity(0.05))
+                                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+
+                    if let lastError = manager.lastError, !lastError.isEmpty {
+                        Text(lastError)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct HomeWidgetCard<Content: View>: View {
+    let title: String
+    let subtitle: String
+    let content: Content
+
+    init(title: String, subtitle: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.subtitle = subtitle
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(title)
+                    .font(.headline)
+                Spacer(minLength: 8)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            content
+        }
+        .frame(maxWidth: .infinity, minHeight: 214, alignment: .topLeading)
+        .padding(12)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private func compactMetric(_ title: String, _ value: String) -> some View {
+    VStack(alignment: .leading, spacing: 3) {
+        Text(title)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.72)
+        Text(value)
+            .font(.caption.weight(.semibold))
+            .lineLimit(1)
+            .minimumScaleFactor(0.82)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.horizontal, 8)
+    .padding(.vertical, 7)
+    .background(Color.white.opacity(0.05))
+    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+}
+
+private func actionButton(
+    _ title: String,
+    systemImage: String,
+    prominent: Bool = false,
+    tint: Color? = nil,
+    action: @escaping () -> Void
+) -> some View {
+    Group {
+        if prominent {
+            Button(action: action) {
+                Label(title, systemImage: systemImage)
+            }
+            .buttonStyle(.borderedProminent)
+        } else {
+            Button(action: action) {
+                Label(title, systemImage: systemImage)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+    .tint(tint)
+    .controlSize(.small)
+}
+
+private func iconOnlyAction(_ systemImage: String, help: String, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+        Image(systemName: systemImage)
+            .frame(width: 22)
+    }
+    .buttonStyle(.bordered)
+    .controlSize(.small)
+    .help(help)
 }
 
 struct MusicSliderView: View {

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -628,6 +628,14 @@ private struct HomeWeatherCard: View {
                         }
                     }
 
+                    if let precipitationSummary = snapshot.upcomingPrecipitationSummary {
+                        Label(precipitationSummary, systemImage: "cloud.rain.fill")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.72)
+                    }
+
                     HStack(spacing: 8) {
                         compactMetric("体感", "\(Int(snapshot.current.feelsLike.rounded()))\(snapshot.current.unitSymbol)")
                         compactMetric("湿度", "\(snapshot.current.humidity)%")
@@ -730,11 +738,20 @@ private struct HomeWeatherHour: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
             HomeWeatherIcon(symbolName: entry.symbolName, size: 24, cornerRadius: 6)
-            Text("\(Int(entry.temperature.rounded()))\(entry.unitSymbol)")
-                .font(.caption2.weight(.semibold))
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-                .monospacedDigit()
+            HStack(spacing: 4) {
+                Text("\(Int(entry.temperature.rounded()))\(entry.unitSymbol)")
+                    .font(.caption2.weight(.semibold))
+
+                if let probability = entry.precipitationProbability {
+                    Label("\(probability)%", systemImage: "drop.fill")
+                        .labelStyle(.titleAndIcon)
+                        .font(.system(size: 8, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+            .monospacedDigit()
         }
         .frame(maxWidth: .infinity, minHeight: 54)
         .padding(.horizontal, 7)
@@ -852,18 +869,21 @@ private struct HomePomodoroCard: View {
 
 private struct QuickLaunchHomeCard: View {
     @ObservedObject private var manager = QuickLaunchManager.shared
+    @ObservedObject private var batteryManager = BluetoothAccessoryBatteryManager.shared
+    @Default(.showBluetoothAccessoryBatteries) private var showBluetoothAccessoryBatteries
+    @Default(.hiddenBluetoothAccessoryIDs) private var hiddenBluetoothAccessoryIDs
 
     let apps: [QuickLaunchAppItem]
 
-    private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 3)
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 6), count: 3)
 
     var body: some View {
         HomeWidgetCard(
             title: "Quick launch",
             subtitle: "Apps"
         ) {
-            if apps.isEmpty {
-                VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 8) {
+                if apps.isEmpty {
                     Text("Add apps in Settings > General.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -871,26 +891,24 @@ private struct QuickLaunchHomeCard: View {
                     actionButton("Open settings", systemImage: "slider.horizontal.3") {
                         SettingsWindowController.shared.showWindow()
                     }
-                }
-            } else {
-                VStack(alignment: .leading, spacing: 10) {
-                    LazyVGrid(columns: columns, spacing: 8) {
+                } else {
+                    LazyVGrid(columns: columns, spacing: 6) {
                         ForEach(Array(apps.prefix(6))) { item in
                             Button {
                                 manager.open(item)
                             } label: {
-                                VStack(spacing: 6) {
+                                VStack(spacing: 4) {
                                     AppIcon(for: item)
                                         .resizable()
-                                        .frame(width: 30, height: 30)
-                                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                                        .frame(width: 28, height: 28)
+                                        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
                                     Text(item.displayName)
                                         .font(.caption2)
                                         .lineLimit(1)
                                         .frame(maxWidth: .infinity)
                                 }
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 8)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 6)
                                 .frame(maxWidth: .infinity)
                                 .background(Color.white.opacity(0.05))
                                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
@@ -898,16 +916,162 @@ private struct QuickLaunchHomeCard: View {
                             .buttonStyle(.plain)
                         }
                     }
+                }
 
-                    if let lastError = manager.lastError, !lastError.isEmpty {
-                        Text(lastError)
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
-                    }
+                if showBluetoothAccessoryBatteries {
+                    BluetoothAccessoryBatteryStrip(
+                        manager: batteryManager,
+                        hiddenDeviceIDs: Set(hiddenBluetoothAccessoryIDs)
+                    )
+                }
+
+                if let lastError = manager.lastError, !lastError.isEmpty {
+                    Text(lastError)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
                 }
             }
         }
+        .onAppear {
+            if showBluetoothAccessoryBatteries {
+                batteryManager.startMonitoring()
+            }
+        }
+        .onDisappear {
+            batteryManager.stopMonitoring()
+        }
+        .onChange(of: showBluetoothAccessoryBatteries) { _, isEnabled in
+            if isEnabled {
+                batteryManager.startMonitoring()
+            } else {
+                batteryManager.stopMonitoring()
+            }
+        }
+    }
+}
+
+private struct BluetoothAccessoryBatteryStrip: View {
+    @ObservedObject var manager: BluetoothAccessoryBatteryManager
+    let hiddenDeviceIDs: Set<String>
+
+    private var visibleDevices: [BluetoothAccessoryBatteryDevice] {
+        manager.devices.filter { !hiddenDeviceIDs.contains($0.id) }
+    }
+
+    var body: some View {
+        VStack(spacing: 5) {
+            Divider()
+                .overlay(Color.white.opacity(0.08))
+
+            HStack(spacing: 6) {
+                if visibleDevices.isEmpty {
+                    Image(systemName: "dot.radiowaves.left.and.right")
+                        .foregroundStyle(.secondary)
+                    Text(emptyStateText)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                } else {
+                    ScrollView(.horizontal) {
+                        HStack(spacing: 6) {
+                            ForEach(visibleDevices) { device in
+                                BluetoothAccessoryBatteryChip(device: device)
+                            }
+                        }
+                    }
+                    .scrollIndicators(.hidden)
+                }
+
+                Spacer(minLength: 0)
+
+                Button {
+                    Task {
+                        await manager.refresh(force: true)
+                    }
+                } label: {
+                    if manager.isRefreshing {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .frame(width: 18, height: 18)
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 10, weight: .semibold))
+                            .frame(width: 18, height: 18)
+                    }
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("刷新蓝牙设备电量")
+            }
+            .frame(height: 34)
+        }
+    }
+
+    private var emptyStateText: String {
+        if let lastError = manager.lastError { return lastError }
+        if manager.isRefreshing { return "正在读取设备电量..." }
+        if !manager.devices.isEmpty { return "设备电量已在设置中隐藏" }
+        return "未检测到已连接设备电量"
+    }
+}
+
+private struct BluetoothAccessoryBatteryChip: View {
+    let device: BluetoothAccessoryBatteryDevice
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: device.systemImage)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(Color.effectiveAccent)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(device.name)
+                    .font(.caption2.weight(.medium))
+                    .lineLimit(1)
+
+                HStack(spacing: 5) {
+                    ForEach(device.parts) { part in
+                        HStack(spacing: 2) {
+                            if !part.kind.shortLabel.isEmpty {
+                                Text(part.kind.shortLabel)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Image(systemName: batterySymbol(for: part.percentage, isCharging: part.isCharging))
+                            Text("\(part.percentage)%")
+                                .monospacedDigit()
+                        }
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(batteryColor(for: part.percentage, isCharging: part.isCharging))
+                    }
+                }
+                .lineLimit(1)
+            }
+        }
+        .padding(.horizontal, 7)
+        .frame(height: 32)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .accessibilityElement(children: .combine)
+    }
+
+    private func batterySymbol(for percentage: Int, isCharging: Bool) -> String {
+        if isCharging { return "battery.100.bolt" }
+        switch percentage {
+        case 76 ... 100: return "battery.100"
+        case 51 ... 75: return "battery.75"
+        case 26 ... 50: return "battery.50"
+        case 1 ... 25: return "battery.25"
+        default: return "battery.0"
+        }
+    }
+
+    private func batteryColor(for percentage: Int, isCharging: Bool) -> Color {
+        if isCharging { return .green }
+        if percentage <= 10 { return .red }
+        if percentage <= 25 { return .orange }
+        return .primary
     }
 }
 
@@ -976,10 +1140,27 @@ private struct HomeMediaCard: View {
                 .frame(maxWidth: .infinity, alignment: .center)
 
                 if Defaults[.enableLyrics], musicManager.isPlaying {
-                    Text(currentLyricLine)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
+                    TimelineView(.periodic(from: .now, by: 0.35)) { timeline in
+                        let snapshot = musicManager.lyricDisplaySnapshot(
+                            at: musicManager.estimatedElapsedTime(at: timeline.date)
+                        )
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(snapshot.current)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(snapshot.isPlaceholder ? .tertiary : .secondary)
+                                .lineLimit(2)
+                                .help(snapshot.current)
+
+                            if let next = snapshot.next, !next.isEmpty {
+                                Text(next)
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                                    .lineLimit(1)
+                                    .help(next)
+                            }
+                        }
+                        .animation(.easeInOut(duration: 0.18), value: snapshot.current)
+                    }
                 }
             }
         }
@@ -1012,11 +1193,6 @@ private struct HomeMediaCard: View {
 
     private var activeSourceLabel: String {
         Defaults[.mediaController].rawValue
-    }
-
-    private var currentLyricLine: String {
-        let trimmed = musicManager.currentLyrics.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? "Lyrics enabled" : trimmed.replacingOccurrences(of: "\n", with: " ")
     }
 
     private func mediaButton(

--- a/boringNotch/components/Notch/PomodoroDashboardView.swift
+++ b/boringNotch/components/Notch/PomodoroDashboardView.swift
@@ -1,0 +1,202 @@
+//
+//  PomodoroDashboardView.swift
+//  boringNotch
+//
+//  Created by Codex on 2026-06-30.
+//
+
+import Defaults
+import SwiftUI
+
+struct PomodoroDashboardView: View {
+    @Default(.pomodoroEnabled) private var pomodoroEnabled
+
+    @ObservedObject private var manager = PomodoroManager.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+
+            if !pomodoroEnabled {
+                featureDisabledState(
+                    title: "Pomodoro is disabled",
+                    subtitle: "Enable it in Settings > Pomodoro to use the focus timer."
+                )
+            } else {
+                timerCard
+                phaseSelector
+                statsRow
+                controls
+            }
+        }
+        .padding(.horizontal, 4)
+        .padding(.bottom, 4)
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Pomodoro")
+                    .font(.headline)
+                Text(manager.phase.rawValue)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Image(systemName: manager.phase.symbolName)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(accentColor(for: manager.phase))
+        }
+    }
+
+    private var timerCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(manager.formattedRemaining)
+                    .font(.system(size: 34, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+
+                Spacer()
+
+                Text(manager.isRunning ? "Running" : "Ready")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+
+            ProgressView(value: manager.progress)
+                .progressViewStyle(.linear)
+                .tint(accentColor(for: manager.phase))
+
+            Text("Next: \(manager.nextPhaseTitle)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(12)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private var phaseSelector: some View {
+        HStack(spacing: 8) {
+            ForEach(PomodoroPhase.allCases) { phase in
+                Button {
+                    manager.selectPhase(phase)
+                } label: {
+                    Text(phase.shortLabel)
+                        .font(.caption.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 7)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .fill(manager.phase == phase ? accentColor(for: phase).opacity(0.24) : Color.white.opacity(0.05))
+                        )
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(manager.phase == phase ? Color.effectiveAccent : .primary)
+            }
+        }
+    }
+
+    private var statsRow: some View {
+        HStack(spacing: 8) {
+            PomodoroStatTile(title: "Session", value: manager.currentCycleIndexLabel)
+            PomodoroStatTile(title: "Completed", value: "\(manager.completedFocusSessions)")
+            PomodoroStatTile(title: "Auto-start", value: Defaults[.pomodoroAutoStartNextPhase] ? "On" : "Off")
+        }
+    }
+
+    private var controls: some View {
+        HStack(spacing: 8) {
+            Button {
+                manager.toggleRunning()
+            } label: {
+                Label(manager.isRunning ? "Pause" : "Start", systemImage: manager.isRunning ? "pause.fill" : "play.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(accentColor(for: manager.phase))
+
+            Button {
+                manager.resetCurrentPhase()
+            } label: {
+                Image(systemName: "arrow.counterclockwise")
+                    .frame(width: 28)
+            }
+            .buttonStyle(.bordered)
+            .help("Reset current phase")
+
+            Button {
+                manager.skipPhase()
+            } label: {
+                Image(systemName: "forward.fill")
+                    .frame(width: 28)
+            }
+            .buttonStyle(.bordered)
+            .help("Skip to next phase")
+
+            Button {
+                manager.resetCycle()
+            } label: {
+                Image(systemName: "stop.fill")
+                    .frame(width: 28)
+            }
+            .buttonStyle(.bordered)
+            .help("Reset full cycle")
+        }
+        .controlSize(.small)
+    }
+
+    private func featureDisabledState(title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Button("Open Settings") {
+                SettingsWindowController.shared.showWindow()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(12)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private func accentColor(for phase: PomodoroPhase) -> Color {
+        switch phase {
+        case .focus:
+            return Color.effectiveAccent
+        case .shortBreak:
+            return .green
+        case .longBreak:
+            return .orange
+        }
+    }
+}
+
+private struct PomodoroStatTile: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}

--- a/boringNotch/components/Notch/ScreenMediaBar.swift
+++ b/boringNotch/components/Notch/ScreenMediaBar.swift
@@ -1,0 +1,311 @@
+//
+//  ScreenMediaBar.swift
+//  boringNotch
+//
+
+import AppKit
+import Combine
+import Defaults
+import SwiftUI
+
+@MainActor
+final class ScreenMediaBarController: NSObject, NSWindowDelegate {
+    static let shared = ScreenMediaBarController()
+
+    private let barSize = CGSize(width: 620, height: 88)
+    private var panel: NSPanel?
+    private var cancellables = Set<AnyCancellable>()
+    private var isApplyingPosition = false
+    private var visibilityTransitionID = UUID()
+
+    private override init() {
+        super.init()
+
+        let musicManager = MusicManager.shared
+        Publishers.MergeMany([
+            musicManager.$isPlaying.removeDuplicates().map { _ in () }.eraseToAnyPublisher(),
+            musicManager.$isPlayerIdle.removeDuplicates().map { _ in () }.eraseToAnyPublisher(),
+            musicManager.$songTitle.removeDuplicates().map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.screenMediaBarEnabled).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.screenMediaBarAlwaysOnTop).map { _ in () }.eraseToAnyPublisher(),
+        ])
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] in
+            self?.updateVisibility()
+        }
+        .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.ensureVisiblePosition()
+            }
+            .store(in: &cancellables)
+
+        updateVisibility()
+    }
+
+    func resetPosition() {
+        Defaults[.screenMediaBarOriginX] = -100_000
+        Defaults[.screenMediaBarOriginY] = -100_000
+        guard let panel else { return }
+        applyPosition(defaultOrigin(for: panel.frame.size))
+    }
+
+    func stop() {
+        cancellables.removeAll()
+        visibilityTransitionID = UUID()
+        panel?.orderOut(nil)
+        panel?.close()
+        panel = nil
+    }
+
+    private func updateVisibility() {
+        updateWindowLevel()
+        let shouldShow = Defaults[.screenMediaBarEnabled]
+            && (MusicManager.shared.isPlaying || !MusicManager.shared.isPlayerIdle)
+            && !MusicManager.shared.songTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+        if shouldShow {
+            show()
+        } else {
+            hide()
+        }
+    }
+
+    private func show() {
+        let panel = panel ?? makePanel()
+        guard !panel.isVisible else {
+            panel.alphaValue = 1
+            return
+        }
+
+        ensureVisiblePosition()
+        let transitionID = UUID()
+        visibilityTransitionID = transitionID
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.20
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = 1
+        } completionHandler: { [weak self, weak panel] in
+            Task { @MainActor in
+                guard self?.visibilityTransitionID == transitionID else { return }
+                panel?.alphaValue = 1
+            }
+        }
+    }
+
+    private func hide() {
+        guard let panel, panel.isVisible else { return }
+        let transitionID = UUID()
+        visibilityTransitionID = transitionID
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.16
+            context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            panel.animator().alphaValue = 0
+        } completionHandler: { [weak self, weak panel] in
+            Task { @MainActor in
+                guard self?.visibilityTransitionID == transitionID else { return }
+                panel?.orderOut(nil)
+                panel?.alphaValue = 1
+            }
+        }
+    }
+
+    private func makePanel() -> NSPanel {
+        let panel = ScreenMediaPanel(
+            contentRect: NSRect(origin: .zero, size: barSize),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.identifier = NSUserInterfaceItemIdentifier("DanShenScreenMediaBar")
+        panel.contentView = NSHostingView(rootView: ScreenMediaBarView())
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.isFloatingPanel = Defaults[.screenMediaBarAlwaysOnTop]
+        panel.hidesOnDeactivate = false
+        panel.isMovable = true
+        panel.isMovableByWindowBackground = true
+        panel.isReleasedWhenClosed = false
+        configureWindowLevel(panel)
+        panel.appearance = NSAppearance(named: .darkAqua)
+        panel.delegate = self
+        self.panel = panel
+
+        applyPosition(restoredOrigin(for: panel.frame.size) ?? defaultOrigin(for: panel.frame.size))
+        return panel
+    }
+
+    private func updateWindowLevel() {
+        guard let panel else { return }
+        configureWindowLevel(panel)
+    }
+
+    private func configureWindowLevel(_ panel: NSPanel) {
+        let staysOnTop = Defaults[.screenMediaBarAlwaysOnTop]
+        panel.isFloatingPanel = staysOnTop
+        panel.level = staysOnTop ? .floating : .normal
+        panel.collectionBehavior = staysOnTop
+            ? [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
+            : [.managed, .ignoresCycle]
+    }
+
+    private func ensureVisiblePosition() {
+        guard let panel else { return }
+        if !isUsablyVisible(panel.frame) {
+            applyPosition(defaultOrigin(for: panel.frame.size))
+        }
+    }
+
+    private func restoredOrigin(for size: CGSize) -> CGPoint? {
+        let x = Defaults[.screenMediaBarOriginX]
+        let y = Defaults[.screenMediaBarOriginY]
+        guard x > -99_999, y > -99_999 else { return nil }
+
+        let origin = CGPoint(x: x, y: y)
+        let frame = NSRect(origin: origin, size: size)
+        return isUsablyVisible(frame) ? origin : nil
+    }
+
+    private func defaultOrigin(for size: CGSize) -> CGPoint {
+        let preferredScreen = NSScreen.screen(withUUID: BoringViewCoordinator.shared.selectedScreenUUID)
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        let visibleFrame = preferredScreen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        return CGPoint(
+            x: visibleFrame.midX - size.width / 2,
+            y: visibleFrame.minY + 24
+        )
+    }
+
+    private func isUsablyVisible(_ frame: NSRect) -> Bool {
+        NSScreen.screens.contains { screen in
+            let intersection = screen.visibleFrame.intersection(frame)
+            return intersection.width >= 120 && intersection.height >= 40
+        }
+    }
+
+    private func applyPosition(_ origin: CGPoint) {
+        guard let panel else { return }
+        isApplyingPosition = true
+        panel.setFrameOrigin(origin)
+        isApplyingPosition = false
+    }
+
+    func windowDidMove(_ notification: Notification) {
+        guard !isApplyingPosition, let panel else { return }
+        Defaults[.screenMediaBarOriginX] = panel.frame.origin.x
+        Defaults[.screenMediaBarOriginY] = panel.frame.origin.y
+    }
+}
+
+private final class ScreenMediaPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+private struct ScreenMediaBarView: View {
+    @ObservedObject private var musicManager = MusicManager.shared
+    @Default(.enableLyrics) private var enableLyrics
+    @Default(.screenMediaBarShowsLyrics) private var showsLyrics
+
+    var body: some View {
+        HStack(spacing: 12) {
+            artwork
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(musicManager.songTitle)
+                    .font(.system(size: 14, weight: .semibold))
+                    .lineLimit(1)
+                Text(musicManager.artistName)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                if enableLyrics, showsLyrics {
+                    TimelineView(.periodic(from: .now, by: 0.35)) { timeline in
+                        let snapshot = musicManager.lyricDisplaySnapshot(
+                            at: musicManager.estimatedElapsedTime(at: timeline.date)
+                        )
+                        HStack(spacing: 5) {
+                            Image(systemName: "quote.bubble.fill")
+                                .font(.system(size: 9, weight: .semibold))
+                            Text(snapshot.current)
+                                .lineLimit(1)
+                                .help(snapshot.current)
+                        }
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(snapshot.isPlaceholder ? .tertiary : .secondary)
+                        .animation(.easeInOut(duration: 0.18), value: snapshot.current)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: 6) {
+                controlButton("backward.fill", help: "上一首") {
+                    musicManager.previousTrack()
+                }
+                controlButton(musicManager.isPlaying ? "pause.fill" : "play.fill", help: "播放或暂停", prominent: true) {
+                    musicManager.togglePlay()
+                }
+                controlButton("forward.fill", help: "下一首") {
+                    musicManager.nextTrack()
+                }
+                controlButton("music.note", help: "打开播放器") {
+                    musicManager.openMusicApp()
+                }
+                controlButton("xmark", help: "隐藏屏幕媒体条") {
+                    Defaults[.screenMediaBarEnabled] = false
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(width: 620, height: 88)
+        .background {
+            VisualEffectView(material: .hudWindow, blendingMode: .behindWindow)
+            Color.black.opacity(0.24)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+        }
+    }
+
+    private var artwork: some View {
+        Image(nsImage: musicManager.albumArt)
+            .resizable()
+            .aspectRatio(1, contentMode: .fill)
+            .frame(width: 58, height: 58)
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .contentShape(Rectangle())
+            .onTapGesture {
+                musicManager.openMusicApp()
+            }
+    }
+
+    private func controlButton(
+        _ symbolName: String,
+        help: String,
+        prominent: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: symbolName)
+                .font(.system(size: prominent ? 14 : 12, weight: .semibold))
+                .frame(width: prominent ? 38 : 32, height: 32)
+                .background(Color.white.opacity(prominent ? 0.16 : 0.07))
+                .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+}

--- a/boringNotch/components/Notch/WeatherDashboardView.swift
+++ b/boringNotch/components/Notch/WeatherDashboardView.swift
@@ -1,0 +1,355 @@
+//
+//  WeatherDashboardView.swift
+//  boringNotch
+//
+//  Created by Codex on 2026-06-30.
+//
+
+import Defaults
+import Foundation
+import SwiftUI
+
+struct WeatherDashboardView: View {
+    @Default(.weatherFeatureEnabled) private var weatherFeatureEnabled
+
+    @ObservedObject private var manager = WeatherManager.shared
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 4)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+
+            if !weatherFeatureEnabled {
+                featureState(
+                    title: "天气已关闭",
+                    subtitle: "在设置 > Weather 中开启后即可获取实时天气。"
+                )
+            } else if let snapshot = manager.snapshot {
+                weatherContent(snapshot: snapshot)
+            } else if manager.isRefreshing {
+                loadingState
+            } else {
+                featureState(
+                    title: "天气不可用",
+                    subtitle: manager.lastError ?? "检查设置里的城市后再试一次。"
+                )
+            }
+        }
+        .task {
+            await manager.refreshWeather(force: false)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("天气")
+                    .font(.headline)
+                Text(
+                    (manager.snapshot?.locationName).flatMap { $0.isEmpty ? nil : $0 }
+                        ?? {
+                            let city = Defaults[.weatherCity].trimmingCharacters(in: .whitespacesAndNewlines)
+                            return city.isEmpty ? defaultWeatherCityName() : city
+                        }()
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+
+            Spacer()
+
+            if manager.isRefreshing {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Button {
+                Task {
+                    await manager.refreshWeather(force: true)
+                }
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("刷新天气")
+        }
+    }
+
+    private func weatherContent(snapshot: WeatherSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 14) {
+                WeatherConditionIcon(symbolName: snapshot.current.symbolName, size: 44)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text(temperatureLabel(snapshot.current.temperature, unit: snapshot.current.unitSymbol))
+                            .font(.system(size: 34, weight: .semibold, design: .rounded))
+                        Text(snapshot.current.condition)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack(spacing: 8) {
+                        Text("体感 \(temperatureLabel(snapshot.current.feelsLike, unit: snapshot.current.unitSymbol))")
+                        if let high = snapshot.current.highTemperature, let low = snapshot.current.lowTemperature {
+                            Text("最高 \(temperatureLabel(high, unit: snapshot.current.unitSymbol))")
+                            Text("最低 \(temperatureLabel(low, unit: snapshot.current.unitSymbol))")
+                        }
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+            }
+
+            if let high = snapshot.current.highTemperature, let low = snapshot.current.lowTemperature {
+                WeatherRangeBar(
+                    low: low,
+                    high: high,
+                    current: snapshot.current.temperature,
+                    unit: snapshot.current.unitSymbol
+                )
+            }
+
+            LazyVGrid(columns: columns, spacing: 8) {
+                WeatherMetricTile(systemImage: "humidity.fill", title: "湿度", value: "\(snapshot.current.humidity)%")
+                WeatherMetricTile(systemImage: "wind", title: "风速", value: "\(Int(snapshot.current.windSpeed.rounded())) \(snapshot.current.windUnit)")
+                WeatherMetricTile(systemImage: "drop.fill", title: "降水", value: precipitationLabel(snapshot.current.precipitation))
+                WeatherMetricTile(systemImage: "clock", title: "更新", value: refreshLabel(snapshot.updatedAt))
+            }
+
+            if !snapshot.hourly.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(snapshot.hourly) { entry in
+                            WeatherHourChip(entry: entry)
+                        }
+                    }
+                    .padding(.vertical, 1)
+                }
+            }
+
+            if let lastError = manager.lastError {
+                Text(lastError)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var loadingState: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text("正在获取最新天气...")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(12)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private func featureState(title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Button("打开设置") {
+                SettingsWindowController.shared.showWindow()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(12)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private func temperatureLabel(_ value: Double, unit: String) -> String {
+        "\(Int(value.rounded()))\(unit)"
+    }
+
+    private func precipitationLabel(_ value: Double) -> String {
+        "\(String(format: "%.1f", value)) mm"
+    }
+
+    private func refreshLabel(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: date)
+    }
+}
+
+private struct WeatherMetricTile: View {
+    let systemImage: String
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 5) {
+                Image(systemName: systemImage)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Color.effectiveAccent)
+                Text(title)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Text(value)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct WeatherHourChip: View {
+    let entry: WeatherSnapshot.HourlyEntry
+
+    var body: some View {
+        VStack(spacing: 5) {
+            Text(entry.timeLabel)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+            WeatherConditionIcon(symbolName: entry.symbolName, size: 22, cornerRadius: 6)
+            Text("\(Int(entry.temperature.rounded()))\(entry.unitSymbol)")
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+                .monospacedDigit()
+            if let probability = entry.precipitationProbability {
+                HStack(spacing: 2) {
+                    Image(systemName: "drop.fill")
+                    Text("\(probability)%")
+                }
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+        }
+        .frame(width: 68)
+        .frame(minHeight: 76)
+        .padding(.vertical, 7)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct WeatherConditionIcon: View {
+    let symbolName: String
+    let size: CGFloat
+    var cornerRadius: CGFloat = 10
+
+    var body: some View {
+        let palette = weatherSymbolPalette(for: symbolName)
+
+        Image(systemName: symbolName)
+            .symbolRenderingMode(.palette)
+            .font(.system(size: size * 0.58, weight: .semibold))
+            .foregroundStyle(palette.primary, palette.secondary)
+            .frame(width: size, height: size)
+            .background(
+                LinearGradient(
+                    colors: [
+                        palette.primary.opacity(0.22),
+                        palette.secondary.opacity(0.10)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    }
+}
+
+private struct WeatherRangeBar: View {
+    let low: Double
+    let high: Double
+    let current: Double
+    let unit: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text("今日温度")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("\(Int(low.rounded()))\(unit) - \(Int(high.rounded()))\(unit)")
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            GeometryReader { proxy in
+                let width = max(proxy.size.width - 8, 1)
+                let ratio = normalizedCurrentTemperature
+
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(
+                            LinearGradient(
+                                colors: [.green, .yellow, .orange, .pink, .purple],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                    Circle()
+                        .fill(Color.white)
+                        .frame(width: 8, height: 8)
+                        .shadow(color: .black.opacity(0.25), radius: 2, y: 1)
+                        .offset(x: width * ratio)
+                }
+            }
+            .frame(height: 8)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private var normalizedCurrentTemperature: Double {
+        guard high > low else { return 0.5 }
+        return min(max((current - low) / (high - low), 0), 1)
+    }
+}
+
+private func weatherSymbolPalette(for symbolName: String) -> (primary: Color, secondary: Color) {
+    if symbolName.contains("sun") {
+        return (.yellow, .orange)
+    }
+    if symbolName.contains("moon") {
+        return (.indigo, .cyan)
+    }
+    if symbolName.contains("bolt") {
+        return (.yellow, .purple)
+    }
+    if symbolName.contains("snow") {
+        return (.cyan, .blue)
+    }
+    if symbolName.contains("rain") || symbolName.contains("drizzle") {
+        return (.cyan, .blue)
+    }
+    if symbolName.contains("fog") {
+        return (.gray, .white.opacity(0.8))
+    }
+    return (.gray, .blue)
+}

--- a/boringNotch/components/Onboarding/OnboardingView.swift
+++ b/boringNotch/components/Onboarding/OnboardingView.swift
@@ -39,9 +39,9 @@ struct OnboardingView: View {
             case .cameraPermission:
                 PermissionRequestView(
                     icon: Image(systemName: "camera.fill"),
-                    title: "Enable Camera Access",
-                    description: "Boring Notch includes a mirror feature that lets you quickly check your appearance using your camera, right from the notch. Camera access is required only to show this live preview. You can turn the mirror feature on or off at any time in the app.",
-                    privacyNote: "Your camera is never used without your consent, and nothing is recorded or stored.",
+                    title: "启用摄像头权限",
+                    description: "Boring Notch包含镜子功能，可以直接在缺口区域快速查看摄像头预览。摄像头权限只用于显示实时画面，你可以随时在应用里关闭镜子功能。",
+                    privacyNote: "未经同意不会使用摄像头，也不会录制或存储画面。",
                     onAllow: {
                         Task {
                             await requestCameraPermission()
@@ -61,9 +61,9 @@ struct OnboardingView: View {
             case .calendarPermission:
                 PermissionRequestView(
                     icon: Image(systemName: "calendar"),
-                    title: "Enable Calendar Access",
-                    description: "Boring Notch can show all your upcoming events in one place. Access to your calendar is needed to display your schedule.",
-                    privacyNote: "Your calendar data is only used to show your events and is never shared.",
+                    title: "启用日历权限",
+                    description: "Boring Notch可以集中展示你的近期日程。需要日历权限来读取并显示日历事件。",
+                    privacyNote: "日历数据只用于本机展示和规划，不会上传或共享。",
                     onAllow: {
                         Task {
                                 await requestCalendarPermission()
@@ -83,9 +83,9 @@ struct OnboardingView: View {
                 case .remindersPermission:
                     PermissionRequestView(
                         icon: Image(systemName: "checklist"),
-                        title: "Enable Reminders Access",
-                        description: "Boring Notch can show your scheduled reminders alongside your calendar events. Access to Reminders is needed to display your reminders.",
-                        privacyNote: "Your reminders data is only used to show your reminders and is never shared.",
+                        title: "启用提醒事项权限",
+                        description: "Boring Notch可以把提醒事项和日历事件放在一起展示。需要提醒事项权限来读取你的待办内容。",
+                        privacyNote: "提醒事项数据只用于本机展示，不会上传或共享。",
                         onAllow: {
                             Task {
                                 await requestRemindersPermission()
@@ -105,9 +105,9 @@ struct OnboardingView: View {
             case .accessibilityPermission:
                 PermissionRequestView(
                     icon: Image(systemName: "hand.raised.fill"),
-                    title: "Enable Accessibility Access",
-                    description: "Accessibility access is required to replace system notifications with the Boring Notch HUD. This allows the app to intercept media and brightness events to display custom HUD overlays.",
-                    privacyNote: "Accessibility access is used only to improve media and brightness notifications. No data is collected or shared.",
+                    title: "启用辅助功能权限",
+                    description: "辅助功能权限用于接管系统媒体和亮度提示，并显示Boring Notch的自定义 HUD。",
+                    privacyNote: "辅助功能只用于改善本机提示体验，不会收集或共享数据。",
                     onAllow: {
                         Task {
                             await requestAccessibilityPermission()

--- a/boringNotch/components/Onboarding/OnboardingView.swift
+++ b/boringNotch/components/Onboarding/OnboardingView.swift
@@ -18,8 +18,6 @@ enum OnboardingStep {
     case finished
 }
 
-private let calendarService = CalendarService()
-
 struct OnboardingView: View {
     @State var step: OnboardingStep = .welcome
     let onFinish: () -> Void
@@ -40,7 +38,7 @@ struct OnboardingView: View {
                 PermissionRequestView(
                     icon: Image(systemName: "camera.fill"),
                     title: "启用摄像头权限",
-                    description: "Boring Notch包含镜子功能，可以直接在缺口区域快速查看摄像头预览。摄像头权限只用于显示实时画面，你可以随时在应用里关闭镜子功能。",
+                    description: "蛋神包含镜子功能，可以直接在缺口区域快速查看摄像头预览。摄像头权限只用于显示实时画面，你可以随时在应用里关闭镜子功能。",
                     privacyNote: "未经同意不会使用摄像头，也不会录制或存储画面。",
                     onAllow: {
                         Task {
@@ -62,7 +60,7 @@ struct OnboardingView: View {
                 PermissionRequestView(
                     icon: Image(systemName: "calendar"),
                     title: "启用日历权限",
-                    description: "Boring Notch可以集中展示你的近期日程。需要日历权限来读取并显示日历事件。",
+                    description: "蛋神可以集中展示你的近期日程。需要日历权限来读取并显示日历事件。",
                     privacyNote: "日历数据只用于本机展示和规划，不会上传或共享。",
                     onAllow: {
                         Task {
@@ -84,7 +82,7 @@ struct OnboardingView: View {
                     PermissionRequestView(
                         icon: Image(systemName: "checklist"),
                         title: "启用提醒事项权限",
-                        description: "Boring Notch可以把提醒事项和日历事件放在一起展示。需要提醒事项权限来读取你的待办内容。",
+                        description: "蛋神可以把提醒事项和日历事件放在一起展示。需要提醒事项权限来读取你的待办内容。",
                         privacyNote: "提醒事项数据只用于本机展示，不会上传或共享。",
                         onAllow: {
                             Task {
@@ -106,7 +104,7 @@ struct OnboardingView: View {
                 PermissionRequestView(
                     icon: Image(systemName: "hand.raised.fill"),
                     title: "启用辅助功能权限",
-                    description: "辅助功能权限用于接管系统媒体和亮度提示，并显示Boring Notch的自定义 HUD。",
+                    description: "辅助功能权限用于接管系统媒体和亮度提示，并显示蛋神的自定义 HUD。",
                     privacyNote: "辅助功能只用于改善本机提示体验，不会收集或共享数据。",
                     onAllow: {
                         Task {
@@ -149,11 +147,11 @@ struct OnboardingView: View {
     }
 
     func requestCalendarPermission() async {
-        _ = try? await calendarService.requestAccess(to: .event)
+        await CalendarManager.shared.checkCalendarAuthorization()
     }
 
     func requestRemindersPermission() async {
-        _ = try? await calendarService.requestAccess(to: .reminder)
+        await CalendarManager.shared.checkReminderAuthorization()
     }
     
     func requestAccessibilityPermission() async {

--- a/boringNotch/components/Onboarding/WelcomeView.swift
+++ b/boringNotch/components/Onboarding/WelcomeView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import SwiftUIIntrospect
 
 struct WelcomeView: View {
     var onGetStarted: (() -> Void)? = nil

--- a/boringNotch/components/Onboarding/WelcomeView.swift
+++ b/boringNotch/components/Onboarding/WelcomeView.swift
@@ -25,7 +25,7 @@ struct WelcomeView: View {
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 100, height: 100)
                         .padding(.bottom, 8)
-                    Text("Boring Notch")
+                    Text("蛋神")
                         .font(.system(.largeTitle, design: .default))
                         .fontWeight(.semibold)
                     Text("Welcome")

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -1580,6 +1580,8 @@ struct Appearance: View {
 struct AISettings: View {
     @ObservedObject private var aiManager = AIChatManager.shared
     @State private var knowledgeImportError: String?
+    @State private var showPluginRegistry = false
+    @State private var showSkillRegistry = false
     private let knowledgeButtonColumns = [GridItem(.adaptive(minimum: 96), spacing: 8)]
 
     @Default(.aiChatEnabled) var aiChatEnabled
@@ -1594,6 +1596,8 @@ struct AISettings: View {
     @Default(.aiChatPanelHeight) var aiChatPanelHeight
     @Default(.aiKnowledgeRetrievalEnabled) var aiKnowledgeRetrievalEnabled
     @Default(.aiKnowledgeRetrievalLimit) var aiKnowledgeRetrievalLimit
+    @Default(.aiShowAgentTrace) var aiShowAgentTrace
+    @Default(.aiWebSearchEnabled) var aiWebSearchEnabled
 
     var body: some View {
         Form {
@@ -1663,6 +1667,22 @@ struct AISettings: View {
             }
 
             Section {
+                Defaults.Toggle(key: .aiWebSearchEnabled) {
+                    Text("允许按需联网检索")
+                }
+                Defaults.Toggle(key: .aiShowAgentTrace) {
+                    Text("在聊天页显示智能体轨迹")
+                }
+            } header: {
+                Text("智能体工具")
+            } footer: {
+                Text("联网检索只在你明确要求搜索、打开 URL 或查看 GitHub 仓库时读取公开网页。轨迹默认隐藏，避免聊天页被插件调试信息占满。")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
                 VStack(alignment: .leading, spacing: 12) {
                     HStack {
                         Text("宽度")
@@ -1697,9 +1717,19 @@ struct AISettings: View {
             }
 
             Section {
-                VStack(alignment: .leading, spacing: 10) {
-                    ForEach(aiManager.availablePlugins) { plugin in
-                        AIPluginSettingsRow(plugin: plugin)
+                DisclosureGroup(isExpanded: $showPluginRegistry) {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(aiManager.availablePlugins) { plugin in
+                            AIPluginSettingsRow(plugin: plugin)
+                        }
+                    }
+                    .padding(.top, 8)
+                } label: {
+                    HStack {
+                        Text("查看插件注册表")
+                        Spacer()
+                        Text("\(aiManager.availablePlugins.count) 个")
+                            .foregroundStyle(.secondary)
                     }
                 }
                 .padding(.vertical, 4)
@@ -1773,7 +1803,7 @@ struct AISettings: View {
                     }
 
                     if aiManager.knowledgeDocuments.isEmpty {
-                        Text("还没有资料。可以导入 Markdown、文本、JSON、CSV 或可抽取文本的 PDF。")
+                        Text("还没有资料。可以导入 Markdown、文本、JSON、CSV、可抽取文本的 PDF 或带文字的图片。")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     } else {
@@ -1795,9 +1825,19 @@ struct AISettings: View {
             }
 
             Section {
-                VStack(alignment: .leading, spacing: 10) {
-                    ForEach(aiManager.availableSkills) { skill in
-                        AISkillSettingsRow(skill: skill)
+                DisclosureGroup(isExpanded: $showSkillRegistry) {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(aiManager.availableSkills) { skill in
+                            AISkillSettingsRow(skill: skill)
+                        }
+                    }
+                    .padding(.top, 8)
+                } label: {
+                    HStack {
+                        Text("查看 Skills 清单")
+                        Spacer()
+                        Text("\(aiManager.availableSkills.count) 个")
+                            .foregroundStyle(.secondary)
                     }
                 }
                 .padding(.vertical, 4)

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -6,23 +6,17 @@
 //
 
 import AVFoundation
+import AppKit
 import Defaults
 import EventKit
 import KeyboardShortcuts
 import LaunchAtLogin
-import Sparkle
 import SwiftUI
-import SwiftUIIntrospect
+import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @State private var selectedTab = "General"
     @State private var accentColorUpdateTrigger = UUID()
-
-    let updaterController: SPUStandardUpdaterController?
-
-    init(updaterController: SPUStandardUpdaterController? = nil) {
-        self.updaterController = updaterController
-    }
 
     var body: some View {
         NavigationSplitView {
@@ -36,8 +30,17 @@ struct SettingsView: View {
                 NavigationLink(value: "Media") {
                     Label("Media", systemImage: "play.laptopcomputer")
                 }
+                NavigationLink(value: "AI") {
+                    Label("AI", systemImage: "sparkles")
+                }
                 NavigationLink(value: "Calendar") {
                     Label("Calendar", systemImage: "calendar")
+                }
+                NavigationLink(value: "Weather") {
+                    Label("Weather", systemImage: "cloud.sun")
+                }
+                NavigationLink(value: "Pomodoro") {
+                    Label("Pomodoro", systemImage: "timer")
                 }
                 NavigationLink(value: "HUD") {
                     Label("HUDs", systemImage: "dial.medium.fill")
@@ -77,8 +80,14 @@ struct SettingsView: View {
                     Appearance()
                 case "Media":
                     Media()
+                case "AI":
+                    AISettings()
                 case "Calendar":
                     CalendarSettings()
+                case "Weather":
+                    WeatherSettings()
+                case "Pomodoro":
+                    PomodoroSettings()
                 case "HUD":
                     HUD()
                 case "Battery":
@@ -92,15 +101,7 @@ struct SettingsView: View {
                 case "Advanced":
                     Advanced()
                 case "About":
-                    if let controller = updaterController {
-                        About(updaterController: controller)
-                    } else {
-                        // Fallback with a default controller
-                        About(
-                            updaterController: SPUStandardUpdaterController(
-                                startingUpdater: false, updaterDelegate: nil,
-                                userDriverDelegate: nil))
-                    }
+                    About()
                 default:
                     GeneralSettings()
                 }
@@ -134,6 +135,7 @@ struct GeneralSettings: View {
     }
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @ObservedObject private var quickLaunchManager = QuickLaunchManager.shared
 
     @Default(.mirrorShape) var mirrorShape
     @Default(.showEmojis) var showEmojis
@@ -143,6 +145,8 @@ struct GeneralSettings: View {
     @Default(.nonNotchHeightMode) var nonNotchHeightMode
     @Default(.notchHeight) var notchHeight
     @Default(.notchHeightMode) var notchHeightMode
+    @Default(.quickLaunchEnabled) var quickLaunchEnabled
+    @Default(.quickLaunchApps) var quickLaunchApps
     @Default(.showOnAllDisplays) var showOnAllDisplays
     @Default(.automaticallySwitchDisplay) var automaticallySwitchDisplay
     @Default(.enableGestures) var enableGestures
@@ -261,6 +265,8 @@ struct GeneralSettings: View {
 
             NotchBehaviour()
 
+            quickLaunchControls()
+
             gestureControls()
         }
         .toolbar {
@@ -345,6 +351,121 @@ struct GeneralSettings: View {
         } header: {
             Text("Notch behavior")
         }
+    }
+
+    @ViewBuilder
+    func quickLaunchControls() -> some View {
+        Section {
+            Defaults.Toggle(key: .quickLaunchEnabled) {
+                Text("Show quick launch on Home")
+            }
+
+            HStack {
+                Button("Add app") {
+                    pickQuickLaunchApp()
+                }
+                .disabled(quickLaunchApps.count >= 6)
+
+                if !quickLaunchApps.isEmpty {
+                    Button("Reset defaults") {
+                        quickLaunchApps = defaultQuickLaunchApps()
+                    }
+                }
+
+                Spacer()
+
+                Text("\(quickLaunchApps.count)/6")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            if quickLaunchApps.isEmpty {
+                Text("No apps selected yet.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(Array(quickLaunchApps.enumerated()), id: \.element.id) { index, item in
+                    HStack(spacing: 10) {
+                        AppIcon(for: item)
+                            .resizable()
+                            .frame(width: 20, height: 20)
+                            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.displayName)
+                                .lineLimit(1)
+                            Text(item.appPath)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+
+                        Spacer()
+
+                        Button("Open") {
+                            quickLaunchManager.open(item)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+
+                        Button("Replace") {
+                            pickQuickLaunchApp(replacing: index)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+
+                        Button {
+                            quickLaunchApps.remove(at: index)
+                        } label: {
+                            Image(systemName: "trash")
+                        }
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            if let lastError = quickLaunchManager.lastError, !lastError.isEmpty {
+                Text(lastError)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            Text("Quick launch")
+        } footer: {
+            Text("These app icons are shown on the Home page. Click one in the notch to launch the app.")
+                .multilineTextAlignment(.trailing)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+        }
+    }
+
+    private func pickQuickLaunchApp(replacing index: Int? = nil) {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.applicationBundle]
+        panel.directoryURL = URL(fileURLWithPath: "/Applications")
+
+        guard panel.runModal() == .OK,
+              let url = panel.url,
+              let selectedApp = QuickLaunchAppItem(appURL: url)
+        else {
+            return
+        }
+
+        var items = quickLaunchApps
+        if let index, items.indices.contains(index) {
+            items[index] = selectedApp
+        } else {
+            items.append(selectedApp)
+        }
+
+        var seen: Set<String> = []
+        quickLaunchApps = Array(
+            items.filter { seen.insert($0.id).inserted }
+                .prefix(6)
+        )
     }
 }
 
@@ -834,7 +955,6 @@ func lighterColor(from nsColor: NSColor, amount: CGFloat = 0.14) -> Color {
 
 struct About: View {
     @State private var showBuildNumber: Bool = false
-    let updaterController: SPUStandardUpdaterController
     @Environment(\.openWindow) var openWindow
     var body: some View {
         VStack {
@@ -865,7 +985,7 @@ struct About: View {
                     Text("Version info")
                 }
 
-                UpdaterSettingsView(updater: updaterController.updater)
+                UpdaterSettingsView()
 
                 HStack(spacing: 30) {
                     Spacer(minLength: 0)
@@ -903,7 +1023,7 @@ struct About: View {
             //                openWindow(id: "onboarding")
             //            }
             //            .controlSize(.extraLarge)
-            CheckForUpdatesView(updater: updaterController.updater)
+            CheckForUpdatesView()
         }
         .navigationTitle("About")
     }
@@ -1406,6 +1526,605 @@ struct Appearance: View {
         }
 
         return false
+    }
+}
+
+struct AISettings: View {
+    @ObservedObject private var aiManager = AIChatManager.shared
+    @State private var knowledgeImportError: String?
+    private let knowledgeButtonColumns = [GridItem(.adaptive(minimum: 96), spacing: 8)]
+
+    @Default(.aiChatEnabled) var aiChatEnabled
+    @Default(.aiCalendarContextEnabled) var aiCalendarContextEnabled
+    @Default(.aiCalendarWriteEnabled) var aiCalendarWriteEnabled
+    @Default(.aiServiceBaseURL) var aiServiceBaseURL
+    @Default(.aiServiceModel) var aiServiceModel
+    @Default(.aiServiceAPIKey) var aiServiceAPIKey
+    @Default(.aiSystemPrompt) var aiSystemPrompt
+    @Default(.aiTemperature) var aiTemperature
+    @Default(.aiChatPanelWidth) var aiChatPanelWidth
+    @Default(.aiChatPanelHeight) var aiChatPanelHeight
+    @Default(.aiKnowledgeRetrievalEnabled) var aiKnowledgeRetrievalEnabled
+    @Default(.aiKnowledgeRetrievalLimit) var aiKnowledgeRetrievalLimit
+
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Toggle(key: .aiChatEnabled) {
+                    Text("启用 AI 智能体")
+                }
+
+                TextField("Base URL", text: $aiServiceBaseURL)
+                    .textFieldStyle(.roundedBorder)
+                TextField("模型", text: $aiServiceModel)
+                    .textFieldStyle(.roundedBorder)
+                SecureField("API Key", text: $aiServiceAPIKey)
+                    .textFieldStyle(.roundedBorder)
+            } header: {
+                Text("OpenAI 兼容接口")
+            } footer: {
+                Text("支持 OpenAI 兼容的 chat completions 接口，例如 https://api.openai.com 或其他兼容网关。")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack {
+                        Text("Temperature")
+                        Spacer()
+                        Text(aiTemperature, format: .number.precision(.fractionLength(2)))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Slider(value: $aiTemperature, in: 0 ... 1, step: 0.05)
+
+                    HStack {
+                        Text("更稳")
+                        Spacer()
+                        Text("更发散")
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Text("模型输出控制")
+            } footer: {
+                Text("建议保持 0.2-0.4。日历写入会自动使用更保守的温度，避免编造或格式错误。")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                Defaults.Toggle(key: .aiCalendarContextEnabled) {
+                    Text("允许 AI 读取日历上下文")
+                }
+                Defaults.Toggle(key: .aiCalendarWriteEnabled) {
+                    Text("允许 AI 创建日历事件")
+                }
+            } header: {
+                Text("日历集成")
+            } footer: {
+                Text("智能体可以读取已选择日历以避开已有安排；只有当你明确要求写入日历且这里允许时，才会创建新事件。")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        Text("宽度")
+                        Spacer()
+                        Text("\(Int(aiChatPanelWidth)) px")
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(value: $aiChatPanelWidth, in: aiChatPanelMinSize.width...aiChatPanelMaxSize.width, step: 10)
+
+                    HStack {
+                        Text("高度")
+                        Spacer()
+                        Text("\(Int(aiChatPanelHeight)) px")
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(value: $aiChatPanelHeight, in: aiChatPanelMinSize.height...aiChatPanelMaxSize.height, step: 10)
+
+                    Button("还原默认尺寸") {
+                        aiChatPanelWidth = aiChatPanelDefaultSize.width
+                        aiChatPanelHeight = aiChatPanelDefaultSize.height
+                    }
+                    .controlSize(.small)
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Text("AI 面板尺寸")
+            } footer: {
+                Text("也可以在 Notch AI 聊天页拖拽右侧、底部或右下角来直接调整尺寸。")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(aiManager.availablePlugins) { plugin in
+                        AIPluginSettingsRow(plugin: plugin)
+                    }
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Text("智能体插件")
+            } footer: {
+                Text("当前版本使用内置插件注册表，不执行第三方动态代码；每个插件都有工具、权限和风险等级。")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 12) {
+                    Defaults.Toggle(key: .aiKnowledgeRetrievalEnabled) {
+                        Text("启用本地知识库检索")
+                    }
+
+                    Stepper(value: $aiKnowledgeRetrievalLimit, in: 1 ... 8) {
+                        HStack {
+                            Text("每次最多注入资料")
+                            Spacer()
+                            Text("Top-\(aiKnowledgeRetrievalLimit)")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .disabled(!aiKnowledgeRetrievalEnabled)
+
+                    HStack {
+                        Text("资料数量")
+                        Spacer()
+                        Text("\(aiManager.knowledgeDocuments.count) 份")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    LazyVGrid(columns: knowledgeButtonColumns, alignment: .leading, spacing: 8) {
+                        Button("导入示例资料") {
+                            let count = aiManager.installStarterKnowledgeBase()
+                            knowledgeImportError = nil
+                            aiManager.appendLocalAssistantMessage("已导入 \(count) 份示例知识库资料。")
+                        }
+                        .controlSize(.small)
+
+                        Button("导入资料") {
+                            openKnowledgeImporter()
+                        }
+                        .controlSize(.small)
+
+                        Button("刷新") {
+                            aiManager.refreshKnowledgeDocuments()
+                        }
+                        .controlSize(.small)
+
+                        Button("定位文件") {
+                            aiManager.revealKnowledgeBaseFile()
+                        }
+                        .controlSize(.small)
+
+                        Button("清空") {
+                            aiManager.clearKnowledgeBase()
+                            knowledgeImportError = nil
+                        }
+                        .controlSize(.small)
+                        .foregroundStyle(.red)
+                    }
+
+                    if let knowledgeImportError {
+                        Label(knowledgeImportError, systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+
+                    if aiManager.knowledgeDocuments.isEmpty {
+                        Text("还没有资料。可以导入 Markdown、文本、JSON、CSV 或可抽取文本的 PDF。")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(aiManager.knowledgeDocuments.prefix(5)) { document in
+                            AIKnowledgeSettingsRow(document: document) {
+                                aiManager.removeKnowledgeDocument(id: document.id)
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Text("本地知识库")
+            } footer: {
+                Text("知识库独立于聊天记录，资料存到本地 JSON；开启后 Agent 会按相关性检索少量片段注入上下文。")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(aiManager.availableSkills) { skill in
+                        AISkillSettingsRow(skill: skill)
+                    }
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Text("Skills 技能")
+            } footer: {
+                Text("Skills 是任务流程手册，会在对应任务路由时注入到模型上下文中。")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                TextField("系统提示词", text: $aiSystemPrompt)
+                    .textFieldStyle(.roundedBorder)
+            } header: {
+                Text("助手行为")
+            } footer: {
+                Text("这段提示词会被附加到 Notch 聊天页的每次请求之前。")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("AI")
+        .onAppear {
+            aiManager.refreshKnowledgeDocuments()
+        }
+    }
+
+    private func openKnowledgeImporter() {
+        knowledgeImportError = nil
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = agentAllowedImportTypes()
+
+        guard panel.runModal() == .OK else { return }
+
+        var imported: [String] = []
+        for url in panel.urls.prefix(8) {
+            do {
+                let file = try readAgentImportableFile(at: url)
+                if let document = aiManager.addKnowledgeDocument(
+                    name: url.lastPathComponent,
+                    path: url.path,
+                    content: file.content,
+                    byteCount: file.byteCount
+                ) {
+                    imported.append(document.title)
+                }
+            } catch {
+                knowledgeImportError = "\(url.lastPathComponent) 读取失败：\(error.localizedDescription)"
+            }
+        }
+
+        if !imported.isEmpty {
+            aiManager.appendLocalAssistantMessage("已导入知识库：\(imported.joined(separator: "、"))")
+        }
+    }
+}
+
+private struct AIPluginSettingsRow: View {
+    let plugin: AgentPluginDescriptor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(plugin.name)
+                        .font(.headline)
+                    Text(plugin.category)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(plugin.riskLevel)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(plugin.riskLevel == "中" ? .orange : .green)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background((plugin.riskLevel == "中" ? Color.orange : Color.green).opacity(0.12))
+                    .clipShape(Capsule())
+            }
+
+            Text(plugin.summary)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 6) {
+                ForEach(plugin.typeTags, id: \.self) { tag in
+                    Text(tag)
+                        .font(.caption.weight(.semibold))
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 3)
+                        .background(Color.effectiveAccent.opacity(0.12))
+                        .clipShape(Capsule())
+                }
+            }
+
+            HStack(alignment: .top, spacing: 8) {
+                Label(plugin.toolNames.joined(separator: ", "), systemImage: "wrench.and.screwdriver")
+                Spacer()
+                Label(plugin.permission, systemImage: "lock.shield")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            Text(plugin.manifestPreview)
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+        }
+        .padding(12)
+        .background(.quaternary.opacity(0.35))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct AISkillSettingsRow: View {
+    let skill: AgentSkillDescriptor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(skill.name)
+                        .font(.headline)
+                    Text(skill.id)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(skill.riskLevel)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(skill.riskLevel == "中" ? .orange : .green)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background((skill.riskLevel == "中" ? Color.orange : Color.green).opacity(0.12))
+                    .clipShape(Capsule())
+            }
+
+            Text(skill.summary)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text(skill.workflowSteps.joined(separator: " -> "))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text("触发词：\(skill.triggerKeywords.joined(separator: "、"))")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Label(skill.requiredTools.joined(separator: ", "), systemImage: "link")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text(skill.frontMatterPreview)
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(4)
+        }
+        .padding(12)
+        .background(.quaternary.opacity(0.35))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct AIKnowledgeSettingsRow: View {
+    let document: AgentKnowledgeDocument
+    let onRemove: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(document.title)
+                        .font(.headline)
+                        .lineLimit(1)
+                    Text(document.sourcePath)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                Spacer()
+
+                Button(role: .destructive, action: onRemove) {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.borderless)
+                .help("移出知识库")
+            }
+
+            Text(document.summary)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+
+            HStack(spacing: 8) {
+                Label(ByteCountFormatter.string(fromByteCount: Int64(document.byteCount), countStyle: .file), systemImage: "doc.text")
+                Label {
+                    Text(document.updatedAt, style: .relative)
+                } icon: {
+                    Image(systemName: "clock")
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .padding(12)
+        .background(.quaternary.opacity(0.35))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+struct WeatherSettings: View {
+    @ObservedObject private var weatherManager = WeatherManager.shared
+
+    @Default(.weatherFeatureEnabled) var weatherFeatureEnabled
+    @Default(.weatherLocationMode) var weatherLocationMode
+    @Default(.weatherCity) var weatherCity
+    @Default(.weatherTemperatureUnit) var weatherTemperatureUnit
+
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Toggle(key: .weatherFeatureEnabled) {
+                    Text("Enable weather")
+                }
+
+                Picker("Source", selection: $weatherLocationMode) {
+                    ForEach(WeatherLocationMode.allCases) { mode in
+                        Text(mode.rawValue).tag(mode)
+                    }
+                }
+
+                if weatherLocationMode == .automatic {
+                    HStack {
+                        Text("Location access")
+                        Spacer()
+                        Text(weatherManager.locationAuthorizationDescription)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack(spacing: 8) {
+                        if weatherManager.locationAuthorizationStatus == .notDetermined {
+                            Button("Allow location access") {
+                                Task {
+                                    await weatherManager.requestLocationAuthorization()
+                                }
+                            }
+                        } else if !weatherManager.locationServicesEnabled {
+                            Button("Open Location Settings") {
+                                weatherManager.openLocationSettings()
+                            }
+                        }
+
+                        if weatherManager.locationAuthorizationStatus == .denied
+                            || weatherManager.locationAuthorizationStatus == .restricted
+                        {
+                            Button("Open Location Settings") {
+                                weatherManager.openLocationSettings()
+                            }
+                        }
+                    }
+                } else {
+                    TextField("City", text: $weatherCity)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                Picker("Temperature unit", selection: $weatherTemperatureUnit) {
+                    ForEach(WeatherTemperatureUnit.allCases) { unit in
+                        Text(unit.rawValue).tag(unit)
+                    }
+                }
+            } header: {
+                Text("Forecast source")
+            } footer: {
+                Text("Weather uses Open-Meteo. Automatic mode uses your current location through macOS Location Services. Manual mode uses the city you enter here.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                Button("Refresh now") {
+                    Task {
+                        await WeatherManager.shared.refreshWeather(force: true)
+                    }
+                }
+                .disabled(!weatherFeatureEnabled)
+            }
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Weather")
+        .onAppear {
+            weatherManager.refreshLocationAccessState()
+        }
+        .onChange(of: weatherLocationMode) { _, newMode in
+            weatherManager.refreshLocationAccessState()
+
+            guard newMode == .automatic else { return }
+
+            Task {
+                if weatherManager.locationAuthorizationStatus == .notDetermined {
+                    await weatherManager.requestLocationAuthorization()
+                } else {
+                    await weatherManager.refreshWeather(force: true)
+                }
+            }
+        }
+    }
+}
+
+struct PomodoroSettings: View {
+    @Default(.pomodoroEnabled) var pomodoroEnabled
+    @Default(.pomodoroFocusMinutes) var pomodoroFocusMinutes
+    @Default(.pomodoroShortBreakMinutes) var pomodoroShortBreakMinutes
+    @Default(.pomodoroLongBreakMinutes) var pomodoroLongBreakMinutes
+    @Default(.pomodoroLongBreakInterval) var pomodoroLongBreakInterval
+    @Default(.pomodoroAutoStartNextPhase) var pomodoroAutoStartNextPhase
+
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Toggle(key: .pomodoroEnabled) {
+                    Text("Enable Pomodoro timer")
+                }
+
+                Defaults.Toggle(key: .pomodoroAutoStartNextPhase) {
+                    Text("Auto-start next phase")
+                }
+                .disabled(!pomodoroEnabled)
+            } header: {
+                Text("Timer behavior")
+            } footer: {
+                Text("The Pomodoro timer runs locally inside the app. No external API is used.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                Stepper(value: $pomodoroFocusMinutes, in: 1 ... 120) {
+                    Text("Focus duration: \(pomodoroFocusMinutes) min")
+                }
+
+                Stepper(value: $pomodoroShortBreakMinutes, in: 1 ... 60) {
+                    Text("Short break: \(pomodoroShortBreakMinutes) min")
+                }
+
+                Stepper(value: $pomodoroLongBreakMinutes, in: 1 ... 90) {
+                    Text("Long break: \(pomodoroLongBreakMinutes) min")
+                }
+
+                Stepper(value: $pomodoroLongBreakInterval, in: 2 ... 8) {
+                    Text("Long break every \(pomodoroLongBreakInterval) focus sessions")
+                }
+            } header: {
+                Text("Durations")
+            } footer: {
+                Text("The notch tab lets you start, pause, skip, and reset the current cycle.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+            .disabled(!pomodoroEnabled)
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Pomodoro")
     }
 }
 

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -135,7 +135,6 @@ struct GeneralSettings: View {
     }
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var coordinator = BoringViewCoordinator.shared
-    @ObservedObject private var quickLaunchManager = QuickLaunchManager.shared
 
     @Default(.mirrorShape) var mirrorShape
     @Default(.showEmojis) var showEmojis
@@ -145,8 +144,6 @@ struct GeneralSettings: View {
     @Default(.nonNotchHeightMode) var nonNotchHeightMode
     @Default(.notchHeight) var notchHeight
     @Default(.notchHeightMode) var notchHeightMode
-    @Default(.quickLaunchEnabled) var quickLaunchEnabled
-    @Default(.quickLaunchApps) var quickLaunchApps
     @Default(.showOnAllDisplays) var showOnAllDisplays
     @Default(.automaticallySwitchDisplay) var automaticallySwitchDisplay
     @Default(.enableGestures) var enableGestures
@@ -265,8 +262,6 @@ struct GeneralSettings: View {
 
             NotchBehaviour()
 
-            quickLaunchControls()
-
             gestureControls()
         }
         .toolbar {
@@ -353,120 +348,6 @@ struct GeneralSettings: View {
         }
     }
 
-    @ViewBuilder
-    func quickLaunchControls() -> some View {
-        Section {
-            Defaults.Toggle(key: .quickLaunchEnabled) {
-                Text("Show quick launch on Home")
-            }
-
-            HStack {
-                Button("Add app") {
-                    pickQuickLaunchApp()
-                }
-                .disabled(quickLaunchApps.count >= 6)
-
-                if !quickLaunchApps.isEmpty {
-                    Button("Reset defaults") {
-                        quickLaunchApps = defaultQuickLaunchApps()
-                    }
-                }
-
-                Spacer()
-
-                Text("\(quickLaunchApps.count)/6")
-                    .foregroundStyle(.secondary)
-                    .font(.caption)
-            }
-
-            if quickLaunchApps.isEmpty {
-                Text("No apps selected yet.")
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(Array(quickLaunchApps.enumerated()), id: \.element.id) { index, item in
-                    HStack(spacing: 10) {
-                        AppIcon(for: item)
-                            .resizable()
-                            .frame(width: 20, height: 20)
-                            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
-
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(item.displayName)
-                                .lineLimit(1)
-                            Text(item.appPath)
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                        }
-
-                        Spacer()
-
-                        Button("Open") {
-                            quickLaunchManager.open(item)
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-
-                        Button("Replace") {
-                            pickQuickLaunchApp(replacing: index)
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-
-                        Button {
-                            quickLaunchApps.remove(at: index)
-                        } label: {
-                            Image(systemName: "trash")
-                        }
-                        .buttonStyle(.borderless)
-                        .foregroundStyle(.secondary)
-                    }
-                }
-            }
-
-            if let lastError = quickLaunchManager.lastError, !lastError.isEmpty {
-                Text(lastError)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        } header: {
-            Text("Quick launch")
-        } footer: {
-            Text("These app icons are shown on the Home page. Click one in the notch to launch the app.")
-                .multilineTextAlignment(.trailing)
-                .foregroundStyle(.secondary)
-                .font(.caption)
-        }
-    }
-
-    private func pickQuickLaunchApp(replacing index: Int? = nil) {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = false
-        panel.canChooseFiles = true
-        panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [.applicationBundle]
-        panel.directoryURL = URL(fileURLWithPath: "/Applications")
-
-        guard panel.runModal() == .OK,
-              let url = panel.url,
-              let selectedApp = QuickLaunchAppItem(appURL: url)
-        else {
-            return
-        }
-
-        var items = quickLaunchApps
-        if let index, items.indices.contains(index) {
-            items[index] = selectedApp
-        } else {
-            items.append(selectedApp)
-        }
-
-        var seen: Set<String> = []
-        quickLaunchApps = Array(
-            items.filter { seen.insert($0.id).inserted }
-                .prefix(6)
-        )
-    }
 }
 
 struct Charge: View {
@@ -1279,11 +1160,15 @@ struct Shelf: View {
 
 struct Appearance: View {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @ObservedObject private var quickLaunchManager = QuickLaunchManager.shared
     @Default(.mirrorShape) var mirrorShape
     @Default(.sliderColor) var sliderColor
     @Default(.useMusicVisualizer) var useMusicVisualizer
     @Default(.customVisualizers) var customVisualizers
     @Default(.selectedVisualizer) var selectedVisualizer
+    @Default(.homeWidgetSlots) var homeWidgetSlots
+    @Default(.quickLaunchEnabled) var quickLaunchEnabled
+    @Default(.quickLaunchApps) var quickLaunchApps
 
     let icons: [String] = ["logo2"]
     @State private var selectedIcon: String = "logo2"
@@ -1303,6 +1188,9 @@ struct Appearance: View {
             } header: {
                 Text("General")
             }
+
+            homeLayoutControls()
+            quickLaunchControls()
 
             Section {
                 Defaults.Toggle(key: .coloredSpectrogram) {
@@ -1518,6 +1406,166 @@ struct Appearance: View {
         }
         .accentColor(.effectiveAccent)
         .navigationTitle("Appearance")
+    }
+
+    @ViewBuilder
+    func homeLayoutControls() -> some View {
+        Section {
+            ForEach(0..<4, id: \.self) { index in
+                Picker("Slot \(index + 1)", selection: homeWidgetBinding(for: index)) {
+                    ForEach(HomeWidgetKind.allCases) { widget in
+                        Label(widget.displayName, systemImage: widget.systemImage)
+                            .tag(widget)
+                    }
+                }
+            }
+
+            HStack {
+                Button("Reset Home layout") {
+                    homeWidgetSlots = defaultHomeWidgetSlots()
+                }
+
+                Button("Hide all") {
+                    homeWidgetSlots = Array(repeating: .hidden, count: 4)
+                }
+                .foregroundStyle(.secondary)
+            }
+        } header: {
+            Text("Home layout")
+        } footer: {
+            Text("Home uses four fixed slots. Pick what each slot shows, or choose Hidden to keep the space empty without changing the row layout.")
+                .multilineTextAlignment(.trailing)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+        }
+    }
+
+    private func homeWidgetBinding(for index: Int) -> Binding<HomeWidgetKind> {
+        Binding(
+            get: {
+                normalizedHomeWidgetSlots(homeWidgetSlots)[index]
+            },
+            set: { newValue in
+                var slots = normalizedHomeWidgetSlots(homeWidgetSlots)
+                slots[index] = newValue
+                homeWidgetSlots = slots
+            }
+        )
+    }
+
+    @ViewBuilder
+    func quickLaunchControls() -> some View {
+        Section {
+            Defaults.Toggle(key: .quickLaunchEnabled) {
+                Text("Show quick launch on Home")
+            }
+
+            HStack {
+                Button("Add app") {
+                    pickQuickLaunchApp()
+                }
+                .disabled(quickLaunchApps.count >= 6)
+
+                if !quickLaunchApps.isEmpty {
+                    Button("Reset defaults") {
+                        quickLaunchApps = defaultQuickLaunchApps()
+                    }
+                }
+
+                Spacer()
+
+                Text("\(quickLaunchApps.count)/6")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            if quickLaunchApps.isEmpty {
+                Text("No apps selected yet.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(Array(quickLaunchApps.enumerated()), id: \.element.id) { index, item in
+                    HStack(spacing: 10) {
+                        AppIcon(for: item)
+                            .resizable()
+                            .frame(width: 20, height: 20)
+                            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.displayName)
+                                .lineLimit(1)
+                            Text(item.appPath)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+
+                        Spacer()
+
+                        Button("Open") {
+                            quickLaunchManager.open(item)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+
+                        Button("Replace") {
+                            pickQuickLaunchApp(replacing: index)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+
+                        Button {
+                            quickLaunchApps.remove(at: index)
+                        } label: {
+                            Image(systemName: "trash")
+                        }
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            if let lastError = quickLaunchManager.lastError, !lastError.isEmpty {
+                Text(lastError)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            Text("Quick launch")
+        } footer: {
+            Text("These app icons are shown on the Home page. Use Home layout above to choose where this widget appears.")
+                .multilineTextAlignment(.trailing)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+        }
+    }
+
+    private func pickQuickLaunchApp(replacing index: Int? = nil) {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.applicationBundle]
+        panel.directoryURL = URL(fileURLWithPath: "/Applications")
+
+        guard panel.runModal() == .OK,
+              let url = panel.url,
+              let selectedApp = QuickLaunchAppItem(appURL: url)
+        else {
+            return
+        }
+
+        var items = quickLaunchApps
+        if let index, items.indices.contains(index) {
+            items[index] = selectedApp
+        } else {
+            items.append(selectedApp)
+        }
+
+        var seen: Set<String> = []
+        quickLaunchApps = Array(
+            items.filter { seen.insert($0.id).inserted }
+                .prefix(6)
+        )
     }
 
     func checkVideoInput() -> Bool {

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -48,6 +48,9 @@ struct SettingsView: View {
                 NavigationLink(value: "Battery") {
                     Label("Battery", systemImage: "battery.100.bolt")
                 }
+                NavigationLink(value: "Bluetooth Devices") {
+                    Label("Bluetooth Devices", systemImage: "dot.radiowaves.left.and.right")
+                }
 //                NavigationLink(value: "Downloads") {
 //                    Label("Downloads", systemImage: "square.and.arrow.down")
 //                }
@@ -92,6 +95,8 @@ struct SettingsView: View {
                     HUD()
                 case "Battery":
                     Charge()
+                case "Bluetooth Devices":
+                    BluetoothDevicesSettings()
                 case "Shelf":
                     Shelf()
                 case "Shortcuts":
@@ -161,6 +166,9 @@ struct GeneralSettings: View {
                 }
                 .tint(.effectiveAccent)
                 LaunchAtLogin.Toggle("Launch at login")
+                Defaults.Toggle(key: .auxiliaryWindowsAlwaysOnTop) {
+                    Text(String(localized: "Keep settings and Agent windows on top"))
+                }
                 Defaults.Toggle(key: .showOnAllDisplays) {
                     Text("Show on all displays")
                 }
@@ -384,6 +392,118 @@ struct Charge: View {
     }
 }
 
+struct BluetoothDevicesSettings: View {
+    @ObservedObject private var accessoryBatteryManager = BluetoothAccessoryBatteryManager.shared
+    @Default(.showBluetoothAccessoryBatteries) private var showBluetoothAccessoryBatteries
+    @Default(.hiddenBluetoothAccessoryIDs) private var hiddenBluetoothAccessoryIDs
+
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Toggle(key: .showBluetoothAccessoryBatteries) {
+                    Text("Show connected-device batteries")
+                }
+            } header: {
+                Text("Home Display")
+            } footer: {
+                Text("Battery levels appear in the Quick Launch Home card. This choice is kept when the card is hidden.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Section {
+                if accessoryBatteryManager.knownDevices.isEmpty {
+                    HStack(spacing: 8) {
+                        if accessoryBatteryManager.isRefreshing {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Image(systemName: "dot.radiowaves.left.and.right")
+                                .foregroundStyle(.secondary)
+                        }
+                        Text("No connected device with battery data has been detected yet.")
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    ForEach(accessoryBatteryManager.knownDevices) { device in
+                        Toggle(isOn: accessoryVisibilityBinding(for: device.id)) {
+                            HStack(spacing: 9) {
+                                Image(systemName: device.systemImage)
+                                    .foregroundStyle(Color.effectiveAccent)
+                                    .frame(width: 20)
+
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(device.name)
+                                        .lineLimit(1)
+                                    Text(accessoryStatusText(for: device.id))
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                HStack {
+                    Button {
+                        Task {
+                            await accessoryBatteryManager.refresh(force: true)
+                        }
+                    } label: {
+                        Label("Refresh Devices", systemImage: "arrow.clockwise")
+                    }
+                    .disabled(accessoryBatteryManager.isRefreshing)
+
+                    if !hiddenBluetoothAccessoryIDs.isEmpty {
+                        Button("Show All") {
+                            hiddenBluetoothAccessoryIDs = []
+                        }
+                    }
+                }
+            } header: {
+                Text("Devices to Display")
+            } footer: {
+                Text("Only devices connected to this Mac with a system-reported battery level are listed. Names and visibility choices stay on this Mac; Bluetooth addresses and serial numbers are not stored.")
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+        }
+        .task {
+            await accessoryBatteryManager.refresh(force: false)
+        }
+        .accentColor(.effectiveAccent)
+        .navigationTitle("Bluetooth Devices")
+    }
+
+    private func accessoryVisibilityBinding(for deviceID: String) -> Binding<Bool> {
+        Binding(
+            get: { !hiddenBluetoothAccessoryIDs.contains(deviceID) },
+            set: { isVisible in
+                var hidden = Set(hiddenBluetoothAccessoryIDs)
+                if isVisible {
+                    hidden.remove(deviceID)
+                } else {
+                    hidden.insert(deviceID)
+                }
+                hiddenBluetoothAccessoryIDs = hidden.sorted()
+            }
+        )
+    }
+
+    private func accessoryStatusText(for deviceID: String) -> String {
+        guard let device = accessoryBatteryManager.devices.first(where: { $0.id == deviceID }) else {
+            return String(localized: "Previously Detected")
+        }
+        return device.parts.map { part in
+            let label = part.kind.shortLabel.isEmpty ? "" : "\(part.kind.shortLabel) "
+            return "\(label)\(part.percentage)%"
+        }
+        .joined(separator: "  ")
+    }
+}
+
 //struct Downloads: View {
 //    @Default(.selectedDownloadIndicatorStyle) var selectedDownloadIndicatorStyle
 //    @Default(.selectedDownloadIconStyle) var selectedDownloadIconStyle
@@ -471,7 +591,11 @@ struct HUD: View {
     @Default(.optionKeyAction) var optionKeyAction
     @Default(.hudReplacement) var hudReplacement
     @ObservedObject var coordinator = BoringViewCoordinator.shared
-    @State private var accessibilityAuthorized = false
+    @State private var permissionStatus = HUDPermissionStatus(
+        accessibilityAuthorized: false,
+        inputMonitoringAuthorized: false
+    )
+    @State private var interceptorFailureReason: String?
     
     var body: some View {
         Form {
@@ -490,10 +614,10 @@ struct HUD: View {
                     .labelsHidden()
                     .toggleStyle(.switch)
                     .controlSize(.large)
-                    .disabled(!accessibilityAuthorized)
+                    .disabled(!permissionStatus.isAuthorized)
                 }
                 
-                if !accessibilityAuthorized {
+                if !permissionStatus.isAuthorized {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Accessibility access is required to replace the system HUD.")
                             .font(.subheadline)
@@ -507,6 +631,15 @@ struct HUD: View {
                         }
                     }
                     .padding(.top, 6)
+                }
+
+                if permissionStatus.isAuthorized, let interceptorFailureReason {
+                    Label(
+                        "Permissions are enabled, but the media-key listener could not start (\(interceptorFailureReason)). Restart the app and try again.",
+                        systemImage: "exclamationmark.triangle"
+                    )
+                    .font(.subheadline)
+                    .foregroundStyle(.orange)
                 }
             }
             
@@ -577,18 +710,17 @@ struct HUD: View {
         .accentColor(.effectiveAccent)
         .navigationTitle("HUDs")
         .task {
-            accessibilityAuthorized = await XPCHelperClient.shared.isAccessibilityAuthorized()
+            permissionStatus = await XPCHelperClient.shared.hudPermissionStatus()
         }
-        .onAppear {
-            XPCHelperClient.shared.startMonitoringAccessibilityAuthorization()
+        .onReceive(NotificationCenter.default.publisher(for: .hudPermissionStatusChanged)) { notification in
+            permissionStatus = HUDPermissionStatus(
+                accessibilityAuthorized: notification.userInfo?["accessibilityAuthorized"] as? Bool ?? false,
+                inputMonitoringAuthorized: notification.userInfo?["inputMonitoringAuthorized"] as? Bool ?? false
+            )
         }
-        .onDisappear {
-            XPCHelperClient.shared.stopMonitoringAccessibilityAuthorization()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .accessibilityAuthorizationChanged)) { notification in
-            if let granted = notification.userInfo?["granted"] as? Bool {
-                accessibilityAuthorized = granted
-            }
+        .onReceive(NotificationCenter.default.publisher(for: .mediaKeyInterceptorStateChanged)) { notification in
+            let running = notification.userInfo?["running"] as? Bool ?? false
+            interceptorFailureReason = running ? nil : notification.userInfo?["reason"] as? String
         }
     }
 }
@@ -602,6 +734,9 @@ struct Media: View {
     @Default(.sneakPeekStyles) var sneakPeekStyles
 
     @Default(.enableLyrics) var enableLyrics
+    @Default(.screenMediaBarEnabled) private var screenMediaBarEnabled
+    @Default(.screenMediaBarShowsLyrics) private var screenMediaBarShowsLyrics
+    @Default(.screenMediaBarAlwaysOnTop) private var screenMediaBarAlwaysOnTop
 
     var body: some View {
         Form {
@@ -687,6 +822,16 @@ struct Media: View {
                         customBadge(text: "Beta")
                     }
                 }
+                Toggle(String(localized: "Show screen media bar"), isOn: $screenMediaBarEnabled)
+                Toggle(String(localized: "Keep screen media bar on top"), isOn: $screenMediaBarAlwaysOnTop)
+                    .disabled(!screenMediaBarEnabled)
+                Toggle(String(localized: "Show lyrics in screen media bar"), isOn: $screenMediaBarShowsLyrics)
+                    .disabled(!screenMediaBarEnabled || !enableLyrics)
+
+                Button(String(localized: "Reset screen media bar position")) {
+                    ScreenMediaBarController.shared.resetPosition()
+                }
+                .disabled(!screenMediaBarEnabled)
             } header: {
                 Text("Media controls")
             }  footer: {
@@ -1532,7 +1677,7 @@ struct Appearance: View {
         } header: {
             Text("Quick launch")
         } footer: {
-            Text("These app icons are shown on the Home page. Use Home layout above to choose where this widget appears.")
+            Text("Choose up to six apps for the Quick Launch Home card. Connected-device batteries are configured in Bluetooth Devices.")
                 .multilineTextAlignment(.trailing)
                 .foregroundStyle(.secondary)
                 .font(.caption)
@@ -1580,6 +1725,9 @@ struct Appearance: View {
 struct AISettings: View {
     @ObservedObject private var aiManager = AIChatManager.shared
     @State private var knowledgeImportError: String?
+    @State private var aiServiceAPIKey = ""
+    @State private var aiCredentialError: String?
+    @State private var hasLoadedAICredential = false
     @State private var showPluginRegistry = false
     @State private var showSkillRegistry = false
     private let knowledgeButtonColumns = [GridItem(.adaptive(minimum: 96), spacing: 8)]
@@ -1589,7 +1737,6 @@ struct AISettings: View {
     @Default(.aiCalendarWriteEnabled) var aiCalendarWriteEnabled
     @Default(.aiServiceBaseURL) var aiServiceBaseURL
     @Default(.aiServiceModel) var aiServiceModel
-    @Default(.aiServiceAPIKey) var aiServiceAPIKey
     @Default(.aiSystemPrompt) var aiSystemPrompt
     @Default(.aiTemperature) var aiTemperature
     @Default(.aiChatPanelWidth) var aiChatPanelWidth
@@ -1612,6 +1759,11 @@ struct AISettings: View {
                     .textFieldStyle(.roundedBorder)
                 SecureField("API Key", text: $aiServiceAPIKey)
                     .textFieldStyle(.roundedBorder)
+                if let aiCredentialError {
+                    Text(aiCredentialError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
             } header: {
                 Text("OpenAI 兼容接口")
             } footer: {
@@ -1802,8 +1954,14 @@ struct AISettings: View {
                             .foregroundStyle(.orange)
                     }
 
+                    if let persistenceError = aiManager.persistenceError {
+                        Label(persistenceError, systemImage: "externaldrive.badge.exclamationmark")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+
                     if aiManager.knowledgeDocuments.isEmpty {
-                        Text("还没有资料。可以导入 Markdown、文本、JSON、CSV、可抽取文本的 PDF 或带文字的图片。")
+                        Text("还没有资料。可以导入 Markdown、文本、JSON、CSV、PDF（含扫描件 OCR）或带文字的图片。")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     } else {
@@ -1865,7 +2023,24 @@ struct AISettings: View {
         .accentColor(.effectiveAccent)
         .navigationTitle("AI")
         .onAppear {
-            aiManager.refreshKnowledgeDocuments()
+            if !hasLoadedAICredential {
+                aiServiceAPIKey = AIProviderCredentialStore.apiKey
+                hasLoadedAICredential = true
+            }
+            aiManager.refreshPersistentState()
+        }
+        .onChange(of: aiServiceAPIKey) { _, newValue in
+            guard hasLoadedAICredential else { return }
+            do {
+                try AIProviderCredentialStore.saveAPIKey(newValue)
+                aiCredentialError = nil
+                aiManager.refreshCredentialState()
+            } catch {
+                aiCredentialError = error.localizedDescription
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            aiManager.refreshPersistentState()
         }
     }
 
@@ -1877,12 +2052,23 @@ struct AISettings: View {
         panel.canChooseFiles = true
         panel.allowedContentTypes = agentAllowedImportTypes()
 
-        guard panel.runModal() == .OK else { return }
+        runAgentOpenPanel(panel) { urls in
+            Task { @MainActor in
+                await importKnowledgeFiles(urls)
+            }
+        }
+    }
+
+    @MainActor
+    private func importKnowledgeFiles(_ urls: [URL]) async {
+        guard !urls.isEmpty else { return }
 
         var imported: [String] = []
-        for url in panel.urls.prefix(8) {
+        for url in urls.prefix(8) {
             do {
-                let file = try readAgentImportableFile(at: url)
+                let file = try await Task.detached(priority: .userInitiated) {
+                    try readAgentImportableFile(at: url)
+                }.value
                 if let document = aiManager.addKnowledgeDocument(
                     name: url.lastPathComponent,
                     path: url.path,

--- a/boringNotch/components/Settings/SettingsWindowController.swift
+++ b/boringNotch/components/Settings/SettingsWindowController.swift
@@ -8,11 +8,10 @@
 import AppKit
 import SwiftUI
 import Defaults
-import Sparkle
 
 class SettingsWindowController: NSWindowController {
     static let shared = SettingsWindowController()
-    private var updaterController: SPUStandardUpdaterController?
+    private let frontLevel = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue + 4)
     
     private init() {
         let window = NSWindow(
@@ -31,16 +30,10 @@ class SettingsWindowController: NSWindowController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func setUpdaterController(_ controller: SPUStandardUpdaterController) {
-        self.updaterController = controller
-        // Recreate the content view with the proper updater controller
-        setupWindow()
-    }
-    
     private func setupWindow() {
         guard let window = window else { return }
         
-        window.title = "Boring Notch Settings"
+        window.title = "Boring Notch设置"
         window.titlebarAppearsTransparent = false
         window.titleVisibility = .visible
         window.toolbarStyle = .unified
@@ -52,13 +45,14 @@ class SettingsWindowController: NSWindowController {
         // Ensure proper window behavior
         window.hidesOnDeactivate = false
         window.isExcludedFromWindowsMenu = false
+        window.level = frontLevel
         
         // Configure window to be a standard document-style window
         window.isRestorable = true
         window.identifier = NSUserInterfaceItemIdentifier("BoringNotchSettingsWindow")
         
         // Create the SwiftUI content
-        let settingsView = SettingsView(updaterController: updaterController)
+        let settingsView = SettingsView()
         let hostingView = NSHostingView(rootView: settingsView)
         window.contentView = hostingView
         
@@ -69,18 +63,21 @@ class SettingsWindowController: NSWindowController {
     func showWindow() {
         // Set app to regular mode first
         NSApp.setActivationPolicy(.regular)
+        window?.level = frontLevel
         
         // If window is already visible, bring it to front properly
         if window?.isVisible == true {
             NSApp.activate(ignoringOtherApps: true)
             window?.orderFrontRegardless()
             window?.makeKeyAndOrderFront(nil)
+            window?.order(.above, relativeTo: 0)
             return
         }
         
         // Show the window with proper ordering
         window?.orderFrontRegardless()
         window?.makeKeyAndOrderFront(nil)
+        window?.order(.above, relativeTo: 0)
         window?.center()
         
         // Activate the app and ensure window gets focus
@@ -88,6 +85,8 @@ class SettingsWindowController: NSWindowController {
         
         // Force window to front after activation
         DispatchQueue.main.async { [weak self] in
+            self?.window?.level = self?.frontLevel ?? .floating
+            self?.window?.orderFrontRegardless()
             self?.window?.makeKeyAndOrderFront(nil)
         }
     }
@@ -98,6 +97,7 @@ class SettingsWindowController: NSWindowController {
     }
     
     private func relinquishFocus() {
+        window?.level = .normal
         window?.orderOut(nil)
         
         // Set app back to accessory mode immediately

--- a/boringNotch/components/Settings/SettingsWindowController.swift
+++ b/boringNotch/components/Settings/SettingsWindowController.swift
@@ -11,7 +11,6 @@ import Defaults
 
 class SettingsWindowController: NSWindowController {
     static let shared = SettingsWindowController()
-    private let frontLevel = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue + 4)
     
     private init() {
         let window = NSWindow(
@@ -33,7 +32,7 @@ class SettingsWindowController: NSWindowController {
     private func setupWindow() {
         guard let window = window else { return }
         
-        window.title = "Boring Notch设置"
+        window.title = "蛋神设置"
         window.titlebarAppearsTransparent = false
         window.titleVisibility = .visible
         window.toolbarStyle = .unified
@@ -45,11 +44,12 @@ class SettingsWindowController: NSWindowController {
         // Ensure proper window behavior
         window.hidesOnDeactivate = false
         window.isExcludedFromWindowsMenu = false
-        window.level = frontLevel
+        window.level = .normal
         
         // Configure window to be a standard document-style window
         window.isRestorable = true
-        window.identifier = NSUserInterfaceItemIdentifier("BoringNotchSettingsWindow")
+        window.isReleasedWhenClosed = false
+        window.identifier = NSUserInterfaceItemIdentifier("DanShenSettingsWindow")
         
         // Create the SwiftUI content
         let settingsView = SettingsView()
@@ -61,47 +61,27 @@ class SettingsWindowController: NSWindowController {
     }
     
     func showWindow() {
-        // Set app to regular mode first
+        guard let window else { return }
+        let shouldCenter = !window.isVisible
+
         NSApp.setActivationPolicy(.regular)
-        window?.level = frontLevel
-        
-        // If window is already visible, bring it to front properly
-        if window?.isVisible == true {
-            NSApp.activate(ignoringOtherApps: true)
-            window?.orderFrontRegardless()
-            window?.makeKeyAndOrderFront(nil)
-            window?.order(.above, relativeTo: 0)
-            return
-        }
-        
-        // Show the window with proper ordering
-        window?.orderFrontRegardless()
-        window?.makeKeyAndOrderFront(nil)
-        window?.order(.above, relativeTo: 0)
-        window?.center()
-        
-        // Activate the app and ensure window gets focus
         NSApp.activate(ignoringOtherApps: true)
-        
-        // Force window to front after activation
-        DispatchQueue.main.async { [weak self] in
-            self?.window?.level = self?.frontLevel ?? .floating
-            self?.window?.orderFrontRegardless()
-            self?.window?.makeKeyAndOrderFront(nil)
+        AppWindowPresentationCoordinator.shared.present(window)
+
+        if shouldCenter {
+            window.center()
         }
+        window.makeKeyAndOrderFront(nil)
     }
     
     override func close() {
         super.close()
-        relinquishFocus()
     }
     
     private func relinquishFocus() {
-        window?.level = .normal
-        window?.orderOut(nil)
-        
-        // Set app back to accessory mode immediately
-        NSApp.setActivationPolicy(.accessory)
+        guard let window else { return }
+        AppWindowPresentationCoordinator.shared.dismiss(window)
+        AppWindowPresentationCoordinator.shared.relinquishApplicationFocusIfPossible()
     }
 }
 
@@ -115,8 +95,20 @@ extension SettingsWindowController: NSWindowDelegate {
     }
     
     func windowDidBecomeKey(_ notification: Notification) {
-        // Ensure app is in regular mode when window becomes key
         NSApp.setActivationPolicy(.regular)
+        if let window {
+            AppWindowPresentationCoordinator.shared.present(window)
+        }
+    }
+
+    func windowDidMiniaturize(_ notification: Notification) {
+        AppWindowPresentationCoordinator.shared.refresh()
+    }
+
+    func windowDidDeminiaturize(_ notification: Notification) {
+        if let window {
+            AppWindowPresentationCoordinator.shared.present(window)
+        }
     }
     
     func windowDidResignKey(_ notification: Notification) {

--- a/boringNotch/components/Settings/SoftwareUpdater.swift
+++ b/boringNotch/components/Settings/SoftwareUpdater.swift
@@ -5,59 +5,25 @@
 //  Created by Richard Kunkli on 09/08/2024.
 //
 
+import AppKit
 import SwiftUI
-import Sparkle
-
-final class CheckForUpdatesViewModel: ObservableObject {
-    @Published var canCheckForUpdates = false
-
-    init(updater: SPUUpdater) {
-        updater.publisher(for: \.canCheckForUpdates)
-            .assign(to: &$canCheckForUpdates)
-    }
-}
 
 struct CheckForUpdatesView: View {
-    @ObservedObject private var checkForUpdatesViewModel: CheckForUpdatesViewModel
-    private let updater: SPUUpdater
-    
-    init(updater: SPUUpdater) {
-        self.updater = updater
-        
-        // Create our view model for our CheckForUpdatesView
-        self.checkForUpdatesViewModel = CheckForUpdatesViewModel(updater: updater)
-    }
-    
     var body: some View {
-        Button("Check for Updates…", action: updater.checkForUpdates)
-            .disabled(!checkForUpdatesViewModel.canCheckForUpdates)
+        Button("Check for Updates...") {
+            if let url = URL(string: "https://github.com/TheBoredTeam/boring.notch/releases") {
+                NSWorkspace.shared.open(url)
+            }
+        }
     }
 }
 
 struct UpdaterSettingsView: View {
-    private let updater: SPUUpdater
-    
-    @State private var automaticallyChecksForUpdates: Bool
-    @State private var automaticallyDownloadsUpdates: Bool
-    
-    init(updater: SPUUpdater) {
-        self.updater = updater
-        self.automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
-        self.automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
-    }
-    
     var body: some View {
         Section {
-            Toggle("Automatically check for updates", isOn: $automaticallyChecksForUpdates)
-                .onChange(of: automaticallyChecksForUpdates) { _, newValue in
-                    updater.automaticallyChecksForUpdates = newValue
-                }
-            
-            Toggle("Automatically download updates", isOn: $automaticallyDownloadsUpdates)
-                .disabled(!automaticallyChecksForUpdates)
-                .onChange(of: automaticallyDownloadsUpdates) { _, newValue in
-                    updater.automaticallyDownloadsUpdates = newValue
-                }
+            Text("Automatic updates are disabled in this local build.")
+                .foregroundStyle(.secondary)
+            CheckForUpdatesView()
         } header: {
             HStack {
                 Text("Software updates")

--- a/boringNotch/components/Tabs/TabButton.swift
+++ b/boringNotch/components/Tabs/TabButton.swift
@@ -15,16 +15,23 @@ struct TabButton: View {
     
     var body: some View {
         Button(action: onClick) {
-            Image(systemName: icon)
-                .padding(.horizontal, 15)
-                .contentShape(Capsule())
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 12, weight: .semibold))
+                Text(label)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 26)
+            .contentShape(Capsule())
         }
         .buttonStyle(PlainButtonStyle())
+        .help(label)
     }
 }
 
 #Preview {
     TabButton(label: "Home", icon: "tray.fill", selected: true) {
-        print("Tapped")
     }
 }

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -5,6 +5,7 @@
 //  Created by Hugo Persson on 2024-08-25.
 //
 
+import Defaults
 import SwiftUI
 
 struct TabModel: Identifiable {
@@ -14,39 +15,73 @@ struct TabModel: Identifiable {
     let view: NotchViews
 }
 
-let tabs = [
-    TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
-]
-
 struct TabSelectionView: View {
+    @Default(.boringShelf) private var boringShelf
+    @Default(.aiChatEnabled) private var aiChatEnabled
+
     @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @StateObject private var shelfState = ShelfStateViewModel.shared
     @Namespace var animation
+    private let tabSwitchAnimation = NotchPanelAnimation.spring
+
+    private var visibleTabs: [TabModel] {
+        var items: [TabModel] = [
+            TabModel(label: "Home", icon: "house.fill", view: .home)
+        ]
+
+        if boringShelf && (!shelfState.isEmpty || coordinator.alwaysShowTabs) {
+            items.append(TabModel(label: "Shelf", icon: "tray.fill", view: .shelf))
+        }
+        if aiChatEnabled {
+            items.append(TabModel(label: "AI", icon: "sparkles", view: .assistant))
+        }
+
+        return items
+    }
+
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(tabs) { tab in
-                    TabButton(label: tab.label, icon: tab.icon, selected: coordinator.currentView == tab.view) {
-                        withAnimation(.smooth) {
-                            coordinator.currentView = tab.view
-                        }
+            ForEach(visibleTabs) { tab in
+                TabButton(label: tab.label, icon: tab.icon, selected: coordinator.currentView == tab.view) {
+                    withAnimation(tabSwitchAnimation) {
+                        coordinator.currentView = tab.view
                     }
-                    .frame(height: 26)
-                    .foregroundStyle(tab.view == coordinator.currentView ? .white : .gray)
-                    .background {
-                        if tab.view == coordinator.currentView {
-                            Capsule()
-                                .fill(coordinator.currentView == tab.view ? Color(nsColor: .secondarySystemFill) : Color.clear)
-                                .matchedGeometryEffect(id: "capsule", in: animation)
-                        } else {
-                            Capsule()
-                                .fill(coordinator.currentView == tab.view ? Color(nsColor: .secondarySystemFill) : Color.clear)
-                                .matchedGeometryEffect(id: "capsule", in: animation)
-                                .hidden()
-                        }
+                }
+                .frame(height: 26)
+                .foregroundStyle(tab.view == coordinator.currentView ? .white : .gray)
+                .background {
+                    if tab.view == coordinator.currentView {
+                        Capsule()
+                            .fill(coordinator.currentView == tab.view ? Color(nsColor: .secondarySystemFill) : Color.clear)
+                            .matchedGeometryEffect(id: "capsule", in: animation)
+                    } else {
+                        Capsule()
+                            .fill(coordinator.currentView == tab.view ? Color(nsColor: .secondarySystemFill) : Color.clear)
+                            .matchedGeometryEffect(id: "capsule", in: animation)
+                            .hidden()
                     }
+                }
             }
         }
+        .padding(3)
+        .background(Color.white.opacity(0.06))
         .clipShape(Capsule())
+        .onAppear(perform: normalizeSelection)
+        .onChange(of: aiChatEnabled) { _, _ in
+            normalizeSelection()
+        }
+        .onChange(of: boringShelf) { _, _ in
+            normalizeSelection()
+        }
+        .onChange(of: shelfState.isEmpty) { _, _ in
+            normalizeSelection()
+        }
+    }
+
+    private func normalizeSelection() {
+        if !visibleTabs.contains(where: { $0.view == coordinator.currentView }) {
+            coordinator.currentView = .home
+        }
     }
 }
 

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -19,6 +19,7 @@ struct TabSelectionView: View {
     @Default(.boringShelf) private var boringShelf
     @Default(.aiChatEnabled) private var aiChatEnabled
 
+    @EnvironmentObject private var vm: BoringViewModel
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     @StateObject private var shelfState = ShelfStateViewModel.shared
     @Namespace var animation
@@ -44,7 +45,7 @@ struct TabSelectionView: View {
             ForEach(visibleTabs) { tab in
                 TabButton(label: tab.label, icon: tab.icon, selected: coordinator.currentView == tab.view) {
                     withAnimation(tabSwitchAnimation) {
-                        coordinator.currentView = tab.view
+                        vm.selectOpenView(tab.view)
                     }
                 }
                 .frame(height: 26)
@@ -80,7 +81,7 @@ struct TabSelectionView: View {
 
     private func normalizeSelection() {
         if !visibleTabs.contains(where: { $0.view == coordinator.currentView }) {
-            coordinator.currentView = .home
+            vm.selectOpenView(.home)
         }
     }
 }

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -24,9 +24,12 @@ public enum NotchState {
     case open
 }
 
-public enum NotchViews {
+public enum NotchViews: Equatable {
     case home
     case shelf
+    case assistant
+    case weather
+    case pomodoro
 }
 
 enum SettingsEnum {

--- a/boringNotch/helpers/AppIcons.swift
+++ b/boringNotch/helpers/AppIcons.swift
@@ -59,3 +59,35 @@ func AppIconAsNSImage(for bundleID: String) -> NSImage? {
     return nil
 }
 
+func AppIcon(forFilePath path: String) -> Image {
+    let workspace = NSWorkspace.shared
+    let standardizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+
+    if FileManager.default.fileExists(atPath: standardizedPath) {
+        let appIcon = workspace.icon(forFile: standardizedPath)
+        return Image(nsImage: appIcon)
+    }
+
+    return Image(nsImage: workspace.icon(for: .applicationBundle))
+}
+
+func AppIconAsNSImage(forFilePath path: String) -> NSImage? {
+    let standardizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+    guard FileManager.default.fileExists(atPath: standardizedPath) else { return nil }
+
+    let appIcon = NSWorkspace.shared.icon(forFile: standardizedPath)
+    appIcon.size = NSSize(width: 256, height: 256)
+    return appIcon
+}
+
+func AppIcon(for item: QuickLaunchAppItem) -> Image {
+    if !item.appPath.isEmpty {
+        return AppIcon(forFilePath: item.appPath)
+    }
+
+    if !item.bundleIdentifier.isEmpty {
+        return AppIcon(for: item.bundleIdentifier)
+    }
+
+    return Image(nsImage: NSWorkspace.shared.icon(for: .applicationBundle))
+}

--- a/boringNotch/managers/AIWeatherManagers.swift
+++ b/boringNotch/managers/AIWeatherManagers.swift
@@ -12,6 +12,7 @@ import Defaults
 import Foundation
 import PDFKit
 import UniformTypeIdentifiers
+import Vision
 
 struct AgentFileReadError: LocalizedError {
     let errorDescription: String?
@@ -41,6 +42,17 @@ func readAgentImportableFile(at url: URL) throws -> (content: String, byteCount:
         return ("[PDF text extracted]\n\(String(text.prefix(24_000)))", byteCount)
     }
 
+    if agentFileIsImage(url) {
+        guard byteCount <= 12_000_000 else {
+            throw AgentFileReadError("图片太大，当前限制 12 MB。")
+        }
+        let text = try extractAgentImageText(at: url)
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AgentFileReadError("图片没有识别到文字；当前只支持图片 OCR，不做视觉理解。")
+        }
+        return ("[Image OCR text extracted]\n\(String(text.prefix(12_000)))", byteCount)
+    }
+
     let data = try Data(contentsOf: url)
     guard data.count <= 512_000 else {
         throw AgentFileReadError("文件太大，当前限制 500 KB。")
@@ -61,7 +73,7 @@ func agentAllowedImportTypes() -> [UTType] {
         "md", "markdown", "swift", "py", "js", "ts", "tsx", "jsx",
         "html", "css", "xml", "yaml", "yml", "java", "c", "cpp", "h"
     ].compactMap { UTType(filenameExtension: $0) }
-    return [.plainText, .utf8PlainText, .text, .json, .commaSeparatedText, .pdf] + extraTextTypes
+    return [.plainText, .utf8PlainText, .text, .json, .commaSeparatedText, .pdf, .image] + extraTextTypes
 }
 
 private func agentFileByteCount(at url: URL) throws -> Int {
@@ -71,6 +83,24 @@ private func agentFileByteCount(at url: URL) throws -> Int {
     }
     let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
     return attributes[.size] as? Int ?? 0
+}
+
+private func agentFileIsImage(_ url: URL) -> Bool {
+    guard let type = UTType(filenameExtension: url.pathExtension) else { return false }
+    return type.conforms(to: .image)
+}
+
+private func extractAgentImageText(at url: URL) throws -> String {
+    let request = VNRecognizeTextRequest()
+    request.recognitionLevel = .fast
+    request.usesLanguageCorrection = true
+
+    let handler = VNImageRequestHandler(url: url, options: [:])
+    try handler.perform([request])
+
+    return (request.results ?? [])
+        .compactMap { $0.topCandidates(1).first?.string }
+        .joined(separator: "\n")
 }
 
 struct AIChatMessage: Identifiable, Equatable, Codable {
@@ -414,6 +444,23 @@ private struct AgentPreparedRun {
     let systemContext: String
     let calendarContext: String?
     let route: AgentRoute
+}
+
+private struct AgentWebResult {
+    let title: String
+    let url: String
+    let snippet: String
+    let source: String
+}
+
+private struct GitHubTreeResponse: Decodable {
+    struct Item: Decodable {
+        let path: String
+        let type: String
+        let size: Int?
+    }
+
+    let tree: [Item]
 }
 
 private struct AgentRoute {
@@ -982,13 +1029,26 @@ private final class AgentOrchestrator {
             id: "knowledge",
             name: "本地知识库",
             typeTags: ["context"],
-            summary: "检索用户导入的study materials、作业要求、论文笔记和 Markdown 文档。",
+            summary: "检索用户导入的课程资料、作业要求、论文笔记和 Markdown 文档。",
             toolNames: ["knowledge.add_document", "knowledge.retrieve"],
             permission: "只读取用户显式导入的文件",
             riskLevel: "低",
-            discoveryKeywords: ["knowledge", "rag", "notes", "document", "知识库", "资料库", "study materials", "笔记", "文档"],
+            discoveryKeywords: ["knowledge", "rag", "notes", "document", "知识库", "资料库", "课程资料", "笔记", "文档"],
             manifestPreview: """
             {"id":"knowledge","type":["context"],"tools":["knowledge.add_document","knowledge.retrieve"],"permissions":{"read":"user-imported-only","write":"explicit-import"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "web",
+            name: "联网检索",
+            typeTags: ["context"],
+            summary: "按需读取公开网页、URL 和 GitHub 仓库源码片段。",
+            toolNames: ["web.search", "web.fetch_url", "github.repo_context"],
+            permission: "只读公开网络；由设置开关控制",
+            riskLevel: "中",
+            discoveryKeywords: ["web", "search", "google", "github", "git", "repo", "url", "http", "联网", "搜索", "查一下", "网上", "仓库", "源码", "官网", "boring.notch", "hud"],
+            manifestPreview: """
+            {"id":"web","type":["context"],"tools":["web.search","web.fetch_url","github.repo_context"],"permissions":{"read":"settings-gated-public-web","write":"never"},"riskLevel":"medium"}
             """
         ),
         .init(
@@ -1379,6 +1439,23 @@ private final class AgentOrchestrator {
             )
         }
 
+        if selectedIDs.contains("web") {
+            if Defaults[.aiWebSearchEnabled] {
+                let webContext = await webSearchSummary(for: prompt)
+                contextBlocks.append("[web.search]\n\(webContext)")
+                steps.append(
+                    .init(
+                        title: "工具 web.search",
+                        detail: webContext.contains("未返回") || webContext.contains("失败") ? "联网检索未获得可用结果" : "已读取公开网络/GitHub 上下文",
+                        status: webContext.contains("未返回") || webContext.contains("失败") ? "fallback" : "done"
+                    )
+                )
+            } else {
+                contextBlocks.append("[web.search]\nDisabled in Settings > AI.")
+                steps.append(.init(title: "工具 web.search", detail: "用户设置已关闭", status: "skipped"))
+            }
+        }
+
         if selectedIDs.contains("calendar") {
             if Defaults[.aiCalendarContextEnabled] {
                 calendarContext = await CalendarManager.shared.aiScheduleContext()
@@ -1703,6 +1780,10 @@ private final class AgentOrchestrator {
             return .init(kind: .researchPlanning, confidence: 0.76)
         }
 
+        if wantsWebContext(for: prompt) {
+            return .init(kind: .researchPlanning, confidence: 0.72)
+        }
+
         let agentArchitecture = [
             "agent", "plugin", "plugins", "skill", "skills", "memory", "mcp",
             "智能体", "插件", "技能", "记忆", "长期记忆", "工作记忆", "短期记忆", "架构"
@@ -1755,13 +1836,16 @@ private final class AgentOrchestrator {
         }
 
         let hasProvidedFile = lowered.contains("[file:") || lowered.contains("本地文件上下文") || lowered.contains("上传")
-        let asksKnowledge = ["knowledge", "rag", "资料库", "知识库", "study materials", "笔记"].contains { lowered.contains($0) }
+        let asksKnowledge = ["knowledge", "rag", "资料库", "知识库", "课程资料", "笔记"].contains { lowered.contains($0) }
         let knowledgeEnabled = Defaults[.aiKnowledgeRetrievalEnabled]
         let hasKnowledgeHit = knowledgeEnabled && AgentKnowledgeStore.shared.hasRelevantContent(for: prompt)
+        let webEnabled = Defaults[.aiWebSearchEnabled]
+        let asksWeb = webEnabled && wantsWebContext(for: prompt)
         let selectedIDs = Set(
             routeIDs
                 + (hasProvidedFile ? ["shelf"] : [])
                 + (knowledgeEnabled && (asksKnowledge || hasKnowledgeHit) ? ["knowledge"] : [])
+                + (asksWeb ? ["web"] : [])
         )
 
         return plugins.map { plugin in
@@ -1838,6 +1922,388 @@ private final class AgentOrchestrator {
         }
 
         return "检测到动作型工具 \(writeTools.joined(separator: ", "))，但当前路由不自动执行，只用于说明能力边界。"
+    }
+
+    private func wantsWebContext(for prompt: String) -> Bool {
+        guard Defaults[.aiWebSearchEnabled] else { return false }
+
+        let lowered = prompt.lowercased()
+        if !extractHTTPURLs(from: prompt).isEmpty {
+            return true
+        }
+
+        if lowered.contains("github")
+            || lowered.contains("git ")
+            || lowered.contains(" git")
+            || lowered.contains("repo")
+            || lowered.contains("仓库")
+            || lowered.contains("源码")
+            || lowered.contains("boring.notch")
+        {
+            return true
+        }
+
+        let searchSignals = [
+            "联网", "网上", "搜索", "搜一下", "查一下", "帮我查", "去查", "官网",
+            "web search", "search web", "look up", "google", "browse"
+        ]
+        return searchSignals.contains(where: lowered.contains)
+    }
+
+    private func webSearchSummary(for prompt: String) async -> String {
+        var results: [AgentWebResult] = []
+
+        for url in extractHTTPURLs(from: prompt).prefix(3) {
+            if let result = await fetchURLResult(url) {
+                results.append(result)
+            }
+        }
+
+        if let slug = githubRepositorySlug(in: prompt) {
+            results.append(contentsOf: await githubRepositoryResults(slug: slug, prompt: prompt))
+        }
+
+        if results.isEmpty {
+            results.append(contentsOf: await duckDuckGoResults(for: prompt))
+        }
+
+        let uniqueResults = uniqueWebResults(results).prefix(6)
+        guard !uniqueResults.isEmpty else {
+            return "联网检索未返回可用结果。可能是网络受限、目标页面不可访问，或需要更具体的 URL/GitHub 仓库名。"
+        }
+
+        return uniqueResults.enumerated().map { index, result in
+            """
+            \(index + 1). \(result.title)
+            source: \(result.url)
+            type: \(result.source)
+            excerpt: \(result.snippet)
+            """
+        }.joined(separator: "\n\n")
+    }
+
+    private func githubRepositorySlug(in prompt: String) -> String? {
+        for url in extractHTTPURLs(from: prompt) where url.host?.lowercased().contains("github.com") == true {
+            let components = url.pathComponents.filter { $0 != "/" }
+            if components.count >= 2 {
+                return "\(components[0])/\(components[1])"
+            }
+        }
+
+        let lowered = prompt.lowercased()
+        if lowered.contains("boring.notch") {
+            return "TheBoredTeam/boring.notch"
+        }
+
+        guard lowered.contains("github") || lowered.contains("git") || lowered.contains("仓库") else {
+            return nil
+        }
+
+        let pattern = #"([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: prompt, range: NSRange(prompt.startIndex..., in: prompt)),
+              match.numberOfRanges >= 3,
+              let ownerRange = Range(match.range(at: 1), in: prompt),
+              let repoRange = Range(match.range(at: 2), in: prompt)
+        else {
+            return nil
+        }
+
+        return "\(prompt[ownerRange])/\(prompt[repoRange])"
+    }
+
+    private func githubRepositoryResults(slug: String, prompt: String) async -> [AgentWebResult] {
+        let terms = webSearchTerms(from: prompt, repoSlug: slug)
+
+        for branch in ["dev", "main", "master"] {
+            guard let tree = await githubTree(slug: slug, branch: branch) else { continue }
+
+            var results: [AgentWebResult] = []
+            for item in githubCandidates(from: tree, terms: terms).prefix(6) {
+                guard let rawURL = githubRawURL(slug: slug, branch: branch, path: item.path),
+                      let text = try? await fetchPublicText(from: rawURL)
+                else {
+                    continue
+                }
+
+                results.append(
+                    AgentWebResult(
+                        title: "\(slug): \(item.path)",
+                        url: "https://github.com/\(slug)/blob/\(branch)/\(item.path)",
+                        snippet: sourceSnippet(from: text, terms: terms),
+                        source: "github.repo_context"
+                    )
+                )
+            }
+
+            if !results.isEmpty {
+                return results
+            }
+        }
+
+        return []
+    }
+
+    private func githubTree(slug: String, branch: String) async -> [GitHubTreeResponse.Item]? {
+        guard let url = URL(string: "https://api.github.com/repos/\(slug)/git/trees/\(branch)?recursive=1"),
+              let data = try? await fetchPublicData(from: url),
+              let response = try? JSONDecoder().decode(GitHubTreeResponse.self, from: data)
+        else {
+            return nil
+        }
+
+        return response.tree
+    }
+
+    private func githubCandidates(from tree: [GitHubTreeResponse.Item], terms: [String]) -> [GitHubTreeResponse.Item] {
+        let usefulExtensions = ["swift", "md", "markdown", "json", "yml", "yaml", "plist", "xcstrings", "txt"]
+
+        let scored = tree.compactMap { item -> (GitHubTreeResponse.Item, Int)? in
+            guard item.type == "blob" else { return nil }
+            if let size = item.size, size > 180_000 { return nil }
+
+            let lowerPath = item.path.lowercased()
+            let pathExtension = URL(fileURLWithPath: lowerPath).pathExtension
+            guard usefulExtensions.contains(pathExtension) else { return nil }
+
+            var score = terms.filter { lowerPath.contains($0) }.count * 3
+            if lowerPath.contains("hud") { score += 3 }
+            if lowerPath.contains("notch") { score += 1 }
+            if lowerPath.contains("readme") { score += 1 }
+            return score > 0 ? (item, score) : nil
+        }
+
+        let sorted = scored.sorted { lhs, rhs in
+            if lhs.1 != rhs.1 { return lhs.1 > rhs.1 }
+            return lhs.0.path < rhs.0.path
+        }.map(\.0)
+
+        if !sorted.isEmpty {
+            return sorted
+        }
+
+        let fallbackPaths = [
+            "README.md",
+            "boringNotch/models/Constants.swift",
+            "boringNotch/BoringViewCoordinator.swift",
+            "boringNotch/ContentView.swift",
+            "boringNotch/observers/MediaKeyInterceptor.swift",
+            "boringNotch/components/Settings/Views/OSDSettingsView.swift",
+            "boringNotch/components/Settings/Views/AppearanceSettingsView.swift",
+            "boringNotch/components/Notch/BoringHeader.swift",
+            "boringNotch/components/Notch/NotchHomeView.swift",
+        ]
+        let fallbackSet = Set(fallbackPaths)
+        return tree
+            .filter { item in
+                item.type == "blob"
+                    && fallbackSet.contains(item.path)
+                    && (item.size ?? 0) <= 180_000
+            }
+            .sorted { lhs, rhs in
+                (fallbackPaths.firstIndex(of: lhs.path) ?? Int.max)
+                    < (fallbackPaths.firstIndex(of: rhs.path) ?? Int.max)
+            }
+    }
+
+    private func githubRawURL(slug: String, branch: String, path: String) -> URL? {
+        let encodedPath = path
+            .split(separator: "/")
+            .map { String($0).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? String($0) }
+            .joined(separator: "/")
+        return URL(string: "https://raw.githubusercontent.com/\(slug)/\(branch)/\(encodedPath)")
+    }
+
+    private func duckDuckGoResults(for prompt: String) async -> [AgentWebResult] {
+        let query = prompt
+            .replacingOccurrences(of: "请联网检索", with: "")
+            .replacingOccurrences(of: "联网检索", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty,
+              let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "https://duckduckgo.com/html/?q=\(encoded)"),
+              let html = try? await fetchPublicText(from: url)
+        else {
+            return []
+        }
+
+        let pattern = #"<a[^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>(.*?)</a>"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) else {
+            return []
+        }
+
+        let matches = regex.matches(in: html, range: NSRange(html.startIndex..., in: html))
+        return matches.prefix(4).compactMap { match in
+            guard match.numberOfRanges >= 3,
+                  let hrefRange = Range(match.range(at: 1), in: html),
+                  let titleRange = Range(match.range(at: 2), in: html)
+            else {
+                return nil
+            }
+
+            let href = decodedDuckDuckGoURL(String(html[hrefRange]))
+            let title = htmlToPlainText(String(html[titleRange]))
+            guard !href.isEmpty, !title.isEmpty else { return nil }
+
+            return AgentWebResult(
+                title: title,
+                url: href,
+                snippet: "搜索结果标题命中。需要更精确内容时可提供 URL，或指定 GitHub 仓库名进行源码检索。",
+                source: "web.search"
+            )
+        }
+    }
+
+    private func fetchURLResult(_ url: URL) async -> AgentWebResult? {
+        guard let text = try? await fetchPublicText(from: url) else { return nil }
+        let title = webPageTitle(from: text) ?? url.host ?? url.absoluteString
+        return AgentWebResult(
+            title: title,
+            url: url.absoluteString,
+            snippet: String(htmlToPlainText(text).prefix(1_600)),
+            source: "web.fetch_url"
+        )
+    }
+
+    private func fetchPublicData(from url: URL) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 12
+        request.setValue("BoringNotchAgent/1.0", forHTTPHeaderField: "User-Agent")
+        request.setValue("application/vnd.github+json, text/html, text/plain;q=0.9, */*;q=0.8", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        if let httpResponse = response as? HTTPURLResponse, !(200 ... 299).contains(httpResponse.statusCode) {
+            throw FeatureError("Network request failed with status \(httpResponse.statusCode).")
+        }
+        return data
+    }
+
+    private func fetchPublicText(from url: URL) async throws -> String {
+        let data = try await fetchPublicData(from: url)
+        let text = String(data: data, encoding: .utf8)
+            ?? String(data: data, encoding: .unicode)
+            ?? String(data: data, encoding: .isoLatin1)
+        guard let text else {
+            throw FeatureError("Unable to decode web response.")
+        }
+        return text
+    }
+
+    private func extractHTTPURLs(from text: String) -> [URL] {
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            return []
+        }
+
+        return detector.matches(in: text, range: NSRange(text.startIndex..., in: text))
+            .compactMap(\.url)
+            .filter { ["http", "https"].contains($0.scheme?.lowercased() ?? "") }
+    }
+
+    private func webSearchTerms(from prompt: String, repoSlug: String?) -> [String] {
+        let lower = prompt.lowercased()
+        var generic = Set([
+            "http", "https", "github", "com", "the", "and", "for", "with", "this", "that",
+            "please", "search", "look", "联网", "搜索", "查一下", "看看", "是什么", "什么",
+            "repo", "repository", "仓库", "源码", "项目"
+        ])
+
+        if let repoSlug {
+            repoSlug.lowercased().split(separator: "/").forEach { generic.insert(String($0)) }
+            repoSlug.lowercased().split(separator: ".").forEach { generic.insert(String($0)) }
+        }
+
+        var terms = lower
+            .split { !$0.isLetter && !$0.isNumber && $0 != "." && $0 != "_" && $0 != "-" }
+            .map(String.init)
+            .filter { $0.count >= 2 && $0.count <= 32 && !generic.contains($0) }
+
+        if lower.contains("hud"), !terms.contains("hud") {
+            terms.insert("hud", at: 0)
+        }
+        if lower.contains("boring.notch"), !terms.contains("boring.notch") {
+            terms.append("boring.notch")
+        }
+
+        var seen = Set<String>()
+        return terms.filter { seen.insert($0).inserted }.prefix(6).map { $0 }
+    }
+
+    private func sourceSnippet(from text: String, terms: [String]) -> String {
+        let lines = text.components(separatedBy: .newlines)
+        let loweredTerms = terms.map { $0.lowercased() }
+        let hitIndex = lines.firstIndex { line in
+            let lowerLine = line.lowercased()
+            return loweredTerms.contains(where: lowerLine.contains)
+        } ?? 0
+        let start = max(0, hitIndex - 4)
+        let end = min(lines.count, hitIndex + 10)
+        let snippet = lines[start..<end]
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((snippet.isEmpty ? text : snippet).prefix(1_800))
+    }
+
+    private func webPageTitle(from html: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: #"<title[^>]*>(.*?)</title>"#, options: [.caseInsensitive, .dotMatchesLineSeparators]),
+              let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
+              match.numberOfRanges >= 2,
+              let range = Range(match.range(at: 1), in: html)
+        else {
+            return nil
+        }
+
+        return htmlToPlainText(String(html[range]))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func htmlToPlainText(_ html: String) -> String {
+        let withoutScripts = html.replacingOccurrences(
+            of: #"(?is)<(script|style).*?</\1>"#,
+            with: " ",
+            options: .regularExpression
+        )
+        let withoutTags = withoutScripts.replacingOccurrences(
+            of: #"(?s)<[^>]+>"#,
+            with: " ",
+            options: .regularExpression
+        )
+        let collapsed = withoutTags.replacingOccurrences(
+            of: #"\s+"#,
+            with: " ",
+            options: .regularExpression
+        )
+
+        guard let data = collapsed.data(using: .utf8),
+              let decoded = try? NSAttributedString(
+                data: data,
+                options: [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue,
+                ],
+                documentAttributes: nil
+              ).string
+        else {
+            return collapsed
+        }
+        return decoded
+    }
+
+    private func decodedDuckDuckGoURL(_ href: String) -> String {
+        let decoded = href.replacingOccurrences(of: "&amp;", with: "&")
+        if let components = URLComponents(string: decoded),
+           let uddg = components.queryItems?.first(where: { $0.name == "uddg" })?.value
+        {
+            return uddg
+        }
+        if decoded.hasPrefix("//") {
+            return "https:\(decoded)"
+        }
+        return decoded
+    }
+
+    private func uniqueWebResults(_ results: [AgentWebResult]) -> [AgentWebResult] {
+        var seen = Set<String>()
+        return results.filter { seen.insert($0.url).inserted }
     }
 
     private func weatherSummary() async -> String {
@@ -2061,6 +2527,7 @@ private final class AgentOrchestrator {
         回复规则：
         - 相关时使用已选择的工具上下文；如果上下文显示工具失败，不要声称工具成功。
         - 如果知识库命中资料，优先基于 knowledge.retrieve 的摘要和 excerpt 回答；没有命中时明确说明未检索到相关资料。
+        - 如果 web.search 提供了 source URL，回答网络/GitHub 问题时要基于这些 excerpt，并在句末列出来源 URL；如果 web.search 失败，不要假装已经联网。
         - 如果 Skills 已装载，按 workflow 输出过程型计划，不要只给泛泛建议。
         - 记忆上下文分为短期会话、工作记忆和长期记忆；长期记忆只代表检索命中的稳定信息，不要把普通聊天当成长期事实。
         - 日程或作业规划要给出具体步骤，并指出冲突或缺失信息。
@@ -2426,7 +2893,7 @@ final class AIChatManager: ObservableObject {
             对我们的实现启发：
             1. 插件负责“能拿到什么上下文/能做什么动作”，Skill 负责“这类任务应该按什么流程做”。
             2. Skill 的 description 应该写成触发条件，不只是说明文字，例如“当用户要求把作业要求拆成评分点、里程碑和日程计划时使用”。
-            3. 支持文件可以被延迟读取，适合study materials、评分标准模板、论文写作模板。
+            3. 支持文件可以被延迟读取，适合课程资料、评分标准模板、论文写作模板。
             4. 有副作用的技能不要自动运行，例如写日历、发消息、删除文件，应该用确认门控。
 
             Boring Notch可落地设计：
@@ -2459,11 +2926,11 @@ final class AIChatManager: ObservableObject {
             2. Tool Discovery：先根据用户任务选相关插件，不一次性把所有工具上下文塞给模型。
             3. Context Plugin 和 Action Plugin 分开：天气、知识库、日历读取属于 context；写日历、启动计时器属于 action。
             4. Permission Gate：读操作可以自动，写操作必须设置允许并由用户明确请求。
-            5. Trace Logger：记录本轮路由、命中插件、上下文准备和安全检查，方便product demonstration“智能体不是黑箱”。
+            5. Trace Logger：记录本轮路由、命中插件、上下文准备和安全检查，方便课程展示“智能体不是黑箱”。
 
             Boring Notch可以对齐的 MCP 分层：
             - Tools：weather.current、calendar.create_event、memory.save_preference。
-            - Resources：本地知识库文档、study materials、拖入文件、日历上下文。
+            - Resources：本地知识库文档、课程资料、拖入文件、日历上下文。
             - Prompts：/skills、/knowledge、作业拆解模板、天气决策模板。
 
             最小可演示架构：
@@ -2547,10 +3014,10 @@ final class AIChatManager: ObservableObject {
             """
         ),
         (
-            "GitHub 案例：Boring Notch Agent product demo 脚本",
-            "seed://boring-notch-agent-course-demo-script",
+            "GitHub 案例：Boring Notch Agent 课堂 demo 脚本",
+            "seed://danshen-agent-course-demo-script",
             """
-            # GitHub 案例：Boring Notch Agent product demo 脚本
+            # GitHub 案例：Boring Notch Agent 课堂 demo 脚本
 
             目标：展示Boring Notch不是普通聊天框，而是一个 macOS 桌面 Agent Host。
 
@@ -2785,6 +3252,7 @@ final class AIChatManager: ObservableObject {
         - If the user asks about today's plan, schedule, agenda, free time, meetings, or calendar, answer only from the provided calendar context.
         - If calendar context is missing, disabled, permission-denied, or empty, say that you cannot confirm local schedule from the calendar; do not fabricate events.
         - If a retrieved memory or knowledge-base excerpt is absent, state that no relevant local record was found.
+        - Do not claim you browsed the web unless [web.search] context is present. If web context is unavailable, say the local web tool did not retrieve usable results.
         - Keep answers concise unless the user asks for a detailed plan.
         """
     }

--- a/boringNotch/managers/AIWeatherManagers.swift
+++ b/boringNotch/managers/AIWeatherManagers.swift
@@ -1,0 +1,3992 @@
+//
+//  AIWeatherManagers.swift
+//  boringNotch
+//
+//  Created by Codex on 2026-06-06.
+//
+
+import AppKit
+import Combine
+import CoreLocation
+import Defaults
+import Foundation
+import PDFKit
+import UniformTypeIdentifiers
+
+struct AgentFileReadError: LocalizedError {
+    let errorDescription: String?
+
+    init(_ message: String) {
+        self.errorDescription = message
+    }
+}
+
+func readAgentImportableFile(at url: URL) throws -> (content: String, byteCount: Int) {
+    let byteCount = try agentFileByteCount(at: url)
+
+    if url.pathExtension.lowercased() == "pdf" {
+        guard byteCount <= 20_000_000 else {
+            throw AgentFileReadError("PDF 太大，当前限制 20 MB。")
+        }
+        guard let document = PDFDocument(url: url) else {
+            throw AgentFileReadError("无法打开 PDF。")
+        }
+        let pageTexts = (0..<document.pageCount).compactMap { index in
+            document.page(at: index)?.string?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let text = pageTexts.joined(separator: "\n\n")
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AgentFileReadError("PDF 没有可抽取文本，当前不做 OCR。")
+        }
+        return ("[PDF text extracted]\n\(String(text.prefix(24_000)))", byteCount)
+    }
+
+    let data = try Data(contentsOf: url)
+    guard data.count <= 512_000 else {
+        throw AgentFileReadError("文件太大，当前限制 500 KB。")
+    }
+
+    guard let text = String(data: data, encoding: .utf8)
+        ?? String(data: data, encoding: .unicode)
+        ?? String(data: data, encoding: .utf16)
+    else {
+        throw AgentFileReadError("不是可读取的文本文件。")
+    }
+
+    return (String(text.prefix(16_000)), data.count)
+}
+
+func agentAllowedImportTypes() -> [UTType] {
+    let extraTextTypes = [
+        "md", "markdown", "swift", "py", "js", "ts", "tsx", "jsx",
+        "html", "css", "xml", "yaml", "yml", "java", "c", "cpp", "h"
+    ].compactMap { UTType(filenameExtension: $0) }
+    return [.plainText, .utf8PlainText, .text, .json, .commaSeparatedText, .pdf] + extraTextTypes
+}
+
+private func agentFileByteCount(at url: URL) throws -> Int {
+    let values = try url.resourceValues(forKeys: [.fileSizeKey])
+    if let fileSize = values.fileSize {
+        return fileSize
+    }
+    let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+    return attributes[.size] as? Int ?? 0
+}
+
+struct AIChatMessage: Identifiable, Equatable, Codable {
+    enum Role: String, Codable {
+        case user
+        case assistant
+    }
+
+    let id: UUID
+    let role: Role
+    let content: String
+    let createdAt: Date
+
+    init(id: UUID = UUID(), role: Role, content: String, createdAt: Date = Date()) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.createdAt = createdAt
+    }
+}
+
+struct AgentChatConversation: Identifiable, Equatable, Codable {
+    let id: UUID
+    var title: String
+    var createdAt: Date
+    var updatedAt: Date
+    var messages: [AIChatMessage]
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        messages: [AIChatMessage] = []
+    ) {
+        self.id = id
+        self.title = title
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.messages = messages
+    }
+}
+
+struct AgentKnowledgeDocument: Identifiable, Equatable, Codable {
+    let id: UUID
+    var title: String
+    var sourcePath: String
+    var summary: String
+    var content: String
+    var keywords: [String]
+    var byteCount: Int
+    var createdAt: Date
+    var updatedAt: Date
+}
+
+struct AgentKnowledgeSearchHit: Identifiable, Equatable {
+    let id: UUID
+    let document: AgentKnowledgeDocument
+    let score: Double
+    let reason: String
+}
+
+struct AgentPluginDescriptor: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let typeTags: [String]
+    let summary: String
+    let toolNames: [String]
+    let permission: String
+    let riskLevel: String
+    let discoveryKeywords: [String]
+    let manifestPreview: String
+
+    var category: String {
+        typeTags.joined(separator: "/")
+    }
+}
+
+struct AgentSkillDescriptor: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let summary: String
+    let category: String
+    let source: String
+    let requiredTools: [String]
+    let riskLevel: String
+    let triggerKeywords: [String]
+    let workflowSteps: [String]
+    let frontMatterPreview: String
+
+    init(
+        id: String,
+        name: String,
+        summary: String,
+        category: String = "桌面",
+        source: String = "built-in",
+        requiredTools: [String],
+        riskLevel: String,
+        triggerKeywords: [String],
+        workflowSteps: [String],
+        frontMatterPreview: String
+    ) {
+        self.id = id
+        self.name = name
+        self.summary = summary
+        self.category = category
+        self.source = source
+        self.requiredTools = requiredTools
+        self.riskLevel = riskLevel
+        self.triggerKeywords = triggerKeywords
+        self.workflowSteps = workflowSteps
+        self.frontMatterPreview = frontMatterPreview
+    }
+}
+
+struct AgentPluginMatch: Identifiable, Equatable {
+    let id: String
+    let pluginName: String
+    let score: Double
+    let reason: String
+    let selected: Bool
+}
+
+struct AgentTaskUnderstanding: Equatable {
+    let taskType: String
+    let complexity: String
+    let riskLevel: String
+    let needsTools: Bool
+    let needsMemory: Bool
+    let requiresClarification: Bool
+    let summary: String
+    let signals: [String]
+
+    var contextText: String {
+        """
+        task_type: \(taskType)
+        complexity: \(complexity)
+        risk_level: \(riskLevel)
+        needs_tools: \(needsTools ? "yes" : "no")
+        needs_memory: \(needsMemory ? "yes" : "no")
+        requires_clarification: \(requiresClarification ? "yes" : "no")
+        signals: \(signals.isEmpty ? "无" : signals.joined(separator: ", "))
+        summary: \(summary)
+        """
+    }
+}
+
+struct AgentReasoningProfile: Equatable {
+    let mode: String
+    let loop: String
+    let shouldPlan: Bool
+    let maxReviewRounds: Int
+    let stopCondition: String
+
+    var contextText: String {
+        """
+        mode: \(mode)
+        loop: \(loop)
+        should_plan: \(shouldPlan ? "yes" : "no")
+        max_review_rounds: \(maxReviewRounds)
+        stop_condition: \(stopCondition)
+        """
+    }
+}
+
+struct AgentPlanStep: Identifiable, Equatable {
+    let id = UUID()
+    let order: Int
+    let title: String
+    let detail: String
+    let status: String
+}
+
+struct AgentRecoveryStrategy: Identifiable, Equatable {
+    let id = UUID()
+    let trigger: String
+    let strategy: String
+    let fallback: String
+    let status: String
+}
+
+struct AgentWorkingMemory: Equatable {
+    let currentGoal: String
+    let taskProgress: String
+    let keyEntities: [String]
+    let pendingQuestions: [String]
+
+    var contextText: String {
+        """
+        current_goal: \(currentGoal)
+        task_progress: \(taskProgress)
+        key_entities: \(keyEntities.joined(separator: ", "))
+        pending_questions: \(pendingQuestions.isEmpty ? "无" : pendingQuestions.joined(separator: "；"))
+        """
+    }
+}
+
+struct AgentMemoryRecord: Identifiable, Codable, Equatable {
+    enum Kind: String, Codable {
+        case fact
+        case episodic
+        case procedural
+
+        var displayName: String {
+            switch self {
+            case .fact:
+                return "事实记忆"
+            case .episodic:
+                return "情景记忆"
+            case .procedural:
+                return "程序记忆"
+            }
+        }
+    }
+
+    let id: UUID
+    var kind: Kind
+    var content: String
+    var keywords: [String]
+    var createdAt: Date
+    var updatedAt: Date
+    var source: String
+    var importance: Double
+    var confidence: Double
+    var accessCount: Int
+    var lastAccessedAt: Date?
+    var retrievalScore: Double?
+    var retrievalReason: String?
+
+    init(
+        id: UUID = UUID(),
+        kind: Kind,
+        content: String,
+        keywords: [String],
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        source: String,
+        importance: Double = 0.55,
+        confidence: Double = 0.82,
+        accessCount: Int = 0,
+        lastAccessedAt: Date? = nil,
+        retrievalScore: Double? = nil,
+        retrievalReason: String? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.content = content
+        self.keywords = keywords
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.source = source
+        self.importance = importance
+        self.confidence = confidence
+        self.accessCount = accessCount
+        self.lastAccessedAt = lastAccessedAt
+        self.retrievalScore = retrievalScore
+        self.retrievalReason = retrievalReason
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case kind
+        case content
+        case keywords
+        case createdAt
+        case updatedAt
+        case source
+        case importance
+        case confidence
+        case accessCount
+        case lastAccessedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        kind = try container.decodeIfPresent(Kind.self, forKey: .kind) ?? .fact
+        content = try container.decode(String.self, forKey: .content)
+        keywords = try container.decodeIfPresent([String].self, forKey: .keywords) ?? []
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+        updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? createdAt
+        source = try container.decodeIfPresent(String.self, forKey: .source) ?? "legacy"
+        importance = try container.decodeIfPresent(Double.self, forKey: .importance) ?? 0.55
+        confidence = try container.decodeIfPresent(Double.self, forKey: .confidence) ?? 0.82
+        accessCount = try container.decodeIfPresent(Int.self, forKey: .accessCount) ?? 0
+        lastAccessedAt = try container.decodeIfPresent(Date.self, forKey: .lastAccessedAt)
+        retrievalScore = nil
+        retrievalReason = nil
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(content, forKey: .content)
+        try container.encode(keywords, forKey: .keywords)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encode(source, forKey: .source)
+        try container.encode(importance, forKey: .importance)
+        try container.encode(confidence, forKey: .confidence)
+        try container.encode(accessCount, forKey: .accessCount)
+        try container.encodeIfPresent(lastAccessedAt, forKey: .lastAccessedAt)
+    }
+}
+
+struct AgentTraceStep: Identifiable, Equatable {
+    let id = UUID()
+    let title: String
+    let detail: String
+    let status: String
+}
+
+struct AgentRunTrace: Identifiable, Equatable {
+    let id = UUID()
+    var routeKind: String
+    var routeName: String
+    var routeConfidence: Double
+    var taskUnderstanding: AgentTaskUnderstanding
+    var reasoningProfile: AgentReasoningProfile
+    var discoveredPlugins: [AgentPluginMatch]
+    var selectedPlugins: [AgentPluginDescriptor]
+    var selectedSkills: [AgentSkillDescriptor]
+    var planSteps: [AgentPlanStep]
+    var workingMemory: AgentWorkingMemory?
+    var retrievedMemories: [AgentMemoryRecord]
+    var storedMemory: AgentMemoryRecord?
+    var recoveryStrategies: [AgentRecoveryStrategy]
+    var steps: [AgentTraceStep]
+    var safetyNotes: [String]
+    var status: String
+    var requiresConfirmation: Bool
+
+    var selectedToolNames: [String] {
+        selectedPlugins.flatMap(\.toolNames)
+    }
+}
+
+private struct AgentPreparedRun {
+    var trace: AgentRunTrace
+    let systemContext: String
+    let calendarContext: String?
+    let route: AgentRoute
+}
+
+private struct AgentRoute {
+    enum Kind: String {
+        case generalChat = "general_chat"
+        case schedulePlanning = "schedule_planning"
+        case calendarWrite = "calendar_write"
+        case weatherDecision = "weather_decision"
+        case focusCoaching = "focus_coaching"
+        case assignmentPlanning = "assignment_planning"
+        case agentArchitecture = "agent_architecture"
+        case fileProcessing = "file_processing"
+        case researchPlanning = "research_planning"
+    }
+
+    let kind: Kind
+    let confidence: Double
+}
+
+@MainActor
+private final class AgentMemoryStore {
+    static let shared = AgentMemoryStore()
+
+    private(set) var records: [AgentMemoryRecord] = []
+    private let fileURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    private let semanticKeywords = [
+        "日历", "日程", "会议", "空闲", "天气", "户外", "跑步", "学习", "复习", "作业", "大作业",
+        "评分", "提交", "番茄钟", "专注", "偏好", "习惯", "周末", "晚上", "早上", "课程", "论文",
+        "记忆", "长期记忆", "工作记忆", "短期记忆", "智能体", "插件", "技能", "架构", "文件",
+        "calendar", "schedule", "weather", "assignment", "homework", "study", "focus", "pomodoro",
+        "preference", "habit", "deadline", "paper", "memory", "agent", "plugin", "skill", "file"
+    ]
+
+    private init() {
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+
+        let baseDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? temporaryDirectory
+        let directory = baseDirectory
+            .appendingPathComponent("DanShenAgent", isDirectory: true)
+        fileURL = directory.appendingPathComponent("memories.json")
+
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        migrateLegacyMemoryIfNeeded(from: baseDirectory)
+        load()
+    }
+
+    var recentRecords: [AgentMemoryRecord] {
+        Array(records.sorted { $0.updatedAt > $1.updatedAt }.prefix(20))
+    }
+
+    var storageURL: URL {
+        fileURL
+    }
+
+    private func migrateLegacyMemoryIfNeeded(from baseDirectory: URL) {
+        let legacyDirectoryName = "Nook" + "XAgent"
+        let legacyURL = baseDirectory
+            .appendingPathComponent(legacyDirectoryName, isDirectory: true)
+            .appendingPathComponent("memories.json")
+        let previousDirectoryName = "Notch" + "MindAgent"
+        let previousURL = baseDirectory
+            .appendingPathComponent(previousDirectoryName, isDirectory: true)
+            .appendingPathComponent("memories.json")
+
+        let fileManager = FileManager.default
+        guard !fileManager.fileExists(atPath: fileURL.path) else {
+            return
+        }
+
+        if fileManager.fileExists(atPath: previousURL.path) {
+            try? fileManager.copyItem(at: previousURL, to: fileURL)
+        } else if fileManager.fileExists(atPath: legacyURL.path) {
+            try? fileManager.copyItem(at: legacyURL, to: fileURL)
+        }
+    }
+
+    func retrieve(prompt: String, route: AgentRoute, limit: Int = 5) -> [AgentMemoryRecord] {
+        let queryKeywords = keywords(for: prompt + " " + route.kind.rawValue)
+        guard !records.isEmpty, !queryKeywords.isEmpty else { return [] }
+
+        let now = Date()
+        let matches = records
+            .enumerated()
+            .map { index, record -> (index: Int, score: Double, reason: String) in
+                let recordKeywords = Set(record.keywords)
+                let matchedKeywords = Array(queryKeywords.intersection(recordKeywords)).sorted()
+                let overlap = matchedKeywords.count
+                let semanticScore = Double(overlap) / Double(max(queryKeywords.count, 1))
+                let contentScore = queryKeywords.reduce(0.0) { partial, keyword in
+                    record.content.lowercased().contains(keyword.lowercased()) ? partial + 0.05 : partial
+                }
+                let ageDays = max(0, now.timeIntervalSince(record.updatedAt) / 86_400)
+                let recencyScore = max(0, 0.18 - min(ageDays, 30) * 0.006)
+                let typeBoost = record.kind == .fact ? 0.08 : 0.03
+                let importanceBoost = min(record.importance, 1.0) * 0.07
+                let confidenceBoost = min(record.confidence, 1.0) * 0.04
+                let score = semanticScore
+                    + min(contentScore, 0.2)
+                    + recencyScore
+                    + typeBoost
+                    + importanceBoost
+                    + confidenceBoost
+                let reason = retrievalReason(
+                    matchedKeywords: matchedKeywords,
+                    contentScore: contentScore,
+                    recencyScore: recencyScore,
+                    kind: record.kind
+                )
+                return (index, score, reason)
+            }
+            .filter { $0.score > 0.08 }
+            .sorted { $0.score > $1.score }
+            .prefix(limit)
+
+        guard !matches.isEmpty else { return [] }
+
+        for match in matches {
+            records[match.index].accessCount += 1
+            records[match.index].lastAccessedAt = now
+        }
+        save()
+
+        return matches.map { match in
+            var record = records[match.index]
+            record.retrievalScore = match.score
+            record.retrievalReason = match.reason
+            return record
+        }
+    }
+
+    func storeIfUseful(prompt: String, route: AgentRoute) -> AgentMemoryRecord? {
+        guard shouldPersist(prompt) else { return nil }
+
+        let content = normalizedMemoryContent(from: prompt)
+        return store(content: content, routeKind: route.kind.rawValue, source: "explicit-user-message")
+    }
+
+    func storeManual(_ content: String) -> AgentMemoryRecord? {
+        store(content: content, routeKind: "manual_memory", source: "slash-remember")
+    }
+
+    func forget(matching query: String) -> Int {
+        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedQuery.isEmpty else {
+            let count = records.count
+            clear()
+            return count
+        }
+
+        let queryKeywords = keywords(for: normalizedQuery)
+        let beforeCount = records.count
+        records.removeAll { record in
+            record.content.localizedCaseInsensitiveContains(normalizedQuery)
+                || Set(record.keywords).intersection(queryKeywords).count >= 2
+        }
+        let removedCount = beforeCount - records.count
+        if removedCount > 0 {
+            save()
+        }
+        return removedCount
+    }
+
+    private func store(content rawContent: String, routeKind: String, source: String) -> AgentMemoryRecord? {
+        let content = rawContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        let record = AgentMemoryRecord(
+            id: UUID(),
+            kind: memoryKind(for: content, routeKind: routeKind),
+            content: String(content.prefix(320)),
+            keywords: Array(keywords(for: content + " " + routeKind)).sorted(),
+            createdAt: Date(),
+            updatedAt: Date(),
+            source: source,
+            importance: importance(for: content, source: source),
+            confidence: confidence(for: source)
+        )
+        guard !record.content.isEmpty else { return nil }
+
+        if let existingIndex = records.firstIndex(where: { existing in
+            Set(existing.keywords).intersection(record.keywords).count >= 2
+                && existing.content.localizedCaseInsensitiveContains(String(record.content.prefix(24)))
+        }) {
+            records[existingIndex].content = record.content
+            records[existingIndex].keywords = record.keywords
+            records[existingIndex].kind = record.kind
+            records[existingIndex].source = record.source
+            records[existingIndex].importance = max(records[existingIndex].importance, record.importance)
+            records[existingIndex].confidence = max(records[existingIndex].confidence, record.confidence)
+            records[existingIndex].updatedAt = Date()
+            save()
+            return records[existingIndex]
+        }
+
+        records.append(record)
+        records = Array(records.sorted { $0.updatedAt > $1.updatedAt }.prefix(100))
+        save()
+        return record
+    }
+
+    func clear() {
+        records.removeAll()
+        save()
+    }
+
+    func keywords(for text: String) -> Set<String> {
+        let lowered = text.lowercased()
+        var result = Set(
+            lowered
+                .split { !$0.isLetter && !$0.isNumber }
+                .map(String.init)
+                .filter { $0.count >= 2 && $0.count <= 28 }
+        )
+
+        for keyword in semanticKeywords where lowered.contains(keyword.lowercased()) {
+            result.insert(keyword.lowercased())
+        }
+
+        return result
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        records = (try? decoder.decode([AgentMemoryRecord].self, from: data)) ?? []
+    }
+
+    private func save() {
+        guard let data = try? encoder.encode(records) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    private func shouldPersist(_ prompt: String) -> Bool {
+        let lowered = prompt.lowercased()
+        let explicitSignals = [
+            "记住", "记一下", "请记", "以后", "我的偏好", "我的习惯", "我喜欢", "我不喜欢",
+            "默认", "remember", "my preference", "i prefer", "always", "never"
+        ]
+        return explicitSignals.contains(where: lowered.contains)
+    }
+
+    private func normalizedMemoryContent(from prompt: String) -> String {
+        let withoutFiles = prompt
+            .components(separatedBy: "本地文件上下文：")
+            .first ?? prompt
+        return withoutFiles
+            .replacingOccurrences(of: "请记住", with: "")
+            .replacingOccurrences(of: "记住", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func memoryKind(for content: String, routeKind: String) -> AgentMemoryRecord.Kind {
+        let lowered = content.lowercased()
+        if lowered.contains("流程") || lowered.contains("步骤") || lowered.contains("workflow") {
+            return .procedural
+        }
+        if routeKind == AgentRoute.Kind.assignmentPlanning.rawValue
+            || lowered.contains("上次")
+            || lowered.contains("过去")
+        {
+            return .episodic
+        }
+        return .fact
+    }
+
+    private func importance(for content: String, source: String) -> Double {
+        let lowered = content.lowercased()
+        var score = source == "slash-remember" ? 0.72 : 0.58
+        if ["默认", "偏好", "习惯", "喜欢", "不喜欢", "always", "never", "prefer"].contains(where: lowered.contains) {
+            score += 0.2
+        }
+        if ["流程", "步骤", "workflow", "以后"].contains(where: lowered.contains) {
+            score += 0.12
+        }
+        return min(score, 1.0)
+    }
+
+    private func confidence(for source: String) -> Double {
+        source == "slash-remember" ? 0.96 : 0.9
+    }
+
+    private func retrievalReason(
+        matchedKeywords: [String],
+        contentScore: Double,
+        recencyScore: Double,
+        kind: AgentMemoryRecord.Kind
+    ) -> String {
+        var reasons: [String] = []
+        if !matchedKeywords.isEmpty {
+            reasons.append("关键词 \(matchedKeywords.prefix(4).joined(separator: ", "))")
+        }
+        if contentScore > 0 {
+            reasons.append("内容命中")
+        }
+        if recencyScore > 0.12 {
+            reasons.append("近期更新")
+        }
+        if kind == .fact {
+            reasons.append("稳定事实")
+        }
+        return reasons.isEmpty ? "低权重相关" : reasons.joined(separator: " + ")
+    }
+}
+
+@MainActor
+private final class AgentKnowledgeStore {
+    static let shared = AgentKnowledgeStore()
+
+    private(set) var documents: [AgentKnowledgeDocument] = []
+    private let fileURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private let semanticKeywords = [
+        "知识库", "资料库", "课程", "作业", "评分", "提交", "论文", "文献", "报告", "计划",
+        "插件", "技能", "智能体", "记忆", "天气", "日程", "番茄钟", "knowledge", "rag",
+        "assignment", "rubric", "paper", "research", "agent", "plugin", "skill", "memory"
+    ]
+
+    private init() {
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+
+        let directory = Self.storageDirectory()
+        fileURL = directory.appendingPathComponent("knowledge.json")
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        load()
+    }
+
+    var storageURL: URL {
+        fileURL
+    }
+
+    @discardableResult
+    func addDocument(
+        title rawTitle: String,
+        sourcePath: String,
+        content rawContent: String,
+        byteCount: Int
+    ) -> AgentKnowledgeDocument? {
+        let content = rawContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !content.isEmpty else { return nil }
+
+        let title = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "未命名资料"
+            : rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let now = Date()
+        let summary = summarize(content)
+        let keywords = Array(keywords(for: "\(title) \(summary) \(content.prefix(2400))")).sorted()
+
+        if let index = documents.firstIndex(where: { $0.sourcePath == sourcePath }) {
+            documents[index].title = title
+            documents[index].summary = summary
+            documents[index].content = String(content.prefix(32_000))
+            documents[index].keywords = keywords
+            documents[index].byteCount = byteCount
+            documents[index].updatedAt = now
+            save()
+            return documents[index]
+        }
+
+        let document = AgentKnowledgeDocument(
+            id: UUID(),
+            title: title,
+            sourcePath: sourcePath,
+            summary: summary,
+            content: String(content.prefix(32_000)),
+            keywords: keywords,
+            byteCount: byteCount,
+            createdAt: now,
+            updatedAt: now
+        )
+        documents.insert(document, at: 0)
+        documents = Array(documents.sorted { $0.updatedAt > $1.updatedAt }.prefix(80))
+        save()
+        return document
+    }
+
+    func retrieve(query: String, limit: Int = 3) -> [AgentKnowledgeSearchHit] {
+        let queryKeywords = keywords(for: query)
+        let lowered = query.lowercased()
+        guard !documents.isEmpty else { return [] }
+
+        return documents.compactMap { document in
+            let documentKeywords = Set(document.keywords)
+            let matched = documentKeywords.intersection(queryKeywords)
+            let titleHit = document.title.lowercased().contains(lowered) && lowered.count >= 2
+            let contentHit = document.content.lowercased().contains(lowered) && lowered.count >= 3
+            let age = max(0, Date().timeIntervalSince(document.updatedAt))
+            let recency = max(0.0, 0.12 - min(age / 604_800, 1.0) * 0.12)
+            let score = min(Double(matched.count) * 0.18 + (titleHit ? 0.24 : 0) + (contentHit ? 0.16 : 0) + recency, 1.0)
+            guard score >= 0.18 else { return nil }
+
+            let reason = matched.isEmpty
+                ? "标题/正文命中"
+                : "关键词 \(matched.prefix(5).joined(separator: ", "))"
+            return AgentKnowledgeSearchHit(
+                id: document.id,
+                document: document,
+                score: score,
+                reason: reason
+            )
+        }
+        .sorted { $0.score > $1.score }
+        .prefix(limit)
+        .map { $0 }
+    }
+
+    func hasRelevantContent(for query: String) -> Bool {
+        !retrieve(query: query, limit: 1).isEmpty
+    }
+
+    func removeDocument(id: UUID) {
+        documents.removeAll { $0.id == id }
+        save()
+    }
+
+    func clear() {
+        documents.removeAll()
+        save()
+    }
+
+    private static func storageDirectory() -> URL {
+        let baseDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? temporaryDirectory
+        return baseDirectory.appendingPathComponent("DanShenAgent", isDirectory: true)
+    }
+
+    private func summarize(_ content: String) -> String {
+        let cleanedLines = content
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let seed = cleanedLines.prefix(3).joined(separator: " ")
+        return String(seed.prefix(220))
+    }
+
+    private func keywords(for text: String) -> Set<String> {
+        let lowered = text.lowercased()
+        var result = Set(
+            lowered
+                .split { !$0.isLetter && !$0.isNumber }
+                .map(String.init)
+                .filter { $0.count >= 2 && $0.count <= 28 }
+        )
+
+        for keyword in semanticKeywords where lowered.contains(keyword.lowercased()) {
+            result.insert(keyword.lowercased())
+        }
+        return result
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        documents = (try? decoder.decode([AgentKnowledgeDocument].self, from: data)) ?? []
+    }
+
+    private func save() {
+        guard let data = try? encoder.encode(documents) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+}
+
+@MainActor
+private final class AgentOrchestrator {
+    static let shared = AgentOrchestrator()
+    private static let weatherCalendarKeywords = [
+        "schedule", "calendar", "available", "outdoor", "run",
+        "安排", "计划", "日程", "行程", "空闲", "会议", "户外", "跑步", "出门", "运动"
+    ]
+
+    let plugins: [AgentPluginDescriptor] = [
+        .init(
+            id: "calendar",
+            name: "日程管理",
+            typeTags: ["context", "action"],
+            summary: "读取近期日程，并在明确要求时创建日历计划。",
+            toolNames: ["calendar.read", "calendar.create_event"],
+            permission: "读取自动，写入受设置控制",
+            riskLevel: "中",
+            discoveryKeywords: ["calendar", "schedule", "agenda", "日程", "行程", "会议", "空闲", "写入日历"],
+            manifestPreview: """
+            {"id":"calendar","type":["context","action"],"tools":["calendar.read","calendar.create_event"],"permissions":{"read":"auto","write":"settings-gated"},"riskLevel":"medium"}
+            """
+        ),
+        .init(
+            id: "weather",
+            name: "天气查询",
+            typeTags: ["context"],
+            summary: "获取 Open-Meteo 当前天气，用于出行和户外决策。",
+            toolNames: ["weather.current", "weather.hourly"],
+            permission: "读取自动",
+            riskLevel: "低",
+            discoveryKeywords: ["weather", "rain", "temperature", "outdoor", "天气", "下雨", "气温", "户外", "跑步"],
+            manifestPreview: """
+            {"id":"weather","type":["context"],"tools":["weather.current","weather.hourly"],"permissions":{"read":"auto"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "focus",
+            name: "焦点计时",
+            typeTags: ["context", "action"],
+            summary: "读取番茄钟状态和专注时长偏好。",
+            toolNames: ["focus.status", "focus.start"],
+            permission: "读取自动，动作由用户触发",
+            riskLevel: "低",
+            discoveryKeywords: ["focus", "pomodoro", "study", "deep work", "专注", "番茄钟", "学习", "冲刺"],
+            manifestPreview: """
+            {"id":"focus","type":["context","action"],"tools":["focus.status","focus.start"],"permissions":{"read":"auto","action":"user-triggered"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "skills",
+            name: "技能手册",
+            typeTags: ["skill"],
+            summary: "注入类似 Codex/Claude Skills 的任务流程。",
+            toolNames: ["skill.study_plan", "skill.assignment_breakdown"],
+            permission: "读取自动",
+            riskLevel: "低",
+            discoveryKeywords: ["skill", "study plan", "assignment", "复习", "作业", "拆解", "规划"],
+            manifestPreview: """
+            {"id":"skills","type":["skill"],"tools":["skill.study_plan","skill.assignment_breakdown"],"permissions":{"read":"auto"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "assignment",
+            name: "作业资料",
+            typeTags: ["context", "skill"],
+            summary: "识别上传或本地文本中的作业要求，提取评分点和交付物。",
+            toolNames: ["assignment.extract_requirements", "assignment.rubric_map"],
+            permission: "读取用户显式提供的文件",
+            riskLevel: "低",
+            discoveryKeywords: ["assignment", "homework", "rubric", "作业", "大作业", "评分", "要求", "提交"],
+            manifestPreview: """
+            {"id":"assignment","type":["context","skill"],"tools":["assignment.extract_requirements","assignment.rubric_map"],"permissions":{"read":"provided-files-only"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "shelf",
+            name: "文件架",
+            typeTags: ["context"],
+            summary: "面向拖入 Notch 的文件做摘要、归类和待办提取。",
+            toolNames: ["shelf.summarize", "shelf.extract_todos"],
+            permission: "读取用户拖入或上传的文件",
+            riskLevel: "低",
+            discoveryKeywords: ["file", "shelf", "summary", "todo", "文件", "上传", "摘要", "待办"],
+            manifestPreview: """
+            {"id":"shelf","type":["context"],"tools":["shelf.summarize","shelf.extract_todos"],"permissions":{"read":"provided-files-only"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "memory",
+            name: "偏好记忆",
+            typeTags: ["context", "action"],
+            summary: "管理短期会话、工作记忆和本地长期记忆检索。",
+            toolNames: ["memory.short_term", "memory.working_state", "memory.retrieve", "memory.save_preference"],
+            permission: "读取自动，长期写入只在用户明确要求记住时发生",
+            riskLevel: "低",
+            discoveryKeywords: ["preference", "habit", "memory", "remember", "偏好", "习惯", "记住", "长期记忆", "工作记忆"],
+            manifestPreview: """
+            {"id":"memory","type":["context","action"],"tools":["memory.short_term","memory.working_state","memory.retrieve","memory.save_preference"],"permissions":{"read":"auto","write":"explicit-memory-request"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "knowledge",
+            name: "本地知识库",
+            typeTags: ["context"],
+            summary: "检索用户导入的study materials、作业要求、论文笔记和 Markdown 文档。",
+            toolNames: ["knowledge.add_document", "knowledge.retrieve"],
+            permission: "只读取用户显式导入的文件",
+            riskLevel: "低",
+            discoveryKeywords: ["knowledge", "rag", "notes", "document", "知识库", "资料库", "study materials", "笔记", "文档"],
+            manifestPreview: """
+            {"id":"knowledge","type":["context"],"tools":["knowledge.add_document","knowledge.retrieve"],"permissions":{"read":"user-imported-only","write":"explicit-import"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "planner",
+            name: "任务规划器",
+            typeTags: ["cognition"],
+            summary: "把复杂目标拆成有顺序、可检查的执行步骤。",
+            toolNames: ["planner.decompose", "planner.dependency_map"],
+            permission: "始终启用，只生成计划",
+            riskLevel: "低",
+            discoveryKeywords: ["plan", "planner", "decompose", "规划", "计划", "拆解", "步骤", "里程碑"],
+            manifestPreview: """
+            {"id":"planner","type":["cognition"],"tools":["planner.decompose","planner.dependency_map"],"permissions":{"read":"always-on","write":"never"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "reasoner",
+            name: "推理模式选择",
+            typeTags: ["cognition"],
+            summary: "根据任务复杂度选择直接回答、工作流、ReAct 或自我修正模式。",
+            toolNames: ["reasoner.mode_select", "reasoner.react_loop", "reasoner.self_correction"],
+            permission: "始终启用，只控制思考流程",
+            riskLevel: "低",
+            discoveryKeywords: ["reason", "react", "cot", "推理", "思考", "自我修正", "复杂任务"],
+            manifestPreview: """
+            {"id":"reasoner","type":["cognition"],"tools":["reasoner.mode_select","reasoner.react_loop","reasoner.self_correction"],"permissions":{"read":"always-on","write":"never"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "reviewer",
+            name: "反思评审器",
+            typeTags: ["guard", "cognition"],
+            summary: "从输出、过程和策略三个层面检查回答质量。",
+            toolNames: ["review.output_check", "review.process_check", "review.strategy_check"],
+            permission: "始终启用，只做质量检查",
+            riskLevel: "低",
+            discoveryKeywords: ["review", "reflect", "quality", "反思", "检查", "评审", "质量"],
+            manifestPreview: """
+            {"id":"reviewer","type":["guard","cognition"],"tools":["review.output_check","review.process_check","review.strategy_check"],"permissions":{"read":"always-on","write":"never"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "recovery",
+            name: "异常恢复器",
+            typeTags: ["guard"],
+            summary: "为工具失败、缺失信息、格式错误和权限不足提供降级策略。",
+            toolNames: ["recovery.retry", "recovery.degrade", "recovery.ask_user"],
+            permission: "始终启用，不自动执行危险动作",
+            riskLevel: "低",
+            discoveryKeywords: ["recovery", "fallback", "error", "失败", "异常", "降级", "恢复", "重试"],
+            manifestPreview: """
+            {"id":"recovery","type":["guard"],"tools":["recovery.retry","recovery.degrade","recovery.ask_user"],"permissions":{"read":"always-on","write":"never"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "safety",
+            name: "安全护栏",
+            typeTags: ["guard"],
+            summary: "检查风险动作、缺失信息和工具失败。",
+            toolNames: ["guard.risk_check", "guard.reflection"],
+            permission: "始终启用",
+            riskLevel: "低",
+            discoveryKeywords: ["risk", "confirm", "safe", "权限", "确认", "安全", "护栏"],
+            manifestPreview: """
+            {"id":"safety","type":["guard"],"tools":["guard.risk_check","guard.reflection"],"permissions":{"read":"always-on","write":"never"},"riskLevel":"low"}
+            """
+        ),
+        .init(
+            id: "trace",
+            name: "执行轨迹",
+            typeTags: ["guard", "context"],
+            summary: "记录路由、插件发现、工具上下文、安全检查和执行结果。",
+            toolNames: ["trace.log", "trace.explain"],
+            permission: "始终启用",
+            riskLevel: "低",
+            discoveryKeywords: ["trace", "explain", "debug", "轨迹", "解释", "调试"],
+            manifestPreview: """
+            {"id":"trace","type":["guard","context"],"tools":["trace.log","trace.explain"],"permissions":{"read":"always-on"},"riskLevel":"low"}
+            """
+        ),
+    ]
+
+    let skills: [AgentSkillDescriptor] = [
+        .init(
+            id: "study_plan",
+            name: "学习计划",
+            summary: "把复习、阅读、作业拆成可执行的专注块。",
+            category: "学习",
+            requiredTools: ["calendar.read", "focus.status", "memory.preferences"],
+            riskLevel: "低",
+            triggerKeywords: ["study", "review", "exam", "学习", "复习", "考试"],
+            workflowSteps: ["读取日程空档", "拆分知识点和任务块", "映射番茄钟节奏", "输出当天/本周计划"],
+            frontMatterPreview: """
+            ---
+            name: study-plan
+            required_tools: calendar.read, focus.status, memory.preferences
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "assignment_breakdown",
+            name: "作业拆解",
+            summary: "按评分标准拆交付物、里程碑和当天任务。",
+            category: "学习",
+            requiredTools: ["calendar.read", "focus.status", "skill.assignment_breakdown"],
+            riskLevel: "低",
+            triggerKeywords: ["assignment", "homework", "rubric", "作业", "大作业", "评分"],
+            workflowSteps: ["提取作业要求", "列出评分点", "拆成里程碑", "安排可执行任务", "标出缺失信息"],
+            frontMatterPreview: """
+            ---
+            name: assignment-breakdown
+            required_tools: assignment.extract_requirements, calendar.read, focus.status
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "calendar_aware_planning",
+            name: "日程感知规划",
+            summary: "读取空闲时间，避免冲突，输出绝对时间安排。",
+            category: "桌面",
+            requiredTools: ["calendar.read", "calendar.create_event"],
+            riskLevel: "中",
+            triggerKeywords: ["calendar", "schedule", "meeting", "日历", "日程", "会议", "空闲", "行程"],
+            workflowSteps: ["读取近期日程", "找空闲窗口", "规避冲突", "给出绝对时间", "写入前确认边界"],
+            frontMatterPreview: """
+            ---
+            name: calendar-aware-planning
+            required_tools: calendar.read, calendar.create_event
+            risk: requires-confirmation
+            ---
+            """
+        ),
+        .init(
+            id: "weather_decision",
+            name: "天气决策",
+            summary: "结合天气、时间和日程给出出行/运动建议。",
+            category: "桌面",
+            requiredTools: ["weather.current"],
+            riskLevel: "低",
+            triggerKeywords: ["weather", "outdoor", "run", "天气", "户外", "跑步", "出门"],
+            workflowSteps: ["读取当前天气", "判断天气风险", "给出穿衣/出行建议", "必要时提示缺失信息"],
+            frontMatterPreview: """
+            ---
+            name: weather-decision
+            required_tools: weather.current
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "agent_memory_design",
+            name: "智能体记忆设计",
+            summary: "把短期记忆、工作记忆、长期记忆和 Token 管理组织成可解释架构。",
+            category: "智能体",
+            requiredTools: ["memory.short_term", "memory.working_state", "memory.retrieve", "planner.decompose"],
+            riskLevel: "低",
+            triggerKeywords: ["memory", "agent", "plugin", "skill", "记忆", "智能体", "插件", "架构"],
+            workflowSteps: ["区分三层记忆", "定义写入策略", "设计混合检索", "控制上下文注入", "暴露 trace 解释"],
+            frontMatterPreview: """
+            ---
+            name: agent-memory-design
+            required_tools: memory.short_term, memory.working_state, memory.retrieve
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "file_context_analysis",
+            name: "文件上下文分析",
+            summary: "读取用户显式上传文本，提取摘要、任务、风险和下一步。",
+            category: "文件",
+            requiredTools: ["shelf.summarize", "shelf.extract_todos"],
+            riskLevel: "低",
+            triggerKeywords: ["file", "upload", "文件", "上传", "摘要", "读取"],
+            workflowSteps: ["确认文件来源", "摘要核心内容", "提取待办和实体", "标出缺失信息", "只引用已提供上下文"],
+            frontMatterPreview: """
+            ---
+            name: file-context-analysis
+            required_tools: shelf.summarize, shelf.extract_todos
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "research_planning",
+            name: "研究规划",
+            summary: "把论文、调研或报告主题拆成检索问题、证据表和产出计划。",
+            category: "学术",
+            requiredTools: ["planner.decompose", "memory.retrieve"],
+            riskLevel: "低",
+            triggerKeywords: ["research", "paper", "literature", "论文", "文献", "调研", "研究"],
+            workflowSteps: ["界定研究问题", "拆分检索方向", "规划证据表", "安排写作里程碑", "说明需要外部资料"],
+            frontMatterPreview: """
+            ---
+            name: research-planning
+            required_tools: planner.decompose, memory.retrieve
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "nature_academic_search",
+            name: "Nature 文献检索",
+            summary: "参考本地 nature-academic-search，把多源文献检索、候选筛选和引用导出拆成流程。",
+            category: "学术",
+            source: "local-codex-nature",
+            requiredTools: ["planner.decompose", "memory.retrieve", "external.literature_search"],
+            riskLevel: "低",
+            triggerKeywords: ["literature", "search", "pubmed", "crossref", "arxiv", "文献", "检索", "调研", "综述"],
+            workflowSteps: ["定义检索问题", "拆英文关键词和同义词", "区分 PubMed/CrossRef/arXiv 场景", "建立候选证据表", "标注可信度和缺口"],
+            frontMatterPreview: """
+            ---
+            name: nature-academic-search
+            required_tools: planner.decompose, external.literature_search
+            source: local-codex-skill-summary
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "nature_reader",
+            name: "Nature 论文精读",
+            summary: "参考本地 nature-reader，把论文转成中英对照、图表贴近原文、可追溯的阅读稿。",
+            category: "学术",
+            source: "local-codex-nature",
+            requiredTools: ["shelf.summarize", "memory.retrieve"],
+            riskLevel: "低",
+            triggerKeywords: ["reader", "pdf", "translate paper", "全文翻译", "中英文", "原文对照", "精读", "读论文", "解读论文"],
+            workflowSteps: ["确认论文来源", "保留章节结构", "中英段落对照", "图表靠近首次解释处", "输出 source anchors 和阅读备注"],
+            frontMatterPreview: """
+            ---
+            name: nature-reader
+            required_tools: shelf.summarize, memory.retrieve
+            source: local-codex-skill-summary
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "nature_writing",
+            name: "Nature 科学写作",
+            summary: "参考本地 nature-writing，从证据、贡献和论证顺序重建摘要、引言、结果或讨论。",
+            category: "学术",
+            source: "local-codex-nature",
+            requiredTools: ["planner.decompose", "memory.retrieve"],
+            riskLevel: "低",
+            triggerKeywords: ["manuscript", "abstract", "introduction", "discussion", "写作", "论文摘要", "写摘要", "摘要写作", "引言", "结果", "讨论", "改写论文"],
+            workflowSteps: ["先列作者证据", "搭建论证骨架", "控制创新性和边界", "按章节写作", "标出缺失证据和占位"],
+            frontMatterPreview: """
+            ---
+            name: nature-writing
+            required_tools: planner.decompose, memory.retrieve
+            source: local-codex-skill-summary
+            risk: low
+            ---
+            """
+        ),
+        .init(
+            id: "nature_citation",
+            name: "Nature 严格引用",
+            summary: "参考本地 nature-citation，把文本切分成可引用片段，并保守匹配 Nature/CNS/Cell 等支撑文献。",
+            category: "学术",
+            source: "local-codex-nature",
+            requiredTools: ["planner.decompose", "external.literature_search"],
+            riskLevel: "低",
+            triggerKeywords: ["citation", "reference", "cns", "nature", "cell", "引用", "参考文献", "支撑文献", "补引用", "分段引用"],
+            workflowSteps: ["切分待支撑句子", "翻译成英文检索 claim", "查找候选文献", "判断强/部分/背景支撑", "输出引用建议和风险"],
+            frontMatterPreview: """
+            ---
+            name: nature-citation
+            required_tools: external.literature_search
+            source: local-codex-skill-summary
+            risk: low
+            ---
+            """
+        ),
+    ]
+
+    private init() {}
+
+    func prepare(prompt: String, recentMessages: [AIChatMessage] = []) async -> AgentPreparedRun {
+        let route = routePrompt(prompt)
+        let discoveredPlugins = discoverPlugins(for: route, prompt: prompt)
+        let selectedPlugins = discoveredPlugins
+            .filter(\.selected)
+            .compactMap { match in plugins.first(where: { $0.id == match.id }) }
+        let selectedSkills = skillsForRoute(route, prompt: prompt)
+        let taskUnderstanding = buildTaskUnderstanding(
+            prompt: prompt,
+            route: route,
+            selectedPlugins: selectedPlugins,
+            selectedSkills: selectedSkills
+        )
+        let reasoningProfile = buildReasoningProfile(for: taskUnderstanding, route: route)
+        let planSteps = buildPlanSteps(
+            route: route,
+            selectedPlugins: selectedPlugins,
+            selectedSkills: selectedSkills
+        )
+        var workingMemory: AgentWorkingMemory?
+        var retrievedMemories: [AgentMemoryRecord] = []
+        var storedMemory: AgentMemoryRecord?
+
+        var steps: [AgentTraceStep] = [
+            .init(
+                title: "路由",
+                detail: "\(route.kind.displayName)，置信度 \(String(format: "%.2f", route.confidence))",
+                status: "done"
+            ),
+            .init(
+                title: "渐进式插件发现",
+                detail: discoveredPlugins.prefix(5).map {
+                    "\($0.pluginName) \(Int(($0.score * 100).rounded()))%：\($0.reason)"
+                }.joined(separator: "；"),
+                status: "done"
+            ),
+            .init(
+                title: "装载插件",
+                detail: selectedPlugins.map { "\($0.name)[\($0.category)]" }.joined(separator: "、"),
+                status: "done"
+            ),
+        ]
+
+        var contextBlocks: [String] = []
+        var calendarContext: String?
+        let selectedIDs = Set(selectedPlugins.map(\.id))
+
+        if selectedIDs.contains("memory") {
+            let memoryStore = AgentMemoryStore.shared
+            let shortTermContext = shortTermSummary(from: recentMessages)
+            workingMemory = buildWorkingMemory(
+                prompt: prompt,
+                route: route,
+                selectedPlugins: selectedPlugins,
+                selectedSkills: selectedSkills
+            )
+            storedMemory = memoryStore.storeIfUseful(prompt: prompt, route: route)
+            retrievedMemories = memoryStore.retrieve(prompt: prompt, route: route)
+
+            contextBlocks.append("[memory.short_term]\n\(shortTermContext)")
+            if let workingMemory {
+                contextBlocks.append("[memory.working_state]\n\(workingMemory.contextText)")
+            }
+            contextBlocks.append("[memory.preferences]\n\(preferenceSummary())")
+            contextBlocks.append("[memory.long_term]\n\(longTermMemorySummary(retrievedMemories))")
+
+            steps.append(.init(title: "短期记忆", detail: "保留最近 \(min(recentMessages.count, 6)) 条会话摘要。", status: "done"))
+            if let workingMemory {
+                steps.append(.init(title: "工作记忆", detail: workingMemory.currentGoal, status: "done"))
+            }
+            steps.append(
+                .init(
+                    title: "长期记忆检索",
+                    detail: retrievedMemories.isEmpty ? "无相关长期记忆" : "命中 \(retrievedMemories.count) 条：\(retrievedMemories.prefix(3).map(\.content).joined(separator: "；"))",
+                    status: retrievedMemories.isEmpty ? "skipped" : "done"
+                )
+            )
+            if let storedMemory {
+                steps.append(.init(title: "长期记忆写入", detail: storedMemory.content, status: "done"))
+            }
+        }
+
+        if selectedIDs.contains("knowledge"), Defaults[.aiKnowledgeRetrievalEnabled] {
+            let retrievalLimit = min(max(Defaults[.aiKnowledgeRetrievalLimit], 1), 8)
+            let hits = AgentKnowledgeStore.shared.retrieve(query: prompt, limit: retrievalLimit)
+            let knowledgeContext: String
+            if hits.isEmpty {
+                knowledgeContext = "知识库没有命中相关资料。"
+            } else {
+                knowledgeContext = hits.enumerated().map { index, hit in
+                    """
+                    \(index + 1). \(hit.document.title) score=\(String(format: "%.2f", hit.score)) reason=\(hit.reason)
+                    source: \(hit.document.sourcePath)
+                    summary: \(hit.document.summary)
+                    excerpt: \(String(hit.document.content.prefix(900)))
+                    """
+                }.joined(separator: "\n\n")
+            }
+            contextBlocks.append("[knowledge.retrieve]\n\(knowledgeContext)")
+            steps.append(
+                .init(
+                    title: "工具 knowledge.retrieve",
+                    detail: hits.isEmpty ? "本地知识库无相关命中" : "命中 \(hits.count) 份资料：\(hits.map { $0.document.title }.joined(separator: "、"))",
+                    status: hits.isEmpty ? "skipped" : "done"
+                )
+            )
+        }
+
+        if selectedIDs.contains("calendar") {
+            if Defaults[.aiCalendarContextEnabled] {
+                calendarContext = await CalendarManager.shared.aiScheduleContext()
+                contextBlocks.append(
+                    """
+                    [calendar.read]
+                    \(calendarContext ?? "日历上下文不可用。如果任务依赖日程，请提示用户开启日历权限。")
+                    """
+                )
+                steps.append(
+                    .init(
+                        title: "工具 calendar.read",
+                        detail: calendarContext == nil ? "不可用或权限不足" : "已读取近期日程",
+                        status: calendarContext == nil ? "fallback" : "done"
+                    )
+                )
+            } else {
+                contextBlocks.append("[calendar.read]\nDisabled in Settings > AI.")
+                steps.append(.init(title: "工具 calendar.read", detail: "用户设置已关闭", status: "skipped"))
+            }
+        }
+
+        if selectedIDs.contains("assignment") {
+            let hasProvidedFile = prompt.contains("[file:") || prompt.contains("本地文件上下文")
+            let assignmentContext = hasProvidedFile
+                ? "已检测到用户上传的作业/文本上下文；后续回复需要提取交付物、评分点和缺失信息。"
+                : "未检测到上传的作业要求文件；如任务依赖评分标准，需要请用户上传或粘贴要求。"
+            contextBlocks.append("[assignment.extract_requirements]\n\(assignmentContext)")
+            steps.append(
+                .init(
+                    title: "工具 assignment.extract_requirements",
+                    detail: assignmentContext,
+                    status: hasProvidedFile ? "done" : "fallback"
+                )
+            )
+        }
+
+        if selectedIDs.contains("shelf") {
+            let hasProvidedFile = prompt.contains("[file:") || prompt.contains("本地文件上下文")
+            let shelfContext = hasProvidedFile
+                ? "已读取本轮显式上传文件，可用于摘要、归类和待办提取。"
+                : "文件架上下文仅在用户上传或拖入文件时启用。"
+            contextBlocks.append("[shelf.summarize]\n\(shelfContext)")
+            steps.append(
+                .init(
+                    title: "工具 shelf.summarize",
+                    detail: shelfContext,
+                    status: hasProvidedFile ? "done" : "skipped"
+                )
+            )
+        }
+
+        if selectedIDs.contains("weather") {
+            let weatherContext = await weatherSummary()
+            contextBlocks.append("[weather.current]\n\(weatherContext)")
+            steps.append(.init(title: "工具 weather.current", detail: weatherContext, status: weatherContext.contains("不可用") ? "fallback" : "done"))
+        }
+
+        if selectedIDs.contains("focus") {
+            let focusContext = focusSummary()
+            contextBlocks.append("[focus.status]\n\(focusContext)")
+            steps.append(.init(title: "工具 focus.status", detail: focusContext, status: "done"))
+        }
+
+        if selectedIDs.contains("skills") {
+            let skillContext = skillPlaybook(for: route, selectedSkills: selectedSkills)
+            contextBlocks.append("[skill.playbook]\n\(skillContext)")
+            steps.append(
+                .init(
+                    title: "Skills 选择",
+                    detail: selectedSkills.isEmpty ? playbookName(for: route) : selectedSkills.map(\.name).joined(separator: "、"),
+                    status: "done"
+                )
+            )
+        }
+
+        let safetyNotes = safetyNotes(for: route, contextBlocks: contextBlocks)
+        let recoveryStrategies = buildRecoveryStrategies(
+            route: route,
+            selectedPlugins: selectedPlugins,
+            contextBlocks: contextBlocks
+        )
+        steps.append(
+            .init(
+                title: "Permission Gate",
+                detail: permissionGateSummary(for: selectedPlugins, route: route),
+                status: route.kind == .calendarWrite ? "prepared" : "done"
+            )
+        )
+        steps.append(
+            .init(
+                title: "Reflector / Guard",
+                detail: safetyNotes.joined(separator: " "),
+                status: "done"
+            )
+        )
+        if selectedIDs.contains("trace") {
+            steps.append(.init(title: "Trace Logger", detail: "记录路由、工具发现、上下文和安全检查。", status: "done"))
+        }
+
+        let systemContext = buildSystemContext(
+            route: route,
+            taskUnderstanding: taskUnderstanding,
+            reasoningProfile: reasoningProfile,
+            planSteps: planSteps,
+            recoveryStrategies: recoveryStrategies,
+            plugins: selectedPlugins,
+            skills: selectedSkills,
+            contextBlocks: contextBlocks,
+            safetyNotes: safetyNotes
+        )
+
+        let trace = AgentRunTrace(
+            routeKind: route.kind.rawValue,
+            routeName: route.kind.displayName,
+            routeConfidence: route.confidence,
+            taskUnderstanding: taskUnderstanding,
+            reasoningProfile: reasoningProfile,
+            discoveredPlugins: discoveredPlugins,
+            selectedPlugins: selectedPlugins,
+            selectedSkills: selectedSkills,
+            planSteps: planSteps,
+            workingMemory: workingMemory,
+            retrievedMemories: retrievedMemories,
+            storedMemory: storedMemory,
+            recoveryStrategies: recoveryStrategies,
+            steps: steps,
+            safetyNotes: safetyNotes,
+            status: "已准备",
+            requiresConfirmation: route.kind == .calendarWrite
+        )
+
+        return AgentPreparedRun(
+            trace: trace,
+            systemContext: systemContext,
+            calendarContext: calendarContext,
+            route: route
+        )
+    }
+
+    private func buildTaskUnderstanding(
+        prompt: String,
+        route: AgentRoute,
+        selectedPlugins: [AgentPluginDescriptor],
+        selectedSkills: [AgentSkillDescriptor]
+    ) -> AgentTaskUnderstanding {
+        let lowered = prompt.lowercased()
+        let signals = selectedPlugins.map(\.id) + selectedSkills.map(\.id)
+        let complexity: String
+        if prompt.count > 420 || !selectedSkills.isEmpty || route.kind == .agentArchitecture || route.kind == .researchPlanning {
+            complexity = "high"
+        } else if route.kind == .generalChat {
+            complexity = "low"
+        } else {
+            complexity = "medium"
+        }
+
+        let riskyWords = ["写入", "创建", "删除", "不用问", "直接", "always", "delete", "create"]
+        let riskLevel = route.kind == .calendarWrite || riskyWords.contains(where: lowered.contains) ? "medium" : "low"
+        let needsTools = route.kind != .generalChat || selectedPlugins.contains { !$0.toolNames.isEmpty }
+        let needsMemory = selectedPlugins.contains { $0.id == "memory" } || lowered.contains("记忆") || lowered.contains("remember")
+        let requiresClarification = pendingQuestions(for: prompt, route: route).isEmpty == false
+
+        return AgentTaskUnderstanding(
+            taskType: route.kind.displayName,
+            complexity: complexity,
+            riskLevel: riskLevel,
+            needsTools: needsTools,
+            needsMemory: needsMemory,
+            requiresClarification: requiresClarification,
+            summary: "\(route.kind.displayName)：\(String(prompt.replacingOccurrences(of: "\n", with: " ").prefix(120)))",
+            signals: Array(signals.prefix(10))
+        )
+    }
+
+    private func buildReasoningProfile(
+        for understanding: AgentTaskUnderstanding,
+        route: AgentRoute
+    ) -> AgentReasoningProfile {
+        let mode: String
+        let loop: String
+        let reviewRounds: Int
+
+        switch route.kind {
+        case .generalChat:
+            mode = "direct"
+            loop = "answer -> light_guard"
+            reviewRounds = 1
+        case .calendarWrite:
+            mode = "permissioned_planning"
+            loop = "plan -> permission_gate -> execute_or_explain -> review"
+            reviewRounds = 2
+        case .agentArchitecture, .researchPlanning:
+            mode = "structured_workflow"
+            loop = "understand -> decompose -> retrieve -> synthesize -> review"
+            reviewRounds = 2
+        case .fileProcessing:
+            mode = "grounded_context"
+            loop = "read_provided_context -> extract -> answer -> guard"
+            reviewRounds = 1
+        case .schedulePlanning, .weatherDecision, .focusCoaching, .assignmentPlanning:
+            mode = understanding.complexity == "high" ? "react_workflow" : "tool_grounded"
+            loop = "route -> collect_context -> skill_playbook -> answer -> review"
+            reviewRounds = 1
+        }
+
+        return AgentReasoningProfile(
+            mode: mode,
+            loop: loop,
+            shouldPlan: understanding.complexity != "low",
+            maxReviewRounds: reviewRounds,
+            stopCondition: "回答已覆盖目标、工具边界和缺失信息。"
+        )
+    }
+
+    private func buildPlanSteps(
+        route: AgentRoute,
+        selectedPlugins: [AgentPluginDescriptor],
+        selectedSkills: [AgentSkillDescriptor]
+    ) -> [AgentPlanStep] {
+        var steps: [AgentPlanStep] = [
+            .init(order: 1, title: "理解任务", detail: "识别 \(route.kind.displayName) 并抽取关键实体。", status: "done"),
+            .init(order: 2, title: "发现插件", detail: selectedPlugins.map(\.name).joined(separator: "、"), status: "done"),
+        ]
+
+        if selectedPlugins.contains(where: { $0.id == "memory" }) {
+            steps.append(.init(order: steps.count + 1, title: "装载记忆", detail: "更新短期/工作记忆，并检索相关长期记忆。", status: "done"))
+        }
+
+        if !selectedSkills.isEmpty {
+            steps.append(.init(order: steps.count + 1, title: "应用 Skills", detail: selectedSkills.map(\.name).joined(separator: "、"), status: "done"))
+        }
+
+        steps.append(.init(order: steps.count + 1, title: "生成与检查", detail: "按权限边界回答，并通过安全护栏检查。", status: "prepared"))
+        return steps
+    }
+
+    private func buildRecoveryStrategies(
+        route: AgentRoute,
+        selectedPlugins: [AgentPluginDescriptor],
+        contextBlocks: [String]
+    ) -> [AgentRecoveryStrategy] {
+        var strategies: [AgentRecoveryStrategy] = []
+
+        if selectedPlugins.contains(where: { $0.id == "calendar" }) {
+            strategies.append(
+                .init(
+                    trigger: "日历权限不可用",
+                    strategy: "改为输出人工可复制的绝对时间计划。",
+                    fallback: "提示用户在设置中开启日历读取/写入。",
+                    status: contextBlocks.contains(where: { $0.contains("calendar.read") }) ? "armed" : "standby"
+                )
+            )
+        }
+
+        if selectedPlugins.contains(where: { $0.id == "weather" }) {
+            strategies.append(
+                .init(
+                    trigger: "天气接口失败",
+                    strategy: "声明天气不可用，使用保守出行假设。",
+                    fallback: "建议用户查看实时天气后再做户外安排。",
+                    status: "armed"
+                )
+            )
+        }
+
+        if route.kind == .fileProcessing {
+            strategies.append(
+                .init(
+                    trigger: "文件缺失或不可读",
+                    strategy: "只基于用户可见文本回答，不编造文件内容。",
+                    fallback: "请用户重新上传文本、Markdown、JSON 或 CSV。",
+                    status: "armed"
+                )
+            )
+        }
+
+        strategies.append(
+            .init(
+                trigger: "上下文不足",
+                strategy: "先给可执行假设，再列出需要补充的信息。",
+                fallback: "询问一个最关键的澄清问题。",
+                status: "always-on"
+            )
+        )
+        return strategies
+    }
+
+    private func routePrompt(_ prompt: String) -> AgentRoute {
+        let lowered = prompt.lowercased()
+        let calendarWrite = [
+            "add to calendar", "put on my calendar", "create calendar event",
+            "write to calendar", "schedule it", "写进日历", "写到日历",
+            "加到日历", "添加到日历", "放到日历", "创建日程", "写入日历"
+        ]
+        if calendarWrite.contains(where: lowered.contains) {
+            return .init(kind: .calendarWrite, confidence: 0.93)
+        }
+
+        let fileProcessing = ["[file:", "本地文件上下文", "upload", "uploaded file", "file summary", "上传", "文件", "摘要", "knowledge", "rag", "知识库", "资料库"]
+        if fileProcessing.contains(where: lowered.contains) {
+            return .init(kind: .fileProcessing, confidence: 0.82)
+        }
+
+        let assignment = ["assignment", "homework", "作业", "大作业", "报告", "deadline", "截止", "提交"]
+        if assignment.contains(where: lowered.contains) {
+            return .init(kind: .assignmentPlanning, confidence: 0.86)
+        }
+
+        let weather = ["weather", "rain", "temperature", "wind", "outdoor", "天气", "下雨", "气温", "出门", "户外", "跑步"]
+        if weather.contains(where: lowered.contains) {
+            return .init(kind: .weatherDecision, confidence: 0.84)
+        }
+
+        let focus = ["focus", "pomodoro", "study", "deep work", "专注", "番茄钟", "复习", "学习", "冲刺"]
+        if focus.contains(where: lowered.contains) {
+            return .init(kind: .focusCoaching, confidence: 0.80)
+        }
+
+        let research = ["research", "literature", "paper", "citation", "论文", "文献", "调研", "研究", "引用"]
+        if research.contains(where: lowered.contains) {
+            return .init(kind: .researchPlanning, confidence: 0.76)
+        }
+
+        let agentArchitecture = [
+            "agent", "plugin", "plugins", "skill", "skills", "memory", "mcp",
+            "智能体", "插件", "技能", "记忆", "长期记忆", "工作记忆", "短期记忆", "架构"
+        ]
+        if agentArchitecture.contains(where: lowered.contains) {
+            return .init(kind: .agentArchitecture, confidence: 0.88)
+        }
+
+        let schedule = [
+            "calendar", "schedule", "agenda", "plan", "安排", "计划", "日程", "行程", "空闲", "会议",
+            "待办", "有什么事", "有啥事", "要做什么", "今天要做", "今日要做",
+            "today's schedule", "what do i have today", "available"
+        ]
+        if schedule.contains(where: lowered.contains) {
+            return .init(kind: .schedulePlanning, confidence: 0.78)
+        }
+
+        return .init(kind: .generalChat, confidence: 0.58)
+    }
+
+    private func discoverPlugins(for route: AgentRoute, prompt: String) -> [AgentPluginMatch] {
+        let lowered = prompt.lowercased()
+        var routeIDs: [String]
+        switch route.kind {
+        case .calendarWrite:
+            routeIDs = ["calendar", "memory", "skills", "safety", "trace"]
+        case .schedulePlanning:
+            routeIDs = ["calendar", "memory", "skills", "safety", "trace"]
+        case .weatherDecision:
+            let calendarNeeded = Self.weatherCalendarKeywords.contains(where: lowered.contains)
+            routeIDs = calendarNeeded
+                ? ["weather", "calendar", "memory", "safety", "trace"]
+                : ["weather", "memory", "safety", "trace"]
+        case .focusCoaching:
+            routeIDs = ["focus", "calendar", "memory", "skills", "safety", "trace"]
+        case .assignmentPlanning:
+            routeIDs = ["assignment", "knowledge", "calendar", "focus", "memory", "skills", "safety", "trace"]
+        case .agentArchitecture:
+            routeIDs = ["memory", "knowledge", "skills", "planner", "reasoner", "reviewer", "recovery", "safety", "trace"]
+        case .fileProcessing:
+            routeIDs = ["shelf", "assignment", "knowledge", "memory", "skills", "recovery", "safety", "trace"]
+        case .researchPlanning:
+            routeIDs = ["knowledge", "memory", "skills", "planner", "reasoner", "reviewer", "recovery", "safety", "trace"]
+        case .generalChat:
+            routeIDs = ["memory", "safety", "trace"]
+        }
+
+        if !Defaults[.aiKnowledgeRetrievalEnabled] {
+            routeIDs.removeAll { $0 == "knowledge" }
+        }
+
+        let hasProvidedFile = lowered.contains("[file:") || lowered.contains("本地文件上下文") || lowered.contains("上传")
+        let asksKnowledge = ["knowledge", "rag", "资料库", "知识库", "study materials", "笔记"].contains { lowered.contains($0) }
+        let knowledgeEnabled = Defaults[.aiKnowledgeRetrievalEnabled]
+        let hasKnowledgeHit = knowledgeEnabled && AgentKnowledgeStore.shared.hasRelevantContent(for: prompt)
+        let selectedIDs = Set(
+            routeIDs
+                + (hasProvidedFile ? ["shelf"] : [])
+                + (knowledgeEnabled && (asksKnowledge || hasKnowledgeHit) ? ["knowledge"] : [])
+        )
+
+        return plugins.map { plugin in
+            let keywordHits = plugin.discoveryKeywords.filter { lowered.contains($0.lowercased()) }.count
+            let routeBoost = selectedIDs.contains(plugin.id) ? 0.58 : 0
+            let keywordBoost = min(Double(keywordHits) * 0.12, 0.32)
+            let alwaysOnBoost = ["safety", "trace"].contains(plugin.id) ? 0.14 : 0
+            let score = min(routeBoost + keywordBoost + alwaysOnBoost, 0.99)
+            let reason: String
+
+            if selectedIDs.contains(plugin.id), keywordHits > 0 {
+                reason = "路由匹配 + \(keywordHits) 个关键词"
+            } else if selectedIDs.contains(plugin.id) {
+                reason = "路由需要"
+            } else if keywordHits > 0 {
+                reason = "\(keywordHits) 个关键词命中"
+            } else {
+                reason = "暂不相关"
+            }
+
+            return AgentPluginMatch(
+                id: plugin.id,
+                pluginName: plugin.name,
+                score: score,
+                reason: reason,
+                selected: selectedIDs.contains(plugin.id)
+            )
+        }
+        .sorted { lhs, rhs in
+            if lhs.selected != rhs.selected { return lhs.selected && !rhs.selected }
+            return lhs.score > rhs.score
+        }
+    }
+
+    private func skillsForRoute(_ route: AgentRoute, prompt: String) -> [AgentSkillDescriptor] {
+        let lowered = prompt.lowercased()
+        let routeSkillIDs: [String]
+
+        switch route.kind {
+        case .assignmentPlanning:
+            routeSkillIDs = ["assignment_breakdown", "study_plan"]
+        case .calendarWrite, .schedulePlanning:
+            routeSkillIDs = ["calendar_aware_planning"]
+        case .focusCoaching:
+            routeSkillIDs = ["study_plan"]
+        case .weatherDecision:
+            routeSkillIDs = ["weather_decision"]
+        case .agentArchitecture:
+            routeSkillIDs = ["agent_memory_design"]
+        case .fileProcessing:
+            routeSkillIDs = ["file_context_analysis"]
+        case .researchPlanning:
+            routeSkillIDs = ["research_planning"]
+        case .generalChat:
+            routeSkillIDs = []
+        }
+
+        let routeSet = Set(routeSkillIDs)
+        return skills.filter { skill in
+            routeSet.contains(skill.id)
+                || skill.triggerKeywords.contains(where: { lowered.contains($0.lowercased()) })
+        }
+    }
+
+    private func permissionGateSummary(for plugins: [AgentPluginDescriptor], route: AgentRoute) -> String {
+        let writeTools = plugins.flatMap(\.toolNames).filter { $0.contains("create") || $0.contains("start") || $0.contains("save") }
+
+        guard !writeTools.isEmpty else {
+            return "本轮只读上下文为主；无本地写动作。"
+        }
+
+        if route.kind == .calendarWrite {
+            return "检测到写动作候选：\(writeTools.joined(separator: ", "))。日历写入必须满足：用户明确要求 + 设置允许 + 日历权限可用。"
+        }
+
+        return "检测到动作型工具 \(writeTools.joined(separator: ", "))，但当前路由不自动执行，只用于说明能力边界。"
+    }
+
+    private func weatherSummary() async -> String {
+        let manager = WeatherManager.shared
+        await manager.refreshWeather(force: false)
+
+        guard let snapshot = manager.snapshot else {
+            return manager.lastError.map { "天气不可用：\($0)" } ?? "天气不可用。"
+        }
+
+        let current = snapshot.current
+        return "\(snapshot.locationName)：\(Int(current.temperature.rounded()))\(current.unitSymbol)，\(current.condition)，体感 \(Int(current.feelsLike.rounded()))\(current.unitSymbol)，风速 \(Int(current.windSpeed.rounded())) \(current.windUnit)，降水 \(String(format: "%.1f", current.precipitation)) mm。"
+    }
+
+    private func focusSummary() -> String {
+        let manager = PomodoroManager.shared
+        let state = manager.isRunning ? "运行中" : "待开始"
+        return "番茄钟\(state)，阶段 \(manager.phase.rawValue)，剩余 \(manager.formattedRemaining)，默认专注 \(Defaults[.pomodoroFocusMinutes]) 分钟，已完成 \(manager.completedFocusSessions) 个专注段。"
+    }
+
+    private func preferenceSummary() -> String {
+        let city = Defaults[.weatherCity].trimmingCharacters(in: .whitespacesAndNewlines)
+        let cityLabel = city.isEmpty ? defaultWeatherCityName() : city
+        return "日历上下文：\(Defaults[.aiCalendarContextEnabled] ? "开启" : "关闭")；日历写入：\(Defaults[.aiCalendarWriteEnabled] ? "开启" : "关闭")；天气城市：\(cityLabel)；默认专注/休息：\(Defaults[.pomodoroFocusMinutes])/\(Defaults[.pomodoroShortBreakMinutes]) 分钟。"
+    }
+
+    private func shortTermSummary(from messages: [AIChatMessage]) -> String {
+        let recent = messages.suffix(6)
+        guard !recent.isEmpty else {
+            return "当前会话刚开始；无历史消息。"
+        }
+
+        return recent.map { message in
+            let role = message.role == .user ? "user" : "assistant"
+            let content = message.content
+                .replacingOccurrences(of: "\n", with: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return "- \(role): \(String(content.prefix(180)))"
+        }.joined(separator: "\n")
+    }
+
+    private func buildWorkingMemory(
+        prompt: String,
+        route: AgentRoute,
+        selectedPlugins: [AgentPluginDescriptor],
+        selectedSkills: [AgentSkillDescriptor]
+    ) -> AgentWorkingMemory {
+        let goal = "\(route.kind.displayName)：\(String(prompt.replacingOccurrences(of: "\n", with: " ").prefix(90)))"
+        let entities = workingMemoryEntities(
+            from: prompt,
+            selectedPlugins: selectedPlugins,
+            selectedSkills: selectedSkills
+        )
+        let pending = pendingQuestions(for: prompt, route: route)
+
+        return AgentWorkingMemory(
+            currentGoal: goal,
+            taskProgress: "已完成路由、插件发现和上下文准备，等待模型生成回答。",
+            keyEntities: entities,
+            pendingQuestions: pending
+        )
+    }
+
+    private func workingMemoryEntities(
+        from prompt: String,
+        selectedPlugins: [AgentPluginDescriptor],
+        selectedSkills: [AgentSkillDescriptor]
+    ) -> [String] {
+        let lowered = prompt.lowercased()
+        let candidates = [
+            "短期记忆", "工作记忆", "长期记忆", "向量数据库", "Token", "日历", "天气", "作业",
+            "番茄钟", "插件", "Skills", "MCP", "calendar", "weather", "assignment", "memory"
+        ]
+        var entities = candidates.filter { lowered.contains($0.lowercased()) }
+        entities += selectedPlugins.map(\.name)
+        entities += selectedSkills.map(\.name)
+
+        if prompt.contains("[file:") || prompt.contains("本地文件上下文") {
+            entities.append("上传文件")
+        }
+
+        var seen = Set<String>()
+        return entities.filter { seen.insert($0).inserted }.prefix(12).map { $0 }
+    }
+
+    private func pendingQuestions(for prompt: String, route: AgentRoute) -> [String] {
+        var questions: [String] = []
+        let hasProvidedFile = prompt.contains("[file:") || prompt.contains("本地文件上下文")
+
+        if route.kind == .assignmentPlanning && !hasProvidedFile {
+            questions.append("是否需要上传作业要求或评分标准？")
+        }
+        if route.kind == .calendarWrite {
+            questions.append("日历写入是否满足用户明确要求、设置允许和权限可用？")
+        }
+        if route.kind == .weatherDecision && !Defaults[.weatherFeatureEnabled] {
+            questions.append("天气功能当前关闭，是否使用保守假设？")
+        }
+
+        return questions
+    }
+
+    private func longTermMemorySummary(_ memories: [AgentMemoryRecord]) -> String {
+        guard !memories.isEmpty else {
+            return "没有检索到与当前任务相关的长期记忆。"
+        }
+
+        return memories.enumerated().map { index, memory in
+            let scoreText = memory.retrievalScore.map { String(format: "%.2f", $0) } ?? "n/a"
+            let reasonText = memory.retrievalReason ?? "未记录"
+            return "\(index + 1). [\(memory.kind.displayName)] \(memory.content) score=\(scoreText) reason=\(reasonText) keywords=\(memory.keywords.prefix(6).joined(separator: ", "))"
+        }.joined(separator: "\n")
+    }
+
+    private func skillPlaybook(for route: AgentRoute, selectedSkills: [AgentSkillDescriptor]) -> String {
+        if !selectedSkills.isEmpty {
+            return selectedSkills.map { skill in
+                """
+                \(skill.name)：
+                \(skill.workflowSteps.enumerated().map { "\($0.offset + 1). \($0.element)" }.joined(separator: "\n"))
+                """
+            }.joined(separator: "\n\n")
+        }
+
+        switch route.kind {
+        case .assignmentPlanning:
+            return "作业拆解技能：提取交付物，映射评分点，拆成里程碑，预留专注块，并指出缺失信息。"
+        case .calendarWrite, .schedulePlanning:
+            return "日程感知规划技能：寻找空闲窗口，避免冲突，使用绝对时间，并在创建事件前说明取舍。"
+        case .focusCoaching:
+            return "专注辅导技能：把目标拆成番茄钟大小的任务块，包含休息，保持计划现实。"
+        default:
+            return "通用助手技能：简洁回答，并说明使用了哪些本地上下文。"
+        }
+    }
+
+    private func playbookName(for route: AgentRoute) -> String {
+        switch route.kind {
+        case .assignmentPlanning:
+            return "作业拆解"
+        case .calendarWrite, .schedulePlanning:
+            return "日程感知规划"
+        case .focusCoaching:
+            return "专注辅导"
+        default:
+            return "通用助手"
+        }
+    }
+
+    private func safetyNotes(for route: AgentRoute, contextBlocks: [String]) -> [String] {
+        var notes = [
+            "不要编造不可用的本地上下文。",
+            "工具失败或权限不足影响答案时必须说明。",
+        ]
+
+        if route.kind == .calendarWrite {
+            notes.append("只有在用户明确要求写入且设置允许时才创建日历事件。")
+        }
+
+        if contextBlocks.contains(where: { $0.contains("unavailable") || $0.contains("Disabled") }) {
+            notes.append("至少一个工具没有返回可用上下文，需要降级推理。")
+        }
+
+        return notes
+    }
+
+    private func buildSystemContext(
+        route: AgentRoute,
+        taskUnderstanding: AgentTaskUnderstanding,
+        reasoningProfile: AgentReasoningProfile,
+        planSteps: [AgentPlanStep],
+        recoveryStrategies: [AgentRecoveryStrategy],
+        plugins: [AgentPluginDescriptor],
+        skills: [AgentSkillDescriptor],
+        contextBlocks: [String],
+        safetyNotes: [String]
+    ) -> String {
+        let pluginLines = plugins.map {
+            "- \($0.id): type=\($0.category); tools=\($0.toolNames.joined(separator: ", ")); permission=\($0.permission); risk=\($0.riskLevel)"
+        }.joined(separator: "\n")
+        let manifestLines = plugins.map {
+            "- \($0.name): \($0.manifestPreview.replacingOccurrences(of: "\n", with: " "))"
+        }.joined(separator: "\n")
+        let skillLines = skills.isEmpty ? "本轮未装载专用 Skill。" : skills.map { skill in
+            """
+            - \(skill.name): required_tools=\(skill.requiredTools.joined(separator: ", ")); workflow=\(skill.workflowSteps.joined(separator: " -> "))
+            """
+        }.joined(separator: "\n")
+
+        return """
+        Boring Notch Agent 编排上下文：
+        路由：\(route.kind.displayName)，置信度 \(String(format: "%.2f", route.confidence))。
+
+        任务理解：
+        \(taskUnderstanding.contextText)
+
+        推理模式：
+        \(reasoningProfile.contextText)
+
+        计划步骤：
+        \(planSteps.map { "\($0.order). \($0.title)：\($0.detail) [\($0.status)]" }.joined(separator: "\n"))
+
+        已选择插件：
+        \(pluginLines)
+
+        插件 Manifest 摘要：
+        \(manifestLines)
+
+        已选择 Skills：
+        \(skillLines)
+
+        工具上下文：
+        \(contextBlocks.joined(separator: "\n\n"))
+
+        反思与安全护栏：
+        \(safetyNotes.map { "- \($0)" }.joined(separator: "\n"))
+
+        异常恢复策略：
+        \(recoveryStrategies.map { "- \($0.trigger)：\($0.strategy) fallback=\($0.fallback)" }.joined(separator: "\n"))
+
+        回复规则：
+        - 相关时使用已选择的工具上下文；如果上下文显示工具失败，不要声称工具成功。
+        - 如果知识库命中资料，优先基于 knowledge.retrieve 的摘要和 excerpt 回答；没有命中时明确说明未检索到相关资料。
+        - 如果 Skills 已装载，按 workflow 输出过程型计划，不要只给泛泛建议。
+        - 记忆上下文分为短期会话、工作记忆和长期记忆；长期记忆只代表检索命中的稳定信息，不要把普通聊天当成长期事实。
+        - 日程或作业规划要给出具体步骤，并指出冲突或缺失信息。
+        - 对本地风险动作，要清楚说明动作边界。
+        """
+    }
+}
+
+private extension AgentRoute.Kind {
+    var displayName: String {
+        switch self {
+        case .generalChat:
+            return "通用对话"
+        case .schedulePlanning:
+            return "日程规划"
+        case .calendarWrite:
+            return "日历写入"
+        case .weatherDecision:
+            return "天气决策"
+        case .focusCoaching:
+            return "专注辅导"
+        case .assignmentPlanning:
+            return "作业拆解"
+        case .agentArchitecture:
+            return "智能体架构"
+        case .fileProcessing:
+            return "文件处理"
+        case .researchPlanning:
+            return "研究规划"
+        }
+    }
+}
+
+@MainActor
+final class AIChatManager: ObservableObject {
+    static let shared = AIChatManager()
+
+    @Published private(set) var conversations: [AgentChatConversation] = []
+    @Published private(set) var activeConversationID: UUID?
+    @Published private(set) var isSending: Bool = false
+    @Published var lastError: String?
+    @Published private(set) var lastResolvedModelName: String?
+    @Published private(set) var lastAgentTrace: AgentRunTrace?
+    @Published private(set) var knowledgeDocuments: [AgentKnowledgeDocument] = []
+
+    private let conversationStoreURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    private init() {
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+
+        let directory = Self.storageDirectory()
+        conversationStoreURL = directory.appendingPathComponent("conversations.json")
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        loadConversations()
+        refreshKnowledgeDocuments()
+    }
+
+    var activeConversation: AgentChatConversation? {
+        guard let activeConversationID else { return conversations.first }
+        return conversations.first { $0.id == activeConversationID } ?? conversations.first
+    }
+
+    var messages: [AIChatMessage] {
+        activeConversation?.messages ?? []
+    }
+
+    func clearConversation() {
+        mutateActiveConversation { conversation in
+            conversation.messages.removeAll()
+            conversation.updatedAt = Date()
+        }
+        lastError = nil
+        lastResolvedModelName = nil
+        lastAgentTrace = nil
+    }
+
+    func appendLocalAssistantMessage(_ content: String) {
+        appendMessage(AIChatMessage(role: .assistant, content: content))
+    }
+
+    func startNewConversation() {
+        let conversation = AgentChatConversation(title: "新对话")
+        conversations.insert(conversation, at: 0)
+        activeConversationID = conversation.id
+        lastError = nil
+        lastAgentTrace = nil
+        persistConversations()
+    }
+
+    func selectConversation(_ id: UUID) {
+        guard conversations.contains(where: { $0.id == id }) else { return }
+        activeConversationID = id
+        lastError = nil
+        lastAgentTrace = nil
+    }
+
+    func deleteConversation(_ id: UUID) {
+        guard conversations.count > 1 else {
+            clearConversation()
+            return
+        }
+        conversations.removeAll { $0.id == id }
+        if activeConversationID == id {
+            activeConversationID = conversations.first?.id
+            lastError = nil
+            lastAgentTrace = nil
+        }
+        persistConversations()
+    }
+
+    var displayedModelName: String {
+        if let resolved = normalizedModelName(lastResolvedModelName) {
+            return resolved
+        }
+
+        let configured = Defaults[.aiServiceModel].trimmingCharacters(in: .whitespacesAndNewlines)
+        return configured.isEmpty ? "No model configured" : configured
+    }
+
+    var availablePlugins: [AgentPluginDescriptor] {
+        AgentOrchestrator.shared.plugins
+    }
+
+    var availableSkills: [AgentSkillDescriptor] {
+        AgentOrchestrator.shared.skills
+    }
+
+    var longTermMemories: [AgentMemoryRecord] {
+        AgentMemoryStore.shared.recentRecords
+    }
+
+    var longTermMemoryLocation: URL {
+        AgentMemoryStore.shared.storageURL
+    }
+
+    var knowledgeStorageLocation: URL {
+        AgentKnowledgeStore.shared.storageURL
+    }
+
+    func refreshKnowledgeDocuments() {
+        knowledgeDocuments = AgentKnowledgeStore.shared.documents
+    }
+
+    @discardableResult
+    func addKnowledgeDocument(
+        name: String,
+        path: String,
+        content: String,
+        byteCount: Int
+    ) -> AgentKnowledgeDocument? {
+        let document = AgentKnowledgeStore.shared.addDocument(
+            title: name,
+            sourcePath: path,
+            content: content,
+            byteCount: byteCount
+        )
+        if document != nil {
+            refreshKnowledgeDocuments()
+        }
+        return document
+    }
+
+    func removeKnowledgeDocument(id: UUID) {
+        AgentKnowledgeStore.shared.removeDocument(id: id)
+        refreshKnowledgeDocuments()
+    }
+
+    func clearKnowledgeBase() {
+        AgentKnowledgeStore.shared.clear()
+        refreshKnowledgeDocuments()
+    }
+
+    @discardableResult
+    func installStarterKnowledgeBase() -> Int {
+        var importedCount = 0
+        for seed in Self.starterKnowledgeDocuments {
+            let content = seed.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !content.isEmpty else { continue }
+            if AgentKnowledgeStore.shared.addDocument(
+                title: seed.title,
+                sourcePath: seed.sourcePath,
+                content: content,
+                byteCount: content.utf8.count
+            ) != nil {
+                importedCount += 1
+            }
+        }
+        refreshKnowledgeDocuments()
+        return importedCount
+    }
+
+    func revealKnowledgeBaseFile() {
+        let store = AgentKnowledgeStore.shared
+        if !FileManager.default.fileExists(atPath: store.storageURL.path) {
+            store.clear()
+            refreshKnowledgeDocuments()
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([store.storageURL])
+    }
+
+    @discardableResult
+    func rememberMemory(_ content: String) -> AgentMemoryRecord? {
+        let record = AgentMemoryStore.shared.storeManual(content)
+        if record != nil {
+            objectWillChange.send()
+        }
+        return record
+    }
+
+    @discardableResult
+    func forgetMemory(matching query: String = "") -> Int {
+        let removedCount = AgentMemoryStore.shared.forget(matching: query)
+        if removedCount > 0 {
+            objectWillChange.send()
+        }
+        return removedCount
+    }
+
+    func clearLongTermMemory() {
+        AgentMemoryStore.shared.clear()
+        objectWillChange.send()
+    }
+
+    func revealLongTermMemoryFile() {
+        NSWorkspace.shared.activateFileViewerSelecting([AgentMemoryStore.shared.storageURL])
+    }
+
+    func send(prompt: String, displayPrompt: String? = nil) async {
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPrompt.isEmpty, !isSending else { return }
+
+        appendMessage(AIChatMessage(role: .user, content: displayPrompt ?? trimmedPrompt))
+        lastError = nil
+        isSending = true
+        defer { isSending = false }
+
+        do {
+            var agentRun = await AgentOrchestrator.shared.prepare(prompt: trimmedPrompt, recentMessages: messages)
+            lastAgentTrace = agentRun.trace
+            let reply: AIReply
+
+            if agentRun.route.kind == .calendarWrite {
+                reply = try await requestCalendarWriteReply(
+                    for: trimmedPrompt,
+                    agentRun: agentRun
+                )
+            } else {
+                reply = try await requestReply(
+                    for: trimmedPrompt,
+                    agentRun: agentRun
+                )
+            }
+
+            lastResolvedModelName = reply.resolvedModelName ?? reply.requestedModelName
+            appendMessage(AIChatMessage(role: .assistant, content: reply.content))
+            agentRun.trace.status = "已完成"
+            agentRun.trace.steps.append(
+                .init(
+                    title: "模型回复",
+                    detail: "实际模型：\(reply.resolvedModelName ?? reply.requestedModelName)",
+                    status: "done"
+                )
+            )
+            lastAgentTrace = agentRun.trace
+        } catch {
+            lastError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            if var trace = lastAgentTrace {
+                trace.status = "Failed"
+                trace.steps.append(
+                    .init(
+                        title: "失败",
+                        detail: lastError ?? "Unknown error",
+                        status: "error"
+                    )
+                )
+                lastAgentTrace = trace
+            }
+        }
+    }
+
+    private static func storageDirectory() -> URL {
+        let baseDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? temporaryDirectory
+        return baseDirectory.appendingPathComponent("DanShenAgent", isDirectory: true)
+    }
+
+    private func loadConversations() {
+        if let data = try? Data(contentsOf: conversationStoreURL),
+           let decoded = try? decoder.decode([AgentChatConversation].self, from: data),
+           !decoded.isEmpty
+        {
+            conversations = decoded.sorted { $0.updatedAt > $1.updatedAt }
+            activeConversationID = conversations.first?.id
+            return
+        }
+
+        let starter = AgentChatConversation(title: "新对话")
+        conversations = [starter]
+        activeConversationID = starter.id
+        persistConversations()
+    }
+
+    private func persistConversations() {
+        guard let data = try? encoder.encode(conversations) else { return }
+        try? data.write(to: conversationStoreURL, options: .atomic)
+    }
+
+    private func appendMessage(_ message: AIChatMessage) {
+        if conversations.isEmpty {
+            startNewConversation()
+        }
+
+        mutateActiveConversation { conversation in
+            if conversation.messages.isEmpty, message.role == .user {
+                conversation.title = Self.title(from: message.content)
+            }
+            conversation.messages.append(message)
+            conversation.updatedAt = message.createdAt
+        }
+    }
+
+    private func mutateActiveConversation(_ mutate: (inout AgentChatConversation) -> Void) {
+        if conversations.isEmpty {
+            let starter = AgentChatConversation(title: "新对话")
+            conversations = [starter]
+            activeConversationID = starter.id
+        }
+
+        let resolvedID = activeConversationID ?? conversations.first?.id
+        guard let resolvedID,
+              let index = conversations.firstIndex(where: { $0.id == resolvedID })
+        else { return }
+
+        mutate(&conversations[index])
+        conversations.sort { $0.updatedAt > $1.updatedAt }
+        activeConversationID = resolvedID
+        persistConversations()
+    }
+
+    private static func title(from prompt: String) -> String {
+        let withoutFiles = prompt
+            .components(separatedBy: "本地文件上下文：")
+            .first ?? prompt
+        let normalized = withoutFiles
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "用户问题：", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? "新对话" : String(normalized.prefix(18))
+    }
+
+    private static let starterKnowledgeDocuments: [(title: String, sourcePath: String, content: String)] = [
+        (
+            "GitHub 案例：Agent Skills 渐进式加载",
+            "seed://github-agent-skills-progressive-disclosure",
+            """
+            # GitHub 案例：Agent Skills 渐进式加载
+
+            适合Boring Notch Agent 的结论：Skills 不是普通 prompt 集合，而是“按需加载的任务流程包”。一个 Skill 通常由 SKILL.md 作为入口，使用 YAML frontmatter 描述名称、触发描述、权限或工具边界，再用 Markdown 写执行步骤。复杂 Skill 可以把长参考资料、模板、脚本放在同目录，只有任务需要时才读取，避免每轮对话塞满上下文。
+
+            对我们的实现启发：
+            1. 插件负责“能拿到什么上下文/能做什么动作”，Skill 负责“这类任务应该按什么流程做”。
+            2. Skill 的 description 应该写成触发条件，不只是说明文字，例如“当用户要求把作业要求拆成评分点、里程碑和日程计划时使用”。
+            3. 支持文件可以被延迟读取，适合study materials、评分标准模板、论文写作模板。
+            4. 有副作用的技能不要自动运行，例如写日历、发消息、删除文件，应该用确认门控。
+
+            Boring Notch可落地设计：
+            - skills/study-plan/SKILL.md：复习计划流程。
+            - skills/assignment-breakdown/SKILL.md：作业拆解流程。
+            - skills/weather-decision/SKILL.md：天气 + 日程的出行建议流程。
+            - skills/agent-memory-design/SKILL.md：短期/工作/长期记忆说明。
+
+            和 Claude/Codex/Roo 的对应关系：
+            - Codex: openai/skills 仓库提供可安装 Skill catalog。
+            - Claude Code: 个人、项目、插件级 skills 都以 SKILL.md 为入口，description 用于自动加载。
+            - Roo Code: 先索引 frontmatter，命中后再读取完整 SKILL.md，属于典型 progressive disclosure。
+
+            Sources:
+            - https://github.com/openai/skills
+            - https://code.claude.com/docs/en/skills
+            - https://roocodeinc.github.io/Roo-Code/features/skills
+            """
+        ),
+        (
+            "GitHub 案例：Cline/Roo 的插件与 MCP 思路",
+            "seed://github-cline-roo-mcp-plugin-patterns",
+            """
+            # GitHub 案例：Cline/Roo 的插件与 MCP 思路
+
+            适合Boring Notch Agent 的结论：现代 agent host 一般不把所有能力写死在 prompt 里，而是把能力拆成插件、工具、资源和提示模板。Cline 支持通过 SDK 注册工具和生命周期 hooks，也能通过 MCP server 扩展外部数据源和动作；Roo Code 把 MCP 配置分成全局和项目级，并强调工具需要明确配置和审批。
+
+            对我们的实现启发：
+            1. Plugin Registry：每个插件有 id、类型、工具名、权限和风险等级。
+            2. Tool Discovery：先根据用户任务选相关插件，不一次性把所有工具上下文塞给模型。
+            3. Context Plugin 和 Action Plugin 分开：天气、知识库、日历读取属于 context；写日历、启动计时器属于 action。
+            4. Permission Gate：读操作可以自动，写操作必须设置允许并由用户明确请求。
+            5. Trace Logger：记录本轮路由、命中插件、上下文准备和安全检查，方便product demonstration“智能体不是黑箱”。
+
+            Boring Notch可以对齐的 MCP 分层：
+            - Tools：weather.current、calendar.create_event、memory.save_preference。
+            - Resources：本地知识库文档、study materials、拖入文件、日历上下文。
+            - Prompts：/skills、/knowledge、作业拆解模板、天气决策模板。
+
+            最小可演示架构：
+            User Prompt -> Agent Router -> Plugin Registry -> Tool Discovery -> Context Gathering -> Skill Playbook -> Permission Gate -> LLM Reply -> Trace Logger
+
+            Sources:
+            - https://github.com/cline/cline
+            - https://docs.cline.bot/mcp/mcp-overview
+            - https://roocodeinc.github.io/Roo-Code/features/mcp/using-mcp-in-roo
+            - https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+            - https://modelcontextprotocol.io/docs/concepts/prompts
+            """
+        ),
+        (
+            "GitHub 案例：知识库与记忆的边界",
+            "seed://agent-memory-vs-knowledge-base-boundary",
+            """
+            # GitHub 案例：知识库与记忆的边界
+
+            适合Boring Notch Agent 的结论：知识库不等于长期记忆。知识库存的是用户显式导入的资料，例如课程文档、作业要求、论文笔记、项目说明；长期记忆存的是跨会话稳定偏好和事实，例如“我喜欢晚上学习”“默认 45 分钟专注”。两者都可以检索，但写入策略不同。
+
+            三层记忆：
+            - 短期记忆：当前会话最近消息，只影响当前聊天页。
+            - 工作记忆：当前任务目标、进度、实体、待澄清问题，来自本轮 agent trace。
+            - 长期记忆：明确请求“记住”后写入，跨会话可检索。
+
+            知识库策略：
+            - 导入：只接受用户显式选择的文件，避免偷偷读取本地隐私。
+            - 检索：先做关键词和语义词粗检索，再按时间和命中质量排序。
+            - 注入：只把 Top-3 相关片段放进上下文，避免污染回答。
+            - 展示：面板显示资料来源、摘要、关键词和大小，方便用户知道 agent 用了什么。
+
+            演示问法：
+            - “根据知识库里的作业要求，帮我列评分点。”
+            - “我之前导入的智能体资料里，插件和 skill 有什么区别？”
+            - “用知识库内容解释 MCP 的 tools/resources/prompts。”
+
+            和 Skills 的关系：
+            Skill 是流程说明，知识库是资料来源。比如 assignment-breakdown skill 规定怎么拆作业；知识库存储具体 assignment requirements。两者结合才像真正的桌面 agent。
+
+            Sources:
+            - https://code.claude.com/docs/en/skills
+            - https://roocodeinc.github.io/Roo-Code/features/skills
+            - https://modelcontextprotocol.io/docs/concepts/prompts
+            """
+        ),
+        (
+            "GitHub 案例：安全护栏与插件权限",
+            "seed://agent-plugin-safety-permission-model",
+            """
+            # GitHub 案例：安全护栏与插件权限
+
+            适合Boring Notch Agent 的结论：插件系统的难点不是“能调用多少工具”，而是“什么时候不该调用”。Cline、Roo、MCP 文档都把外部工具视为可扩展能力，但同时需要配置、确认、权限和错误处理。对 macOS 桌面应用来说，安全模型尤其重要，因为工具可能影响日历、本地文件、App 启动或用户隐私。
+
+            插件权限建议：
+            - read:auto：天气、只读日历、知识库检索、长期记忆检索。
+            - write:explicit：用户明确说“记住”才写长期记忆。
+            - write:settings-gated：写日历必须设置允许 + 用户明确请求。
+            - action:user-triggered：启动番茄钟、打开 App、分享文件必须可见触发。
+            - deny-by-default：删除文件、上传隐私数据、执行未知脚本默认拒绝。
+
+            Trace 需要记录：
+            1. 为什么选择这个插件。
+            2. 插件权限是什么。
+            3. 工具成功、跳过还是降级。
+            4. 如果信息缺失，模型是否说明了缺口。
+            5. 写操作是否经过用户确认。
+
+            报告可写的亮点：
+            - Progressive tool discovery 降低 prompt 噪声。
+            - Human-in-the-loop 防止危险动作。
+            - Tool permission model 区分只读、写入、动作和拒绝。
+            - Agent trace 提升可解释性。
+            - Knowledge base 只读取用户显式导入资料，符合隐私边界。
+
+            Sources:
+            - https://github.com/cline/cline
+            - https://docs.cline.bot/mcp/mcp-overview
+            - https://roocodeinc.github.io/Roo-Code/features/mcp/using-mcp-in-roo
+            - https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+            """
+        ),
+        (
+            "GitHub 案例：Boring Notch Agent product demo 脚本",
+            "seed://boring-notch-agent-course-demo-script",
+            """
+            # GitHub 案例：Boring Notch Agent product demo 脚本
+
+            目标：展示Boring Notch不是普通聊天框，而是一个 macOS 桌面 Agent Host。
+
+            Demo 1：多会话短期记忆
+            1. 新建会话 A，问“帮我记住这轮我们在做天气插件演示”。
+            2. 新建会话 B，问“刚才这个会话说了什么？”。
+            3. 解释：短期记忆按会话隔离，长期记忆只有明确 /remember 或“请记住”才跨会话。
+
+            Demo 2：知识库检索
+            1. 点击知识库，导入 GitHub 示例知识库。
+            2. 问“根据知识库，Skill 和 Plugin 有什么区别？”。
+            3. 展示 trace 中 knowledge.retrieve 命中，说明它不是泛泛回答。
+
+            Demo 3：插件路由
+            1. 问“今天天气怎么样，适合出去跑步吗？”。
+            2. 展示 weather、memory、safety、trace 插件。
+            3. 说明天气插件是 Context Plugin，只读；不会做写操作。
+
+            Demo 4：权限门控
+            1. 问“把明天下午三点的复习写进日历”。
+            2. 展示 calendar action 插件和 Permission Gate。
+            3. 说明写入需要设置允许和用户明确请求。
+
+            Demo 5：Skills
+            1. 输入 /skills。
+            2. 展示 study-plan、assignment-breakdown、weather-decision、Nature 学术类 skill。
+            3. 说明 Skill 是任务流程，Plugin 是工具能力，Knowledge 是资料来源，Memory 是用户状态。
+
+            可以放进报告的一句话：
+            Boring Notch Agent 将 macOS notch utility 升级为桌面 Agent Host：通过插件注册表、渐进式工具发现、Skill 工作流、本地知识库、三层记忆和权限护栏，把聊天界面变成可解释、可扩展、可控的智能体系统。
+            """
+        ),
+    ]
+
+    private func requestReply(for prompt: String, agentRun: AgentPreparedRun) async throws -> AIReply {
+        let config = try resolveServiceConfig()
+        let decoded = try await performChatCompletion(
+            config: config,
+            messages: buildPayloadMessages(
+                requestedModel: config.requestedModel,
+                calendarContext: agentRun.calendarContext,
+                agentContext: agentRun.systemContext
+            ),
+            temperature: configuredTemperature()
+        )
+        let resolvedModelName = normalizedModelName(decoded.model) ?? config.requestedModel
+
+        if isModelIdentityQuestion(prompt) {
+            return AIReply(
+                content: localizedModelIdentityReply(
+                    for: prompt,
+                    resolvedModelName: resolvedModelName
+                ),
+                requestedModelName: config.requestedModel,
+                resolvedModelName: resolvedModelName
+            )
+        }
+
+        let content = decoded.choices.first?.message.content.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        guard !content.isEmpty else {
+            throw FeatureError("The AI service returned an empty response.")
+        }
+
+        return AIReply(
+            content: content,
+            requestedModelName: config.requestedModel,
+            resolvedModelName: resolvedModelName
+        )
+    }
+
+    private func requestCalendarWriteReply(for prompt: String, agentRun: AgentPreparedRun) async throws -> AIReply {
+        guard Defaults[.aiCalendarWriteEnabled] else {
+            throw FeatureError("AI calendar writing is disabled in Settings > AI.")
+        }
+
+        guard agentRun.calendarContext != nil else {
+            throw FeatureError("Calendar access is unavailable. Enable it in Settings > Calendar before asking AI to write plans.")
+        }
+
+        let config = try resolveServiceConfig()
+        let decoded = try await performChatCompletion(
+            config: config,
+            messages: buildPayloadMessages(
+                requestedModel: config.requestedModel,
+                calendarContext: agentRun.calendarContext,
+                agentContext: agentRun.systemContext,
+                extraSystemMessages: [calendarWriteInstruction()]
+            ),
+            temperature: configuredTemperature(maximum: 0.2)
+        )
+
+        let resolvedModelName = normalizedModelName(decoded.model) ?? config.requestedModel
+        let rawContent = decoded.choices.first?.message.content.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let action = try decodeCalendarAction(from: rawContent)
+
+        let drafts = try action.events.compactMap { try makeCalendarDraft(from: $0) }
+        let createdEvents: [CreatedCalendarEvent]
+
+        if action.createEvents && !drafts.isEmpty {
+            createdEvents = try await CalendarManager.shared.createAIPlannedEvents(drafts)
+        } else {
+            createdEvents = []
+        }
+
+        let content = mergedCalendarWriteReply(baseReply: action.reply, createdEvents: createdEvents)
+        return AIReply(
+            content: content,
+            requestedModelName: config.requestedModel,
+            resolvedModelName: resolvedModelName
+        )
+    }
+
+    private func buildPayloadMessages(
+        requestedModel: String,
+        calendarContext: String? = nil,
+        agentContext: String? = nil,
+        extraSystemMessages: [String] = []
+    ) -> [OpenAIChatRequest.Message] {
+        var payloadMessages: [OpenAIChatRequest.Message] = []
+        let systemPrompt = Defaults[.aiSystemPrompt].trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !systemPrompt.isEmpty {
+            payloadMessages.append(.init(role: "system", content: systemPrompt))
+        }
+
+        payloadMessages.append(
+            .init(
+                role: "system",
+                content: """
+                The requested model name for this chat is "\(requestedModel)".
+                If the user asks which model is responding, answer with that exact model name unless the API metadata for the current response proves otherwise.
+                Do not claim to be GPT-4o or any other different model name.
+                """
+            )
+        )
+
+        payloadMessages.append(.init(role: "system", content: groundingInstruction()))
+
+        if let calendarContext, !calendarContext.isEmpty {
+            payloadMessages.append(
+                .init(
+                    role: "system",
+                    content: """
+                    The user's local time zone is \(TimeZone.current.identifier).
+                    The current local date and time is \(isoTimestamp(Date())).
+                    Use the following calendar context only when it is relevant to the request:
+                    \(calendarContext)
+                    """
+                )
+            )
+        }
+
+        if let agentContext, !agentContext.isEmpty {
+            payloadMessages.append(
+                .init(
+                    role: "system",
+                    content: agentContext
+                )
+            )
+        }
+
+        payloadMessages.append(
+            contentsOf: extraSystemMessages.map { .init(role: "system", content: $0) }
+        )
+
+        let history = messages.suffix(12)
+        payloadMessages.append(
+            contentsOf: history.map {
+                OpenAIChatRequest.Message(role: $0.role.rawValue, content: $0.content)
+            }
+        )
+
+        return payloadMessages
+    }
+
+    private func chatCompletionsURL(from baseURL: String) -> URL? {
+        guard !baseURL.isEmpty else { return nil }
+
+        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sanitized = trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed
+        let lowercased = trimmed.lowercased()
+        let sanitizedLowercased = sanitized.lowercased()
+
+        if lowercased.hasSuffix("/chat/completions") {
+            return URL(string: trimmed)
+        }
+        if sanitizedLowercased.hasSuffix("/v1") {
+            return URL(string: sanitized + "/chat/completions")
+        }
+        return URL(string: sanitized + "/v1/chat/completions")
+    }
+
+    private func normalizedModelName(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func resolveServiceConfig() throws -> AIServiceConfig {
+        let baseURL = Defaults[.aiServiceBaseURL].trimmingCharacters(in: .whitespacesAndNewlines)
+        let apiKey = Defaults[.aiServiceAPIKey].trimmingCharacters(in: .whitespacesAndNewlines)
+        let requestedModel = Defaults[.aiServiceModel].trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard Defaults[.aiChatEnabled] else {
+            throw FeatureError("AI chat is disabled in Settings.")
+        }
+
+        guard !apiKey.isEmpty else {
+            throw FeatureError("Missing API key. Set it in Settings > AI.")
+        }
+
+        guard !requestedModel.isEmpty else {
+            throw FeatureError("Missing model name. Set it in Settings > AI.")
+        }
+
+        guard let endpoint = chatCompletionsURL(from: baseURL) else {
+            throw FeatureError("Invalid AI base URL.")
+        }
+
+        return AIServiceConfig(endpoint: endpoint, apiKey: apiKey, requestedModel: requestedModel)
+    }
+
+    private func configuredTemperature(maximum: Double = 1.0) -> Double {
+        min(max(Defaults[.aiTemperature], 0.0), maximum)
+    }
+
+    private func groundingInstruction() -> String {
+        """
+        Grounding and local-context rules:
+        - Do not invent local calendar events, today's schedule, reminders, files, weather, memory, or knowledge-base content.
+        - If the user asks about today's plan, schedule, agenda, free time, meetings, or calendar, answer only from the provided calendar context.
+        - If calendar context is missing, disabled, permission-denied, or empty, say that you cannot confirm local schedule from the calendar; do not fabricate events.
+        - If a retrieved memory or knowledge-base excerpt is absent, state that no relevant local record was found.
+        - Keep answers concise unless the user asks for a detailed plan.
+        """
+    }
+
+    private func performChatCompletion(
+        config: AIServiceConfig,
+        messages: [OpenAIChatRequest.Message],
+        temperature: Double
+    ) async throws -> OpenAIChatResponse {
+        var request = URLRequest(url: config.endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 60
+
+        let payload = OpenAIChatRequest(
+            model: config.requestedModel,
+            messages: messages,
+            temperature: temperature
+        )
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        if let httpResponse = response as? HTTPURLResponse, !(200 ... 299).contains(httpResponse.statusCode) {
+            if let apiError = try? JSONDecoder().decode(OpenAIErrorResponse.self, from: data),
+               let message = apiError.error.message, !message.isEmpty
+            {
+                throw FeatureError(message)
+            }
+            throw FeatureError("AI request failed with status \(httpResponse.statusCode).")
+        }
+
+        return try JSONDecoder().decode(OpenAIChatResponse.self, from: data)
+    }
+
+    private func calendarContextIfRelevant(for prompt: String) async -> String? {
+        guard wantsCalendarContext(for: prompt) else { return nil }
+        return await CalendarManager.shared.aiScheduleContext()
+    }
+
+    private func wantsCalendarContext(for prompt: String) -> Bool {
+        guard Defaults[.aiCalendarContextEnabled] else { return false }
+
+        let lowered = prompt.lowercased()
+        let keywords = [
+            "calendar",
+            "schedule",
+            "agenda",
+            "plan",
+            "安排",
+            "计划",
+            "日程",
+            "日历",
+            "行程",
+            "空闲",
+            "提醒",
+            "会议",
+            "待办",
+            "有什么事",
+            "有啥事",
+            "要做什么",
+            "今天要做",
+            "今日要做",
+            "today's schedule",
+            "what do i have today",
+            "什么时候有空",
+            "when am i free",
+            "available"
+        ]
+        return keywords.contains(where: lowered.contains)
+    }
+
+    private func wantsCalendarWrite(for prompt: String) -> Bool {
+        guard Defaults[.aiCalendarWriteEnabled] else { return false }
+
+        let lowered = prompt.lowercased()
+        let keywords = [
+            "add to calendar",
+            "put on my calendar",
+            "create calendar event",
+            "write to calendar",
+            "schedule it",
+            "写进日历",
+            "写到日历",
+            "加到日历",
+            "添加到日历",
+            "放到日历",
+            "创建日程",
+            "创建日历",
+            "写入日历"
+        ]
+        return keywords.contains(where: lowered.contains)
+    }
+
+    private func calendarWriteInstruction() -> String {
+        """
+        You are creating calendar events for the user.
+        Return only a JSON object with this exact schema:
+        {
+          "reply": "short natural-language confirmation in the user's language",
+          "create_events": true,
+          "events": [
+            {
+              "title": "event title",
+              "start": "ISO-8601 local date-time with timezone offset",
+              "end": "ISO-8601 local date-time with timezone offset",
+              "notes": "optional notes",
+              "location": "optional location"
+            }
+          ]
+        }
+
+        Rules:
+        - Use the user's existing calendar schedule to avoid conflicts.
+        - Use absolute timestamps, never relative phrases.
+        - Keep event titles short and practical.
+        - If the user asked for a study/work plan, split it into sensible time blocks.
+        - If required timing is unclear, make a reasonable plan based on free time in the calendar.
+        - Return JSON only. No markdown fences.
+        """
+    }
+
+    private func decodeCalendarAction(from rawContent: String) throws -> AICalendarWriteAction {
+        guard let jsonString = extractJSONObject(from: rawContent),
+              let data = jsonString.data(using: .utf8)
+        else {
+            throw FeatureError("The AI did not return a usable calendar plan.")
+        }
+
+        do {
+            return try JSONDecoder().decode(AICalendarWriteAction.self, from: data)
+        } catch {
+            throw FeatureError("The AI returned an invalid calendar plan format.")
+        }
+    }
+
+    private func extractJSONObject(from rawContent: String) -> String? {
+        guard let start = rawContent.firstIndex(of: "{"),
+              let end = rawContent.lastIndex(of: "}")
+        else {
+            return nil
+        }
+        return String(rawContent[start...end])
+    }
+
+    private func makeCalendarDraft(from payload: AICalendarEventPayload) throws -> CalendarEventDraft? {
+        let title = payload.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return nil }
+
+        guard let start = parseCalendarDate(payload.start),
+              let end = parseCalendarDate(payload.end)
+        else {
+            throw FeatureError("The AI returned a calendar event with an invalid date.")
+        }
+
+        return CalendarEventDraft(
+            title: title,
+            start: start,
+            end: end,
+            notes: normalizedOptionalText(payload.notes),
+            location: normalizedOptionalText(payload.location)
+        )
+    }
+
+    private func parseCalendarDate(_ rawValue: String) -> Date? {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+
+        let internetFormatter = ISO8601DateFormatter()
+        internetFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let parsed = internetFormatter.date(from: value) {
+            return parsed
+        }
+
+        let fallbackInternetFormatter = ISO8601DateFormatter()
+        fallbackInternetFormatter.formatOptions = [.withInternetDateTime]
+        if let parsed = fallbackInternetFormatter.date(from: value) {
+            return parsed
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+
+        for format in ["yyyy-MM-dd HH:mm", "yyyy-MM-dd HH:mm:ss", "yyyy/MM/dd HH:mm"] {
+            formatter.dateFormat = format
+            if let parsed = formatter.date(from: value) {
+                return parsed
+            }
+        }
+
+        return nil
+    }
+
+    private func normalizedOptionalText(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func mergedCalendarWriteReply(
+        baseReply: String,
+        createdEvents: [CreatedCalendarEvent]
+    ) -> String {
+        let trimmedReply = baseReply.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !createdEvents.isEmpty else {
+            return trimmedReply.isEmpty ? "已生成计划，但没有写入新的日历事件。" : trimmedReply
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "zh_CN")
+        formatter.timeZone = .current
+        formatter.dateFormat = "MM-dd HH:mm"
+
+        let lines = createdEvents.map {
+            "- \($0.title) (\(formatter.string(from: $0.start)) - \(formatter.string(from: $0.end)))"
+        }
+        let creationSummary = "已写入日历：\n" + lines.joined(separator: "\n")
+
+        if trimmedReply.isEmpty {
+            return creationSummary
+        }
+
+        return trimmedReply + "\n\n" + creationSummary
+    }
+
+    private func isoTimestamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = .current
+        return formatter.string(from: date)
+    }
+
+    private func isModelIdentityQuestion(_ prompt: String) -> Bool {
+        let lowered = prompt.lowercased()
+        let keywords = [
+            "what model",
+            "which model",
+            "model are you",
+            "your model",
+            "模型",
+            "什么模型",
+            "哪个模型",
+            "你是什么模型",
+            "真实模型"
+        ]
+        return keywords.contains(where: lowered.contains)
+    }
+
+    private func localizedModelIdentityReply(for prompt: String, resolvedModelName: String) -> String {
+        if prompt.containsChineseCharacters {
+            return "当前接口实际返回的模型是 \(resolvedModelName)。"
+        }
+        return "The current model returned by the API is \(resolvedModelName)."
+    }
+}
+
+private struct WeatherLookupLocation {
+    let displayName: String
+    let latitude: Double
+    let longitude: Double
+}
+
+private final class WeatherLocationProvider: NSObject, CLLocationManagerDelegate {
+    var authorizationDidChange: ((CLAuthorizationStatus) -> Void)?
+
+    private let manager = CLLocationManager()
+    private let geocoder = CLGeocoder()
+
+    private var locationContinuation: CheckedContinuation<CLLocation, Error>?
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyKilometer
+    }
+
+    var authorizationStatus: CLAuthorizationStatus {
+        manager.authorizationStatus
+    }
+
+    func ensureAuthorizationStatus() async -> CLAuthorizationStatus {
+        let status = authorizationStatus
+        guard status == .notDetermined else { return status }
+
+        await MainActor.run {
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+
+        try? await Task.sleep(for: .milliseconds(300))
+
+        await MainActor.run {
+            manager.requestWhenInUseAuthorization()
+        }
+
+        var resolvedStatus = authorizationStatus
+        for _ in 0..<20 {
+            if resolvedStatus != .notDetermined {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(250))
+            resolvedStatus = authorizationStatus
+        }
+
+        if resolvedStatus != .notDetermined {
+            await MainActor.run {
+                NSApp.setActivationPolicy(.accessory)
+            }
+        }
+
+        return resolvedStatus
+    }
+
+    func requestResolvedLocation() async throws -> WeatherLookupLocation {
+        let status = await ensureAuthorizationStatus()
+        let servicesEnabled = CLLocationManager.locationServicesEnabled()
+
+        switch status {
+        case .authorizedAlways, .authorizedWhenInUse:
+            guard servicesEnabled else {
+                throw FeatureError("Location Services are disabled in macOS settings.")
+            }
+            break
+        case .denied:
+            throw FeatureError("Location access is denied. Allow Boring Notch in Privacy & Security > Location Services.")
+        case .restricted:
+            throw FeatureError("Location access is restricted on this Mac.")
+        case .notDetermined:
+            if !servicesEnabled {
+                throw FeatureError("Location Services are disabled in macOS settings.")
+            }
+            throw FeatureError("Location access has not been granted yet.")
+        @unknown default:
+            throw FeatureError("Location access is unavailable.")
+        }
+
+        let location = try await withCheckedThrowingContinuation { continuation in
+            locationContinuation = continuation
+            manager.requestLocation()
+        }
+
+        return WeatherLookupLocation(
+            displayName: await reverseGeocodeDisplayName(for: location) ?? "Current location",
+            latitude: location.coordinate.latitude,
+            longitude: location.coordinate.longitude
+        )
+    }
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        authorizationDidChange?(status)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let continuation = locationContinuation else { return }
+        locationContinuation = nil
+
+        if let location = locations.last {
+            continuation.resume(returning: location)
+        } else {
+            continuation.resume(throwing: FeatureError("Current location was unavailable."))
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        guard let continuation = locationContinuation else { return }
+        locationContinuation = nil
+        continuation.resume(throwing: error)
+    }
+
+    private func reverseGeocodeDisplayName(for location: CLLocation) async -> String? {
+        do {
+            let placemarks = try await geocoder.reverseGeocodeLocation(location)
+            guard let placemark = placemarks.first else { return nil }
+            return [placemark.locality, placemark.administrativeArea, placemark.country]
+                .compactMap { component in
+                    guard let component, !component.isEmpty else { return nil }
+                    return component
+                }
+                .joined(separator: ", ")
+        } catch {
+            return nil
+        }
+    }
+}
+
+@MainActor
+final class WeatherManager: ObservableObject {
+    static let shared = WeatherManager()
+
+    @Published private(set) var snapshot: WeatherSnapshot?
+    @Published private(set) var isRefreshing: Bool = false
+    @Published var lastError: String?
+    @Published private(set) var locationServicesEnabled: Bool
+    @Published private(set) var locationAuthorizationStatus: CLAuthorizationStatus
+
+    private var cancellables: Set<AnyCancellable> = []
+    private let locationProvider: WeatherLocationProvider
+
+    private init() {
+        locationProvider = WeatherLocationProvider()
+        locationServicesEnabled = CLLocationManager.locationServicesEnabled()
+        locationAuthorizationStatus = locationProvider.authorizationStatus
+
+        let cityPublisher = Defaults.publisher(.weatherCity).map { _ in () }.eraseToAnyPublisher()
+        let modePublisher = Defaults.publisher(.weatherLocationMode).map { _ in () }.eraseToAnyPublisher()
+        let unitPublisher = Defaults.publisher(.weatherTemperatureUnit).map { _ in () }.eraseToAnyPublisher()
+        let enabledPublisher = Defaults.publisher(.weatherFeatureEnabled).map { _ in () }.eraseToAnyPublisher()
+
+        Publishers.Merge4(cityPublisher, modePublisher, unitPublisher, enabledPublisher)
+            .sink { [weak self] _ in
+                Task { await self?.refreshWeather(force: true) }
+            }
+            .store(in: &cancellables)
+
+        locationProvider.authorizationDidChange = { [weak self] status in
+            Task { @MainActor in
+                guard let self else { return }
+                self.locationAuthorizationStatus = status
+
+                guard Defaults[.weatherFeatureEnabled], Defaults[.weatherLocationMode] == .automatic else { return }
+                await self.refreshWeather(force: true)
+            }
+        }
+
+        Task {
+            await refreshWeather(force: false)
+        }
+    }
+
+    var locationAuthorizationDescription: String {
+        if !locationServicesEnabled {
+            return "Services off"
+        }
+
+        switch locationAuthorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            return "Allowed"
+        case .notDetermined:
+            return "Not requested"
+        case .denied:
+            return "Denied"
+        case .restricted:
+            return "Restricted"
+        @unknown default:
+            return "Unknown"
+        }
+    }
+
+    func requestLocationAuthorization() async {
+        await MainActor.run {
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        refreshLocationAccessState()
+        let status = await locationProvider.ensureAuthorizationStatus()
+        locationAuthorizationStatus = status
+
+        switch status {
+        case .denied, .restricted, .notDetermined:
+            break
+        default:
+            await refreshWeather(force: true)
+        }
+
+        if status != .notDetermined {
+            await MainActor.run {
+                NSApp.setActivationPolicy(.accessory)
+            }
+        }
+    }
+
+    func openLocationSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices") else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    func refreshWeather(force: Bool) async {
+        refreshLocationAccessState()
+
+        guard Defaults[.weatherFeatureEnabled] else {
+            snapshot = nil
+            lastError = nil
+            return
+        }
+
+        guard !isRefreshing else { return }
+
+        if let snapshot, !force, Date().timeIntervalSince(snapshot.updatedAt) < 900 {
+            return
+        }
+
+        isRefreshing = true
+        lastError = nil
+        defer { isRefreshing = false }
+
+        do {
+            let location = try await resolvedLocation()
+            snapshot = try await fetchWeather(for: location)
+        } catch {
+            if snapshot == nil {
+                snapshot = nil
+            }
+            lastError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    func refreshLocationAccessState() {
+        locationServicesEnabled = CLLocationManager.locationServicesEnabled()
+        locationAuthorizationStatus = locationProvider.authorizationStatus
+    }
+
+    private func resolvedLocation() async throws -> WeatherLookupLocation {
+        if Defaults[.weatherLocationMode] == .automatic {
+            return try await locationProvider.requestResolvedLocation()
+        }
+
+        let query = Defaults[.weatherCity].trimmingCharacters(in: .whitespacesAndNewlines)
+        let city = query.isEmpty ? defaultWeatherCityName() : query
+
+        guard !city.isEmpty else {
+            throw FeatureError("请先在设置 > Weather 中填写城市。")
+        }
+
+        return try await geocode(city: city)
+    }
+
+    private func geocode(city: String) async throws -> WeatherLookupLocation {
+        var components = URLComponents(string: "https://geocoding-api.open-meteo.com/v1/search")
+        components?.queryItems = [
+            URLQueryItem(name: "name", value: city),
+            URLQueryItem(name: "count", value: "1"),
+            URLQueryItem(name: "language", value: "en"),
+            URLQueryItem(name: "format", value: "json"),
+        ]
+
+        guard let url = components?.url else {
+            throw FeatureError("天气城市查询地址无效。")
+        }
+
+        let (data, response) = try await URLSession.shared.data(from: url)
+        if let httpResponse = response as? HTTPURLResponse, !(200 ... 299).contains(httpResponse.statusCode) {
+            throw FeatureError("天气城市查询失败，状态码 \(httpResponse.statusCode)。")
+        }
+
+        let decoded = try JSONDecoder().decode(GeocodingResponse.self, from: data)
+        guard let firstMatch = decoded.results?.first else {
+            throw FeatureError("没有找到“\(city)”的天气结果。")
+        }
+
+        return .init(
+            displayName: firstMatch.displayName,
+            latitude: firstMatch.latitude,
+            longitude: firstMatch.longitude
+        )
+    }
+
+    private func fetchWeather(for location: WeatherLookupLocation) async throws -> WeatherSnapshot {
+        var components = URLComponents(string: "https://api.open-meteo.com/v1/forecast")
+        let unit = Defaults[.weatherTemperatureUnit]
+        components?.queryItems = [
+            URLQueryItem(name: "latitude", value: String(location.latitude)),
+            URLQueryItem(name: "longitude", value: String(location.longitude)),
+            URLQueryItem(
+                name: "current",
+                value: "temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,weather_code,wind_speed_10m,is_day"
+            ),
+            URLQueryItem(name: "hourly", value: "temperature_2m,weather_code,precipitation_probability,is_day"),
+            URLQueryItem(name: "daily", value: "temperature_2m_max,temperature_2m_min"),
+            URLQueryItem(name: "forecast_days", value: "1"),
+            URLQueryItem(name: "timezone", value: "auto"),
+            URLQueryItem(name: "temperature_unit", value: unit.apiValue),
+            URLQueryItem(name: "wind_speed_unit", value: unit.windSpeedAPIValue),
+        ]
+
+        guard let url = components?.url else {
+            throw FeatureError("天气预报地址无效。")
+        }
+
+        let (data, response) = try await URLSession.shared.data(from: url)
+        if let httpResponse = response as? HTTPURLResponse, !(200 ... 299).contains(httpResponse.statusCode) {
+            throw FeatureError("天气获取失败，状态码 \(httpResponse.statusCode)。")
+        }
+
+        let decoded = try JSONDecoder().decode(OpenMeteoForecastResponse.self, from: data)
+        let currentDescriptor = WeatherDescriptor.from(code: decoded.current.weatherCode, isDay: decoded.current.isDay == 1)
+        let hourlySlice = hourlyEntries(from: decoded.hourly, currentTime: decoded.current.time, unit: unit)
+
+        return WeatherSnapshot(
+            locationName: location.displayName,
+            updatedAt: Date(),
+            current: .init(
+                temperature: decoded.current.temperature,
+                feelsLike: decoded.current.apparentTemperature,
+                humidity: decoded.current.relativeHumidity,
+                precipitation: decoded.current.precipitation,
+                windSpeed: decoded.current.windSpeed,
+                condition: currentDescriptor.title,
+                symbolName: currentDescriptor.symbolName,
+                unitSymbol: unit.symbol,
+                windUnit: unit.windSpeedLabel,
+                highTemperature: decoded.daily?.temperatureMax.first,
+                lowTemperature: decoded.daily?.temperatureMin.first
+            ),
+            hourly: hourlySlice
+        )
+    }
+
+    private func hourlyEntries(
+        from hourly: OpenMeteoForecastResponse.Hourly,
+        currentTime: String,
+        unit: WeatherTemperatureUnit
+    ) -> [WeatherSnapshot.HourlyEntry] {
+        guard !hourly.time.isEmpty else { return [] }
+
+        let startIndex = hourly.time.firstIndex(of: currentTime) ?? 0
+        let endIndex = min(startIndex + 5, hourly.time.count)
+
+        return (startIndex ..< endIndex).compactMap { index in
+            guard index < hourly.temperature.count, index < hourly.weatherCode.count else { return nil }
+            let isDay = hourly.isDay.flatMap { index < $0.count ? $0[index] : nil } ?? 1
+            let descriptor = WeatherDescriptor.from(code: hourly.weatherCode[index], isDay: isDay == 1)
+            return WeatherSnapshot.HourlyEntry(
+                timeLabel: formattedHourLabel(from: hourly.time[index]),
+                temperature: hourly.temperature[index],
+                symbolName: descriptor.symbolName,
+                unitSymbol: unit.symbol,
+                precipitationProbability: hourly.precipitationProbability.flatMap { index < $0.count ? $0[index] : nil }
+            )
+        }
+    }
+
+    private func formattedHourLabel(from value: String) -> String {
+        let raw = value.replacingOccurrences(of: "T", with: " ")
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+
+        guard let date = formatter.date(from: raw) else {
+            return String(value.suffix(5))
+        }
+
+        let display = DateFormatter()
+        display.locale = Locale.current
+        display.dateFormat = "HH:mm"
+        return display.string(from: date)
+    }
+}
+
+@MainActor
+final class QuickLaunchManager: ObservableObject {
+    static let shared = QuickLaunchManager()
+
+    @Published var lastError: String?
+
+    private init() {}
+
+    func open(_ item: QuickLaunchAppItem) {
+        lastError = nil
+
+        let standardizedPath = URL(fileURLWithPath: item.appPath).standardizedFileURL.path
+        guard FileManager.default.fileExists(atPath: standardizedPath) else {
+            lastError = "\(item.displayName) is no longer available at \(standardizedPath)."
+            return
+        }
+
+        let appURL = URL(fileURLWithPath: standardizedPath)
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+
+        NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { [weak self] _, error in
+            Task { @MainActor in
+                self?.lastError = error?.localizedDescription
+            }
+        }
+    }
+}
+
+enum PomodoroPhase: String, CaseIterable, Identifiable {
+    case focus = "Focus"
+    case shortBreak = "Short Break"
+    case longBreak = "Long Break"
+
+    var id: String { rawValue }
+
+    var symbolName: String {
+        switch self {
+        case .focus:
+            return "brain.head.profile"
+        case .shortBreak:
+            return "cup.and.saucer.fill"
+        case .longBreak:
+            return "bed.double.fill"
+        }
+    }
+
+    var shortLabel: String {
+        switch self {
+        case .focus:
+            return "Focus"
+        case .shortBreak:
+            return "Short"
+        case .longBreak:
+            return "Long"
+        }
+    }
+}
+
+@MainActor
+final class PomodoroManager: ObservableObject {
+    static let shared = PomodoroManager()
+
+    @Published private(set) var phase: PomodoroPhase = .focus
+    @Published private(set) var remainingSeconds: Int
+    @Published private(set) var isRunning: Bool = false
+    @Published private(set) var completedFocusSessions: Int = 0
+
+    private var timerTask: Task<Void, Never>?
+    private var targetDate: Date?
+    private var cancellables: Set<AnyCancellable> = []
+
+    private init() {
+        remainingSeconds = Self.duration(for: .focus)
+
+        Publishers.MergeMany([
+            Defaults.publisher(.pomodoroEnabled).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.pomodoroFocusMinutes).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.pomodoroShortBreakMinutes).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.pomodoroLongBreakMinutes).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.pomodoroLongBreakInterval).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.pomodoroAutoStartNextPhase).map { _ in () }.eraseToAnyPublisher(),
+        ])
+        .sink { [weak self] _ in
+            self?.handleConfigurationChange()
+        }
+        .store(in: &cancellables)
+    }
+
+    deinit {
+        timerTask?.cancel()
+    }
+
+    var formattedRemaining: String {
+        String(format: "%02d:%02d", remainingSeconds / 60, remainingSeconds % 60)
+    }
+
+    var progress: Double {
+        let total = max(phaseTotalSeconds, 1)
+        return 1 - min(max(Double(remainingSeconds) / Double(total), 0), 1)
+    }
+
+    var phaseTotalSeconds: Int {
+        Self.duration(for: phase)
+    }
+
+    var nextPhaseTitle: String {
+        nextPhase(after: phase, completedFocusCount: phase == .focus ? completedFocusSessions + 1 : completedFocusSessions).rawValue
+    }
+
+    var currentCycleIndexLabel: String {
+        let interval = max(2, Defaults[.pomodoroLongBreakInterval])
+        let completedInCycle = completedFocusSessions % interval
+
+        if phase == .focus {
+            return "\(completedInCycle + 1)/\(interval)"
+        }
+
+        if completedFocusSessions > 0 && completedInCycle == 0 {
+            return "\(interval)/\(interval)"
+        }
+
+        return "\(max(completedInCycle, 1))/\(interval)"
+    }
+
+    func toggleRunning() {
+        isRunning ? pause() : start()
+    }
+
+    func start() {
+        guard Defaults[.pomodoroEnabled] else { return }
+        guard !isRunning else { return }
+
+        if remainingSeconds <= 0 {
+            remainingSeconds = phaseTotalSeconds
+        }
+
+        isRunning = true
+        targetDate = Date().addingTimeInterval(Double(remainingSeconds))
+        scheduleTickTask()
+    }
+
+    func pause() {
+        guard isRunning else { return }
+        syncRemainingToNow()
+        stopTimer(clearRemaining: false)
+    }
+
+    func resetCurrentPhase() {
+        stopTimer(clearRemaining: true)
+    }
+
+    func resetCycle() {
+        completedFocusSessions = 0
+        phase = .focus
+        stopTimer(clearRemaining: true)
+    }
+
+    func skipPhase() {
+        advanceToNextPhase(completedCurrentPhase: false, continueRunning: isRunning)
+    }
+
+    func selectPhase(_ newPhase: PomodoroPhase) {
+        guard phase != newPhase else { return }
+        phase = newPhase
+        stopTimer(clearRemaining: true)
+    }
+
+    private func handleConfigurationChange() {
+        guard Defaults[.pomodoroEnabled] else {
+            resetCycle()
+            return
+        }
+
+        if !isRunning {
+            remainingSeconds = phaseTotalSeconds
+        }
+    }
+
+    private func scheduleTickTask() {
+        timerTask?.cancel()
+        timerTask = Task { [weak self] in
+            while let self, !Task.isCancelled {
+                await self.tick()
+                try? await Task.sleep(for: .seconds(1))
+            }
+        }
+    }
+
+    private func tick() async {
+        guard isRunning, let targetDate else { return }
+
+        let nextRemaining = max(0, Int(ceil(targetDate.timeIntervalSinceNow)))
+        if nextRemaining != remainingSeconds {
+            remainingSeconds = nextRemaining
+        }
+
+        if nextRemaining <= 0 {
+            completeCurrentPhase()
+        }
+    }
+
+    private func completeCurrentPhase() {
+        NSSound.beep()
+        advanceToNextPhase(
+            completedCurrentPhase: true,
+            continueRunning: Defaults[.pomodoroAutoStartNextPhase]
+        )
+    }
+
+    private func advanceToNextPhase(completedCurrentPhase: Bool, continueRunning: Bool) {
+        let previousPhase = phase
+        stopTimer(clearRemaining: false)
+
+        if completedCurrentPhase && previousPhase == .focus {
+            completedFocusSessions += 1
+        }
+
+        phase = nextPhase(
+            after: previousPhase,
+            completedFocusCount: completedFocusSessions
+        )
+        remainingSeconds = phaseTotalSeconds
+
+        if continueRunning {
+            start()
+        }
+    }
+
+    private func nextPhase(after phase: PomodoroPhase, completedFocusCount: Int) -> PomodoroPhase {
+        switch phase {
+        case .focus:
+            let interval = max(2, Defaults[.pomodoroLongBreakInterval])
+            if completedFocusCount > 0 && completedFocusCount % interval == 0 {
+                return .longBreak
+            }
+            return .shortBreak
+        case .shortBreak, .longBreak:
+            return .focus
+        }
+    }
+
+    private func syncRemainingToNow() {
+        guard let targetDate else { return }
+        remainingSeconds = max(0, Int(ceil(targetDate.timeIntervalSinceNow)))
+    }
+
+    private func stopTimer(clearRemaining: Bool) {
+        isRunning = false
+        targetDate = nil
+        timerTask?.cancel()
+        timerTask = nil
+
+        if clearRemaining {
+            remainingSeconds = phaseTotalSeconds
+        }
+    }
+
+    private static func duration(for phase: PomodoroPhase) -> Int {
+        let minutes: Int
+
+        switch phase {
+        case .focus:
+            minutes = max(1, Defaults[.pomodoroFocusMinutes])
+        case .shortBreak:
+            minutes = max(1, Defaults[.pomodoroShortBreakMinutes])
+        case .longBreak:
+            minutes = max(1, Defaults[.pomodoroLongBreakMinutes])
+        }
+
+        return minutes * 60
+    }
+}
+
+struct WeatherSnapshot {
+    struct CurrentConditions {
+        let temperature: Double
+        let feelsLike: Double
+        let humidity: Int
+        let precipitation: Double
+        let windSpeed: Double
+        let condition: String
+        let symbolName: String
+        let unitSymbol: String
+        let windUnit: String
+        let highTemperature: Double?
+        let lowTemperature: Double?
+    }
+
+    struct HourlyEntry: Identifiable {
+        let id = UUID()
+        let timeLabel: String
+        let temperature: Double
+        let symbolName: String
+        let unitSymbol: String
+        let precipitationProbability: Int?
+    }
+
+    let locationName: String
+    let updatedAt: Date
+    let current: CurrentConditions
+    let hourly: [HourlyEntry]
+}
+
+enum WeatherDescriptor {
+    case clear
+    case clearNight
+    case partlyCloudy
+    case partlyCloudyNight
+    case cloudy
+    case fog
+    case drizzle
+    case rain
+    case snow
+    case thunder
+
+    var title: String {
+        switch self {
+        case .clear: return "晴"
+        case .clearNight: return "晴朗夜间"
+        case .partlyCloudy: return "少云"
+        case .partlyCloudyNight: return "少云夜间"
+        case .cloudy: return "多云"
+        case .fog: return "雾"
+        case .drizzle: return "小雨"
+        case .rain: return "雨"
+        case .snow: return "雪"
+        case .thunder: return "雷暴"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .clear: return "sun.max.fill"
+        case .clearNight: return "moon.stars.fill"
+        case .partlyCloudy: return "cloud.sun.fill"
+        case .partlyCloudyNight: return "cloud.moon.fill"
+        case .cloudy: return "cloud.fill"
+        case .fog: return "cloud.fog.fill"
+        case .drizzle: return "cloud.drizzle.fill"
+        case .rain: return "cloud.rain.fill"
+        case .snow: return "cloud.snow.fill"
+        case .thunder: return "cloud.bolt.rain.fill"
+        }
+    }
+
+    static func from(code: Int, isDay: Bool) -> WeatherDescriptor {
+        switch code {
+        case 0:
+            return isDay ? .clear : .clearNight
+        case 1, 2:
+            return isDay ? .partlyCloudy : .partlyCloudyNight
+        case 3:
+            return .cloudy
+        case 45, 48:
+            return .fog
+        case 51, 53, 55, 56, 57:
+            return .drizzle
+        case 61, 63, 65, 66, 67, 80, 81, 82:
+            return .rain
+        case 71, 73, 75, 77, 85, 86:
+            return .snow
+        case 95, 96, 99:
+            return .thunder
+        default:
+            return .cloudy
+        }
+    }
+}
+
+private struct OpenAIChatRequest: Encodable {
+    struct Message: Encodable {
+        let role: String
+        let content: String
+    }
+
+    let model: String
+    let messages: [Message]
+    let temperature: Double
+}
+
+private struct OpenAIChatResponse: Decodable {
+    struct Choice: Decodable {
+        let message: Message
+    }
+
+    struct Message: Decodable {
+        let content: String
+
+        enum CodingKeys: String, CodingKey {
+            case content
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if let plainText = try? container.decode(String.self, forKey: .content) {
+                content = plainText
+                return
+            }
+
+            if let array = try? container.decode([ContentPart].self, forKey: .content) {
+                content = array.compactMap(\.text).joined(separator: "\n")
+                return
+            }
+
+            content = ""
+        }
+    }
+
+    struct ContentPart: Decodable {
+        let text: String?
+    }
+
+    let choices: [Choice]
+    let model: String?
+}
+
+private struct AIReply {
+    let content: String
+    let requestedModelName: String
+    let resolvedModelName: String?
+}
+
+private struct AIServiceConfig {
+    let endpoint: URL
+    let apiKey: String
+    let requestedModel: String
+}
+
+private struct AICalendarWriteAction: Decodable {
+    let reply: String
+    let createEvents: Bool
+    let events: [AICalendarEventPayload]
+
+    enum CodingKeys: String, CodingKey {
+        case reply
+        case createEvents = "create_events"
+        case events
+    }
+}
+
+private struct AICalendarEventPayload: Decodable {
+    let title: String
+    let start: String
+    let end: String
+    let notes: String?
+    let location: String?
+}
+
+private struct OpenAIErrorResponse: Decodable {
+    struct ErrorPayload: Decodable {
+        let message: String?
+    }
+
+    let error: ErrorPayload
+}
+
+private struct GeocodingResponse: Decodable {
+    struct ResultItem: Decodable {
+        let name: String
+        let latitude: Double
+        let longitude: Double
+        let country: String?
+        let admin1: String?
+
+        var displayName: String {
+            [name, admin1, country]
+                .compactMap { component in
+                    guard let component, !component.isEmpty else { return nil }
+                    return component
+                }
+                .joined(separator: ", ")
+        }
+    }
+
+    let results: [ResultItem]?
+}
+
+private extension String {
+    var containsChineseCharacters: Bool {
+        unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x4E00 ... 0x9FFF, 0x3400 ... 0x4DBF, 0x20000 ... 0x2A6DF:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}
+
+private struct OpenMeteoForecastResponse: Decodable {
+    struct Current: Decodable {
+        let time: String
+        let temperature: Double
+        let relativeHumidity: Int
+        let apparentTemperature: Double
+        let precipitation: Double
+        let weatherCode: Int
+        let windSpeed: Double
+        let isDay: Int
+
+        enum CodingKeys: String, CodingKey {
+            case time
+            case temperature = "temperature_2m"
+            case relativeHumidity = "relative_humidity_2m"
+            case apparentTemperature = "apparent_temperature"
+            case precipitation
+            case weatherCode = "weather_code"
+            case windSpeed = "wind_speed_10m"
+            case isDay = "is_day"
+        }
+    }
+
+    struct Hourly: Decodable {
+        let time: [String]
+        let temperature: [Double]
+        let weatherCode: [Int]
+        let precipitationProbability: [Int]?
+        let isDay: [Int]?
+
+        enum CodingKeys: String, CodingKey {
+            case time
+            case temperature = "temperature_2m"
+            case weatherCode = "weather_code"
+            case precipitationProbability = "precipitation_probability"
+            case isDay = "is_day"
+        }
+    }
+
+    struct Daily: Decodable {
+        let temperatureMax: [Double]
+        let temperatureMin: [Double]
+
+        enum CodingKeys: String, CodingKey {
+            case temperatureMax = "temperature_2m_max"
+            case temperatureMin = "temperature_2m_min"
+        }
+    }
+
+    let current: Current
+    let hourly: Hourly
+    let daily: Daily?
+}
+
+private struct FeatureError: LocalizedError {
+    let errorDescription: String?
+
+    init(_ message: String) {
+        errorDescription = message
+    }
+}

--- a/boringNotch/managers/AIWeatherManagers.swift
+++ b/boringNotch/managers/AIWeatherManagers.swift
@@ -8,9 +8,11 @@
 import AppKit
 import Combine
 import CoreLocation
+import Darwin
 import Defaults
 import Foundation
 import PDFKit
+import Security
 import UniformTypeIdentifiers
 import Vision
 
@@ -19,6 +21,170 @@ struct AgentFileReadError: LocalizedError {
 
     init(_ message: String) {
         self.errorDescription = message
+    }
+}
+
+enum AIProviderCredentialStore {
+    private static let service = "\(Bundle.main.bundleIdentifier ?? "theboringteam.boringnotch").ai-provider"
+    private static let account = "chat-completions-api-key"
+
+    static var apiKey: String {
+        if let value = try? readKeychainValue(), !value.isEmpty {
+            return value
+        }
+
+        let legacyValue = Defaults[.aiServiceAPIKey]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !legacyValue.isEmpty else { return "" }
+
+        if (try? saveAPIKey(legacyValue)) != nil {
+            Defaults[.aiServiceAPIKey] = ""
+        }
+        return legacyValue
+    }
+
+    static var hasAPIKey: Bool {
+        !apiKey.isEmpty
+    }
+
+    static func saveAPIKey(_ rawValue: String) throws {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let query = baseQuery
+
+        if value.isEmpty {
+            let status = SecItemDelete(query as CFDictionary)
+            guard status == errSecSuccess || status == errSecItemNotFound else {
+                throw credentialError(status)
+            }
+            Defaults[.aiServiceAPIKey] = ""
+            return
+        }
+
+        let attributes: [CFString: Any] = [
+            kSecValueData: Data(value.utf8),
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        var status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if status == errSecItemNotFound {
+            var item = query
+            for (key, value) in attributes {
+                item[key] = value
+            }
+            status = SecItemAdd(item as CFDictionary, nil)
+        }
+
+        guard status == errSecSuccess else {
+            throw credentialError(status)
+        }
+        Defaults[.aiServiceAPIKey] = ""
+    }
+
+    private static var baseQuery: [CFString: Any] {
+        [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+        ]
+    }
+
+    private static func readKeychainValue() throws -> String {
+        var query = baseQuery
+        query[kSecReturnData] = true
+        query[kSecMatchLimit] = kSecMatchLimitOne
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound {
+            return ""
+        }
+        guard status == errSecSuccess else {
+            throw credentialError(status)
+        }
+        guard let data = result as? Data,
+              let value = String(data: data, encoding: .utf8)
+        else {
+            throw credentialError(errSecDecode)
+        }
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func credentialError(_ status: OSStatus) -> AgentFileReadError {
+        let message = SecCopyErrorMessageString(status, nil) as String?
+        return AgentFileReadError("无法访问 macOS Keychain：\(message ?? "错误码 \(status)")")
+    }
+}
+
+private func isAgentPublicHTTPURL(_ url: URL) -> Bool {
+    guard let scheme = url.scheme?.lowercased(),
+          ["http", "https"].contains(scheme),
+          url.user == nil,
+          url.password == nil,
+          let rawHost = url.host?.lowercased(),
+          !rawHost.isEmpty
+    else {
+        return false
+    }
+
+    if let port = url.port, ![80, 443].contains(port) {
+        return false
+    }
+
+    let host = rawHost.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+    let blockedNames = ["localhost", "localhost.localdomain"]
+    if blockedNames.contains(host)
+        || host.hasSuffix(".localhost")
+        || host.hasSuffix(".local")
+        || host.hasSuffix(".internal")
+        || host.hasSuffix(".lan")
+        || host.hasSuffix(".home")
+    {
+        return false
+    }
+
+    let ipv4Parts = host.split(separator: ".").compactMap { Int($0) }
+    if ipv4Parts.count == 4, ipv4Parts.allSatisfy({ (0...255).contains($0) }) {
+        let first = ipv4Parts[0]
+        let second = ipv4Parts[1]
+        if first == 0
+            || first == 10
+            || first == 127
+            || (first == 169 && second == 254)
+            || (first == 172 && (16...31).contains(second))
+            || (first == 192 && second == 168)
+            || first >= 224
+        {
+            return false
+        }
+    } else if host.allSatisfy({ $0.isNumber || $0 == "." }) {
+        return false
+    }
+
+    if host.contains(":") {
+        if host == "::" || host == "::1" || host.hasPrefix("fc") || host.hasPrefix("fd") {
+            return false
+        }
+        let firstGroup = host.split(separator: ":", omittingEmptySubsequences: true).first.map(String.init) ?? ""
+        if ["fe8", "fe9", "fea", "feb"].contains(where: firstGroup.hasPrefix) {
+            return false
+        }
+    }
+
+    return true
+}
+
+private final class AgentPublicURLSessionDelegate: NSObject, URLSessionTaskDelegate {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard let url = request.url, isAgentPublicHTTPURL(url) else {
+            completionHandler(nil)
+            return
+        }
+        completionHandler(request)
     }
 }
 
@@ -32,14 +198,12 @@ func readAgentImportableFile(at url: URL) throws -> (content: String, byteCount:
         guard let document = PDFDocument(url: url) else {
             throw AgentFileReadError("无法打开 PDF。")
         }
-        let pageTexts = (0..<document.pageCount).compactMap { index in
-            document.page(at: index)?.string?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let extraction = try extractAgentPDFText(from: document)
+        guard !extraction.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AgentFileReadError("PDF 没有可抽取或识别的文字。")
         }
-        let text = pageTexts.joined(separator: "\n\n")
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw AgentFileReadError("PDF 没有可抽取文本，当前不做 OCR。")
-        }
-        return ("[PDF text extracted]\n\(String(text.prefix(24_000)))", byteCount)
+        let method = extraction.usedOCR ? "PDF OCR" : "PDF text extracted"
+        return ("[\(method)]\n\(String(extraction.text.prefix(24_000)))", byteCount)
     }
 
     if agentFileIsImage(url) {
@@ -90,12 +254,64 @@ private func agentFileIsImage(_ url: URL) -> Bool {
     return type.conforms(to: .image)
 }
 
+private func extractAgentPDFText(from document: PDFDocument) throws -> (text: String, usedOCR: Bool) {
+    let readablePageLimit = min(document.pageCount, 120)
+    var extractedPages: [String] = []
+    var extractedCharacterCount = 0
+
+    for index in 0..<readablePageLimit {
+        guard let text = document.page(at: index)?.string?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !text.isEmpty
+        else { continue }
+
+        extractedPages.append(text)
+        extractedCharacterCount += text.count
+        if extractedCharacterCount >= 24_000 {
+            break
+        }
+    }
+
+    if !extractedPages.isEmpty {
+        return (extractedPages.joined(separator: "\n\n"), false)
+    }
+
+    let ocrPageLimit = min(document.pageCount, 12)
+    var recognizedPages: [String] = []
+    for index in 0..<ocrPageLimit {
+        guard let page = document.page(at: index) else { continue }
+        let thumbnail = page.thumbnail(of: CGSize(width: 1_600, height: 2_200), for: .mediaBox)
+        var proposedRect = NSRect(origin: .zero, size: thumbnail.size)
+        guard let image = thumbnail.cgImage(forProposedRect: &proposedRect, context: nil, hints: nil) else {
+            continue
+        }
+        let text = try recognizeAgentText(in: image)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if !text.isEmpty {
+            recognizedPages.append(text)
+        }
+    }
+
+    return (recognizedPages.joined(separator: "\n\n"), true)
+}
+
 private func extractAgentImageText(at url: URL) throws -> String {
+    guard let imageSource = NSImage(contentsOf: url) else {
+        throw AgentFileReadError("无法打开图片。")
+    }
+    var proposedRect = NSRect(origin: .zero, size: imageSource.size)
+    guard let image = imageSource.cgImage(forProposedRect: &proposedRect, context: nil, hints: nil) else {
+        throw AgentFileReadError("无法解析图片像素。")
+    }
+    return try recognizeAgentText(in: image)
+}
+
+private func recognizeAgentText(in image: CGImage) throws -> String {
     let request = VNRecognizeTextRequest()
     request.recognitionLevel = .fast
     request.usesLanguageCorrection = true
 
-    let handler = VNImageRequestHandler(url: url, options: [:])
+    let handler = VNImageRequestHandler(cgImage: image, options: [:])
     try handler.perform([request])
 
     return (request.results ?? [])
@@ -299,7 +515,7 @@ struct AgentWorkingMemory: Equatable {
 }
 
 struct AgentMemoryRecord: Identifiable, Codable, Equatable {
-    enum Kind: String, Codable {
+    enum Kind: String, Codable, CaseIterable {
         case fact
         case episodic
         case procedural
@@ -485,6 +701,7 @@ private final class AgentMemoryStore {
     static let shared = AgentMemoryStore()
 
     private(set) var records: [AgentMemoryRecord] = []
+    private(set) var lastPersistenceError: String?
     private let fileURL: URL
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
@@ -507,13 +724,21 @@ private final class AgentMemoryStore {
             .appendingPathComponent("DanShenAgent", isDirectory: true)
         fileURL = directory.appendingPathComponent("memories.json")
 
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            lastPersistenceError = "无法创建记忆存储目录：\(error.localizedDescription)"
+        }
         migrateLegacyMemoryIfNeeded(from: baseDirectory)
-        load()
+        reloadFromDisk()
     }
 
     var recentRecords: [AgentMemoryRecord] {
-        Array(records.sorted { $0.updatedAt > $1.updatedAt }.prefix(20))
+        Array(records.filter(isEligibleForRetrieval).sorted { $0.updatedAt > $1.updatedAt }.prefix(20))
+    }
+
+    var allRecords: [AgentMemoryRecord] {
+        records.sorted { $0.updatedAt > $1.updatedAt }
     }
 
     var storageURL: URL {
@@ -549,6 +774,7 @@ private final class AgentMemoryStore {
         let now = Date()
         let matches = records
             .enumerated()
+            .filter { isEligibleForRetrieval($0.element) }
             .map { index, record -> (index: Int, score: Double, reason: String) in
                 let recordKeywords = Set(record.keywords)
                 let matchedKeywords = Array(queryKeywords.intersection(recordKeywords)).sorted()
@@ -586,7 +812,7 @@ private final class AgentMemoryStore {
             records[match.index].accessCount += 1
             records[match.index].lastAccessedAt = now
         }
-        save()
+        _ = save()
 
         return matches.map { match in
             var record = records[match.index]
@@ -603,8 +829,53 @@ private final class AgentMemoryStore {
         return store(content: content, routeKind: route.kind.rawValue, source: "explicit-user-message")
     }
 
-    func storeManual(_ content: String) -> AgentMemoryRecord? {
-        store(content: content, routeKind: "manual_memory", source: "slash-remember")
+    func storeManual(
+        _ content: String,
+        kind: AgentMemoryRecord.Kind? = nil
+    ) -> AgentMemoryRecord? {
+        store(
+            content: content,
+            routeKind: "manual_memory",
+            source: "slash-remember",
+            kindOverride: kind
+        )
+    }
+
+    func update(
+        id: UUID,
+        content rawContent: String,
+        kind: AgentMemoryRecord.Kind
+    ) -> AgentMemoryRecord? {
+        let content = rawContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !content.isEmpty, let index = records.firstIndex(where: { $0.id == id }) else {
+            return nil
+        }
+
+        let previousRecords = records
+        records[index].content = String(content.prefix(320))
+        records[index].kind = kind
+        records[index].keywords = Array(keywords(for: content + " " + kind.rawValue)).sorted()
+        records[index].updatedAt = Date()
+        records[index].source = "manual-edit"
+        records[index].retrievalScore = nil
+        records[index].retrievalReason = nil
+        guard save() else {
+            records = previousRecords
+            return nil
+        }
+        return records[index]
+    }
+
+    @discardableResult
+    func remove(id: UUID) -> Bool {
+        let previousRecords = records
+        records.removeAll { $0.id == id }
+        guard records.count != previousRecords.count else { return false }
+        guard save() else {
+            records = previousRecords
+            return false
+        }
+        return true
     }
 
     func forget(matching query: String) -> Int {
@@ -617,22 +888,29 @@ private final class AgentMemoryStore {
 
         let queryKeywords = keywords(for: normalizedQuery)
         let beforeCount = records.count
+        let previousRecords = records
         records.removeAll { record in
             record.content.localizedCaseInsensitiveContains(normalizedQuery)
                 || Set(record.keywords).intersection(queryKeywords).count >= 2
         }
         let removedCount = beforeCount - records.count
-        if removedCount > 0 {
-            save()
+        if removedCount > 0, !save() {
+            records = previousRecords
+            return 0
         }
         return removedCount
     }
 
-    private func store(content rawContent: String, routeKind: String, source: String) -> AgentMemoryRecord? {
+    private func store(
+        content rawContent: String,
+        routeKind: String,
+        source: String,
+        kindOverride: AgentMemoryRecord.Kind? = nil
+    ) -> AgentMemoryRecord? {
         let content = rawContent.trimmingCharacters(in: .whitespacesAndNewlines)
         let record = AgentMemoryRecord(
             id: UUID(),
-            kind: memoryKind(for: content, routeKind: routeKind),
+            kind: kindOverride ?? memoryKind(for: content, routeKind: routeKind),
             content: String(content.prefix(320)),
             keywords: Array(keywords(for: content + " " + routeKind)).sorted(),
             createdAt: Date(),
@@ -647,6 +925,7 @@ private final class AgentMemoryStore {
             Set(existing.keywords).intersection(record.keywords).count >= 2
                 && existing.content.localizedCaseInsensitiveContains(String(record.content.prefix(24)))
         }) {
+            let previousRecords = records
             records[existingIndex].content = record.content
             records[existingIndex].keywords = record.keywords
             records[existingIndex].kind = record.kind
@@ -654,19 +933,29 @@ private final class AgentMemoryStore {
             records[existingIndex].importance = max(records[existingIndex].importance, record.importance)
             records[existingIndex].confidence = max(records[existingIndex].confidence, record.confidence)
             records[existingIndex].updatedAt = Date()
-            save()
+            guard save() else {
+                records = previousRecords
+                return nil
+            }
             return records[existingIndex]
         }
 
+        let previousRecords = records
         records.append(record)
         records = Array(records.sorted { $0.updatedAt > $1.updatedAt }.prefix(100))
-        save()
+        guard save() else {
+            records = previousRecords
+            return nil
+        }
         return record
     }
 
     func clear() {
+        let previousRecords = records
         records.removeAll()
-        save()
+        if !save() {
+            records = previousRecords
+        }
     }
 
     func keywords(for text: String) -> Set<String> {
@@ -685,23 +974,55 @@ private final class AgentMemoryStore {
         return result
     }
 
-    private func load() {
-        guard let data = try? Data(contentsOf: fileURL) else { return }
-        records = (try? decoder.decode([AgentMemoryRecord].self, from: data)) ?? []
+    @discardableResult
+    func reloadFromDisk() -> Bool {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            records = []
+            lastPersistenceError = nil
+            return true
+        }
+
+        do {
+            let data = try Data(contentsOf: fileURL)
+            records = try decoder.decode([AgentMemoryRecord].self, from: data)
+            lastPersistenceError = nil
+            return true
+        } catch {
+            lastPersistenceError = "长期记忆文件读取失败：\(error.localizedDescription)"
+            return false
+        }
     }
 
-    private func save() {
-        guard let data = try? encoder.encode(records) else { return }
-        try? data.write(to: fileURL, options: .atomic)
+    @discardableResult
+    private func save() -> Bool {
+        do {
+            let data = try encoder.encode(records)
+            try data.write(to: fileURL, options: .atomic)
+            lastPersistenceError = nil
+            return true
+        } catch {
+            lastPersistenceError = "长期记忆保存失败：\(error.localizedDescription)"
+            return false
+        }
     }
 
     private func shouldPersist(_ prompt: String) -> Bool {
         let lowered = prompt.lowercased()
-        let explicitSignals = [
-            "记住", "记一下", "请记", "以后", "我的偏好", "我的习惯", "我喜欢", "我不喜欢",
-            "默认", "remember", "my preference", "i prefer", "always", "never"
+        let explicitCommands = [
+            "记住", "记一下", "请记", "帮我记", "remember this", "please remember"
         ]
-        return explicitSignals.contains(where: lowered.contains)
+        if explicitCommands.contains(where: lowered.contains) {
+            return true
+        }
+
+        guard !isQuestionLike(prompt) else { return false }
+
+        let stablePreferenceSignals = [
+            "我的偏好", "我的习惯", "我喜欢", "我不喜欢", "我通常", "我一般",
+            "以后请", "以后都", "默认请", "my preference", "i prefer", "i usually",
+            "always use", "never use"
+        ]
+        return stablePreferenceSignals.contains(where: lowered.contains)
     }
 
     private func normalizedMemoryContent(from prompt: String) -> String {
@@ -710,8 +1031,34 @@ private final class AgentMemoryStore {
             .first ?? prompt
         return withoutFiles
             .replacingOccurrences(of: "请记住", with: "")
+            .replacingOccurrences(of: "帮我记住", with: "")
+            .replacingOccurrences(of: "记一下", with: "")
             .replacingOccurrences(of: "记住", with: "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func isEligibleForRetrieval(_ record: AgentMemoryRecord) -> Bool {
+        if record.source == "slash-remember" {
+            return !record.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        let normalized = record.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalized.count >= 6, !isQuestionLike(normalized) else { return false }
+        let lowInformationFragments = ["用默认的", "默认就好", "随便", "都可以"]
+        return !lowInformationFragments.contains(normalized.lowercased())
+    }
+
+    private func isQuestionLike(_ text: String) -> Bool {
+        let lowered = text.lowercased()
+        if lowered.contains("?") || lowered.contains("？") {
+            return true
+        }
+        let questionSignals = [
+            "什么", "多少", "怎么", "为什么", "哪一个", "哪个", "是否", "有没有",
+            "可以吗", "行吗", "好吗", "who", "what", "when", "where", "why", "how",
+            "do i", "can i", "should i"
+        ]
+        return questionSignals.contains(where: lowered.contains)
     }
 
     private func memoryKind(for content: String, routeKind: String) -> AgentMemoryRecord.Kind {
@@ -772,6 +1119,7 @@ private final class AgentKnowledgeStore {
     static let shared = AgentKnowledgeStore()
 
     private(set) var documents: [AgentKnowledgeDocument] = []
+    private(set) var lastPersistenceError: String?
     private let fileURL: URL
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
@@ -788,8 +1136,12 @@ private final class AgentKnowledgeStore {
 
         let directory = Self.storageDirectory()
         fileURL = directory.appendingPathComponent("knowledge.json")
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        load()
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            lastPersistenceError = "无法创建知识库存储目录：\(error.localizedDescription)"
+        }
+        reloadFromDisk()
     }
 
     var storageURL: URL {
@@ -814,13 +1166,17 @@ private final class AgentKnowledgeStore {
         let keywords = Array(keywords(for: "\(title) \(summary) \(content.prefix(2400))")).sorted()
 
         if let index = documents.firstIndex(where: { $0.sourcePath == sourcePath }) {
+            let previousDocuments = documents
             documents[index].title = title
             documents[index].summary = summary
             documents[index].content = String(content.prefix(32_000))
             documents[index].keywords = keywords
             documents[index].byteCount = byteCount
             documents[index].updatedAt = now
-            save()
+            guard save() else {
+                documents = previousDocuments
+                return nil
+            }
             return documents[index]
         }
 
@@ -835,9 +1191,13 @@ private final class AgentKnowledgeStore {
             createdAt: now,
             updatedAt: now
         )
+        let previousDocuments = documents
         documents.insert(document, at: 0)
         documents = Array(documents.sorted { $0.updatedAt > $1.updatedAt }.prefix(80))
-        save()
+        guard save() else {
+            documents = previousDocuments
+            return nil
+        }
         return document
     }
 
@@ -875,14 +1235,26 @@ private final class AgentKnowledgeStore {
         !retrieve(query: query, limit: 1).isEmpty
     }
 
-    func removeDocument(id: UUID) {
+    @discardableResult
+    func removeDocument(id: UUID) -> Bool {
+        let previousDocuments = documents
         documents.removeAll { $0.id == id }
-        save()
+        guard save() else {
+            documents = previousDocuments
+            return false
+        }
+        return true
     }
 
-    func clear() {
+    @discardableResult
+    func clear() -> Bool {
+        let previousDocuments = documents
         documents.removeAll()
-        save()
+        guard save() else {
+            documents = previousDocuments
+            return false
+        }
+        return true
     }
 
     private static func storageDirectory() -> URL {
@@ -914,14 +1286,36 @@ private final class AgentKnowledgeStore {
         return result
     }
 
-    private func load() {
-        guard let data = try? Data(contentsOf: fileURL) else { return }
-        documents = (try? decoder.decode([AgentKnowledgeDocument].self, from: data)) ?? []
+    @discardableResult
+    func reloadFromDisk() -> Bool {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            documents = []
+            lastPersistenceError = nil
+            return true
+        }
+
+        do {
+            let data = try Data(contentsOf: fileURL)
+            documents = try decoder.decode([AgentKnowledgeDocument].self, from: data)
+            lastPersistenceError = nil
+            return true
+        } catch {
+            lastPersistenceError = "知识库文件读取失败：\(error.localizedDescription)"
+            return false
+        }
     }
 
-    private func save() {
-        guard let data = try? encoder.encode(documents) else { return }
-        try? data.write(to: fileURL, options: .atomic)
+    @discardableResult
+    private func save() -> Bool {
+        do {
+            let data = try encoder.encode(documents)
+            try data.write(to: fileURL, options: .atomic)
+            lastPersistenceError = nil
+            return true
+        } catch {
+            lastPersistenceError = "知识库保存失败：\(error.localizedDescription)"
+            return false
+        }
     }
 }
 
@@ -1332,14 +1726,15 @@ private final class AgentOrchestrator {
     private init() {}
 
     func prepare(prompt: String, recentMessages: [AIChatMessage] = []) async -> AgentPreparedRun {
-        let route = routePrompt(prompt)
-        let discoveredPlugins = discoverPlugins(for: route, prompt: prompt)
+        let routingPrompt = routingPrompt(for: prompt, recentMessages: recentMessages)
+        let route = routePrompt(routingPrompt)
+        let discoveredPlugins = discoverPlugins(for: route, prompt: routingPrompt)
         let selectedPlugins = discoveredPlugins
             .filter(\.selected)
             .compactMap { match in plugins.first(where: { $0.id == match.id }) }
-        let selectedSkills = skillsForRoute(route, prompt: prompt)
+        let selectedSkills = skillsForRoute(route, prompt: routingPrompt)
         let taskUnderstanding = buildTaskUnderstanding(
-            prompt: prompt,
+            prompt: routingPrompt,
             route: route,
             selectedPlugins: selectedPlugins,
             selectedSkills: selectedSkills
@@ -1388,7 +1783,7 @@ private final class AgentOrchestrator {
                 selectedSkills: selectedSkills
             )
             storedMemory = memoryStore.storeIfUseful(prompt: prompt, route: route)
-            retrievedMemories = memoryStore.retrieve(prompt: prompt, route: route)
+            retrievedMemories = memoryStore.retrieve(prompt: routingPrompt, route: route)
 
             contextBlocks.append("[memory.short_term]\n\(shortTermContext)")
             if let workingMemory {
@@ -1415,7 +1810,7 @@ private final class AgentOrchestrator {
 
         if selectedIDs.contains("knowledge"), Defaults[.aiKnowledgeRetrievalEnabled] {
             let retrievalLimit = min(max(Defaults[.aiKnowledgeRetrievalLimit], 1), 8)
-            let hits = AgentKnowledgeStore.shared.retrieve(query: prompt, limit: retrievalLimit)
+            let hits = AgentKnowledgeStore.shared.retrieve(query: routingPrompt, limit: retrievalLimit)
             let knowledgeContext: String
             if hits.isEmpty {
                 knowledgeContext = "知识库没有命中相关资料。"
@@ -1441,7 +1836,7 @@ private final class AgentOrchestrator {
 
         if selectedIDs.contains("web") {
             if Defaults[.aiWebSearchEnabled] {
-                let webContext = await webSearchSummary(for: prompt)
+                let webContext = await webSearchSummary(for: routingPrompt)
                 contextBlocks.append("[web.search]\n\(webContext)")
                 steps.append(
                     .init(
@@ -1479,7 +1874,7 @@ private final class AgentOrchestrator {
         }
 
         if selectedIDs.contains("assignment") {
-            let hasProvidedFile = prompt.contains("[file:") || prompt.contains("本地文件上下文")
+            let hasProvidedFile = routingPrompt.contains("[file:") || routingPrompt.contains("本地文件上下文")
             let assignmentContext = hasProvidedFile
                 ? "已检测到用户上传的作业/文本上下文；后续回复需要提取交付物、评分点和缺失信息。"
                 : "未检测到上传的作业要求文件；如任务依赖评分标准，需要请用户上传或粘贴要求。"
@@ -1494,7 +1889,7 @@ private final class AgentOrchestrator {
         }
 
         if selectedIDs.contains("shelf") {
-            let hasProvidedFile = prompt.contains("[file:") || prompt.contains("本地文件上下文")
+            let hasProvidedFile = routingPrompt.contains("[file:") || routingPrompt.contains("本地文件上下文")
             let shelfContext = hasProvidedFile
                 ? "已读取本轮显式上传文件，可用于摘要、归类和待办提取。"
                 : "文件架上下文仅在用户上传或拖入文件时启用。"
@@ -1744,12 +2139,48 @@ private final class AgentOrchestrator {
         return strategies
     }
 
+    private func routingPrompt(for prompt: String, recentMessages: [AIChatMessage]) -> String {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isShortFollowUp = trimmed.count <= 8 || ["?", "？", "继续", "看一下", "你看", "能看到吗"].contains(trimmed)
+
+        guard isShortFollowUp else {
+            return prompt
+        }
+
+        // A short prompt can still be a complete request. Do not let an earlier
+        // write command turn a later read-only calendar question into an action.
+        guard routePrompt(trimmed).kind == .generalChat else {
+            return prompt
+        }
+
+        let previousUserMessages = recentMessages
+            .filter { $0.role == .user }
+            .map(\.content)
+            .filter { $0.trimmingCharacters(in: .whitespacesAndNewlines) != trimmed }
+            .suffix(3)
+
+        guard !previousUserMessages.isEmpty else {
+            return prompt
+        }
+
+        return (Array(previousUserMessages) + [prompt]).joined(separator: "\n")
+    }
+
     private func routePrompt(_ prompt: String) -> AgentRoute {
         let lowered = prompt.lowercased()
         let calendarWrite = [
             "add to calendar", "put on my calendar", "create calendar event",
-            "write to calendar", "schedule it", "写进日历", "写到日历",
-            "加到日历", "添加到日历", "放到日历", "创建日程", "写入日历"
+            "write to calendar", "schedule it", "create reminder", "set reminder",
+            "remind me", "写进日历", "写到日历",
+            "加到日历", "添加到日历", "放到日历", "创建日程", "创建日历",
+            "写入日历", "写入日程", "写到日程", "加到日程", "加入日程",
+            "添加日程", "添加到日程", "放到日程", "安排到日历", "安排进日历",
+            "安排到日程", "安排进日程", "把计划写", "把安排写",
+            "加一个日程", "加个日程", "加一条日程", "新增日程", "新建日程",
+            "新增一个日程", "新建一个日程", "帮我加日程", "给我加日程",
+            "给我今晚加", "给我明天加", "今晚加一个", "明天加一个",
+            "加一个提醒", "加个提醒", "新增提醒", "新建提醒",
+            "提醒我", "设置提醒", "设个提醒", "设一个提醒"
         ]
         if calendarWrite.contains(where: lowered.contains) {
             return .init(kind: .calendarWrite, confidence: 0.93)
@@ -2057,6 +2488,8 @@ private final class AgentOrchestrator {
 
     private func githubCandidates(from tree: [GitHubTreeResponse.Item], terms: [String]) -> [GitHubTreeResponse.Item] {
         let usefulExtensions = ["swift", "md", "markdown", "json", "yml", "yaml", "plist", "xcstrings", "txt"]
+        let pathTerms = expandedRepositoryTerms(terms)
+        let asksAboutHUD = terms.contains("hud")
 
         let scored = tree.compactMap { item -> (GitHubTreeResponse.Item, Int)? in
             guard item.type == "blob" else { return nil }
@@ -2066,8 +2499,10 @@ private final class AgentOrchestrator {
             let pathExtension = URL(fileURLWithPath: lowerPath).pathExtension
             guard usefulExtensions.contains(pathExtension) else { return nil }
 
-            var score = terms.filter { lowerPath.contains($0) }.count * 3
-            if lowerPath.contains("hud") { score += 3 }
+            var score = pathTerms.filter { lowerPath.contains($0) }.count * 3
+            if lowerPath.contains("hud") { score += 5 }
+            if asksAboutHUD && lowerPath.contains("/osd/") { score += 6 }
+            if asksAboutHUD && lowerPath.contains("osdsettings") { score += 3 }
             if lowerPath.contains("notch") { score += 1 }
             if lowerPath.contains("readme") { score += 1 }
             return score > 0 ? (item, score) : nil
@@ -2166,14 +2601,35 @@ private final class AgentOrchestrator {
     }
 
     private func fetchPublicData(from url: URL) async throws -> Data {
+        guard isAgentPublicHTTPURL(url) else {
+            throw FeatureError("出于隐私和安全考虑，联网工具只读取公开的 HTTP/HTTPS 地址。")
+        }
+
         var request = URLRequest(url: url)
         request.timeoutInterval = 12
-        request.setValue("BoringNotchAgent/1.0", forHTTPHeaderField: "User-Agent")
+        request.setValue("DanShenAgent/1.0", forHTTPHeaderField: "User-Agent")
         request.setValue("application/vnd.github+json, text/html, text/plain;q=0.9, */*;q=0.8", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpShouldSetCookies = false
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        let session = URLSession(
+            configuration: configuration,
+            delegate: AgentPublicURLSessionDelegate(),
+            delegateQueue: nil
+        )
+        defer { session.finishTasksAndInvalidate() }
+
+        let (data, response) = try await session.data(for: request)
+        guard let finalURL = response.url, isAgentPublicHTTPURL(finalURL) else {
+            throw FeatureError("联网请求被重定向到了非公开地址，已停止读取。")
+        }
         if let httpResponse = response as? HTTPURLResponse, !(200 ... 299).contains(httpResponse.statusCode) {
             throw FeatureError("Network request failed with status \(httpResponse.statusCode).")
+        }
+        guard data.count <= 8_000_000 else {
+            throw FeatureError("联网结果超过 8 MB，已停止读取。")
         }
         return data
     }
@@ -2230,7 +2686,7 @@ private final class AgentOrchestrator {
 
     private func sourceSnippet(from text: String, terms: [String]) -> String {
         let lines = text.components(separatedBy: .newlines)
-        let loweredTerms = terms.map { $0.lowercased() }
+        let loweredTerms = expandedRepositoryTerms(terms)
         let hitIndex = lines.firstIndex { line in
             let lowerLine = line.lowercased()
             return loweredTerms.contains(where: lowerLine.contains)
@@ -2241,6 +2697,15 @@ private final class AgentOrchestrator {
             .joined(separator: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return String((snippet.isEmpty ? text : snippet).prefix(1_800))
+    }
+
+    private func expandedRepositoryTerms(_ terms: [String]) -> [String] {
+        var expanded = terms.map { $0.lowercased() }
+        if expanded.contains("hud") {
+            expanded.append(contentsOf: ["osd", "overlay", "indicator", "heads-up"])
+        }
+        var seen = Set<String>()
+        return expanded.filter { !$0.isEmpty && seen.insert($0).inserted }
     }
 
     private func webPageTitle(from html: String) -> String? {
@@ -2494,7 +2959,7 @@ private final class AgentOrchestrator {
         }.joined(separator: "\n")
 
         return """
-        Boring Notch Agent 编排上下文：
+        蛋神 Agent 编排上下文：
         路由：\(route.kind.displayName)，置信度 \(String(format: "%.2f", route.confidence))。
 
         任务理解：
@@ -2572,10 +3037,13 @@ final class AIChatManager: ObservableObject {
     @Published private(set) var lastResolvedModelName: String?
     @Published private(set) var lastAgentTrace: AgentRunTrace?
     @Published private(set) var knowledgeDocuments: [AgentKnowledgeDocument] = []
+    @Published private(set) var persistenceError: String?
+    @Published private(set) var hasConfiguredAPIKey = AIProviderCredentialStore.hasAPIKey
 
     private let conversationStoreURL: URL
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
+    private var conversationPersistenceError: String?
 
     private init() {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -2584,9 +3052,13 @@ final class AIChatManager: ObservableObject {
 
         let directory = Self.storageDirectory()
         conversationStoreURL = directory.appendingPathComponent("conversations.json")
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            conversationPersistenceError = "无法创建智能体存储目录：\(error.localizedDescription)"
+        }
         loadConversations()
-        refreshKnowledgeDocuments()
+        refreshPersistentState()
     }
 
     var activeConversation: AgentChatConversation? {
@@ -2660,7 +3132,7 @@ final class AIChatManager: ObservableObject {
     }
 
     var longTermMemories: [AgentMemoryRecord] {
-        AgentMemoryStore.shared.recentRecords
+        AgentMemoryStore.shared.allRecords
     }
 
     var longTermMemoryLocation: URL {
@@ -2672,7 +3144,24 @@ final class AIChatManager: ObservableObject {
     }
 
     func refreshKnowledgeDocuments() {
-        knowledgeDocuments = AgentKnowledgeStore.shared.documents
+        let store = AgentKnowledgeStore.shared
+        _ = store.reloadFromDisk()
+        knowledgeDocuments = store.documents
+        updatePersistenceError()
+    }
+
+    func refreshPersistentState() {
+        let knowledgeStore = AgentKnowledgeStore.shared
+        let memoryStore = AgentMemoryStore.shared
+        _ = knowledgeStore.reloadFromDisk()
+        _ = memoryStore.reloadFromDisk()
+        knowledgeDocuments = knowledgeStore.documents
+        refreshCredentialState()
+        updatePersistenceError()
+    }
+
+    func refreshCredentialState() {
+        hasConfiguredAPIKey = AIProviderCredentialStore.hasAPIKey
     }
 
     @discardableResult
@@ -2690,18 +3179,24 @@ final class AIChatManager: ObservableObject {
         )
         if document != nil {
             refreshKnowledgeDocuments()
+        } else {
+            updatePersistenceError()
         }
         return document
     }
 
     func removeKnowledgeDocument(id: UUID) {
-        AgentKnowledgeStore.shared.removeDocument(id: id)
-        refreshKnowledgeDocuments()
+        let store = AgentKnowledgeStore.shared
+        _ = store.removeDocument(id: id)
+        knowledgeDocuments = store.documents
+        updatePersistenceError()
     }
 
     func clearKnowledgeBase() {
-        AgentKnowledgeStore.shared.clear()
-        refreshKnowledgeDocuments()
+        let store = AgentKnowledgeStore.shared
+        _ = store.clear()
+        knowledgeDocuments = store.documents
+        updatePersistenceError()
     }
 
     @discardableResult
@@ -2738,7 +3233,45 @@ final class AIChatManager: ObservableObject {
         if record != nil {
             objectWillChange.send()
         }
+        updatePersistenceError()
         return record
+    }
+
+    @discardableResult
+    func createMemory(
+        _ content: String,
+        kind: AgentMemoryRecord.Kind
+    ) -> AgentMemoryRecord? {
+        let record = AgentMemoryStore.shared.storeManual(content, kind: kind)
+        if record != nil {
+            objectWillChange.send()
+        }
+        updatePersistenceError()
+        return record
+    }
+
+    @discardableResult
+    func updateMemory(
+        id: UUID,
+        content: String,
+        kind: AgentMemoryRecord.Kind
+    ) -> Bool {
+        let updated = AgentMemoryStore.shared.update(id: id, content: content, kind: kind)
+        if updated != nil {
+            objectWillChange.send()
+        }
+        updatePersistenceError()
+        return updated != nil
+    }
+
+    @discardableResult
+    func deleteMemory(id: UUID) -> Bool {
+        let removed = AgentMemoryStore.shared.remove(id: id)
+        if removed {
+            objectWillChange.send()
+        }
+        updatePersistenceError()
+        return removed
     }
 
     @discardableResult
@@ -2747,12 +3280,14 @@ final class AIChatManager: ObservableObject {
         if removedCount > 0 {
             objectWillChange.send()
         }
+        updatePersistenceError()
         return removedCount
     }
 
     func clearLongTermMemory() {
         AgentMemoryStore.shared.clear()
         objectWillChange.send()
+        updatePersistenceError()
     }
 
     func revealLongTermMemoryFile() {
@@ -2770,6 +3305,7 @@ final class AIChatManager: ObservableObject {
 
         do {
             var agentRun = await AgentOrchestrator.shared.prepare(prompt: trimmedPrompt, recentMessages: messages)
+            updatePersistenceError()
             lastAgentTrace = agentRun.trace
             let reply: AIReply
 
@@ -2818,24 +3354,55 @@ final class AIChatManager: ObservableObject {
     }
 
     private func loadConversations() {
-        if let data = try? Data(contentsOf: conversationStoreURL),
-           let decoded = try? decoder.decode([AgentChatConversation].self, from: data),
-           !decoded.isEmpty
-        {
-            conversations = decoded.sorted { $0.updatedAt > $1.updatedAt }
-            activeConversationID = conversations.first?.id
+        guard FileManager.default.fileExists(atPath: conversationStoreURL.path) else {
+            installStarterConversation(persist: true)
             return
         }
 
+        do {
+            let data = try Data(contentsOf: conversationStoreURL)
+            let decoded = try decoder.decode([AgentChatConversation].self, from: data)
+            guard !decoded.isEmpty else {
+                installStarterConversation(persist: true)
+                return
+            }
+            conversations = decoded.sorted { $0.updatedAt > $1.updatedAt }
+            activeConversationID = conversations.first?.id
+            conversationPersistenceError = nil
+        } catch {
+            conversationPersistenceError = "会话记录读取失败，原文件已保留：\(error.localizedDescription)"
+            installStarterConversation(persist: false)
+        }
+    }
+
+    private func installStarterConversation(persist: Bool) {
         let starter = AgentChatConversation(title: "新对话")
         conversations = [starter]
         activeConversationID = starter.id
-        persistConversations()
+        if persist {
+            persistConversations()
+        }
     }
 
-    private func persistConversations() {
-        guard let data = try? encoder.encode(conversations) else { return }
-        try? data.write(to: conversationStoreURL, options: .atomic)
+    @discardableResult
+    private func persistConversations() -> Bool {
+        do {
+            let data = try encoder.encode(conversations)
+            try data.write(to: conversationStoreURL, options: .atomic)
+            conversationPersistenceError = nil
+            updatePersistenceError()
+            return true
+        } catch {
+            conversationPersistenceError = "会话记录保存失败：\(error.localizedDescription)"
+            updatePersistenceError()
+            return false
+        }
+    }
+
+    private func updatePersistenceError() {
+        persistenceError = conversationPersistenceError
+            ?? AgentKnowledgeStore.shared.lastPersistenceError
+            ?? AgentMemoryStore.shared.lastPersistenceError
     }
 
     private func appendMessage(_ message: AIChatMessage) {
@@ -2888,7 +3455,7 @@ final class AIChatManager: ObservableObject {
             """
             # GitHub 案例：Agent Skills 渐进式加载
 
-            适合Boring Notch Agent 的结论：Skills 不是普通 prompt 集合，而是“按需加载的任务流程包”。一个 Skill 通常由 SKILL.md 作为入口，使用 YAML frontmatter 描述名称、触发描述、权限或工具边界，再用 Markdown 写执行步骤。复杂 Skill 可以把长参考资料、模板、脚本放在同目录，只有任务需要时才读取，避免每轮对话塞满上下文。
+            适合蛋神 Agent 的结论：Skills 不是普通 prompt 集合，而是“按需加载的任务流程包”。一个 Skill 通常由 SKILL.md 作为入口，使用 YAML frontmatter 描述名称、触发描述、权限或工具边界，再用 Markdown 写执行步骤。复杂 Skill 可以把长参考资料、模板、脚本放在同目录，只有任务需要时才读取，避免每轮对话塞满上下文。
 
             对我们的实现启发：
             1. 插件负责“能拿到什么上下文/能做什么动作”，Skill 负责“这类任务应该按什么流程做”。
@@ -2896,7 +3463,7 @@ final class AIChatManager: ObservableObject {
             3. 支持文件可以被延迟读取，适合课程资料、评分标准模板、论文写作模板。
             4. 有副作用的技能不要自动运行，例如写日历、发消息、删除文件，应该用确认门控。
 
-            Boring Notch可落地设计：
+            蛋神可落地设计：
             - skills/study-plan/SKILL.md：复习计划流程。
             - skills/assignment-breakdown/SKILL.md：作业拆解流程。
             - skills/weather-decision/SKILL.md：天气 + 日程的出行建议流程。
@@ -2919,7 +3486,7 @@ final class AIChatManager: ObservableObject {
             """
             # GitHub 案例：Cline/Roo 的插件与 MCP 思路
 
-            适合Boring Notch Agent 的结论：现代 agent host 一般不把所有能力写死在 prompt 里，而是把能力拆成插件、工具、资源和提示模板。Cline 支持通过 SDK 注册工具和生命周期 hooks，也能通过 MCP server 扩展外部数据源和动作；Roo Code 把 MCP 配置分成全局和项目级，并强调工具需要明确配置和审批。
+            适合蛋神 Agent 的结论：现代 agent host 一般不把所有能力写死在 prompt 里，而是把能力拆成插件、工具、资源和提示模板。Cline 支持通过 SDK 注册工具和生命周期 hooks，也能通过 MCP server 扩展外部数据源和动作；Roo Code 把 MCP 配置分成全局和项目级，并强调工具需要明确配置和审批。
 
             对我们的实现启发：
             1. Plugin Registry：每个插件有 id、类型、工具名、权限和风险等级。
@@ -2928,7 +3495,7 @@ final class AIChatManager: ObservableObject {
             4. Permission Gate：读操作可以自动，写操作必须设置允许并由用户明确请求。
             5. Trace Logger：记录本轮路由、命中插件、上下文准备和安全检查，方便课程展示“智能体不是黑箱”。
 
-            Boring Notch可以对齐的 MCP 分层：
+            蛋神可以对齐的 MCP 分层：
             - Tools：weather.current、calendar.create_event、memory.save_preference。
             - Resources：本地知识库文档、课程资料、拖入文件、日历上下文。
             - Prompts：/skills、/knowledge、作业拆解模板、天气决策模板。
@@ -2950,7 +3517,7 @@ final class AIChatManager: ObservableObject {
             """
             # GitHub 案例：知识库与记忆的边界
 
-            适合Boring Notch Agent 的结论：知识库不等于长期记忆。知识库存的是用户显式导入的资料，例如课程文档、作业要求、论文笔记、项目说明；长期记忆存的是跨会话稳定偏好和事实，例如“我喜欢晚上学习”“默认 45 分钟专注”。两者都可以检索，但写入策略不同。
+            适合蛋神 Agent 的结论：知识库不等于长期记忆。知识库存的是用户显式导入的资料，例如课程文档、作业要求、论文笔记、项目说明；长期记忆存的是跨会话稳定偏好和事实，例如“我喜欢晚上学习”“默认 45 分钟专注”。两者都可以检索，但写入策略不同。
 
             三层记忆：
             - 短期记忆：当前会话最近消息，只影响当前聊天页。
@@ -2983,7 +3550,7 @@ final class AIChatManager: ObservableObject {
             """
             # GitHub 案例：安全护栏与插件权限
 
-            适合Boring Notch Agent 的结论：插件系统的难点不是“能调用多少工具”，而是“什么时候不该调用”。Cline、Roo、MCP 文档都把外部工具视为可扩展能力，但同时需要配置、确认、权限和错误处理。对 macOS 桌面应用来说，安全模型尤其重要，因为工具可能影响日历、本地文件、App 启动或用户隐私。
+            适合蛋神 Agent 的结论：插件系统的难点不是“能调用多少工具”，而是“什么时候不该调用”。Cline、Roo、MCP 文档都把外部工具视为可扩展能力，但同时需要配置、确认、权限和错误处理。对 macOS 桌面应用来说，安全模型尤其重要，因为工具可能影响日历、本地文件、App 启动或用户隐私。
 
             插件权限建议：
             - read:auto：天气、只读日历、知识库检索、长期记忆检索。
@@ -3014,12 +3581,12 @@ final class AIChatManager: ObservableObject {
             """
         ),
         (
-            "GitHub 案例：Boring Notch Agent 课堂 demo 脚本",
+            "GitHub 案例：蛋神 Agent 课堂 demo 脚本",
             "seed://danshen-agent-course-demo-script",
             """
-            # GitHub 案例：Boring Notch Agent 课堂 demo 脚本
+            # GitHub 案例：蛋神 Agent 课堂 demo 脚本
 
-            目标：展示Boring Notch不是普通聊天框，而是一个 macOS 桌面 Agent Host。
+            目标：展示蛋神不是普通聊天框，而是一个 macOS 桌面 Agent Host。
 
             Demo 1：多会话短期记忆
             1. 新建会话 A，问“帮我记住这轮我们在做天气插件演示”。
@@ -3047,7 +3614,7 @@ final class AIChatManager: ObservableObject {
             3. 说明 Skill 是任务流程，Plugin 是工具能力，Knowledge 是资料来源，Memory 是用户状态。
 
             可以放进报告的一句话：
-            Boring Notch Agent 将 macOS notch utility 升级为桌面 Agent Host：通过插件注册表、渐进式工具发现、Skill 工作流、本地知识库、三层记忆和权限护栏，把聊天界面变成可解释、可扩展、可控的智能体系统。
+            蛋神 Agent 将 macOS notch utility 升级为桌面 Agent Host：通过插件注册表、渐进式工具发现、Skill 工作流、本地知识库、三层记忆和权限护栏，把聊天界面变成可解释、可扩展、可控的智能体系统。
             """
         ),
     ]
@@ -3094,8 +3661,25 @@ final class AIChatManager: ObservableObject {
             throw FeatureError("AI calendar writing is disabled in Settings > AI.")
         }
 
+        guard wantsCalendarWrite(for: prompt) else {
+            throw FeatureError("当前问题只是查询，没有检测到明确的日历写入指令，因此未创建任何日程。")
+        }
+
         guard agentRun.calendarContext != nil else {
             throw FeatureError("Calendar access is unavailable. Enable it in Settings > Calendar before asking AI to write plans.")
+        }
+
+        if let localDraft = deterministicCalendarDraft(for: prompt) {
+            let createdEvents = try await CalendarManager.shared.createAIPlannedEvents([localDraft])
+            let configuredModel = Defaults[.aiServiceModel].trimmingCharacters(in: .whitespacesAndNewlines)
+            return AIReply(
+                content: mergedCalendarWriteReply(
+                    baseReply: "已按你的明确要求创建日程，并设置开始时提醒。",
+                    createdEvents: createdEvents
+                ),
+                requestedModelName: configuredModel.isEmpty ? "蛋神本地日历工具" : configuredModel,
+                resolvedModelName: nil
+            )
         }
 
         let config = try resolveServiceConfig()
@@ -3112,18 +3696,27 @@ final class AIChatManager: ObservableObject {
 
         let resolvedModelName = normalizedModelName(decoded.model) ?? config.requestedModel
         let rawContent = decoded.choices.first?.message.content.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let action = try decodeCalendarAction(from: rawContent)
+        let content: String
 
-        let drafts = try action.events.compactMap { try makeCalendarDraft(from: $0) }
-        let createdEvents: [CreatedCalendarEvent]
+        do {
+            let action = try decodeCalendarAction(from: rawContent)
+            var drafts = try action.events.compactMap { try makeCalendarDraft(from: $0) }
 
-        if action.createEvents && !drafts.isEmpty {
-            createdEvents = try await CalendarManager.shared.createAIPlannedEvents(drafts)
-        } else {
-            createdEvents = []
+            if drafts.isEmpty {
+                drafts = fallbackCalendarDrafts(for: prompt)
+            }
+
+            let createdEvents = try await CalendarManager.shared.createAIPlannedEvents(drafts)
+            content = mergedCalendarWriteReply(baseReply: action.reply, createdEvents: createdEvents)
+        } catch {
+            let drafts = fallbackCalendarDrafts(for: prompt)
+            let createdEvents = try await CalendarManager.shared.createAIPlannedEvents(drafts)
+            content = mergedCalendarWriteReply(
+                baseReply: "没有拿到稳定的结构化日历计划，我先按你的请求创建了一个可编辑的默认日程。",
+                createdEvents: createdEvents
+            )
         }
 
-        let content = mergedCalendarWriteReply(baseReply: action.reply, createdEvents: createdEvents)
         return AIReply(
             content: content,
             requestedModelName: config.requestedModel,
@@ -3219,7 +3812,7 @@ final class AIChatManager: ObservableObject {
 
     private func resolveServiceConfig() throws -> AIServiceConfig {
         let baseURL = Defaults[.aiServiceBaseURL].trimmingCharacters(in: .whitespacesAndNewlines)
-        let apiKey = Defaults[.aiServiceAPIKey].trimmingCharacters(in: .whitespacesAndNewlines)
+        let apiKey = AIProviderCredentialStore.apiKey
         let requestedModel = Defaults[.aiServiceModel].trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard Defaults[.aiChatEnabled] else {
@@ -3253,7 +3846,10 @@ final class AIChatManager: ObservableObject {
         - If calendar context is missing, disabled, permission-denied, or empty, say that you cannot confirm local schedule from the calendar; do not fabricate events.
         - If a retrieved memory or knowledge-base excerpt is absent, state that no relevant local record was found.
         - Do not claim you browsed the web unless [web.search] context is present. If web context is unavailable, say the local web tool did not retrieve usable results.
+        - Separate source-backed facts from inference. If repository excerpts do not explicitly define the user's term, say so and report the closest source-code naming instead of inventing a definition.
+        - Put source URLs in a short bullet list with one URL per line.
         - Keep answers concise unless the user asks for a detailed plan.
+        - Format for a narrow macOS chat panel: use short paragraphs and bullet/numbered lists. Do not use Markdown tables.
         """
     }
 
@@ -3317,6 +3913,12 @@ final class AIChatManager: ObservableObject {
             "要做什么",
             "今天要做",
             "今日要做",
+            "今日安排",
+            "今天安排",
+            "日程安排",
+            "我的安排",
+            "今天有什么",
+            "今日有什么",
             "today's schedule",
             "what do i have today",
             "什么时候有空",
@@ -3336,6 +3938,9 @@ final class AIChatManager: ObservableObject {
             "create calendar event",
             "write to calendar",
             "schedule it",
+            "create reminder",
+            "set reminder",
+            "remind me",
             "写进日历",
             "写到日历",
             "加到日历",
@@ -3343,7 +3948,41 @@ final class AIChatManager: ObservableObject {
             "放到日历",
             "创建日程",
             "创建日历",
-            "写入日历"
+            "写入日历",
+            "写入日程",
+            "写到日程",
+            "加到日程",
+            "加入日程",
+            "添加日程",
+            "添加到日程",
+            "放到日程",
+            "安排到日历",
+            "安排进日历",
+            "安排到日程",
+            "安排进日程",
+            "把计划写",
+            "把安排写",
+            "加一个日程",
+            "加个日程",
+            "加一条日程",
+            "新增日程",
+            "新建日程",
+            "新增一个日程",
+            "新建一个日程",
+            "帮我加日程",
+            "给我加日程",
+            "给我今晚加",
+            "给我明天加",
+            "今晚加一个",
+            "明天加一个",
+            "加一个提醒",
+            "加个提醒",
+            "新增提醒",
+            "新建提醒",
+            "提醒我",
+            "设置提醒",
+            "设个提醒",
+            "设一个提醒"
         ]
         return keywords.contains(where: lowered.contains)
     }
@@ -3351,9 +3990,12 @@ final class AIChatManager: ObservableObject {
     private func calendarWriteInstruction() -> String {
         """
         You are creating calendar events for the user.
+        The app only enters this mode after the user has explicitly asked to add/create/schedule/write a calendar item or reminder, and calendar writing is enabled in settings.
+        Do not ask for another confirmation. Produce the event JSON so the app can create it now.
+        The app will write created events into the dedicated local calendar named "蛋神"; do not tell the user it will be written to any other calendar.
         Return only a JSON object with this exact schema:
         {
-          "reply": "short natural-language confirmation in the user's language",
+          "reply": "short natural-language confirmation in the user's language, written as if the event will be created now",
           "create_events": true,
           "events": [
             {
@@ -3370,6 +4012,9 @@ final class AIChatManager: ObservableObject {
         - Use the user's existing calendar schedule to avoid conflicts.
         - Use absolute timestamps, never relative phrases.
         - Keep event titles short and practical.
+        - If the user explicitly asked to write/create/add/schedule a calendar item, set "create_events" to true and include at least one event.
+        - If the user says "提醒我", "设置提醒", "remind me", or similar, create a short calendar event at the requested time with the reminder target as the title.
+        - Do not say "需要我帮你创建吗", "确认后我就写入", "should I create it", or similar confirmation-seeking text.
         - If the user asked for a study/work plan, split it into sensible time blocks.
         - If required timing is unclear, make a reasonable plan based on free time in the calendar.
         - Return JSON only. No markdown fences.
@@ -3400,8 +4045,9 @@ final class AIChatManager: ObservableObject {
     }
 
     private func makeCalendarDraft(from payload: AICalendarEventPayload) throws -> CalendarEventDraft? {
-        let title = payload.title.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !title.isEmpty else { return nil }
+        let rawTitle = payload.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawTitle.isEmpty else { return nil }
+        let title = fallbackCalendarTitle(from: rawTitle)
 
         guard let start = parseCalendarDate(payload.start),
               let end = parseCalendarDate(payload.end)
@@ -3414,7 +4060,8 @@ final class AIChatManager: ObservableObject {
             start: start,
             end: end,
             notes: normalizedOptionalText(payload.notes),
-            location: normalizedOptionalText(payload.location)
+            location: normalizedOptionalText(payload.location),
+            alarmOffsetMinutes: 0
         )
     }
 
@@ -3454,6 +4101,187 @@ final class AIChatManager: ObservableObject {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    private func fallbackCalendarDrafts(for prompt: String) -> [CalendarEventDraft] {
+        let start = fallbackCalendarStart(for: prompt)
+        return [
+            CalendarEventDraft(
+                title: fallbackCalendarTitle(from: prompt),
+                start: start,
+                end: start.addingTimeInterval(60 * 60),
+                notes: "由蛋神 Agent 在结构化日历计划解析失败时创建。原始请求：\(prompt)",
+                location: nil,
+                alarmOffsetMinutes: 0
+            )
+        ]
+    }
+
+    private func deterministicCalendarDraft(for prompt: String) -> CalendarEventDraft? {
+        guard requestedClockTime(in: prompt) != nil else { return nil }
+
+        let lowered = prompt.lowercased()
+        let complexSignals = [
+            "一周", "整周", "每天", "多个", "几个", "拆成", "时间块", "复习计划", "学习计划",
+            "from ", " to ", "every day", "weekly", "multiple"
+        ]
+        guard !complexSignals.contains(where: lowered.contains) else { return nil }
+
+        let start = fallbackCalendarStart(for: prompt)
+        let isReminder = ["提醒我", "提醒", "remind me", "reminder"].contains(where: lowered.contains)
+        let duration: TimeInterval = isReminder ? 5 * 60 : 30 * 60
+
+        return CalendarEventDraft(
+            title: fallbackCalendarTitle(from: prompt),
+            start: start,
+            end: start.addingTimeInterval(duration),
+            notes: "由蛋神 Agent 根据用户的明确请求创建。",
+            location: nil,
+            alarmOffsetMinutes: 0
+        )
+    }
+
+    private func fallbackCalendarTitle(from prompt: String) -> String {
+        var title = prompt
+        [
+            "帮我", "给我", "请", "可以", "能不能", "麻烦", "把", "这个",
+            "写进日历", "写到日历", "写入日历", "加到日历", "添加到日历", "放到日历",
+            "写进日程", "写到日程", "写入日程", "加到日程", "加入日程", "添加到日程",
+            "加一个日程", "加个日程", "加一条日程", "新增日程", "新建日程",
+            "新增一个日程", "新建一个日程", "加一个提醒", "加个提醒", "新增提醒", "新建提醒",
+            "安排到日历", "安排进日历", "安排到日程", "安排进日程",
+            "提醒我", "设置提醒", "设个提醒", "设一个提醒",
+            "今天", "今日", "今晚", "今夜", "明天", "后天", "上午", "早上", "中午", "下午", "晚上",
+            "add to calendar", "put on my calendar", "create calendar event", "write to calendar"
+        ].forEach { phrase in
+            title = title.replacingOccurrences(of: phrase, with: "", options: [.caseInsensitive])
+        }
+
+        [
+            #"(\d{1,2})[:：](\d{2})"#,
+            #"(上午|早上|中午|下午|晚上)?\s*\d{1,2}\s*点\s*(半|\d{1,2}\s*分?)?"#
+        ].forEach { pattern in
+            title = title.replacingOccurrences(of: pattern, with: "", options: [.regularExpression])
+        }
+
+        title = title
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "，", with: " ")
+            .replacingOccurrences(of: "。", with: " ")
+            .replacingOccurrences(of: ",", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !title.isEmpty else { return "AI 日程" }
+        return String(title.prefix(28))
+    }
+
+    private func fallbackCalendarStart(for prompt: String, now: Date = Date()) -> Date {
+        let calendar = Calendar.current
+        let dayOffset = requestedDayOffset(in: prompt) ?? 0
+        let baseDay = calendar.date(
+            byAdding: .day,
+            value: dayOffset,
+            to: calendar.startOfDay(for: now)
+        ) ?? calendar.startOfDay(for: now)
+
+        let start: Date
+        if let clock = requestedClockTime(in: prompt) {
+            var components = calendar.dateComponents([.year, .month, .day], from: baseDay)
+            components.hour = clock.hour
+            components.minute = clock.minute
+            start = calendar.date(from: components) ?? nextReasonableCalendarStart(from: now)
+        } else if dayOffset > 0 {
+            var components = calendar.dateComponents([.year, .month, .day], from: baseDay)
+            components.hour = 9
+            components.minute = 0
+            start = calendar.date(from: components) ?? nextReasonableCalendarStart(from: now)
+        } else {
+            start = nextReasonableCalendarStart(from: now)
+        }
+
+        if start <= now {
+            return calendar.date(byAdding: .day, value: 1, to: start) ?? now.addingTimeInterval(10 * 60)
+        }
+        return start
+    }
+
+    private func nextReasonableCalendarStart(from now: Date) -> Date {
+        let calendar = Calendar.current
+        let hour = calendar.component(.hour, from: now)
+
+        if hour < 8 {
+            return calendar.date(bySettingHour: 9, minute: 0, second: 0, of: now) ?? now.addingTimeInterval(60 * 60)
+        }
+
+        if hour >= 21 {
+            let tomorrow = calendar.date(byAdding: .day, value: 1, to: now) ?? now.addingTimeInterval(24 * 60 * 60)
+            return calendar.date(bySettingHour: 9, minute: 0, second: 0, of: tomorrow) ?? tomorrow
+        }
+
+        let nextHour = calendar.dateInterval(of: .hour, for: now)?.end ?? now.addingTimeInterval(60 * 60)
+        return calendar.date(bySetting: .minute, value: 0, of: nextHour) ?? nextHour
+    }
+
+    private func requestedDayOffset(in prompt: String) -> Int? {
+        let lowered = prompt.lowercased()
+        if lowered.contains("后天") {
+            return 2
+        }
+        if lowered.contains("明天") || lowered.contains("tomorrow") {
+            return 1
+        }
+        if lowered.contains("今天") || lowered.contains("今日") || lowered.contains("today") {
+            return 0
+        }
+        return nil
+    }
+
+    private func requestedClockTime(in prompt: String) -> (hour: Int, minute: Int)? {
+        if let groups = firstRegexGroups(in: prompt, pattern: #"(\d{1,2})[:：](\d{2})"#),
+           let hour = Int(groups[safe: 0] ?? ""),
+           let minute = Int(groups[safe: 1] ?? ""),
+           (0...23).contains(hour),
+           (0...59).contains(minute)
+        {
+            return (hour, minute)
+        }
+
+        if let groups = firstRegexGroups(in: prompt, pattern: #"(今晚|今夜|上午|早上|中午|下午|晚上)?\s*(\d{1,2})\s*点\s*(半|(\d{1,2})\s*分?)?"#),
+           var hour = Int(groups[safe: 1] ?? "")
+        {
+            let marker = groups[safe: 0] ?? ""
+            let minute: Int
+            if groups[safe: 2] == "半" {
+                minute = 30
+            } else {
+                minute = Int(groups[safe: 3] ?? "") ?? 0
+            }
+
+            if ["下午", "晚上", "今晚", "今夜"].contains(marker), hour < 12 {
+                hour += 12
+            } else if marker == "中午", hour < 11 {
+                hour += 12
+            }
+
+            if (0...23).contains(hour), (0...59).contains(minute) {
+                return (hour, minute)
+            }
+        }
+
+        return nil
+    }
+
+    private func firstRegexGroups(in text: String, pattern: String) -> [String]? {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let nsText = text as NSString
+        let range = NSRange(location: 0, length: nsText.length)
+        guard let match = regex.firstMatch(in: text, options: [], range: range) else { return nil }
+
+        return (1..<match.numberOfRanges).map { index in
+            let groupRange = match.range(at: index)
+            guard groupRange.location != NSNotFound else { return "" }
+            return nsText.substring(with: groupRange)
+        }
+    }
+
     private func mergedCalendarWriteReply(
         baseReply: String,
         createdEvents: [CreatedCalendarEvent]
@@ -3469,7 +4297,7 @@ final class AIChatManager: ObservableObject {
         formatter.dateFormat = "MM-dd HH:mm"
 
         let lines = createdEvents.map {
-            "- \($0.title) (\(formatter.string(from: $0.start)) - \(formatter.string(from: $0.end)))"
+            "- \($0.title) (\(formatter.string(from: $0.start)) - \(formatter.string(from: $0.end)))，日历：\($0.calendarTitle)"
         }
         let creationSummary = "已写入日历：\n" + lines.joined(separator: "\n")
 
@@ -3517,7 +4345,8 @@ private struct WeatherLookupLocation {
     let longitude: Double
 }
 
-private final class WeatherLocationProvider: NSObject, CLLocationManagerDelegate {
+@MainActor
+private final class WeatherLocationProvider: NSObject, @preconcurrency CLLocationManagerDelegate {
     var authorizationDidChange: ((CLAuthorizationStatus) -> Void)?
 
     private let manager = CLLocationManager()
@@ -3561,7 +4390,7 @@ private final class WeatherLocationProvider: NSObject, CLLocationManagerDelegate
 
         if resolvedStatus != .notDetermined {
             await MainActor.run {
-                NSApp.setActivationPolicy(.accessory)
+                _ = NSApp.setActivationPolicy(.accessory)
             }
         }
 
@@ -3579,7 +4408,7 @@ private final class WeatherLocationProvider: NSObject, CLLocationManagerDelegate
             }
             break
         case .denied:
-            throw FeatureError("Location access is denied. Allow Boring Notch in Privacy & Security > Location Services.")
+            throw FeatureError("Location access is denied. Allow 蛋神 in Privacy & Security > Location Services.")
         case .restricted:
             throw FeatureError("Location access is restricted on this Mac.")
         case .notDetermined:
@@ -3722,7 +4551,7 @@ final class WeatherManager: ObservableObject {
 
         if status != .notDetermined {
             await MainActor.run {
-                NSApp.setActivationPolicy(.accessory)
+                _ = NSApp.setActivationPolicy(.accessory)
             }
         }
     }
@@ -3826,7 +4655,7 @@ final class WeatherManager: ObservableObject {
             ),
             URLQueryItem(name: "hourly", value: "temperature_2m,weather_code,precipitation_probability,is_day"),
             URLQueryItem(name: "daily", value: "temperature_2m_max,temperature_2m_min"),
-            URLQueryItem(name: "forecast_days", value: "1"),
+            URLQueryItem(name: "forecast_days", value: "2"),
             URLQueryItem(name: "timezone", value: "auto"),
             URLQueryItem(name: "temperature_unit", value: unit.apiValue),
             URLQueryItem(name: "wind_speed_unit", value: unit.windSpeedAPIValue),
@@ -3872,8 +4701,9 @@ final class WeatherManager: ObservableObject {
     ) -> [WeatherSnapshot.HourlyEntry] {
         guard !hourly.time.isEmpty else { return [] }
 
-        let startIndex = hourly.time.firstIndex(of: currentTime) ?? 0
-        let endIndex = min(startIndex + 5, hourly.time.count)
+        let startIndex = hourly.time.firstIndex(where: { $0 >= currentTime })
+            ?? max(0, hourly.time.count - 1)
+        let endIndex = min(startIndex + 12, hourly.time.count)
 
         return (startIndex ..< endIndex).compactMap { index in
             guard index < hourly.temperature.count, index < hourly.weatherCode.count else { return nil }
@@ -4208,6 +5038,17 @@ struct WeatherSnapshot {
     let updatedAt: Date
     let current: CurrentConditions
     let hourly: [HourlyEntry]
+
+    var upcomingPrecipitationSummary: String? {
+        let riskyHours = hourly.filter { ($0.precipitationProbability ?? 0) >= 50 }
+        guard let first = riskyHours.first,
+              let peakProbability = riskyHours.compactMap(\.precipitationProbability).max()
+        else {
+            return nil
+        }
+
+        return "预计 \(first.timeLabel) 后降水概率升高，最高 \(peakProbability)%"
+    }
 }
 
 enum WeatherDescriptor {
@@ -4394,6 +5235,12 @@ private extension String {
                 return false
             }
         }
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }
 

--- a/boringNotch/managers/CalendarManager.swift
+++ b/boringNotch/managers/CalendarManager.swift
@@ -66,7 +66,6 @@ class CalendarManager: ObservableObject {
     func checkCalendarAuthorization() async {
         let status = EKEventStore.authorizationStatus(for: .event)
         DispatchQueue.main.async {
-            print("📅 Current calendar authorization status: \(status)")
             self.calendarAuthorizationStatus = status
         }
 
@@ -85,25 +84,23 @@ class CalendarManager: ObservableObject {
                     calendars: selectedCalendars.map { $0.id })
             }
         case .restricted, .denied:
-            NSLog("Calendar access denied or restricted")
+            break
         case .fullAccess:
-            NSLog("Full access")
             await reloadCalendarAndReminderLists()
             events = await calendarService.events(
                 from: currentWeekStartDate,
                 to: Calendar.current.date(byAdding: .day, value: 1, to: currentWeekStartDate)!,
                 calendars: selectedCalendars.map { $0.id })
         case .writeOnly:
-            NSLog("Write only")
+            break
         @unknown default:
-            print("Unknown authorization status")
+            break
         }
     }
     
     func checkReminderAuthorization() async {
         let status = EKEventStore.authorizationStatus(for: .reminder)
         DispatchQueue.main.async {
-            print("📅 Current reminder authorization status: \(status)")
             self.reminderAuthorizationStatus = status
         }
 
@@ -118,14 +115,13 @@ class CalendarManager: ObservableObject {
                 await reloadCalendarAndReminderLists()
             }
         case .restricted, .denied:
-            NSLog("Reminder access denied or restricted")
+            break
         case .fullAccess:
-            NSLog("Full access")
             await reloadCalendarAndReminderLists()
         case .writeOnly:
-            NSLog("Write only")
+            break
         @unknown default:
-            print("Unknown authorization status")
+            break
         }
     }
         
@@ -200,5 +196,99 @@ class CalendarManager: ObservableObject {
             from: currentWeekStartDate,
             to: Calendar.current.date(byAdding: .day, value: 1, to: currentWeekStartDate)!,
             calendars: selectedCalendars.map { $0.id })
+    }
+
+    func ensureCalendarAccessIfNeeded() async -> Bool {
+        let status = EKEventStore.authorizationStatus(for: .event)
+        calendarAuthorizationStatus = status
+
+        if status == .notDetermined {
+            await checkCalendarAuthorization()
+        } else if status == .fullAccess {
+            await reloadCalendarAndReminderLists()
+        }
+
+        return calendarAuthorizationStatus == .fullAccess
+    }
+
+    func aiScheduleContext(daysAhead: Int = 7, limit: Int = 18) async -> String? {
+        guard Defaults[.aiCalendarContextEnabled] else { return nil }
+        guard await ensureCalendarAccessIfNeeded() else { return nil }
+
+        await reloadCalendarAndReminderLists()
+        updateSelectedCalendars()
+
+        let start = Date()
+        let end = Calendar.current.date(byAdding: .day, value: daysAhead, to: start) ?? start
+        let calendarIDs = selectedCalendars.map { $0.id }
+        let fetchedEvents = await calendarService.events(from: start, to: end, calendars: calendarIDs)
+
+        let relevantEvents = fetchedEvents
+            .filter { event in
+                if event.type.isReminder,
+                   case let .reminder(completed) = event.type,
+                   completed && Defaults[.hideCompletedReminders]
+                {
+                    return false
+                }
+                return true
+            }
+            .prefix(limit)
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "zh_CN")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+
+        let lines = relevantEvents.map { event in
+            let timeRange: String
+            if event.isAllDay {
+                timeRange = "\(formatter.string(from: event.start)) (all day)"
+            } else {
+                timeRange = "\(formatter.string(from: event.start)) - \(formatter.string(from: event.end))"
+            }
+
+            let typeLabel: String
+            switch event.type {
+            case .birthday:
+                typeLabel = "birthday"
+            case .reminder:
+                typeLabel = "reminder"
+            case .event:
+                typeLabel = "event"
+            }
+
+            return "- [\(typeLabel)] \(timeRange) | \(event.title) | calendar: \(event.calendar.title)"
+        }
+
+        if lines.isEmpty {
+            return "No scheduled calendar events were found in the next \(daysAhead) days."
+        }
+
+        return """
+        Calendar events in the next \(daysAhead) days:
+        \(lines.joined(separator: "\n"))
+        """
+    }
+
+    func createAIPlannedEvents(_ drafts: [CalendarEventDraft]) async throws -> [CreatedCalendarEvent] {
+        guard Defaults[.aiCalendarWriteEnabled] else {
+            throw CalendarWriteError.accessDenied
+        }
+
+        guard await ensureCalendarAccessIfNeeded() else {
+            throw CalendarWriteError.accessDenied
+        }
+
+        await reloadCalendarAndReminderLists()
+        updateSelectedCalendars()
+
+        let preferredEventCalendarIDs = selectedCalendars
+            .filter { !$0.isReminder && !$0.isSubscribed }
+            .map(\.id)
+
+        let created = try await calendarService.createEvents(drafts, preferredCalendarIDs: preferredEventCalendarIDs)
+        await updateEvents()
+        return created
     }
 }

--- a/boringNotch/managers/CalendarManager.swift
+++ b/boringNotch/managers/CalendarManager.swift
@@ -27,16 +27,18 @@ class CalendarManager: ObservableObject {
     private let calendarService = CalendarService()
 
     private var eventStoreChangedObserver: NSObjectProtocol?
+    private var eventStoreRefreshTask: Task<Void, Never>?
 
     private init() {
         self.currentWeekStartDate = CalendarManager.startOfDay(Date())
         setupEventStoreChangedObserver()
         Task {
-            await reloadCalendarAndReminderLists()
+            await refreshVisibleCalendar(for: Date())
         }
     }
 
     deinit {
+        eventStoreRefreshTask?.cancel()
         if let observer = eventStoreChangedObserver {
             NotificationCenter.default.removeObserver(observer)
         }
@@ -48,8 +50,14 @@ class CalendarManager: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task {
-                await self?.reloadCalendarAndReminderLists()
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.eventStoreRefreshTask?.cancel()
+                self.eventStoreRefreshTask = Task { @MainActor [weak self] in
+                    try? await Task.sleep(for: .milliseconds(150))
+                    guard !Task.isCancelled, let self else { return }
+                    await self.refreshCalendarData(updateVisibleEvents: true)
+                }
             }
         }
     }
@@ -65,9 +73,7 @@ class CalendarManager: ObservableObject {
 
     func checkCalendarAuthorization() async {
         let status = EKEventStore.authorizationStatus(for: .event)
-        DispatchQueue.main.async {
-            self.calendarAuthorizationStatus = status
-        }
+        calendarAuthorizationStatus = status
 
         switch status {
         case .notDetermined:
@@ -75,22 +81,15 @@ class CalendarManager: ObservableObject {
                 self.calendarAuthorizationStatus = .notDetermined
                 return
             }
-            self.calendarAuthorizationStatus = granted ? .fullAccess : .denied
-            if granted {
-                await reloadCalendarAndReminderLists()
-                events = await calendarService.events(
-                    from: currentWeekStartDate,
-                    to: Calendar.current.date(byAdding: .day, value: 1, to: currentWeekStartDate)!,
-                    calendars: selectedCalendars.map { $0.id })
+            let refreshedStatus = EKEventStore.authorizationStatus(for: .event)
+            calendarAuthorizationStatus = refreshedStatus
+            if granted, refreshedStatus == .fullAccess {
+                await refreshCalendarData(updateVisibleEvents: true)
             }
         case .restricted, .denied:
             break
         case .fullAccess:
-            await reloadCalendarAndReminderLists()
-            events = await calendarService.events(
-                from: currentWeekStartDate,
-                to: Calendar.current.date(byAdding: .day, value: 1, to: currentWeekStartDate)!,
-                calendars: selectedCalendars.map { $0.id })
+            await refreshCalendarData(updateVisibleEvents: true)
         case .writeOnly:
             break
         @unknown default:
@@ -100,9 +99,7 @@ class CalendarManager: ObservableObject {
     
     func checkReminderAuthorization() async {
         let status = EKEventStore.authorizationStatus(for: .reminder)
-        DispatchQueue.main.async {
-            self.reminderAuthorizationStatus = status
-        }
+        reminderAuthorizationStatus = status
 
         switch status {
         case .notDetermined:
@@ -110,8 +107,9 @@ class CalendarManager: ObservableObject {
                 self.reminderAuthorizationStatus = .notDetermined
                 return
             }
-            self.reminderAuthorizationStatus = granted ? .fullAccess : .denied
-            if granted {
+            let refreshedStatus = EKEventStore.authorizationStatus(for: .reminder)
+            reminderAuthorizationStatus = refreshedStatus
+            if granted, refreshedStatus == .fullAccess {
                 await reloadCalendarAndReminderLists()
             }
         case .restricted, .denied:
@@ -179,6 +177,11 @@ class CalendarManager: ObservableObject {
         await updateEvents()
     }
 
+    func refreshVisibleCalendar(for date: Date) async {
+        currentWeekStartDate = Calendar.current.startOfDay(for: date)
+        await refreshCalendarData(updateVisibleEvents: true)
+    }
+
     private func updateEvents() async {
         let calendarIDs = selectedCalendars.map { $0.id }
         let eventsResult = await calendarService.events(
@@ -187,6 +190,31 @@ class CalendarManager: ObservableObject {
             calendars: calendarIDs
         )
         self.events = eventsResult
+    }
+
+    private func refreshCalendarData(updateVisibleEvents: Bool) async {
+        calendarAuthorizationStatus = EKEventStore.authorizationStatus(for: .event)
+        reminderAuthorizationStatus = EKEventStore.authorizationStatus(for: .reminder)
+        await reloadCalendarAndReminderLists()
+        if updateVisibleEvents, calendarAuthorizationStatus == .fullAccess {
+            await updateEvents()
+        }
+    }
+
+    private func includeAgentCalendarAfterWrite() {
+        guard let agentCalendar = eventCalendars.first(where: { $0.title == "蛋神" }) else {
+            return
+        }
+
+        guard case .selected(var identifiers) = Defaults[.calendarSelectionState],
+              !identifiers.contains(agentCalendar.id)
+        else {
+            return
+        }
+
+        identifiers.insert(agentCalendar.id)
+        Defaults[.calendarSelectionState] = .selected(identifiers)
+        updateSelectedCalendars()
     }
     
     func setReminderCompleted(reminderID: String, completed: Bool) async {
@@ -199,15 +227,15 @@ class CalendarManager: ObservableObject {
     }
 
     func ensureCalendarAccessIfNeeded() async -> Bool {
-        let status = EKEventStore.authorizationStatus(for: .event)
-        calendarAuthorizationStatus = status
+        calendarAuthorizationStatus = EKEventStore.authorizationStatus(for: .event)
 
-        if status == .notDetermined {
+        if calendarAuthorizationStatus == .notDetermined {
             await checkCalendarAuthorization()
-        } else if status == .fullAccess {
-            await reloadCalendarAndReminderLists()
+        } else if calendarAuthorizationStatus == .fullAccess {
+            await refreshCalendarData(updateVisibleEvents: false)
         }
 
+        calendarAuthorizationStatus = EKEventStore.authorizationStatus(for: .event)
         return calendarAuthorizationStatus == .fullAccess
     }
 
@@ -218,10 +246,12 @@ class CalendarManager: ObservableObject {
         await reloadCalendarAndReminderLists()
         updateSelectedCalendars()
 
-        let start = Date()
-        let end = Calendar.current.date(byAdding: .day, value: daysAhead, to: start) ?? start
-        let calendarIDs = selectedCalendars.map { $0.id }
-        let fetchedEvents = await calendarService.events(from: start, to: end, calendars: calendarIDs)
+        let calendar = Calendar.current
+        let start = calendar.startOfDay(for: Date())
+        let end = calendar.date(byAdding: .day, value: daysAhead, to: start) ?? start
+        let fetchedEvents = await calendarService.events(from: start, to: end, calendars: [])
+        let readableEventCalendarCount = eventCalendars.count
+        let readableReminderListCount = reminderLists.count
 
         let relevantEvents = fetchedEvents
             .filter { event in
@@ -262,11 +292,18 @@ class CalendarManager: ObservableObject {
         }
 
         if lines.isEmpty {
-            return "No scheduled calendar events were found in the next \(daysAhead) days."
+            return """
+            Calendar read succeeded.
+            Range: \(formatter.string(from: start)) - \(formatter.string(from: end)).
+            Scope: all accessible EventKit calendars (\(readableEventCalendarCount) event calendars, \(readableReminderListCount) reminder lists).
+            Result: 0 events or dated reminders found in this range.
+            """
         }
 
         return """
-        Calendar events in the next \(daysAhead) days:
+        Calendar events from today through the next \(daysAhead) days:
+        Current local time: \(formatter.string(from: Date()))
+        Scope: all accessible EventKit calendars (\(readableEventCalendarCount) event calendars, \(readableReminderListCount) reminder lists).
         \(lines.joined(separator: "\n"))
         """
     }
@@ -288,7 +325,108 @@ class CalendarManager: ObservableObject {
             .map(\.id)
 
         let created = try await calendarService.createEvents(drafts, preferredCalendarIDs: preferredEventCalendarIDs)
+        await reloadCalendarAndReminderLists()
+        includeAgentCalendarAfterWrite()
         await updateEvents()
+
+        let verificationStart = drafts.map(\.start).min()?.addingTimeInterval(-60) ?? Date()
+        let verificationEnd = drafts.map(\.end).max()?.addingTimeInterval(60) ?? Date().addingTimeInterval(60)
+        let persistedEvents = await calendarService.events(
+            from: verificationStart,
+            to: verificationEnd,
+            calendars: []
+        )
+        let persistedIDs = Set(persistedEvents.map(\.id))
+        guard created.allSatisfy({ $0.calendarTitle == "蛋神" && persistedIDs.contains($0.identifier) }) else {
+            throw CalendarWriteError.verificationFailed
+        }
         return created
     }
+
+    #if DEBUG
+    func runCalendarRuntimeSelfTest() async -> CalendarRuntimeSelfTestResult {
+        guard await ensureCalendarAccessIfNeeded() else {
+            return .init(
+                authorizationStatus: calendarAuthorizationStatus.rawValue,
+                readSucceeded: false,
+                writeSucceeded: false,
+                readAfterWriteSucceeded: false,
+                cleanupSucceeded: false,
+                message: "Calendar full access is unavailable."
+            )
+        }
+
+        let token = UUID().uuidString.prefix(8)
+        let title = "蛋神日历自检-\(token)"
+        let start = Date().addingTimeInterval(5 * 60)
+        let end = start.addingTimeInterval(10 * 60)
+        let initialContext = await aiScheduleContext(daysAhead: 1, limit: 100)
+        var created: [CreatedCalendarEvent] = []
+
+        do {
+            created = try await createAIPlannedEvents([
+                .init(
+                    title: title,
+                    start: start,
+                    end: end,
+                    notes: "蛋神 Debug 日历读写回归；完成后自动清理。",
+                    location: nil,
+                    alarmOffsetMinutes: nil
+                )
+            ])
+
+            let contextAfterWrite = await aiScheduleContext(daysAhead: 1, limit: 100)
+            let writeSucceeded = created.count == 1 && created[0].calendarTitle == "蛋神"
+            let readAfterWriteSucceeded = contextAfterWrite?.contains(title) == true
+            let removedCount = try calendarService.removeEventsForRuntimeTest(
+                calendarItemIdentifiers: created.map(\.identifier)
+            )
+            let eventsAfterCleanup = await calendarService.events(
+                from: start.addingTimeInterval(-60),
+                to: end.addingTimeInterval(60),
+                calendars: []
+            )
+            let cleanupSucceeded = removedCount == created.count
+                && !eventsAfterCleanup.contains(where: { $0.title == title })
+            await refreshCalendarData(updateVisibleEvents: true)
+
+            return .init(
+                authorizationStatus: calendarAuthorizationStatus.rawValue,
+                readSucceeded: initialContext != nil,
+                writeSucceeded: writeSucceeded,
+                readAfterWriteSucceeded: readAfterWriteSucceeded,
+                cleanupSucceeded: cleanupSucceeded,
+                message: writeSucceeded && readAfterWriteSucceeded && cleanupSucceeded
+                    ? "Calendar runtime self-test passed."
+                    : "Calendar runtime self-test returned an incomplete result."
+            )
+        } catch {
+            if !created.isEmpty {
+                _ = try? calendarService.removeEventsForRuntimeTest(
+                    calendarItemIdentifiers: created.map(\.identifier)
+                )
+            }
+            await refreshCalendarData(updateVisibleEvents: true)
+            return .init(
+                authorizationStatus: calendarAuthorizationStatus.rawValue,
+                readSucceeded: initialContext != nil,
+                writeSucceeded: !created.isEmpty,
+                readAfterWriteSucceeded: false,
+                cleanupSucceeded: created.isEmpty,
+                message: error.localizedDescription
+            )
+        }
+    }
+    #endif
 }
+
+#if DEBUG
+struct CalendarRuntimeSelfTestResult: Codable {
+    let authorizationStatus: Int
+    let readSucceeded: Bool
+    let writeSucceeded: Bool
+    let readAfterWriteSucceeded: Bool
+    let cleanupSucceeded: Bool
+    let message: String
+}
+#endif

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -14,12 +14,19 @@ let defaultImage: NSImage = .init(
     accessibilityDescription: "Album Art"
 )!
 
+struct LyricDisplaySnapshot: Equatable {
+    let current: String
+    let next: String?
+    let isPlaceholder: Bool
+}
+
 class MusicManager: ObservableObject {
     // MARK: - Properties
     static let shared = MusicManager()
     private var cancellables = Set<AnyCancellable>()
     private var controllerCancellables = Set<AnyCancellable>()
     private var debounceIdleTask: Task<Void, Never>?
+    private var lyricsRequestID = UUID()
 
     // Helper to check if macOS has removed support for NowPlayingController
     public private(set) var isNowPlayingDeprecated: Bool = false
@@ -74,6 +81,22 @@ class MusicManager: ObservableObject {
         NotificationCenter.default.publisher(for: Notification.Name.mediaControllerChanged)
             .sink { [weak self] _ in
                 self?.setActiveControllerBasedOnPreference()
+            }
+            .store(in: &cancellables)
+
+        Defaults.publisher(.enableLyrics)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] change in
+                guard let self else { return }
+                if change.newValue {
+                    self.fetchLyricsIfAvailable(
+                        bundleIdentifier: self.bundleIdentifier,
+                        title: self.songTitle,
+                        artist: self.artistName
+                    )
+                } else {
+                    self.clearLyrics()
+                }
             }
             .store(in: &cancellables)
 
@@ -342,11 +365,11 @@ class MusicManager: ObservableObject {
 
     // MARK: - Lyrics
     private func fetchLyricsIfAvailable(bundleIdentifier: String?, title: String, artist: String) {
+        let requestID = UUID()
+        lyricsRequestID = requestID
+
         guard Defaults[.enableLyrics], !title.isEmpty else {
-            DispatchQueue.main.async {
-                self.isFetchingLyrics = false
-                self.currentLyrics = ""
-            }
+            clearLyrics()
             return
         }
 
@@ -355,12 +378,13 @@ class MusicManager: ObservableObject {
             Task { @MainActor in
                 let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.Music")
                 guard !runningApps.isEmpty else {
-                    await self.fetchLyricsFromWeb(title: title, artist: artist)
+                    await self.fetchLyricsFromWeb(title: title, artist: artist, requestID: requestID)
                     return
                 }
 
                 self.isFetchingLyrics = true
                 self.currentLyrics = ""
+                self.syncedLyrics = []
                 do {
                     let script = """
                     tell application \"Music\"
@@ -384,7 +408,10 @@ class MusicManager: ObservableObject {
                         end if
                     end tell
                     """
-                    if let result = try await AppleScriptHelper.execute(script), let lyricsString = result.stringValue, !lyricsString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    if let result = try await AppleScriptHelper.execute(script),
+                       requestID == self.lyricsRequestID,
+                       let lyricsString = result.stringValue,
+                       !lyricsString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         self.currentLyrics = lyricsString.trimmingCharacters(in: .whitespacesAndNewlines)
                         self.isFetchingLyrics = false
                         self.syncedLyrics = []
@@ -393,15 +420,23 @@ class MusicManager: ObservableObject {
                 } catch {
                     // fall through to web lookup
                 }
-                await self.fetchLyricsFromWeb(title: title, artist: artist)
+                await self.fetchLyricsFromWeb(title: title, artist: artist, requestID: requestID)
             }
         } else {
             Task { @MainActor in
                 self.isFetchingLyrics = true
                 self.currentLyrics = ""
-                await self.fetchLyricsFromWeb(title: title, artist: artist)
+                self.syncedLyrics = []
+                await self.fetchLyricsFromWeb(title: title, artist: artist, requestID: requestID)
             }
         }
+    }
+
+    private func clearLyrics() {
+        lyricsRequestID = UUID()
+        isFetchingLyrics = false
+        currentLyrics = ""
+        syncedLyrics = []
     }
 
     private func normalizedQuery(_ string: String) -> String {
@@ -411,28 +446,31 @@ class MusicManager: ObservableObject {
     }
 
     @MainActor
-    private func fetchLyricsFromWeb(title: String, artist: String) async {
+    private func fetchLyricsFromWeb(title: String, artist: String, requestID: UUID) async {
+        guard requestID == lyricsRequestID, Defaults[.enableLyrics] else { return }
         let cleanTitle = normalizedQuery(title)
         let cleanArtist = normalizedQuery(artist)
         guard let encodedTitle = cleanTitle.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
               let encodedArtist = cleanArtist.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
-            self.currentLyrics = ""
-            self.isFetchingLyrics = false
+            if requestID == lyricsRequestID {
+                clearLyrics()
+            }
             return
         }
 
         // LRCLIB simple search (no auth): https://lrclib.net/api/search?track_name=...&artist_name=...
         let urlString = "https://lrclib.net/api/search?track_name=\(encodedTitle)&artist_name=\(encodedArtist)"
         guard let url = URL(string: urlString) else {
-            self.currentLyrics = ""
-            self.isFetchingLyrics = false
+            if requestID == lyricsRequestID {
+                clearLyrics()
+            }
             return
         }
         do {
             let (data, response) = try await URLSession.shared.data(from: url)
+            guard requestID == lyricsRequestID, Defaults[.enableLyrics] else { return }
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-                self.currentLyrics = ""
-                self.isFetchingLyrics = false
+                clearLyrics()
                 return
             }
             if let jsonArray = try JSONSerialization.jsonObject(with: data) as? [[String: Any]],
@@ -449,14 +487,11 @@ class MusicManager: ObservableObject {
                     self.syncedLyrics = []
                 }
             } else {
-                self.currentLyrics = ""
-                self.isFetchingLyrics = false
-                self.syncedLyrics = []
+                clearLyrics()
             }
         } catch {
-            self.currentLyrics = ""
-            self.isFetchingLyrics = false
-            self.syncedLyrics = []
+            guard requestID == lyricsRequestID else { return }
+            clearLyrics()
         }
     }
 
@@ -504,6 +539,60 @@ class MusicManager: ObservableObject {
             }
         }
         return syncedLyrics[idx].text
+    }
+
+    func estimatedElapsedTime(at date: Date = .now) -> TimeInterval {
+        guard isPlaying else { return min(max(elapsedTime, 0), songDuration) }
+        let progressed = elapsedTime + date.timeIntervalSince(timestampDate) * playbackRate
+        return min(max(progressed, 0), songDuration)
+    }
+
+    func lyricDisplaySnapshot(at elapsed: TimeInterval) -> LyricDisplaySnapshot {
+        if isFetchingLyrics {
+            return LyricDisplaySnapshot(current: "正在获取歌词…", next: nil, isPlaceholder: true)
+        }
+
+        if !syncedLyrics.isEmpty {
+            let index = syncedLyricIndex(at: elapsed)
+            let next = syncedLyrics.indices.contains(index + 1) ? syncedLyrics[index + 1].text : nil
+            return LyricDisplaySnapshot(
+                current: syncedLyrics[index].text,
+                next: next,
+                isPlaceholder: false
+            )
+        }
+
+        let lines = currentLyrics
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && !($0.hasPrefix("[") && $0.hasSuffix("]")) }
+        guard !lines.isEmpty else {
+            return LyricDisplaySnapshot(current: "暂未找到歌词", next: nil, isPlaceholder: true)
+        }
+
+        // Plain lyrics have no timestamps. Follow playback progress without pretending
+        // the estimate is an exact synchronized timestamp.
+        let progress = songDuration > 0 ? min(max(elapsed / songDuration, 0), 0.999_999) : 0
+        let index = min(Int(progress * Double(lines.count)), lines.count - 1)
+        let next = lines.indices.contains(index + 1) ? lines[index + 1] : nil
+        return LyricDisplaySnapshot(current: lines[index], next: next, isPlaceholder: false)
+    }
+
+    private func syncedLyricIndex(at elapsed: TimeInterval) -> Int {
+        guard !syncedLyrics.isEmpty else { return 0 }
+        var low = 0
+        var high = syncedLyrics.count - 1
+        var index = 0
+        while low <= high {
+            let middle = (low + high) / 2
+            if syncedLyrics[middle].time <= elapsed {
+                index = middle
+                low = middle + 1
+            } else {
+                high = middle - 1
+            }
+        }
+        return index
     }
 
     private func triggerFlipAnimation() {

--- a/boringNotch/menu/StatusBarMenu.swift
+++ b/boringNotch/menu/StatusBarMenu.swift
@@ -11,7 +11,7 @@ class BoringStatusMenu: NSMenu {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         
         if let button = statusItem.button {
-            button.image = NSImage(systemSymbolName: "music.note", accessibilityDescription: "BoringNotch")
+            button.image = NSImage(systemSymbolName: "music.note", accessibilityDescription: "Boring Notch")
             button.action = #selector(showMenu)
         }
         

--- a/boringNotch/menu/StatusBarMenu.swift
+++ b/boringNotch/menu/StatusBarMenu.swift
@@ -11,7 +11,7 @@ class BoringStatusMenu: NSMenu {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         
         if let button = statusItem.button {
-            button.image = NSImage(systemSymbolName: "music.note", accessibilityDescription: "Boring Notch")
+            button.image = NSImage(systemSymbolName: "music.note", accessibilityDescription: "蛋神")
             button.action = #selector(showMenu)
         }
         

--- a/boringNotch/models/BatteryStatusViewModel.swift
+++ b/boringNotch/models/BatteryStatusViewModel.swift
@@ -53,7 +53,6 @@ class BatteryStatusViewModel: ObservableObject {
     private func handleBatteryEvent(_ event: BatteryActivityManager.BatteryEvent) {
         switch event {
         case .powerSourceChanged(let isPluggedIn):
-            print("🔌 Power source: \(isPluggedIn ? "Connected" : "Disconnected")")
             withAnimation {
                 self.isPluggedIn = isPluggedIn
                 self.statusText = isPluggedIn ? "Plugged In" : "Unplugged"
@@ -61,13 +60,11 @@ class BatteryStatusViewModel: ObservableObject {
             }
 
         case .batteryLevelChanged(let level):
-            print("🔋 Battery level: \(Int(level))%")
             withAnimation {
                 self.levelBattery = level
             }
 
         case .lowPowerModeChanged(let isEnabled):
-            print("⚡ Low power mode: \(isEnabled ? "Enabled" : "Disabled")")
             self.notifyImportanChangeStatus()
             withAnimation {
                 self.isInLowPowerMode = isEnabled
@@ -75,9 +72,6 @@ class BatteryStatusViewModel: ObservableObject {
             }
 
         case .isChargingChanged(let isCharging):
-            print("🔌 Charging: \(isCharging ? "Yes" : "No")")
-            print("maxCapacity: \(self.maxCapacity)")
-            print("levelBattery: \(self.levelBattery)")
             self.notifyImportanChangeStatus()
             withAnimation {
                 self.isCharging = isCharging
@@ -88,19 +82,17 @@ class BatteryStatusViewModel: ObservableObject {
             }
 
         case .timeToFullChargeChanged(let time):
-            print("🕒 Time to full charge: \(time) minutes")
             withAnimation {
                 self.timeToFullCharge = time
             }
 
         case .maxCapacityChanged(let capacity):
-            print("🔋 Max capacity: \(capacity)")
             withAnimation {
                 self.maxCapacity = capacity
             }
 
-        case .error(let description):
-            print("⚠️ Error: \(description)")
+        case .error:
+            break
         }
     }
 
@@ -128,7 +120,6 @@ class BatteryStatusViewModel: ObservableObject {
     }
 
     deinit {
-        print("🔌 Cleaning up battery monitoring...")
         if let managerBatteryId: Int = managerBatteryId {
             managerBattery.removeObserver(byId: managerBatteryId)
         }

--- a/boringNotch/models/BatteryStatusViewModel.swift
+++ b/boringNotch/models/BatteryStatusViewModel.swift
@@ -126,3 +126,155 @@ class BatteryStatusViewModel: ObservableObject {
     }
 
 }
+
+struct BluetoothAccessoryBatteryPart: Codable, Hashable, Identifiable {
+    enum Kind: String, Codable {
+        case left
+        case right
+        case chargingCase = "case"
+        case main
+        case combined
+
+        var shortLabel: String {
+            switch self {
+            case .left: return "L"
+            case .right: return "R"
+            case .chargingCase: return "C"
+            case .main, .combined: return ""
+            }
+        }
+    }
+
+    let kind: Kind
+    let percentage: Int
+    let isCharging: Bool
+
+    var id: Kind { kind }
+}
+
+struct BluetoothAccessoryBatteryDevice: Codable, Hashable, Identifiable {
+    let name: String
+    let category: String
+    let parts: [BluetoothAccessoryBatteryPart]
+
+    var id: String {
+        "\(category.lowercased()):\(name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())"
+    }
+
+    var systemImage: String {
+        switch category {
+        case "headphones": return "airpodspro"
+        case "keyboard": return "keyboard"
+        case "trackpad": return "rectangle.and.hand.point.up.left"
+        case "mouse": return "computermouse"
+        default: return "dot.radiowaves.left.and.right"
+        }
+    }
+}
+
+struct KnownBluetoothAccessory: Codable, Hashable, Identifiable, Defaults.Serializable {
+    let id: String
+    let name: String
+    let category: String
+
+    init(device: BluetoothAccessoryBatteryDevice) {
+        id = device.id
+        name = device.name
+        category = device.category
+    }
+
+    var systemImage: String {
+        switch category {
+        case "headphones": return "airpodspro"
+        case "keyboard": return "keyboard"
+        case "trackpad": return "rectangle.and.hand.point.up.left"
+        case "mouse": return "computermouse"
+        default: return "dot.radiowaves.left.and.right"
+        }
+    }
+}
+
+@MainActor
+final class BluetoothAccessoryBatteryManager: ObservableObject {
+    static let shared = BluetoothAccessoryBatteryManager()
+
+    @Published private(set) var devices: [BluetoothAccessoryBatteryDevice] = []
+    @Published private(set) var knownDevices: [KnownBluetoothAccessory]
+    @Published private(set) var isRefreshing = false
+    @Published private(set) var lastError: String?
+
+    private var lastRefreshDate: Date?
+    private var refreshLoop: Task<Void, Never>?
+
+    private init() {
+        knownDevices = Defaults[.knownBluetoothAccessories]
+    }
+
+    func startMonitoring() {
+        guard refreshLoop == nil else { return }
+        refreshLoop = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await refresh(force: false)
+
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(120))
+                } catch {
+                    break
+                }
+                guard !Task.isCancelled else { break }
+                await refresh(force: true)
+            }
+        }
+    }
+
+    func stopMonitoring() {
+        refreshLoop?.cancel()
+        refreshLoop = nil
+    }
+
+    func refresh(force: Bool = false) async {
+        if !force,
+           let lastRefreshDate,
+           Date().timeIntervalSince(lastRefreshDate) < 20
+        {
+            return
+        }
+        guard !isRefreshing else { return }
+
+        isRefreshing = true
+        defer { isRefreshing = false }
+
+        guard let data = await XPCHelperClient.shared.bluetoothAccessoryBatteryData() else {
+            lastError = "设备电量暂时不可用"
+            return
+        }
+
+        do {
+            devices = try JSONDecoder().decode([BluetoothAccessoryBatteryDevice].self, from: data)
+            remember(devices)
+            lastRefreshDate = Date()
+            lastError = nil
+        } catch {
+            lastError = "无法读取设备电量"
+        }
+    }
+
+    private func remember(_ devices: [BluetoothAccessoryBatteryDevice]) {
+        guard !devices.isEmpty else { return }
+
+        var rememberedByID: [String: KnownBluetoothAccessory] = [:]
+        for device in knownDevices {
+            rememberedByID[device.id] = device
+        }
+        for device in devices {
+            rememberedByID[device.id] = KnownBluetoothAccessory(device: device)
+        }
+        let updated = rememberedByID.values.sorted {
+            $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+        guard updated != knownDevices else { return }
+        knownDevices = updated
+        Defaults[.knownBluetoothAccessories] = updated
+    }
+}

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -31,6 +31,9 @@ class BoringViewModel: NSObject, ObservableObject {
     @Published var edgeAutoOpenActive: Bool = false
     @Published var isHoveringCalendar: Bool = false
     @Published var isBatteryPopoverActive: Bool = false
+    @Published var preventAutoClose: Bool = false
+    @Published var isResizingAssistantPanel: Bool = false
+    private var hoverAutoOpenSuppressedUntil: Date?
 
     @Published var screenUUID: String?
 
@@ -190,11 +193,79 @@ class BoringViewModel: NSObject, ObservableObject {
     }
 
     func open() {
-        self.notchSize = openNotchSize
+        let targetSize = openNotchSize(for: coordinator.currentView, screenUUID: screenUUID)
+        if notchState == .open
+            && abs(notchSize.width - targetSize.width) < 1
+            && abs(notchSize.height - targetSize.height) < 1
+        {
+            return
+        }
+
+        self.notchSize = targetSize
         self.notchState = .open
+        notifyPanelSizeChanged()
         
         // Force music information update when notch is opened
         MusicManager.shared.forceUpdate()
+    }
+
+    func updateOpenSizeForCurrentView() {
+        guard notchState == .open else { return }
+        self.notchSize = openNotchSize(for: coordinator.currentView, screenUUID: screenUUID)
+        notifyPanelSizeChanged()
+    }
+
+    func suppressHoverAutoOpen(for interval: TimeInterval = 1.0) {
+        hoverAutoOpenSuppressedUntil = Date().addingTimeInterval(interval)
+    }
+
+    func isHoverAutoOpenSuppressed(now: Date = Date()) -> Bool {
+        guard let suppressedUntil = hoverAutoOpenSuppressedUntil else { return false }
+        if suppressedUntil > now {
+            return true
+        }
+
+        hoverAutoOpenSuppressedUntil = nil
+        return false
+    }
+
+    func resizeAssistantPanel(to requestedSize: CGSize, persist: Bool = true) {
+        if !persist {
+            isResizingAssistantPanel = true
+        }
+
+        let nextSize = clampedAIChatPanelSize(
+            width: requestedSize.width,
+            height: requestedSize.height,
+            screenUUID: screenUUID
+        )
+        let changeThreshold: CGFloat = isResizingAssistantPanel ? 8 : 4
+        let widthChanged = abs(nextSize.width - notchSize.width) >= changeThreshold
+        let heightChanged = abs(nextSize.height - notchSize.height) >= changeThreshold
+
+        if persist {
+            Defaults[.aiChatPanelWidth] = nextSize.width
+            Defaults[.aiChatPanelHeight] = nextSize.height
+        }
+
+        guard notchState == .open, coordinator.currentView == .assistant else { return }
+        guard persist || widthChanged || heightChanged else { return }
+        self.notchSize = nextSize
+        notifyPanelSizeChanged()
+    }
+
+    func finishAssistantPanelResize() {
+        let finalSize = clampedAIChatPanelSize(
+            width: notchSize.width,
+            height: notchSize.height,
+            screenUUID: screenUUID
+        )
+        Defaults[.aiChatPanelWidth] = finalSize.width
+        Defaults[.aiChatPanelHeight] = finalSize.height
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) { [weak self] in
+            self?.isResizingAssistantPanel = false
+        }
     }
 
     func close() {
@@ -205,6 +276,7 @@ class BoringViewModel: NSObject, ObservableObject {
         self.notchSize = getClosedNotchSize(screenUUID: self.screenUUID)
         self.closedNotchSize = self.notchSize
         self.notchState = .closed
+        notifyPanelSizeChanged()
         self.isBatteryPopoverActive = false
         self.coordinator.sneakPeek.show = false
         self.edgeAutoOpenActive = false
@@ -216,6 +288,10 @@ class BoringViewModel: NSObject, ObservableObject {
         } else if !coordinator.openLastTabByDefault {
             coordinator.currentView = .home
         }
+    }
+
+    private func notifyPanelSizeChanged() {
+        NotificationCenter.default.post(name: .notchPanelSizeChanged, object: screenUUID)
     }
 
     func closeHello() {

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -211,8 +211,24 @@ class BoringViewModel: NSObject, ObservableObject {
 
     func updateOpenSizeForCurrentView() {
         guard notchState == .open else { return }
-        self.notchSize = openNotchSize(for: coordinator.currentView, screenUUID: screenUUID)
+        let targetSize = openNotchSize(for: coordinator.currentView, screenUUID: screenUUID)
+        guard abs(notchSize.width - targetSize.width) >= 1
+                || abs(notchSize.height - targetSize.height) >= 1
+        else { return }
+
+        self.notchSize = targetSize
         notifyPanelSizeChanged()
+    }
+
+    func selectOpenView(_ view: NotchViews) {
+        guard coordinator.currentView != view else { return }
+
+        if notchState == .open {
+            self.notchSize = openNotchSize(for: view, screenUUID: screenUUID)
+            notifyPanelSizeChanged()
+        }
+
+        coordinator.currentView = view
     }
 
     func suppressHoverAutoOpen(for interval: TimeInterval = 1.0) {
@@ -239,7 +255,7 @@ class BoringViewModel: NSObject, ObservableObject {
             height: requestedSize.height,
             screenUUID: screenUUID
         )
-        let changeThreshold: CGFloat = isResizingAssistantPanel ? 8 : 4
+        let changeThreshold: CGFloat = isResizingAssistantPanel ? 2 : 4
         let widthChanged = abs(nextSize.width - notchSize.width) >= changeThreshold
         let heightChanged = abs(nextSize.height - notchSize.height) >= changeThreshold
 

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -18,6 +18,20 @@ let appVersion = "\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as
 let temporaryDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
 let spacing: CGFloat = 16
 
+func defaultWeatherCityName() -> String {
+    let fallback = TimeZone.current.identifier
+        .split(separator: "/")
+        .last
+        .map(String.init)?
+        .replacingOccurrences(of: "_", with: " ")
+
+    if let fallback, !fallback.isEmpty {
+        return fallback
+    }
+
+    return "San Francisco"
+}
+
 struct CustomVisualizer: Codable, Hashable, Equatable, Defaults.Serializable {
     let UUID: UUID
     var name: String
@@ -68,6 +82,124 @@ enum OptionKeyAction: String, CaseIterable, Identifiable, Defaults.Serializable 
     var id: String { self.rawValue }
 }
 
+enum WeatherTemperatureUnit: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case celsius = "Celsius"
+    case fahrenheit = "Fahrenheit"
+
+    var id: String { self.rawValue }
+
+    var apiValue: String {
+        switch self {
+        case .celsius:
+            return "celsius"
+        case .fahrenheit:
+            return "fahrenheit"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .celsius:
+            return "°C"
+        case .fahrenheit:
+            return "°F"
+        }
+    }
+
+    var windSpeedAPIValue: String {
+        switch self {
+        case .celsius:
+            return "kmh"
+        case .fahrenheit:
+            return "mph"
+        }
+    }
+
+    var windSpeedLabel: String {
+        switch self {
+        case .celsius:
+            return "km/h"
+        case .fahrenheit:
+            return "mph"
+        }
+    }
+}
+
+enum WeatherLocationMode: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case automatic = "Automatic location"
+    case manualCity = "Manual city"
+
+    var id: String { self.rawValue }
+}
+
+struct QuickLaunchAppItem: Codable, Hashable, Equatable, Identifiable, Defaults.Serializable {
+    var name: String
+    var appPath: String
+    var bundleIdentifier: String
+
+    var id: String {
+        appPath.isEmpty ? bundleIdentifier : appPath
+    }
+
+    var displayName: String {
+        if !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return name
+        }
+
+        if !appPath.isEmpty {
+            return URL(fileURLWithPath: appPath).deletingPathExtension().lastPathComponent
+        }
+
+        return bundleIdentifier
+    }
+
+    init(name: String, appPath: String, bundleIdentifier: String = "") {
+        self.name = name
+        self.appPath = appPath
+        self.bundleIdentifier = bundleIdentifier
+    }
+
+    init?(appURL: URL) {
+        let standardizedURL = appURL.standardizedFileURL
+        guard standardizedURL.pathExtension == "app" else { return nil }
+
+        let bundle = Bundle(url: standardizedURL)
+        let resolvedName =
+            (bundle?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? (bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? standardizedURL.deletingPathExtension().lastPathComponent
+
+        self.init(
+            name: resolvedName,
+            appPath: standardizedURL.path,
+            bundleIdentifier: bundle?.bundleIdentifier ?? ""
+        )
+    }
+}
+
+enum PomodoroPhaseDefaults: String, Defaults.Serializable {
+    case focus
+    case shortBreak
+    case longBreak
+}
+
+func defaultQuickLaunchApps() -> [QuickLaunchAppItem] {
+    let candidatePaths = [
+        "/System/Applications/Safari.app",
+        "/System/Applications/Notes.app",
+        "/System/Applications/Calendar.app",
+        "/System/Applications/Music.app",
+    ]
+
+    return candidatePaths.compactMap { path in
+        let url = URL(fileURLWithPath: path)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return QuickLaunchAppItem(appURL: url)
+    }
+}
+
 extension Defaults.Keys {
     // MARK: General
     static let menubarIcon = Key<Bool>("menubarIcon", default: true)
@@ -116,6 +248,42 @@ extension Defaults.Keys {
     static let useMusicVisualizer = Key<Bool>("useMusicVisualizer", default: true)
     static let customVisualizers = Key<[CustomVisualizer]>("customVisualizers", default: [])
     static let selectedVisualizer = Key<CustomVisualizer?>("selectedVisualizer", default: nil)
+    static let aiChatEnabled = Key<Bool>("aiChatEnabled", default: true)
+    static let aiServiceBaseURL = Key<String>("aiServiceBaseURL", default: "https://api.openai.com")
+    static let aiServiceModel = Key<String>("aiServiceModel", default: "gpt-4o-mini")
+    static let aiServiceAPIKey = Key<String>("aiServiceAPIKey", default: "")
+    static let aiSystemPrompt = Key<String>(
+        "aiSystemPrompt",
+        default: "You are a concise assistant inside a macOS notch utility. Answer in the user's language. Use available local context when relevant, and clearly say when local context is unavailable instead of guessing."
+    )
+    static let aiTemperature = Key<Double>("aiTemperature", default: 0.35)
+    static let aiCalendarContextEnabled = Key<Bool>("aiCalendarContextEnabled", default: true)
+    static let aiCalendarWriteEnabled = Key<Bool>("aiCalendarWriteEnabled", default: true)
+    static let aiChatPanelWidth = Key<CGFloat>("aiChatPanelWidth", default: aiChatPanelDefaultSize.width)
+    static let aiChatPanelHeight = Key<CGFloat>("aiChatPanelHeight", default: aiChatPanelDefaultSize.height)
+    static let aiKnowledgeRetrievalEnabled = Key<Bool>("aiKnowledgeRetrievalEnabled", default: true)
+    static let aiKnowledgeRetrievalLimit = Key<Int>("aiKnowledgeRetrievalLimit", default: 3)
+    static let weatherFeatureEnabled = Key<Bool>("weatherFeatureEnabled", default: true)
+    static let weatherLocationMode = Key<WeatherLocationMode>(
+        "weatherLocationMode",
+        default: .automatic
+    )
+    static let weatherCity = Key<String>("weatherCity", default: defaultWeatherCityName())
+    static let weatherTemperatureUnit = Key<WeatherTemperatureUnit>(
+        "weatherTemperatureUnit",
+        default: .celsius
+    )
+    static let pomodoroEnabled = Key<Bool>("pomodoroEnabled", default: true)
+    static let pomodoroFocusMinutes = Key<Int>("pomodoroFocusMinutes", default: 25)
+    static let pomodoroShortBreakMinutes = Key<Int>("pomodoroShortBreakMinutes", default: 5)
+    static let pomodoroLongBreakMinutes = Key<Int>("pomodoroLongBreakMinutes", default: 15)
+    static let pomodoroLongBreakInterval = Key<Int>("pomodoroLongBreakInterval", default: 4)
+    static let pomodoroAutoStartNextPhase = Key<Bool>("pomodoroAutoStartNextPhase", default: false)
+    static let quickLaunchEnabled = Key<Bool>("quickLaunchEnabled", default: true)
+    static let quickLaunchApps = Key<[QuickLaunchAppItem]>(
+        "quickLaunchApps",
+        default: defaultQuickLaunchApps()
+    )
     
     // MARK: Gestures
     static let enableGestures = Key<Bool>("enableGestures", default: true)

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -185,6 +185,51 @@ enum PomodoroPhaseDefaults: String, Defaults.Serializable {
     case longBreak
 }
 
+enum HomeWidgetKind: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case weather
+    case pomodoro
+    case quickLaunch
+    case calendar
+    case media
+    case hidden
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .weather:
+            return "Weather"
+        case .pomodoro:
+            return "Pomodoro"
+        case .quickLaunch:
+            return "Quick launch"
+        case .calendar:
+            return "Calendar"
+        case .media:
+            return "Media controls"
+        case .hidden:
+            return "Hidden"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .weather:
+            return "cloud.sun"
+        case .pomodoro:
+            return "timer"
+        case .quickLaunch:
+            return "square.grid.2x2"
+        case .calendar:
+            return "calendar"
+        case .media:
+            return "music.note"
+        case .hidden:
+            return "eye.slash"
+        }
+    }
+}
+
 func defaultQuickLaunchApps() -> [QuickLaunchAppItem] {
     let candidatePaths = [
         "/System/Applications/Safari.app",
@@ -198,6 +243,19 @@ func defaultQuickLaunchApps() -> [QuickLaunchAppItem] {
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }
         return QuickLaunchAppItem(appURL: url)
     }
+}
+
+func defaultHomeWidgetSlots() -> [HomeWidgetKind] {
+    [.weather, .pomodoro, .quickLaunch, .calendar]
+}
+
+func normalizedHomeWidgetSlots(_ slots: [HomeWidgetKind]) -> [HomeWidgetKind] {
+    let maxSlots = 4
+    var normalized = Array(slots.prefix(maxSlots))
+    if normalized.count < maxSlots {
+        normalized.append(contentsOf: Array(repeating: .hidden, count: maxSlots - normalized.count))
+    }
+    return normalized
 }
 
 extension Defaults.Keys {
@@ -283,6 +341,10 @@ extension Defaults.Keys {
     static let quickLaunchApps = Key<[QuickLaunchAppItem]>(
         "quickLaunchApps",
         default: defaultQuickLaunchApps()
+    )
+    static let homeWidgetSlots = Key<[HomeWidgetKind]>(
+        "homeWidgetSlots",
+        default: defaultHomeWidgetSlots()
     )
     
     // MARK: Gestures

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -321,6 +321,8 @@ extension Defaults.Keys {
     static let aiChatPanelHeight = Key<CGFloat>("aiChatPanelHeight", default: aiChatPanelDefaultSize.height)
     static let aiKnowledgeRetrievalEnabled = Key<Bool>("aiKnowledgeRetrievalEnabled", default: true)
     static let aiKnowledgeRetrievalLimit = Key<Int>("aiKnowledgeRetrievalLimit", default: 3)
+    static let aiShowAgentTrace = Key<Bool>("aiShowAgentTrace", default: false)
+    static let aiWebSearchEnabled = Key<Bool>("aiWebSearchEnabled", default: true)
     static let weatherFeatureEnabled = Key<Bool>("weatherFeatureEnabled", default: true)
     static let weatherLocationMode = Key<WeatherLocationMode>(
         "weatherLocationMode",

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -283,6 +283,10 @@ extension Defaults.Keys {
     //static let openLastTabByDefault = Key<Bool>("openLastTabByDefault", default: false)
     static let showOnLockScreen = Key<Bool>("showOnLockScreen", default: false)
     static let hideFromScreenRecording = Key<Bool>("hideFromScreenRecording", default: false)
+    static let auxiliaryWindowsAlwaysOnTop = Key<Bool>(
+        "auxiliaryWindowsAlwaysOnTop",
+        default: false
+    )
     
     // MARK: Appearance
     static let showEmojis = Key<Bool>("showEmojis", default: false)
@@ -309,6 +313,7 @@ extension Defaults.Keys {
     static let aiChatEnabled = Key<Bool>("aiChatEnabled", default: true)
     static let aiServiceBaseURL = Key<String>("aiServiceBaseURL", default: "https://api.openai.com")
     static let aiServiceModel = Key<String>("aiServiceModel", default: "gpt-4o-mini")
+    // Legacy migration source only. New credentials are stored in macOS Keychain.
     static let aiServiceAPIKey = Key<String>("aiServiceAPIKey", default: "")
     static let aiSystemPrompt = Key<String>(
         "aiSystemPrompt",
@@ -319,6 +324,14 @@ extension Defaults.Keys {
     static let aiCalendarWriteEnabled = Key<Bool>("aiCalendarWriteEnabled", default: true)
     static let aiChatPanelWidth = Key<CGFloat>("aiChatPanelWidth", default: aiChatPanelDefaultSize.width)
     static let aiChatPanelHeight = Key<CGFloat>("aiChatPanelHeight", default: aiChatPanelDefaultSize.height)
+    static let aiPluginPanelWidth = Key<CGFloat>("aiPluginPanelWidth", default: 760)
+    static let aiPluginPanelHeight = Key<CGFloat>("aiPluginPanelHeight", default: 460)
+    static let aiSkillsPanelWidth = Key<CGFloat>("aiSkillsPanelWidth", default: 760)
+    static let aiSkillsPanelHeight = Key<CGFloat>("aiSkillsPanelHeight", default: 460)
+    static let aiMemoryPanelWidth = Key<CGFloat>("aiMemoryPanelWidth", default: 820)
+    static let aiMemoryPanelHeight = Key<CGFloat>("aiMemoryPanelHeight", default: 500)
+    static let aiKnowledgePanelWidth = Key<CGFloat>("aiKnowledgePanelWidth", default: 820)
+    static let aiKnowledgePanelHeight = Key<CGFloat>("aiKnowledgePanelHeight", default: 500)
     static let aiKnowledgeRetrievalEnabled = Key<Bool>("aiKnowledgeRetrievalEnabled", default: true)
     static let aiKnowledgeRetrievalLimit = Key<Int>("aiKnowledgeRetrievalLimit", default: 3)
     static let aiShowAgentTrace = Key<Bool>("aiShowAgentTrace", default: false)
@@ -340,6 +353,18 @@ extension Defaults.Keys {
     static let pomodoroLongBreakInterval = Key<Int>("pomodoroLongBreakInterval", default: 4)
     static let pomodoroAutoStartNextPhase = Key<Bool>("pomodoroAutoStartNextPhase", default: false)
     static let quickLaunchEnabled = Key<Bool>("quickLaunchEnabled", default: true)
+    static let showBluetoothAccessoryBatteries = Key<Bool>(
+        "showBluetoothAccessoryBatteries",
+        default: true
+    )
+    static let hiddenBluetoothAccessoryIDs = Key<[String]>(
+        "hiddenBluetoothAccessoryIDs",
+        default: []
+    )
+    static let knownBluetoothAccessories = Key<[KnownBluetoothAccessory]>(
+        "knownBluetoothAccessories",
+        default: []
+    )
     static let quickLaunchApps = Key<[QuickLaunchAppItem]>(
         "quickLaunchApps",
         default: defaultQuickLaunchApps()
@@ -361,6 +386,11 @@ extension Defaults.Keys {
     static let waitInterval = Key<Double>("waitInterval", default: 3)
     static let showShuffleAndRepeat = Key<Bool>("showShuffleAndRepeat", default: false)
     static let enableLyrics = Key<Bool>("enableLyrics", default: false)
+    static let screenMediaBarEnabled = Key<Bool>("screenMediaBarEnabled", default: true)
+    static let screenMediaBarShowsLyrics = Key<Bool>("screenMediaBarShowsLyrics", default: true)
+    static let screenMediaBarAlwaysOnTop = Key<Bool>("screenMediaBarAlwaysOnTop", default: false)
+    static let screenMediaBarOriginX = Key<Double>("screenMediaBarOriginX", default: -100_000)
+    static let screenMediaBarOriginY = Key<Double>("screenMediaBarOriginY", default: -100_000)
     static let musicControlSlots = Key<[MusicControlButton]>(
         "musicControlSlots",
         default: MusicControlButton.defaultLayout

--- a/boringNotch/observers/MediaKeyInterceptor.swift
+++ b/boringNotch/observers/MediaKeyInterceptor.swift
@@ -160,12 +160,9 @@ final class MediaKeyInterceptor {
         if FileManager.default.fileExists(atPath: defaultPath) {
             do {
                 audioPlayer = try AVAudioPlayer(contentsOf: URL(fileURLWithPath: defaultPath))
-                print("🔊 [MediaKeyInterceptor] Loaded default Bezel audio from: \(defaultPath)")
             } catch {
-                print("⚠️ [MediaKeyInterceptor] Failed to init AVAudioPlayer with default path \(defaultPath): \(error.localizedDescription)")
+                audioPlayer = nil
             }
-        } else {
-            print("⚠️ [MediaKeyInterceptor] Default bezel audio not found at: \(defaultPath)")
         }
 
         if let player = audioPlayer {
@@ -181,13 +178,7 @@ final class MediaKeyInterceptor {
 
         prepareAudioPlayerIfNeeded()
         guard let player = audioPlayer else {
-            print("⚠️ [MediaKeyInterceptor] No audio player available to play feedback sound")
             return
-        }
-        if let url = player.url {
-            print("🔊 [MediaKeyInterceptor] Playing feedback sound from: \(url.path)")
-        } else {
-            print("🔊 [MediaKeyInterceptor] Playing feedback sound (no url available for AVAudioPlayer)")
         }
         if player.isPlaying {
             player.stop()

--- a/boringNotch/observers/MediaKeyInterceptor.swift
+++ b/boringNotch/observers/MediaKeyInterceptor.swift
@@ -31,6 +31,11 @@ final class MediaKeyInterceptor {
     private var audioPlayer: AVAudioPlayer?
     
     private init() {}
+
+    private var isTapActive: Bool {
+        guard let eventTap, runLoopSource != nil else { return false }
+        return CGEvent.tapIsEnabled(tap: eventTap)
+    }
     
     // MARK: - Accessibility (via XPC)
     
@@ -44,52 +49,73 @@ final class MediaKeyInterceptor {
     
     // MARK: - Event Tap
     
-    func start(promptIfNeeded: Bool = false) async {
-        guard eventTap == nil else { return }
-        
+    @discardableResult
+    func start(promptIfNeeded: Bool = false) async -> Bool {
         // Ensure HUD replacement is enabled
         guard Defaults[.hudReplacement] else {
             stop()
-            return
+            return false
         }
-        
-        // Check accessibility authorization
-        let authorized = await XPCHelperClient.shared.isAccessibilityAuthorized()
-        if !authorized {
-            if promptIfNeeded {
-                let granted = await ensureAccessibilityAuthorization(promptIfNeeded: true)
-                guard granted else { return }
-            } else {
-                return
-            }
+
+        var permissionStatus = await XPCHelperClient.shared.hudPermissionStatus()
+        if !permissionStatus.isAuthorized, promptIfNeeded {
+            permissionStatus = await XPCHelperClient.shared.requestHUDPermissions()
         }
-        
+        guard permissionStatus.isAuthorized else {
+            publishState(running: false, reason: "permissions")
+            return false
+        }
+
+        if isTapActive {
+            return true
+        }
+        if eventTap != nil || runLoopSource != nil {
+            stop()
+        }
+
         let mask = CGEventMask(1 << kSystemDefinedEventType.rawValue)
         eventTap = CGEvent.tapCreate(
             tap: .cghidEventTap,
             place: .headInsertEventTap,
             options: .defaultTap,
             eventsOfInterest: mask,
-            callback: { _, _, cgEvent, userInfo in
-                guard let userInfo else { return Unmanaged.passRetained(cgEvent) }
+            callback: { _, type, cgEvent, userInfo in
+                guard let userInfo else { return Unmanaged.passUnretained(cgEvent) }
                 let interceptor = Unmanaged<MediaKeyInterceptor>.fromOpaque(userInfo).takeUnretainedValue()
+
+                if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+                    interceptor.reenableEventTap(after: type)
+                    return nil
+                }
+
                 return interceptor.handleEvent(cgEvent)
             },
             userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
         )
-        
-        if let eventTap {
-            runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
-            if let runLoopSource {
-                CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
-            }
-            CGEvent.tapEnable(tap: eventTap, enable: true)
+
+        guard let eventTap else {
+            publishState(running: false, reason: "eventTap")
+            return false
         }
+        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0) else {
+            CFMachPortInvalidate(eventTap)
+            self.eventTap = nil
+            publishState(running: false, reason: "runLoop")
+            return false
+        }
+
+        runLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: eventTap, enable: true)
+        let running = isTapActive
+        publishState(running: running, reason: running ? nil : "eventTap")
+        return running
     }
     
     func stop() {
         if let eventTap {
             CGEvent.tapEnable(tap: eventTap, enable: false)
+            CFMachPortInvalidate(eventTap)
         }
         if let runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
@@ -97,18 +123,35 @@ final class MediaKeyInterceptor {
         runLoopSource = nil
         eventTap = nil
     }
+
+    private func reenableEventTap(after type: CGEventType) {
+        guard let eventTap else { return }
+        CGEvent.tapEnable(tap: eventTap, enable: true)
+        NSLog("[HUD] media-key event tap re-enabled after type=%d", type.rawValue)
+    }
+
+    private func publishState(running: Bool, reason: String?) {
+        NSLog("[HUD] media-key interceptor running=%@ reason=%@", running.description, reason ?? "none")
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: .mediaKeyInterceptorStateChanged,
+                object: nil,
+                userInfo: ["running": running, "reason": reason as Any]
+            )
+        }
+    }
     
     // MARK: - Event Handling
     
     private func handleEvent(_ cgEvent: CGEvent) -> Unmanaged<CGEvent>? {
         // Ensure the CGEvent has a valid type before converting to NSEvent
         guard cgEvent.type != .null else {
-            return Unmanaged.passRetained(cgEvent)
+            return Unmanaged.passUnretained(cgEvent)
         }
         guard let nsEvent = NSEvent(cgEvent: cgEvent),
               nsEvent.type == .systemDefined,
               nsEvent.subtype.rawValue == 8 else {
-            return Unmanaged.passRetained(cgEvent)
+            return Unmanaged.passUnretained(cgEvent)
         }
         
         let data1 = nsEvent.data1
@@ -118,7 +161,7 @@ final class MediaKeyInterceptor {
         // 0xA = key down, 0xB = key up. Only handle key down.
         guard stateByte == 0xA,
               let keyType = NXKeyType(rawValue: keyCode) else {
-            return Unmanaged.passRetained(cgEvent)
+            return Unmanaged.passUnretained(cgEvent)
         }
         
         let flags = nsEvent.modifierFlags

--- a/boringNotch/sizing/matters.swift
+++ b/boringNotch/sizing/matters.swift
@@ -13,8 +13,11 @@ let downloadSneakSize: CGSize = .init(width: 65, height: 1)
 let batterySneakSize: CGSize = .init(width: 160, height: 1)
 
 let shadowPadding: CGFloat = 20
-let openNotchSize: CGSize = .init(width: 640, height: 190)
+let openNotchSize: CGSize = .init(width: 920, height: 320)
 let windowSize: CGSize = .init(width: openNotchSize.width, height: openNotchSize.height + shadowPadding)
+let aiChatPanelDefaultSize: CGSize = .init(width: 1_080, height: 560)
+let aiChatPanelMinSize: CGSize = .init(width: 820, height: 360)
+let aiChatPanelMaxSize: CGSize = .init(width: 1_680, height: 900)
 let cornerRadiusInsets: (opened: (top: CGFloat, bottom: CGFloat), closed: (top: CGFloat, bottom: CGFloat)) = (opened: (top: 19, bottom: 24), closed: (top: 6, bottom: 14))
 
 enum MusicPlayerImageSizes {
@@ -34,6 +37,30 @@ enum MusicPlayerImageSizes {
     }
     
     return nil
+}
+
+@MainActor func clampedAIChatPanelSize(
+    width: CGFloat = Defaults[.aiChatPanelWidth],
+    height: CGFloat = Defaults[.aiChatPanelHeight],
+    screenUUID: String? = nil
+) -> CGSize {
+    let screen = screenUUID.flatMap { NSScreen.screen(withUUID: $0) } ?? NSScreen.main
+    let visibleFrame = screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? .init(x: 0, y: 0, width: 1_440, height: 900)
+    let maxWidth = min(aiChatPanelMaxSize.width, max(aiChatPanelMinSize.width, visibleFrame.width - 80))
+    let maxHeight = min(aiChatPanelMaxSize.height, max(aiChatPanelMinSize.height, visibleFrame.height - 80))
+
+    return .init(
+        width: min(max(width, aiChatPanelMinSize.width), maxWidth),
+        height: min(max(height, aiChatPanelMinSize.height), maxHeight)
+    )
+}
+
+@MainActor func openNotchSize(for view: NotchViews, screenUUID: String? = nil) -> CGSize {
+    view == .assistant ? clampedAIChatPanelSize(screenUUID: screenUUID) : openNotchSize
+}
+
+@MainActor func hostingWindowSize(for notchSize: CGSize) -> CGSize {
+    .init(width: notchSize.width, height: notchSize.height + shadowPadding)
 }
 
 @MainActor func getClosedNotchSize(screenUUID: String? = nil) -> CGSize {


### PR DESCRIPTION
## Summary

This PR adds a set of optional productivity features to Boring Notch:

- a resizable notch assistant surface with smoother open, close, and collapse behavior;
- an optional OpenAI-compatible AI chat tab;
- an assistant plugin/skill registry with local trace inspection, hidden by default;
- PDF text extraction, image OCR for text-bearing screenshots, and local knowledge imports;
- settings-gated public web/GitHub context lookup for explicit search requests;
- an Open-Meteo weather dashboard with condition icons and hourly forecasts;
- a local Pomodoro focus timer;
- a configurable four-slot Home layout with optional media controls.

Weather, Pomodoro, Home layout, and media controls work without any AI provider configuration. AI chat stays opt-in and uses local app settings for provider configuration. No provider credentials are committed; API keys remain user-entered settings only.

## Changes

### Resizable notch panel

- Adds persisted assistant panel width and height settings.
- Adds resize handles for the panel right edge, bottom edge, and bottom-right corner.
- Reduces resize sensitivity and clamps size changes to display-safe bounds.
- Uses a shared panel animation for open, close, tab switches, and collapse.
- Keeps panel positioning centered during size changes to avoid side jumps.
- Adds a collapse control in the assistant panel and suppresses accidental hover re-open immediately after collapse.
- Raises settings and file picker windows above the notch panel when opened from the assistant surface.

### AI chat and assistant tools

- Adds an optional AI tab backed by OpenAI-compatible chat completion providers.
- Adds configurable model, base URL, API key, temperature, and system prompt fields.
- Adds multi-conversation support, slash commands, file attachments, and inspector panels.
- Keeps the verbose agent trace hidden by default, with a Settings toggle for debugging.
- Collapses plugin and skill registries in Settings so the AI settings page remains navigable.
- Adds PDF text extraction and lightweight Vision OCR for text-bearing images.
- Adds a settings-gated web context plugin for explicit URL, public web, and GitHub repository lookup requests.
- Grounds calendar/weather/web answers in available context and asks for missing context instead of inventing unavailable local state.

### Weather

- Adds a notch weather dashboard.
- Uses Open-Meteo for geocoding and forecast data.
- Supports automatic location and manual city modes.
- Shows current condition, high/low, feels-like temperature, humidity, wind speed, and hourly forecast cards.
- Uses SF Symbols-based weather icons so the UI works without bundled image assets.

### Pomodoro

- Adds a local Pomodoro dashboard.
- Supports focus, short break, and long break phases.
- Adds start, pause, skip, reset, session count, completed count, and progress display.
- Adds settings for focus and break durations.

### Home layout and media controls

- Adds a fixed four-slot Home widget layout so cards keep a stable size.
- Lets users choose the widget shown in each slot from Appearance settings.
- Supports Weather, Pomodoro, Quick Launch, Calendar, Media, and Hidden slots.
- Moves Quick Launch configuration into Appearance next to the Home layout controls.
- Adds a compact Home media card with artwork, playback position, previous/play-next controls, source label, and optional lyric text.

### Code organization

- Moves shared panel animation behavior into `NotchPanelAnimation`.
- Splits weather and Pomodoro dashboard UI into separate SwiftUI files.
- Removes unused SwiftPM package pins after project dependency cleanup.
- Removes temporary local branding from the contribution branch so the app remains Boring Notch upstream.
- Removes several high-frequency debug prints from runtime paths.

## Validation

```bash
xcodebuild -resolvePackageDependencies -project boringNotch.xcodeproj -scheme boringNotch -derivedDataPath .derivedData -onlyUsePackageVersionsFromResolvedFile
xcodebuild -project boringNotch.xcodeproj -scheme boringNotch -configuration Debug -derivedDataPath .derivedData -disableAutomaticPackageResolution build
```

The build succeeds locally. Existing warnings remain in unrelated areas such as YouTubeMusicController concurrency warnings and the MediaRemoteAdapter deployment target warning.

Manual checks performed or recommended:

- open and collapse the notch panel from Home and AI tabs;
- resize the assistant panel from each handle;
- open settings from the assistant panel and confirm it appears above the panel;
- open the file attachment picker from AI chat and confirm it appears above the panel;
- import text/PDF/image files into chat or the local knowledge base;
- ask an explicit web/GitHub lookup question and confirm web context is loaded when enabled;
- refresh weather in automatic and manual city modes;
- start, pause, skip, and reset the Pomodoro timer;
- configure Home slots from Appearance settings;
- enable, reorder, replace, and hide Quick Launch apps;
- use the Home media card while media is playing and while nothing is playing;
- run AI chat in disabled, missing-key, and configured states.

## Review Notes

This is a larger UI/productivity contribution. If the maintainers prefer smaller reviews, I can split it into:

1. resizable panel and animation infrastructure;
2. weather dashboard;
3. Pomodoro timer;
4. Home layout and media controls;
5. optional AI chat, assistant settings, and context tools.
