### PR TITLE
Add basic home view

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ We’re all about good vibes and awesome contributions! Read [CONTRIBUTING.md](C
 <a href="https://discord.gg/GvYcYpAKTu" target="_blank"><img src="https://iili.io/28m3GHv.png" alt="Join The Boring Server!" style="height: 60px !important;width: 217px !important;" ></a>
 
 ## Star History
-
+<!-- BROKEN: GitHub now restricts the stargazer API for privacy reasons
 <a href="https://www.star-history.com/#TheBoredTeam/boring.notch&Timeline">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=TheBoredTeam/boring.notch&type=Timeline&theme=dark" />
@@ -167,6 +167,12 @@ We’re all about good vibes and awesome contributions! Read [CONTRIBUTING.md](C
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=TheBoredTeam/boring.notch&type=Timeline" />
  </picture>
 </a>
+-->
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/TheBoredTeam/org-star-chart-updater/main/projects/boring.notch/chart-dark.svg">
+   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/TheBoredTeam/org-star-chart-updater/main/projects/boring.notch/chart-light.svg">
+   <img src="https://raw.githubusercontent.com/TheBoredTeam/org-star-chart-updater/main/projects/boring.notch/chart-light.svg" alt="TheBoredTeam/boring.notch GitHub star history">
+ </picture>
 
 ## Support us on Ko-fi!
 <!-- <a href="https://www.buymeacoffee.com/jfxh67wvfxq" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-red.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a> -->

--- a/boringNotch/BoringViewCoordinator.swift
+++ b/boringNotch/BoringViewCoordinator.swift
@@ -53,6 +53,7 @@ class BoringViewCoordinator: ObservableObject {
     static let shared = BoringViewCoordinator()
 
     @Published var currentView: NotchViews = .home
+    @Published var currentTab: HomeTabs = .player
     @Published var helloAnimationRunning: Bool = false
     private var sneakPeekDispatch: DispatchWorkItem?
     private var expandingViewDispatch: DispatchWorkItem?

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -23707,6 +23707,17 @@
         }
       }
     },
