### PR TITLE
Fix inconsistent tab switch animation

### DIFF
--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -430,7 +430,6 @@ struct NotchHomeView: View {
 
     var body: some View {
         mainContent
-            // simplified: use a straightforward opacity transition
             .transition(.opacity)
     }
 
@@ -464,7 +463,7 @@ struct NotchHomeView: View {
                     .animation(.interactiveSpring(response: 0.32, dampingFraction: 0.76, blendDuration: 0), value: shouldShowCamera)
             }
         }
-        .transition(.asymmetric(insertion: .opacity.combined(with: .move(edge: .top)), removal: .opacity))
+        .transition(.opacity)
         .blur(radius: vm.notchState == .closed ? 30 : 0)
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #1392
- Home → shelf already faded, but shelf → home slid in from the top because `NotchHomeView` used an asymmetric transition (opacity + move on insert, opacity only on remove).
- Both directions now use a plain `.opacity` transition so tab switches fade consistently.

## Test plan
- [ ] Open the notch with shelf enabled and tabs visible
- [ ] Switch Home → Shelf and confirm contents fade
- [ ] Switch Shelf → Home and confirm contents fade (no slide from top)
- [ ] Repeat a few times to confirm both directions stay consistent