### PR TITLE
Fix shelf file drag-and-drop into WhatsApp

### DIFF
--- a/boringNotch/components/Shelf/Views/ShelfItemView.swift
+++ b/boringNotch/components/Shelf/Views/ShelfItemView.swift
@@ -245,7 +245,7 @@ private struct DraggableClickHandler<Content: View>: NSViewRepresentable {
             var draggingItems: [NSDraggingItem] = []
 
             for dragItem in itemsToDrag {
-                if let pasteboardWriter = createPasteboardItem(for: dragItem) {
+                if let pasteboardWriter = pasteboardWriter(for: dragItem) {
                     let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardWriter)
 
                     // Use the drag preview image - generated on demand
@@ -267,7 +267,7 @@ private struct DraggableClickHandler<Content: View>: NSViewRepresentable {
             beginDraggingSession(with: draggingItems, event: event, source: self)
         }
         
-        private func createPasteboardItem(for item: ShelfItem) -> NSPasteboardWriting? {
+        private func pasteboardWriter(for item: ShelfItem) -> (any NSPasteboardWriting)? {
             switch item.kind {
             case .file:
                 guard let url = ShelfStateViewModel.shared.resolveAndUpdateBookmark(for: item) else {
@@ -282,9 +282,6 @@ private struct DraggableClickHandler<Content: View>: NSViewRepresentable {
                     NSLog("🔐 Started security-scoped access for drag: \(url.path)")
                 }
 
-                // Write the URL object itself (not a string) so file-aware receivers,
-                // such as WhatsApp, see a real file promise instead of falling back
-                // to the plain-text path.
                 return url as NSURL
 
             case .text(let string):

--- a/boringNotch/components/Shelf/Views/ShelfItemView.swift
+++ b/boringNotch/components/Shelf/Views/ShelfItemView.swift
@@ -245,8 +245,8 @@ private struct DraggableClickHandler<Content: View>: NSViewRepresentable {
             var draggingItems: [NSDraggingItem] = []
 
             for dragItem in itemsToDrag {
-                if let pasteboardItem = createPasteboardItem(for: dragItem) {
-                    let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
+                if let pasteboardWriter = createPasteboardItem(for: dragItem) {
+                    let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardWriter)
 
                     // Use the drag preview image - generated on demand
                     let image = getDragPreview?() ?? dragItem.icon
@@ -267,31 +267,33 @@ private struct DraggableClickHandler<Content: View>: NSViewRepresentable {
             beginDraggingSession(with: draggingItems, event: event, source: self)
         }
         
-        private func createPasteboardItem(for item: ShelfItem) -> NSPasteboardItem? {
-            let pasteboardItem = NSPasteboardItem()
-
+        private func createPasteboardItem(for item: ShelfItem) -> NSPasteboardWriting? {
             switch item.kind {
             case .file:
                 guard let url = ShelfStateViewModel.shared.resolveAndUpdateBookmark(for: item) else {
-                    pasteboardItem.setString(item.displayName, forType: .string)
-                    return pasteboardItem
+                    let fallback = NSPasteboardItem()
+                    fallback.setString(item.displayName, forType: .string)
+                    return fallback
                 }
-                
+
                 // Start accessing security-scoped resource and keep it active during drag
                 if url.startAccessingSecurityScopedResource() {
                     draggedURLs.append(url)
                     NSLog("🔐 Started security-scoped access for drag: \(url.path)")
                 }
-                
-                pasteboardItem.setString(url.absoluteString, forType: .fileURL)
-                pasteboardItem.setString(url.path, forType: .string)
-                return pasteboardItem
+
+                // Write the URL object itself (not a string) so file-aware receivers,
+                // such as WhatsApp, see a real file promise instead of falling back
+                // to the plain-text path.
+                return url as NSURL
 
             case .text(let string):
+                let pasteboardItem = NSPasteboardItem()
                 pasteboardItem.setString(string, forType: .string)
                 return pasteboardItem
 
             case .link(let url):
+                let pasteboardItem = NSPasteboardItem()
                 pasteboardItem.setString(url.absoluteString, forType: .URL)
                 pasteboardItem.setString(url.absoluteString, forType: .string)
                 return pasteboardItem


### PR DESCRIPTION
Dragging a file out of the shelf into WhatsApp inserted the file's path as text instead of attaching the file.

The drag payload wrote the file URL as a string alongside a plain-text path, so apps like WhatsApp picked up the path text. It now writes the URL itself, matching the shelf's Copy behavior, so the actual file is attached.

Fixes https://github.com/TheBoredTeam/boring.notch/issues/1312



https://github.com/user-attachments/assets/b0b7687f-482c-46bb-a09c-de3db5434d81