+    "System Setting" : {
+      "comment" : "Week starts on: follow the macOS system setting",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System Setting"
+          }
+        }
+      }
+    },
     "Time to Full Charge: %@" : {
       "localizations" : {
         "en" : {
@@ -25581,17 +25592,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Week starts on"
-          }
-        }
-      }
-    },
-    "System Setting" : {
-      "comment" : "Week starts on: follow the macOS system setting (shown with the resolved day in parentheses)",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System Setting"
           }
         }
       }

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -465,16 +465,17 @@ struct NotchHomeView: View {
     
     private var mainContent: some View {
         HStack(alignment: .top, spacing: (shouldShowCamera && Defaults[.showCalendar]) ? 10 : 15) {
-            if(musicManager.isPlaying){
-                MusicPlayerView(
-                    albumArtNamespace: albumArtNamespace,
-                    horizontalMediaGestureFeedback: horizontalMediaGestureFeedback,
-                    isHoveringMusicArea: $isHoveringMusicArea
-                )
-            }else{
-                ExpandedHomeView()
+            VStack{
+                if(coordinator.currentTab == .player){
+                    MusicPlayerView(
+                        albumArtNamespace: albumArtNamespace,
+                        horizontalMediaGestureFeedback: horizontalMediaGestureFeedback,
+                        isHoveringMusicArea: $isHoveringMusicArea
+                    )
+                }else{
+                    ExpandedHomeView()
+                }
             }
-            
             if Defaults[.showCalendar] {
                 CalendarView()
                     .frame(width: shouldShowCamera ? 170 : 215)

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -421,14 +421,18 @@ struct ExpandedHomeView:View{
         VStack{
             Spacer()
             Spacer()
-            Text(Date.now, format: .dateTime.hour().minute())
-                .font(.largeTitle)
-                .bold()
-                .frame(maxWidth: .infinity,alignment: .center)
-                .foregroundStyle(Color.white)
+            TimelineView(.periodic(from: .now, by: 1.0)) { context in
+                Text(Date.now, format: .dateTime.hour().minute())
+                    .font(.largeTitle)
+                    .bold()
+                    .frame(maxWidth: .infinity,alignment: .center)
+                    .foregroundStyle(Color.white)
+            }
             HStack{
-                Text(Date.now, format: .dateTime.weekday(.wide).month(.wide).day())
-                    .font(.title3)
+                TimelineView(.periodic(from: .now, by: 60)) { context in
+                    Text(Date.now, format: .dateTime.weekday(.wide).month(.wide).day())
+                        .font(.title3)
+                }
                 
             }
             .fixedSize(horizontal: false, vertical: true)

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -416,6 +416,30 @@ struct VolumeControlView: View {
         }
     }
 }
+struct ExpandedHomeView:View{
+    var body: some View {
+        VStack{
+            Spacer()
+            Spacer()
+            Text(Date.now, format: .dateTime.hour().minute())
+                .font(.largeTitle)
+                .bold()
+                .frame(maxWidth: .infinity,alignment: .center)
+                .foregroundStyle(Color.white)
+            HStack{
+                Text(Date.now, format: .dateTime.weekday(.wide).month(.wide).day())
+                    .font(.title3)
+                
+            }
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.top, -10)
+            Spacer()
+            Spacer()
+            
+        }
+        
+    }
+}
 
 // MARK: - Main View
 
@@ -424,6 +448,7 @@ struct NotchHomeView: View {
     @ObservedObject var webcamManager = WebcamManager.shared
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @ObservedObject var musicManager = MusicManager.shared
     let albumArtNamespace: Namespace.ID
     let horizontalMediaGestureFeedback: CGFloat
     @Binding var isHoveringMusicArea: Bool
@@ -437,15 +462,19 @@ struct NotchHomeView: View {
     private var shouldShowCamera: Bool {
         Defaults[.showMirror] && webcamManager.cameraAvailable && vm.isCameraExpanded
     }
-
+    
     private var mainContent: some View {
         HStack(alignment: .top, spacing: (shouldShowCamera && Defaults[.showCalendar]) ? 10 : 15) {
-            MusicPlayerView(
-                albumArtNamespace: albumArtNamespace,
-                horizontalMediaGestureFeedback: horizontalMediaGestureFeedback,
-                isHoveringMusicArea: $isHoveringMusicArea
-            )
-
+            if(musicManager.isPlaying){
+                MusicPlayerView(
+                    albumArtNamespace: albumArtNamespace,
+                    horizontalMediaGestureFeedback: horizontalMediaGestureFeedback,
+                    isHoveringMusicArea: $isHoveringMusicArea
+                )
+            }else{
+                ExpandedHomeView()
+            }
+            
             if Defaults[.showCalendar] {
                 CalendarView()
                     .frame(width: shouldShowCamera ? 170 : 215)

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -1,10 +1,3 @@
-//
-//  TabSelectionView.swift
-//  boringNotch
-//
-//  Created by Hugo Persson on 2024-08-25.
-//
-
 import SwiftUI
 
 struct TabModel: Identifiable {
@@ -12,44 +5,85 @@ struct TabModel: Identifiable {
     let label: String
     let icon: String
     let view: NotchViews
+    let homeTab:HomeTabs
 }
 
-let tabs = [
-    TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
-]
-
 struct TabSelectionView: View {
+    var tabs:[TabModel] {
+        if(coordinator.currentView == .shelf){
+            return [
+                TabModel(label: "Home", icon: "house.fill", view: .home, homeTab: .none),
+                TabModel(label: "Shelf", icon: "tray.fill", view: .shelf, homeTab: .none)
+            ]
+        }else{
+            return [
+                TabModel(label: "Clock", icon: "clock.fill", view: .home, homeTab: .clock),
+                TabModel(label: "Player", icon: "music.note", view: .home, homeTab: .player),
+                TabModel(label: "Shelf", icon: "tray.fill", view: .shelf, homeTab: .none)
+            ]
+        }
+    }
+
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     @Namespace var animation
+
     var body: some View {
-        HStack(spacing: 0) {
-            ForEach(tabs) { tab in
-                    TabButton(label: tab.label, icon: tab.icon, selected: coordinator.currentView == tab.view) {
+        ZStack(alignment: .leading) {
+
+            GeometryReader { proxy in
+                let grouped = tabs.enumerated().filter { $0.element.homeTab != .none }
+
+                if let first = grouped.first,
+                   let last = grouped.last {
+
+                    let count = tabs.count
+                    let itemWidth = proxy.size.width / CGFloat(count)
+
+                    let x = CGFloat(first.offset) * itemWidth
+                    let width = CGFloat(Double(last.offset - first.offset)+0.47) * itemWidth
+
+                    Capsule()
+                        .fill(Color.secondary.opacity(0.20))
+                        .frame(width: width, height: 26)
+                        .offset(x: x, y: 0)
+                }
+            }
+            .frame(height: 26)
+
+            HStack(spacing: 0) {
+                ForEach(tabs) { tab in
+                    TabButton(
+                        label: tab.label,
+                        icon: tab.icon,
+                        selected: tab.homeTab != .none
+                            ? (coordinator.currentTab == tab.homeTab)
+                            : (coordinator.currentView == tab.view)
+                    ) {
                         withAnimation(.smooth) {
                             coordinator.currentView = tab.view
+                            if(tab.homeTab != .none){
+                                coordinator.currentTab = tab.homeTab
+                            }
                         }
                     }
                     .frame(height: 26)
                     .foregroundStyle(tab.view == coordinator.currentView ? .white : .gray)
                     .background {
-                        if tab.view == coordinator.currentView {
+                        if (tab.homeTab != .none
+                            ? (coordinator.currentTab == tab.homeTab)
+                            : (coordinator.currentView == tab.view)) {
+
                             Capsule()
-                                .fill(coordinator.currentView == tab.view ? Color(nsColor: .secondarySystemFill) : Color.clear)
+                                .fill(Color(nsColor: .secondarySystemFill))
                                 .matchedGeometryEffect(id: "capsule", in: animation)
                         } else {
                             Capsule()
-                                .fill(coordinator.currentView == tab.view ? Color(nsColor: .secondarySystemFill) : Color.clear)
-                                .matchedGeometryEffect(id: "capsule", in: animation)
+                                .fill(Color.clear)
                                 .hidden()
                         }
                     }
+                }
             }
         }
-        .clipShape(Capsule())
     }
-}
-
-#Preview {
-    BoringHeader().environmentObject(BoringViewModel())
 }

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -26,7 +26,7 @@ struct TabSelectionView: View {
 
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     @Namespace var animation
-
+    
     var body: some View {
         ZStack(alignment: .leading) {
 
@@ -52,12 +52,13 @@ struct TabSelectionView: View {
 
             HStack(spacing: 0) {
                 ForEach(tabs) { tab in
+                    let selected=tab.homeTab != .none
+                    ? (coordinator.currentTab == tab.homeTab)
+                    : (coordinator.currentView == tab.view)
                     TabButton(
                         label: tab.label,
                         icon: tab.icon,
-                        selected: tab.homeTab != .none
-                            ? (coordinator.currentTab == tab.homeTab)
-                            : (coordinator.currentView == tab.view)
+                        selected: selected
                     ) {
                         withAnimation(.smooth) {
                             coordinator.currentView = tab.view
@@ -67,11 +68,10 @@ struct TabSelectionView: View {
                         }
                     }
                     .frame(height: 26)
-                    .foregroundStyle(tab.view == coordinator.currentView ? .white : .gray)
+                    .foregroundStyle(selected ? .white : .gray)
                     .background {
-                        if (tab.homeTab != .none
-                            ? (coordinator.currentTab == tab.homeTab)
-                            : (coordinator.currentView == tab.view)) {
+                        
+                        if (selected) {
 
                             Capsule()
                                 .fill(Color(nsColor: .secondarySystemFill))

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -23,6 +23,17 @@ public enum NotchViews {
     case shelf
 }
 
+public enum HomeTabs {
+    case none
+    case clock
+    case player
+}
+
+public enum TabSelectionType {
+    case main
+    case home
+}
+
 enum DownloadIndicatorStyle: String, Defaults.Serializable {
     case progress = "Progress"
     case percentage = "Percentage"

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -31,7 +31,6 @@ class MusicManager: ObservableObject {
     // Published properties for UI
     @Published var songTitle: String = "I'm Handsome"
     @Published var artistName: String = "Me"
-    @Published var noSongPresented: Bool = true
     @Published var albumArt: NSImage = defaultImage
     @Published var isPlaying = false
     @Published var album: String = "Self Love"

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -31,6 +31,7 @@ class MusicManager: ObservableObject {
     // Published properties for UI
     @Published var songTitle: String = "I'm Handsome"
     @Published var artistName: String = "Me"
+    @Published var noSongPresented: Bool = true
     @Published var albumArt: NSImage = defaultImage
     @Published var isPlaying = false
     @Published var album: String = "Self Love"


### PR DESCRIPTION
Resolves #1364, work in progress 
Adds basic home view with time and date, and places them both in two separate, user-toggleable tabs. 
This is my first PR, so feel free to point out anything I should fix/change!

<img width="756" height="491" alt="Screenshot 2026-07-02 at 10 34 45 PM" src="https://github.com/user-attachments/assets/fad8f1cc-93e4-426d-8704-3e26cad579ec" />

