### PR TITLE
feat: add calendar activity indicator dots below dates (Fixes #1368)

### DIFF
--- a/boringNotch/components/Calendar/BoringCalendar.swift
+++ b/boringNotch/components/Calendar/BoringCalendar.swift
@@ -21,6 +21,7 @@ struct Config: Equatable {
 /// The default scrolling day "dial": a horizontal strip of days centered on the selection.
 struct WheelPicker: View {
     @EnvironmentObject var vm: BoringViewModel
+    @ObservedObject private var calendarManager = CalendarManager.shared
     @Binding var selectedDate: Date
     @State private var scrollPosition: Int?
     @State private var haptics: Bool = false
@@ -148,10 +149,25 @@ struct WheelPicker: View {
         date: Date, isSelected: Bool, id: Int, onClick: @escaping () -> Void
     ) -> some View {
         let isToday = Calendar.current.isDateInToday(date)
+        let indicatorColors = calendarManager.indicatorEvents[Calendar.current.startOfDay(for: date)] ?? []
         return Button(action: onClick) {
             VStack(spacing: 8) {
                 dayText(date: dateToString(for: date), isToday: isToday, isSelected: isSelected)
-                dateCircle(date: date, isToday: isToday, isSelected: isSelected)
+                VStack(spacing: 4) {
+                    dateCircle(date: date, isToday: isToday, isSelected: isSelected)
+                    HStack(spacing: 2) {
+                        if indicatorColors.isEmpty {
+                            Circle().fill(Color.clear).frame(width: 3, height: 3)
+                        } else {
+                            ForEach(0..<indicatorColors.count, id: \.self) { i in
+                                Circle()
+                                    .fill(indicatorColors[i])
+                                    .frame(width: 3, height: 3)
+                            }
+                        }
+                    }
+                    .frame(height: 3)
+                }
             }
             .padding(.vertical, 4)
             .padding(.horizontal, 4)

--- a/boringNotch/managers/CalendarManager.swift
+++ b/boringNotch/managers/CalendarManager.swift
@@ -17,6 +17,7 @@ class CalendarManager: ObservableObject {
 
     @Published var currentWeekStartDate: Date
     @Published var events: [EventModel] = []
+    @Published var indicatorEvents: [Date: [Color]] = [:]
     @Published var allCalendars: [CalendarModel] = []
     @Published var eventCalendars: [CalendarModel] = []
     @Published var reminderLists: [CalendarModel] = []
@@ -191,14 +192,46 @@ class CalendarManager: ObservableObject {
             calendars: calendarIDs
         )
         self.events = eventsResult
+        
+        let indicatorStart = Calendar.current.date(byAdding: .day, value: -14, to: currentWeekStartDate)!
+        let indicatorEnd = Calendar.current.date(byAdding: .day, value: 30, to: currentWeekStartDate)!
+        
+        let indicatorEventsResult = await calendarService.events(
+            from: indicatorStart,
+            to: indicatorEnd,
+            calendars: calendarIDs
+        )
+        
+        var newIndicators: [Date: [Color]] = [:]
+        for event in indicatorEventsResult {
+            if event.type.isReminder {
+                if case .reminder(let completed) = event.type {
+                    if completed && Defaults[.hideCompletedReminders] { continue }
+                }
+            }
+            if event.isAllDay && Defaults[.hideAllDayEvents] { continue }
+            
+            let color = Color(event.calendar.color)
+            
+            var currentDate = Calendar.current.startOfDay(for: event.start)
+            let endDate = Calendar.current.startOfDay(for: event.end)
+            
+            while currentDate <= endDate {
+                if newIndicators[currentDate] == nil {
+                    newIndicators[currentDate] = []
+                }
+                if !newIndicators[currentDate]!.contains(color) && newIndicators[currentDate]!.count < 4 {
+                    newIndicators[currentDate]!.append(color)
+                }
+                currentDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate)!
+            }
+        }
+        self.indicatorEvents = newIndicators
     }
     
     func setReminderCompleted(reminderID: String, completed: Bool) async {
         await calendarService.setReminderCompleted(reminderID: reminderID, completed: completed)
         // Refresh events after updating
-        events = await calendarService.events(
-            from: currentWeekStartDate,
-            to: Calendar.current.date(byAdding: .day, value: 1, to: currentWeekStartDate)!,
-            calendars: selectedCalendars.map { $0.id })
+        await updateEvents()
     }
 }


### PR DESCRIPTION
## What?
This PR implements the calendar activity indicator feature proposed in #1368 (inspired by [Itsycal](https://github.com/sfsam/Itsycal)). It adds small colored bullet points beneath the days in the calendar picker to indicate scheduled activities.

## How?
* Updated `CalendarManager` to fetch a broader date range (14 days past to 30 days future) to compute indicators for all visible days in the picker efficiently.
* Event dots are colored dynamically based on their respective calendar `NSColor`.
* Capped the indicators at a maximum of 4 distinct colors per day to prevent UI overflow while still providing a clear overview.
* Handled filtering so all-day events or completed reminders are appropriately omitted from the indicators if the user has disabled them in settings.
* Added placeholders for days without events to ensure strict vertical alignment in the picker.

## Screenshots
<img width="658" height="236" alt="SCR-20260703-mpsv" src="https://github.com/user-attachments/assets/a9facd00-0142-4957-9397-3dcff30d6861" />
<img width="661" height="235" alt="SCR-20260703-mqac" src="https://github.com/user-attachments/assets/b859e060-38ab-4bcd-aab1-fa14ef9503ba" />
