### PR TITLE
Refactor closed notch rendering into extensible regions

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C70000012F00000100000001 /* ClosedNotchRenderSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70000022F00000100000002 /* ClosedNotchRenderSnapshot.swift */; };
+		C50000012F00000100000001 /* ClosedNotchRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50000022F00000100000002 /* ClosedNotchRenderer.swift */; };
+		C40000012F00000100000001 /* MusicLiveActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40000032F00000100000003 /* MusicLiveActivityView.swift */; };
+		C40000022F00000100000002 /* IdleNotchFaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40000042F00000100000004 /* IdleNotchFaceView.swift */; };
+		C30000012F00000100000001 /* ClosedNotchLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30000032F00000100000003 /* ClosedNotchLayout.swift */; };
+		C30000022F00000100000002 /* OpenNotchContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30000042F00000100000004 /* OpenNotchContentView.swift */; };
+		C20000012F00000100000001 /* ClosedNotchPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000022F00000100000002 /* ClosedNotchPresentation.swift */; };
 		1100290C2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1100290B2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift */; };
 		110029272E84FD4C00035A57 /* TemporaryFileStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110029262E84FD4C00035A57 /* TemporaryFileStorageService.swift */; };
 		1100292A2E8691B400035A57 /* FileShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110029292E8691B400035A57 /* FileShareView.swift */; };
@@ -196,6 +203,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		C70000022F00000100000002 /* ClosedNotchRenderSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedNotchRenderSnapshot.swift; sourceTree = "<group>"; };
+		C50000022F00000100000002 /* ClosedNotchRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedNotchRenderer.swift; sourceTree = "<group>"; };
+		C40000032F00000100000003 /* MusicLiveActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicLiveActivityView.swift; sourceTree = "<group>"; };
+		C40000042F00000100000004 /* IdleNotchFaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleNotchFaceView.swift; sourceTree = "<group>"; };
+		C30000032F00000100000003 /* ClosedNotchLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedNotchLayout.swift; sourceTree = "<group>"; };
+		C30000042F00000100000004 /* OpenNotchContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenNotchContentView.swift; sourceTree = "<group>"; };
+		C20000022F00000100000002 /* ClosedNotchPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedNotchPresentation.swift; sourceTree = "<group>"; };
 		1100290B2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSItemProvider+LoadHelpers.swift"; sourceTree = "<group>"; };
 		110029262E84FD4C00035A57 /* TemporaryFileStorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryFileStorageService.swift; sourceTree = "<group>"; };
 		110029292E8691B400035A57 /* FileShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileShareView.swift; sourceTree = "<group>"; };
@@ -799,6 +813,13 @@
 		B186542F2C6F455E000B926A /* Notch */ = {
 			isa = PBXGroup;
 			children = (
+				C70000022F00000100000002 /* ClosedNotchRenderSnapshot.swift */,
+				C50000022F00000100000002 /* ClosedNotchRenderer.swift */,
+				C40000032F00000100000003 /* MusicLiveActivityView.swift */,
+				C40000042F00000100000004 /* IdleNotchFaceView.swift */,
+				C30000032F00000100000003 /* ClosedNotchLayout.swift */,
+				C30000042F00000100000004 /* OpenNotchContentView.swift */,
+				C20000022F00000100000002 /* ClosedNotchPresentation.swift */,
 				1194E8862EA6DDA7009C82D6 /* BoringNotchSkyLightWindow.swift */,
 				1160F8D72DD98230006FBB94 /* NotchShape.swift */,
 				9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */,
@@ -990,6 +1011,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C70000012F00000100000001 /* ClosedNotchRenderSnapshot.swift in Sources */,
+				C50000012F00000100000001 /* ClosedNotchRenderer.swift in Sources */,
+				C40000012F00000100000001 /* MusicLiveActivityView.swift in Sources */,
+				C40000022F00000100000002 /* IdleNotchFaceView.swift in Sources */,
+				C30000012F00000100000001 /* ClosedNotchLayout.swift in Sources */,
+				C30000022F00000100000002 /* OpenNotchContentView.swift in Sources */,
+				C20000012F00000100000001 /* ClosedNotchPresentation.swift in Sources */,
 				115C12EC2ED3D003009754CA /* OpenNotchOSD.swift in Sources */,
 				14C08BB92C8DE4B1000F8AA0 /* BoringCalendar.swift in Sources */,
 				5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -17,13 +17,12 @@ import SwiftUIIntrospect
 @MainActor
 struct ContentView: View {
     @EnvironmentObject var vm: BoringViewModel
-    @ObservedObject var webcamManager = WebcamManager.shared
-
     @ObservedObject var coordinator = BoringViewCoordinator.shared
-    @ObservedObject var musicManager = MusicManager.shared
-    @ObservedObject var brightnessManager = BrightnessManager.shared
-    @ObservedObject var volumeManager = VolumeManager.shared
-    @ObservedObject var batteryModel = BatteryStatusViewModel.shared
+
+    private let musicManager = MusicManager.shared
+    private let batteryModel = BatteryStatusViewModel.shared
+
+    @State private var closedSnapshotRevision = 0
     @State private var hoverTask: Task<Void, Never>?
     @State private var isHovering: Bool = false
     @State private var anyDropDebounceTask: Task<Void, Never>?
@@ -86,6 +85,7 @@ struct ContentView: View {
     }
 
     private func makeClosedNotchSnapshot() -> ClosedNotchRenderSnapshot {
+        _ = closedSnapshotRevision
         let displayHeight = displayClosedNotchHeight
         let cornerScale: CGFloat? = Defaults[.cornerRadiusScaling] && displayHeight > 0
             ? displayHeight / 38
@@ -120,6 +120,20 @@ struct ContentView: View {
         let batteryNotificationVisible = coordinator.expandingView.type == .battery
             && coordinator.expandingView.show
             && Defaults[.showPowerStatusNotifications]
+        let inlineOSDVisible = sneakPeekVisible
+            && Defaults[.inlineOSD]
+            && sneakPeek.type != .music
+            && sneakPeek.type != .battery
+        let musicVisible = (!coordinator.expandingView.show
+            || coordinator.expandingView.type == .music)
+            && (musicManager.isPlaying || !musicManager.isPlayerIdle)
+            && coordinator.musicLiveActivityEnabled
+            && !vm.hideOnClosed
+        let idleFaceVisible = !coordinator.expandingView.show
+            && !musicManager.isPlaying
+            && musicManager.isPlayerIdle
+            && Defaults[.showNotHumanFace]
+            && !vm.hideOnClosed
 
         let supplemental: ClosedNotchSupplementalPresentation?
         if sneakPeekVisible,
@@ -149,21 +163,13 @@ struct ContentView: View {
             batteryLeadingWidth: batteryNotificationVisible
                 ? renderData.battery.leadingWidth
                 : 0,
-            batteryNotificationVisible: batteryNotificationVisible,
-            inlineOSDVisible: sneakPeekVisible
-                && Defaults[.inlineOSD]
-                && sneakPeek.type != .music
-                && sneakPeek.type != .battery,
-            musicVisible: (!coordinator.expandingView.show
-                || coordinator.expandingView.type == .music)
-                && (musicManager.isPlaying || !musicManager.isPlayerIdle)
-                && coordinator.musicLiveActivityEnabled
-                && !vm.hideOnClosed,
-            idleFaceVisible: !coordinator.expandingView.show
-                && !musicManager.isPlaying
-                && musicManager.isPlayerIdle
-                && Defaults[.showNotHumanFace]
-                && !vm.hideOnClosed,
+            candidates: [
+                .init(.batteryNotification, isVisible: batteryNotificationVisible),
+                .init(.inlineOSD, isVisible: inlineOSDVisible),
+                .init(.music, isVisible: musicVisible),
+                .init(.idleFace, isVisible: idleFaceVisible),
+                .init(.idle, isVisible: true)
+            ],
             musicExpanded: musicExpanded,
             supplemental: supplemental
         )
@@ -324,6 +330,12 @@ struct ContentView: View {
         .background(dragDetector)
         .preferredColorScheme(.dark)
         .environmentObject(vm)
+        .onReceive(musicManager.objectWillChange) { _ in
+            invalidateClosedSnapshot()
+        }
+        .onReceive(batteryModel.objectWillChange) { _ in
+            invalidateClosedSnapshot()
+        }
         .onChange(of: vm.anyDropZoneTargeting) { _, isTargeted in
             anyDropDebounceTask?.cancel()
 
@@ -351,6 +363,11 @@ struct ContentView: View {
                 }
             }
         }
+    }
+
+    private func invalidateClosedSnapshot() {
+        guard vm.notchState == .closed else { return }
+        closedSnapshotRevision &+= 1
     }
 
     @ViewBuilder

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -6,18 +6,15 @@
 //  Modified by Richard Kunkli on 24/08/2024.
 //
 
-import AVFoundation
 import AppKit
 import Combine
 import Defaults
-import KeyboardShortcuts
 import SwiftUI
-import SwiftUIIntrospect
 
 @MainActor
 struct ContentView: View {
-    @EnvironmentObject var vm: BoringViewModel
-    @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @EnvironmentObject private var vm: BoringViewModel
+    @ObservedObject private var coordinator = BoringViewCoordinator.shared
 
     private let musicManager = MusicManager.shared
     private let batteryModel = BatteryStatusViewModel.shared
@@ -34,9 +31,9 @@ struct ContentView: View {
 
     @State private var haptics: Bool = false
 
-    @Namespace var albumArtNamespace
+    @Namespace private var albumArtNamespace
 
-    @Default(.showNotHumanFace) var showNotHumanFace
+    @Default(.showNotHumanFace) private var showNotHumanFace
 
     // Use standardized animations from StandardAnimations enum
     private let animationSpring = StandardAnimations.interactive
@@ -45,35 +42,13 @@ struct ContentView: View {
     private let zeroHeightHoverPadding: CGFloat = 10
 
     private func topCornerRadius(for snapshot: ClosedNotchRenderSnapshot?) -> CGFloat {
-        guard let snapshot else { return cornerRadiusInsets.opened.top }
-
-        let baseClosedTop = cornerRadiusInsets.closed.top
-        guard let scaleFactor = snapshot.cornerRadiusScaleFactor else {
-            return snapshot.displayHeight > 0 ? baseClosedTop : 0
-        }
-        return max(0, baseClosedTop * scaleFactor)
+        snapshot?.topCornerRadius ?? cornerRadiusInsets.opened.top
     }
 
     private func currentNotchShape(for snapshot: ClosedNotchRenderSnapshot?) -> NotchShape {
-        guard let snapshot else {
-            return NotchShape(
-                topCornerRadius: cornerRadiusInsets.opened.top,
-                bottomCornerRadius: cornerRadiusInsets.opened.bottom
-            )
-        }
-
-        let baseClosedBottom = cornerRadiusInsets.closed.bottom
-        let bottomCorner: CGFloat
-
-        if let scaleFactor = snapshot.cornerRadiusScaleFactor {
-            bottomCorner = max(0, baseClosedBottom * scaleFactor)
-        } else {
-            bottomCorner = snapshot.displayHeight > 0 ? baseClosedBottom : 0
-        }
-
-        return NotchShape(
-            topCornerRadius: topCornerRadius(for: snapshot),
-            bottomCornerRadius: bottomCorner
+        snapshot?.notchShape ?? NotchShape(
+            topCornerRadius: cornerRadiusInsets.opened.top,
+            bottomCornerRadius: cornerRadiusInsets.opened.bottom
         )
     }
 
@@ -84,16 +59,15 @@ struct ContentView: View {
         isNotchHeightZero ? 10 : vm.effectiveClosedNotchHeight
     }
 
+    private var gestureScale: CGFloat {
+        guard gestureProgress != 0 else { return 1 }
+        return max(0.6, 1 + gestureProgress * 0.01)
+    }
+
     private func makeClosedNotchSnapshot() -> ClosedNotchRenderSnapshot {
         _ = closedSnapshotRevision
         let displayHeight = displayClosedNotchHeight
-        let cornerScale: CGFloat? = Defaults[.cornerRadiusScaling] && displayHeight > 0
-            ? displayHeight / 38
-            : nil
-        let albumArtWidth = max(0, displayHeight - 12 * (cornerScale ?? 1))
-        let spectrumWidth = max(0, displayHeight - 12 + gestureProgress / 2)
         let sneakPeek = coordinator.sneakPeekState(for: vm.screenUUID)
-        let sneakPeekVisible = coordinator.shouldShowSneakPeek(on: vm.screenUUID)
         let renderData = ClosedNotchRenderData(
             music: .init(
                 albumArt: musicManager.albumArt,
@@ -112,93 +86,39 @@ struct ContentView: View {
             ),
             osd: coordinator.binding(for: vm.screenUUID)
         )
-        let musicExpanded = coordinator.expandingView.show
-            && coordinator.expandingView.type == .music
-            && Defaults[.sneakPeekStyles] == .inline
-        let inlineSideWidth = max(0, 100 - (isHovering ? 0 : 12) + gestureProgress / 2)
-        let faceTrailingWidth = 20 + 30 * min(1, displayHeight / 30)
-        let batteryNotificationVisible = coordinator.expandingView.type == .battery
-            && coordinator.expandingView.show
-            && Defaults[.showPowerStatusNotifications]
-        let inlineOSDVisible = sneakPeekVisible
-            && Defaults[.inlineOSD]
-            && sneakPeek.type != .music
-            && sneakPeek.type != .battery
-        let musicVisible = (!coordinator.expandingView.show
-            || coordinator.expandingView.type == .music)
-            && (musicManager.isPlaying || !musicManager.isPlayerIdle)
-            && coordinator.musicLiveActivityEnabled
-            && !vm.hideOnClosed
-        let idleFaceVisible = !coordinator.expandingView.show
-            && !musicManager.isPlaying
-            && musicManager.isPlayerIdle
-            && Defaults[.showNotHumanFace]
-            && !vm.hideOnClosed
 
-        let supplemental: ClosedNotchSupplementalPresentation?
-        if sneakPeekVisible,
-           sneakPeek.type != .music,
-           sneakPeek.type != .battery,
-           !Defaults[.inlineOSD] {
-            supplemental = .systemOSD
-        } else if sneakPeekVisible,
-                  sneakPeek.type == .music,
-                  !vm.hideOnClosed,
-                  Defaults[.sneakPeekStyles] == .standard {
-            supplemental = .music
-        } else {
-            supplemental = nil
-        }
-
-        let presentationInput = ClosedNotchPresentationInput(
+        let context = ClosedNotchSnapshotContext(
             closedNotchWidth: vm.closedNotchSize.width,
-            height: displayHeight,
+            displayHeight: displayHeight,
             idleHeight: vm.hasNotch ? displayHeight : 11,
-            inlineOSDHeight: displayHeight + (isHovering ? 8 : 0),
-            inlineSideWidth: inlineSideWidth,
-            albumArtWidth: albumArtWidth,
-            spectrumWidth: spectrumWidth,
-            expandedMusicCenterWidth: 380,
-            idleFaceTrailingWidth: faceTrailingWidth,
-            batteryLeadingWidth: batteryNotificationVisible
-                ? renderData.battery.leadingWidth
-                : 0,
-            candidates: [
-                .init(.batteryNotification, isVisible: batteryNotificationVisible),
-                .init(.inlineOSD, isVisible: inlineOSDVisible),
-                .init(.music, isVisible: musicVisible),
-                .init(.idleFace, isVisible: idleFaceVisible),
-                .init(.idle, isVisible: true)
-            ],
-            musicExpanded: musicExpanded,
-            supplemental: supplemental
+            isHovering: isHovering,
+            gestureProgress: gestureProgress,
+            hideOnClosed: vm.hideOnClosed,
+            showIdleFace: showNotHumanFace,
+            musicLiveActivityEnabled: coordinator.musicLiveActivityEnabled,
+            musicPlayerIdle: musicManager.isPlayerIdle,
+            expandingViewVisible: coordinator.expandingView.show,
+            expandingViewType: coordinator.expandingView.type,
+            sneakPeek: sneakPeek,
+            sneakPeekVisible: coordinator.shouldShowSneakPeek(on: vm.screenUUID),
+            cornerRadiusScalingEnabled: Defaults[.cornerRadiusScaling],
+            inlineOSDEnabled: Defaults[.inlineOSD],
+            powerStatusNotificationsEnabled: Defaults[.showPowerStatusNotifications],
+            sneakPeekStyle: Defaults[.sneakPeekStyles],
+            renderData: renderData
         )
 
-        return ClosedNotchRenderSnapshot(
-            presentationInput: presentationInput,
-            renderData: renderData,
-            displayHeight: displayHeight,
-            cornerRadiusScaleFactor: cornerScale,
-            albumArtWidth: albumArtWidth,
-            spectrumWidth: spectrumWidth
-        )
+        return ClosedNotchRenderSnapshot(context: context)
     }
 
     var body: some View {
         let closedSnapshot: ClosedNotchRenderSnapshot? = vm.notchState == .closed
             ? makeClosedNotchSnapshot()
             : nil
-
-        // Calculate scale based on gesture progress only
-        let gestureScale: CGFloat = {
-            guard gestureProgress != 0 else { return 1.0 }
-            let scaleFactor = 1.0 + gestureProgress * 0.01
-            return max(0.6, scaleFactor)
-        }()
         
         ZStack(alignment: .top) {
             VStack(spacing: 0) {
-                let mainLayout = NotchLayout(closedSnapshot: closedSnapshot)
+                let mainLayout = notchLayout(closedSnapshot: closedSnapshot)
                     .frame(alignment: .top)
                     .padding(
                         .horizontal,
@@ -208,27 +128,28 @@ struct ContentView: View {
                     .padding([.horizontal, .bottom], vm.notchState == .open ? 12 : 0)
                     .background(.black)
                     .clipShape(currentNotchShape(for: closedSnapshot))
-                          .overlay(alignment: .top) {
-                              closedSnapshot?.displayHeight.isZero == true ? nil
-                        : Rectangle()
-                            .fill(.black)
-                            .frame(height: 1)
-                            .padding(.horizontal, topCornerRadius(for: closedSnapshot))
+                    .overlay(alignment: .top) {
+                        closedSnapshot?.displayHeight.isZero == true ? nil
+                            : Rectangle()
+                                .fill(.black)
+                                .frame(height: 1)
+                                .padding(.horizontal, topCornerRadius(for: closedSnapshot))
                     }
                     .shadow(
                         color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow])
                             ? .black.opacity(0.7) : .clear, radius: 6
                     )
-                    // Removed conditional bottom padding when using custom 0 notch to keep layout stable
                     .opacity((isNotchHeightZero && vm.notchState == .closed) ? 0.01 : 1)
                 
                 mainLayout
                     .frame(height: vm.notchState == .open ? vm.notchSize.height : nil)
-                    .conditionalModifier(true) { view in
-                        return view
-                            .animation(vm.notchState == .open ? StandardAnimations.open : StandardAnimations.close, value: vm.notchState)
-                            .animation(.smooth, value: gestureProgress)
-                    }
+                    .animation(
+                        vm.notchState == .open
+                            ? StandardAnimations.open
+                            : StandardAnimations.close,
+                        value: vm.notchState
+                    )
+                    .animation(.smooth, value: gestureProgress)
                     .contentShape(Rectangle())
                     .onHover { hovering in
                         handleHover(hovering)
@@ -259,16 +180,7 @@ struct ContentView: View {
                     }
                     .onReceive(NotificationCenter.default.publisher(for: .sharingDidFinish)) { _ in
                         if vm.notchState == .open && !isHovering && !vm.isBatteryPopoverActive {
-                            hoverTask?.cancel()
-                            hoverTask = Task {
-                                try? await Task.sleep(for: .milliseconds(100))
-                                guard !Task.isCancelled else { return }
-                                await MainActor.run {
-                                    if self.vm.notchState == .open && !self.isHovering && !self.vm.isBatteryPopoverActive && !SharingStateManager.shared.preventNotchClose {
-                                        self.vm.close()
-                                    }
-                                }
-                            }
+                            scheduleAutomaticClose()
                         }
                     }
                     .onChange(of: vm.notchState) { _, newState in
@@ -280,16 +192,7 @@ struct ContentView: View {
                     }
                     .onChange(of: vm.isBatteryPopoverActive) {
                         if !vm.isBatteryPopoverActive && !isHovering && vm.notchState == .open && !SharingStateManager.shared.preventNotchClose {
-                            hoverTask?.cancel()
-                            hoverTask = Task {
-                                try? await Task.sleep(for: .milliseconds(100))
-                                guard !Task.isCancelled else { return }
-                                await MainActor.run {
-                                    if !self.vm.isBatteryPopoverActive && !self.isHovering && self.vm.notchState == .open && !SharingStateManager.shared.preventNotchClose {
-                                        self.vm.close()
-                                    }
-                                }
-                            }
+                            scheduleAutomaticClose()
                         }
                     }
                     .sensoryFeedback(.alignment, trigger: haptics)
@@ -300,11 +203,6 @@ struct ContentView: View {
                             }
                         }
                         .keyboardShortcut(KeyEquivalent(","), modifiers: .command)
-                        //                    Button("Edit") { // Doesnt work....
-                        //                        let dn = DynamicNotch(content: EditPanelView())
-                        //                        dn.toggle()
-                        //                    }
-                        //                    .keyboardShortcut("E", modifiers: .command)
                     }
                 if vm.chinHeight > 0 {
                     Rectangle()
@@ -371,7 +269,7 @@ struct ContentView: View {
     }
 
     @ViewBuilder
-    func NotchLayout(closedSnapshot: ClosedNotchRenderSnapshot?) -> some View {
+    private func notchLayout(closedSnapshot: ClosedNotchRenderSnapshot?) -> some View {
         VStack(alignment: .leading) {
             VStack(alignment: .leading) {
                 if coordinator.helloAnimationRunning {
@@ -384,21 +282,19 @@ struct ContentView: View {
                     )
                     .padding(.top, 40)
                     Spacer()
+                } else if let closedSnapshot {
+                    ClosedNotchRenderer(
+                        snapshot: closedSnapshot,
+                        albumArtNamespace: albumArtNamespace
+                    )
                 } else {
-                    if let closedSnapshot {
-                        ClosedNotchRenderer(
-                            snapshot: closedSnapshot,
-                            albumArtNamespace: albumArtNamespace
+                    BoringHeader()
+                        .frame(height: max(24, displayClosedNotchHeight))
+                        .opacity(
+                            gestureProgress == 0
+                                ? 1
+                                : 1 - min(abs(gestureProgress) * 0.1, 0.3)
                         )
-                    } else {
-                        BoringHeader()
-                            .frame(height: max(24, displayClosedNotchHeight))
-                            .opacity(
-                                gestureProgress == 0
-                                    ? 1
-                                    : 1 - min(abs(gestureProgress) * 0.1, 0.3)
-                            )
-                    }
                 }
             }
             .zIndex(1)
@@ -416,16 +312,19 @@ struct ContentView: View {
     }
 
     @ViewBuilder
-    var dragDetector: some View {
+    private var dragDetector: some View {
         if Defaults[.boringShelf] && vm.notchState == .closed {
             Color.clear
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .contentShape(Rectangle())
-        .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], isTargeted: $vm.dragDetectorTargeting) { providers in
-            vm.dropEvent = true
-            ShelfStateViewModel.shared.load(providers)
-            return true
-        }
+                .onDrop(
+                    of: [.fileURL, .url, .utf8PlainText, .plainText, .data],
+                    isTargeted: $vm.dragDetectorTargeting
+                ) { providers in
+                    vm.dropEvent = true
+                    ShelfStateViewModel.shared.load(providers)
+                    return true
+                }
         } else {
             EmptyView()
         }
@@ -472,19 +371,31 @@ struct ContentView: View {
                 }
             }
         } else {
-            hoverTask = Task {
-                try? await Task.sleep(for: .milliseconds(100))
-                guard !Task.isCancelled else { return }
-                
-                await MainActor.run {
-                    withAnimation(animationSpring) {
-                        self.isHovering = false
-                    }
-                    
-                    if self.vm.notchState == .open && !self.vm.isBatteryPopoverActive && !SharingStateManager.shared.preventNotchClose {
-                        self.vm.close()
-                    }
+            scheduleAutomaticClose(clearingHover: true)
+        }
+    }
+
+    private var canAutomaticallyClose: Bool {
+        vm.notchState == .open
+            && !isHovering
+            && !vm.isBatteryPopoverActive
+            && !SharingStateManager.shared.preventNotchClose
+    }
+
+    private func scheduleAutomaticClose(clearingHover: Bool = false) {
+        hoverTask?.cancel()
+        hoverTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(100))
+            guard !Task.isCancelled else { return }
+
+            if clearingHover {
+                withAnimation(animationSpring) {
+                    isHovering = false
                 }
+            }
+
+            if canAutomaticallyClose {
+                vm.close()
             }
         }
     }
@@ -624,9 +535,8 @@ struct ContentView: View {
     }
 }
 
-struct FullScreenDropDelegate: DropDelegate {
+private struct GeneralDropTargetDelegate: DropDelegate {
     @Binding var isTargeted: Bool
-    let onDrop: () -> Void
 
     func dropEntered(info _: DropInfo) {
         isTargeted = true
@@ -636,31 +546,12 @@ struct FullScreenDropDelegate: DropDelegate {
         isTargeted = false
     }
 
+    func dropUpdated(info _: DropInfo) -> DropProposal? {
+        DropProposal(operation: .cancel)
+    }
+
     func performDrop(info _: DropInfo) -> Bool {
-        isTargeted = false
-        onDrop()
-        return true
-    }
-
-}
-
-struct GeneralDropTargetDelegate: DropDelegate {
-    @Binding var isTargeted: Bool
-
-    func dropEntered(info: DropInfo) {
-        isTargeted = true
-    }
-
-    func dropExited(info: DropInfo) {
-        isTargeted = false
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        return DropProposal(operation: .cancel)
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        return false
+        false
     }
 }
 

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -7,6 +7,7 @@
 //
 
 import AVFoundation
+import AppKit
 import Combine
 import Defaults
 import KeyboardShortcuts
@@ -20,9 +21,9 @@ struct ContentView: View {
 
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     @ObservedObject var musicManager = MusicManager.shared
-    @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var brightnessManager = BrightnessManager.shared
     @ObservedObject var volumeManager = VolumeManager.shared
+    @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @State private var hoverTask: Task<Void, Never>?
     @State private var isHovering: Bool = false
     @State private var anyDropDebounceTask: Task<Void, Never>?
@@ -44,76 +45,144 @@ struct ContentView: View {
     private let extendedHoverPadding: CGFloat = 30
     private let zeroHeightHoverPadding: CGFloat = 10
 
-    // MARK: - Corner Radius Scaling
-    private var cornerRadiusScaleFactor: CGFloat? {
-        guard Defaults[.cornerRadiusScaling] else { return nil }
-        let effectiveHeight = displayClosedNotchHeight
-        guard effectiveHeight > 0 else { return nil }
-        return effectiveHeight / 38.0
-    }
-    
-    private var topCornerRadius: CGFloat {
-        // If the notch is open, return the opened radius.
-        if vm.notchState == .open {
-            return cornerRadiusInsets.opened.top
-        }
+    private func topCornerRadius(for snapshot: ClosedNotchRenderSnapshot?) -> CGFloat {
+        guard let snapshot else { return cornerRadiusInsets.opened.top }
 
-        // For the closed notch, scale if enabled
         let baseClosedTop = cornerRadiusInsets.closed.top
-        guard let scaleFactor = cornerRadiusScaleFactor else {
-            return displayClosedNotchHeight > 0 ? baseClosedTop : 0
+        guard let scaleFactor = snapshot.cornerRadiusScaleFactor else {
+            return snapshot.displayHeight > 0 ? baseClosedTop : 0
         }
         return max(0, baseClosedTop * scaleFactor)
     }
 
-    private var currentNotchShape: NotchShape {
-        // Scale bottom corner radius for closed notch shape when scaling is enabled.
+    private func currentNotchShape(for snapshot: ClosedNotchRenderSnapshot?) -> NotchShape {
+        guard let snapshot else {
+            return NotchShape(
+                topCornerRadius: cornerRadiusInsets.opened.top,
+                bottomCornerRadius: cornerRadiusInsets.opened.bottom
+            )
+        }
+
         let baseClosedBottom = cornerRadiusInsets.closed.bottom
         let bottomCorner: CGFloat
 
-        if vm.notchState == .open {
-            bottomCorner = cornerRadiusInsets.opened.bottom
-        } else if let scaleFactor = cornerRadiusScaleFactor {
+        if let scaleFactor = snapshot.cornerRadiusScaleFactor {
             bottomCorner = max(0, baseClosedBottom * scaleFactor)
         } else {
-            bottomCorner = displayClosedNotchHeight > 0 ? baseClosedBottom : 0
+            bottomCorner = snapshot.displayHeight > 0 ? baseClosedBottom : 0
         }
 
         return NotchShape(
-            topCornerRadius: topCornerRadius,
+            topCornerRadius: topCornerRadius(for: snapshot),
             bottomCornerRadius: bottomCorner
         )
-    }
-
-    private var computedChinWidth: CGFloat {
-        var chinWidth: CGFloat = vm.closedNotchSize.width
-
-        if coordinator.expandingView.type == .battery && coordinator.expandingView.show
-            && vm.notchState == .closed && Defaults[.showPowerStatusNotifications]
-        {
-            chinWidth = 640
-        } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music)
-            && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle)
-            && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed
-        {
-            chinWidth += (2 * max(0, displayClosedNotchHeight - 12) + 20 + 2 * liveActivityEdgeMargin + 2)
-        } else if !coordinator.expandingView.show && vm.notchState == .closed
-            && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace]
-            && !vm.hideOnClosed
-        {
-            chinWidth += (2 * max(0, displayClosedNotchHeight - 12) + 20)
-        }
-
-        return chinWidth
     }
 
     // If the closed notch height is 0 (any display/setting), display a 10pt nearly-invisible notch
     // instead of fully hiding it. This preserves layout while avoiding visual artifacts.
     private var isNotchHeightZero: Bool { vm.effectiveClosedNotchHeight == 0 }
+    private var displayClosedNotchHeight: CGFloat {
+        isNotchHeightZero ? 10 : vm.effectiveClosedNotchHeight
+    }
 
-    private var displayClosedNotchHeight: CGFloat { isNotchHeightZero ? 10 : vm.effectiveClosedNotchHeight }
+    private func makeClosedNotchSnapshot() -> ClosedNotchRenderSnapshot {
+        let displayHeight = displayClosedNotchHeight
+        let cornerScale: CGFloat? = Defaults[.cornerRadiusScaling] && displayHeight > 0
+            ? displayHeight / 38
+            : nil
+        let albumArtWidth = max(0, displayHeight - 12 * (cornerScale ?? 1))
+        let spectrumWidth = max(0, displayHeight - 12 + gestureProgress / 2)
+        let sneakPeek = coordinator.sneakPeekState(for: vm.screenUUID)
+        let sneakPeekVisible = coordinator.shouldShowSneakPeek(on: vm.screenUUID)
+        let renderData = ClosedNotchRenderData(
+            music: .init(
+                albumArt: musicManager.albumArt,
+                title: musicManager.songTitle,
+                artist: musicManager.artistName,
+                tintColor: musicManager.avgColor,
+                isPlaying: musicManager.isPlaying
+            ),
+            battery: .init(
+                statusTextKey: batteryModel.statusTextKey,
+                level: batteryModel.levelBattery,
+                isCharging: batteryModel.isCharging,
+                isInLowPowerMode: batteryModel.isInLowPowerMode,
+                isPluggedIn: batteryModel.isPluggedIn,
+                maxAdapterWatts: batteryModel.maxAdapterWatts
+            ),
+            osd: coordinator.binding(for: vm.screenUUID)
+        )
+        let musicExpanded = coordinator.expandingView.show
+            && coordinator.expandingView.type == .music
+            && Defaults[.sneakPeekStyles] == .inline
+        let inlineSideWidth = max(0, 100 - (isHovering ? 0 : 12) + gestureProgress / 2)
+        let faceTrailingWidth = 20 + 30 * min(1, displayHeight / 30)
+        let batteryNotificationVisible = coordinator.expandingView.type == .battery
+            && coordinator.expandingView.show
+            && Defaults[.showPowerStatusNotifications]
+
+        let supplemental: ClosedNotchSupplementalPresentation?
+        if sneakPeekVisible,
+           sneakPeek.type != .music,
+           sneakPeek.type != .battery,
+           !Defaults[.inlineOSD] {
+            supplemental = .systemOSD
+        } else if sneakPeekVisible,
+                  sneakPeek.type == .music,
+                  !vm.hideOnClosed,
+                  Defaults[.sneakPeekStyles] == .standard {
+            supplemental = .music
+        } else {
+            supplemental = nil
+        }
+
+        let presentationInput = ClosedNotchPresentationInput(
+            closedNotchWidth: vm.closedNotchSize.width,
+            height: displayHeight,
+            idleHeight: vm.hasNotch ? displayHeight : 11,
+            inlineOSDHeight: displayHeight + (isHovering ? 8 : 0),
+            inlineSideWidth: inlineSideWidth,
+            albumArtWidth: albumArtWidth,
+            spectrumWidth: spectrumWidth,
+            expandedMusicCenterWidth: 380,
+            idleFaceTrailingWidth: faceTrailingWidth,
+            batteryLeadingWidth: batteryNotificationVisible
+                ? renderData.battery.leadingWidth
+                : 0,
+            batteryNotificationVisible: batteryNotificationVisible,
+            inlineOSDVisible: sneakPeekVisible
+                && Defaults[.inlineOSD]
+                && sneakPeek.type != .music
+                && sneakPeek.type != .battery,
+            musicVisible: (!coordinator.expandingView.show
+                || coordinator.expandingView.type == .music)
+                && (musicManager.isPlaying || !musicManager.isPlayerIdle)
+                && coordinator.musicLiveActivityEnabled
+                && !vm.hideOnClosed,
+            idleFaceVisible: !coordinator.expandingView.show
+                && !musicManager.isPlaying
+                && musicManager.isPlayerIdle
+                && Defaults[.showNotHumanFace]
+                && !vm.hideOnClosed,
+            musicExpanded: musicExpanded,
+            supplemental: supplemental
+        )
+
+        return ClosedNotchRenderSnapshot(
+            presentationInput: presentationInput,
+            renderData: renderData,
+            displayHeight: displayHeight,
+            cornerRadiusScaleFactor: cornerScale,
+            albumArtWidth: albumArtWidth,
+            spectrumWidth: spectrumWidth
+        )
+    }
 
     var body: some View {
+        let closedSnapshot: ClosedNotchRenderSnapshot? = vm.notchState == .closed
+            ? makeClosedNotchSnapshot()
+            : nil
+
         // Calculate scale based on gesture progress only
         let gestureScale: CGFloat = {
             guard gestureProgress != 0 else { return 1.0 }
@@ -123,21 +192,22 @@ struct ContentView: View {
         
         ZStack(alignment: .top) {
             VStack(spacing: 0) {
-                let mainLayout = NotchLayout()
+                let mainLayout = NotchLayout(closedSnapshot: closedSnapshot)
                     .frame(alignment: .top)
                     .padding(
                         .horizontal,
-                        vm.notchState == .open ? cornerRadiusInsets.opened.top : cornerRadiusInsets.closed.bottom
+                        closedSnapshot?.presentation.metrics.horizontalChromeInset
+                            ?? cornerRadiusInsets.opened.top
                     )
                     .padding([.horizontal, .bottom], vm.notchState == .open ? 12 : 0)
                     .background(.black)
-                    .clipShape(currentNotchShape)
+                    .clipShape(currentNotchShape(for: closedSnapshot))
                           .overlay(alignment: .top) {
-                              displayClosedNotchHeight.isZero && vm.notchState == .closed ? nil
+                              closedSnapshot?.displayHeight.isZero == true ? nil
                         : Rectangle()
                             .fill(.black)
                             .frame(height: 1)
-                            .padding(.horizontal, topCornerRadius)
+                            .padding(.horizontal, topCornerRadius(for: closedSnapshot))
                     }
                     .shadow(
                         color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow])
@@ -233,7 +303,11 @@ struct ContentView: View {
                 if vm.chinHeight > 0 {
                     Rectangle()
                         .fill(Color.black.opacity(0.01))
-                        .frame(width: computedChinWidth, height: vm.chinHeight)
+                        .frame(
+                            width: closedSnapshot?.presentation.metrics.totalWidth
+                                ?? vm.closedNotchSize.width,
+                            height: vm.chinHeight
+                        )
                 }
             }
         }
@@ -280,7 +354,7 @@ struct ContentView: View {
     }
 
     @ViewBuilder
-    func NotchLayout() -> some View {
+    func NotchLayout(closedSnapshot: ClosedNotchRenderSnapshot?) -> some View {
         VStack(alignment: .leading) {
             VStack(alignment: .leading) {
                 if coordinator.helloAnimationRunning {
@@ -294,249 +368,34 @@ struct ContentView: View {
                     .padding(.top, 40)
                     Spacer()
                 } else {
-                    if coordinator.expandingView.type == .battery && coordinator.expandingView.show
-                        && vm.notchState == .closed && Defaults[.showPowerStatusNotifications]
-                    {
-                        HStack(spacing: 0) {
-                            HStack {
-                                Text(batteryModel.statusText)
-                                    .font(.subheadline)
-                                    .foregroundStyle(.white)
-                            }
-
-                            Rectangle()
-                                .fill(.black)
-                                .frame(width: vm.closedNotchSize.width + 10)
-
-                            HStack {
-                                BoringBatteryView(
-                                    batteryWidth: 30,
-                                    isCharging: batteryModel.isCharging,
-                                    isInLowPowerMode: batteryModel.isInLowPowerMode,
-                                    isPluggedIn: batteryModel.isPluggedIn,
-                                    levelBattery: batteryModel.levelBattery,
-                                    maxAdapterWatts: batteryModel.maxAdapterWatts,
-                                    isForNotification: true
-                                )
-                            }
-                            .frame(width: 76, alignment: .trailing)
-                        }
-                        .frame(height: displayClosedNotchHeight, alignment: .center)
-                      } else if coordinator.shouldShowSneakPeek(on: vm.screenUUID) && Defaults[.inlineOSD] && (coordinator.sneakPeekState(for: vm.screenUUID).type != .music) && (coordinator.sneakPeekState(for: vm.screenUUID).type != .battery) && vm.notchState == .closed {
-                          InlineOSD(
-                              type: coordinator.binding(for: vm.screenUUID).type,
-                              value: coordinator.binding(for: vm.screenUUID).value,
-                              icon: coordinator.binding(for: vm.screenUUID).icon,
-                              accent: coordinator.binding(for: vm.screenUUID).accent,
-                              hoverAnimation: $isHovering,
-                              gestureProgress: $gestureProgress
-                          )
-                              .transition(.opacity)
-                      } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music) && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed {
-                          MusicLiveActivity()
-                              .frame(alignment: .center)
-                      } else if !coordinator.expandingView.show && vm.notchState == .closed && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {
-                          BoringFaceAnimation()
-                       } else if vm.notchState == .open {
-                           BoringHeader()
-                               .frame(height: max(24, displayClosedNotchHeight))
-                               .opacity(gestureProgress != 0 ? 1.0 - min(abs(gestureProgress) * 0.1, 0.3) : 1.0)
-                       }
-                        // New case to enable compact notch on external displays
-                        else if !vm.hasNotch {
-                           Rectangle().fill(.clear).frame(width: vm.closedNotchSize.width - 20, height: 11) // idle notch height is halved on non notch display
-                       } else {
-                           Rectangle().fill(.clear).frame(width: vm.closedNotchSize.width - 20, height: displayClosedNotchHeight)
-                       }
-
-                      if coordinator.shouldShowSneakPeek(on: vm.screenUUID) {
-                          if (coordinator.sneakPeekState(for: vm.screenUUID).type != .music) && (coordinator.sneakPeekState(for: vm.screenUUID).type != .battery) && !Defaults[.inlineOSD] && vm.notchState == .closed {
-                              SystemEventIndicatorModifier(
-                                  eventType: coordinator.binding(for: vm.screenUUID).type,
-                                  value: coordinator.binding(for: vm.screenUUID).value,
-                                  icon: coordinator.binding(for: vm.screenUUID).icon,
-                                  accent: coordinator.binding(for: vm.screenUUID).accent,
-                                  sendEventBack: { newVal in
-                                      switch coordinator.sneakPeekState(for: vm.screenUUID).type {
-                                      case .volume:
-                                          VolumeManager.shared.setAbsolute(Float32(newVal))
-                                      case .brightness:
-                                          BrightnessManager.shared.setAbsolute(value: Float32(newVal))
-                                      default:
-                                          break
-                                      }
-                                  }
-                              )
-                              .padding(.bottom, 10)
-                              .padding(.leading, 4)
-                              .padding(.trailing, 8)
-                          }
-                          // Old sneak peek music
-                          else if coordinator.sneakPeekState(for: vm.screenUUID).type == .music {
-                              if vm.notchState == .closed && !vm.hideOnClosed && Defaults[.sneakPeekStyles] == .standard {
-                                  HStack(alignment: .center) {
-                                      Image(systemName: "music.note")
-                                      GeometryReader { geo in
-                                          MarqueeText(musicManager.songTitle + " - " + musicManager.artistName,  color: Defaults[.playerColorTinting] ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.6) : .gray, delayDuration: 1.0, frameWidth: geo.size.width)
-                                      }
-                                  }
-                                  .foregroundStyle(.gray)
-                                  .padding(.bottom, 10)
-                              }
-                          }
-                      }
-                  }
-              }
-              .conditionalModifier((coordinator.shouldShowSneakPeek(on: vm.screenUUID) && (coordinator.sneakPeekState(for: vm.screenUUID).type == .music) && vm.notchState == .closed && !vm.hideOnClosed && Defaults[.sneakPeekStyles] == .standard) || (coordinator.shouldShowSneakPeek(on: vm.screenUUID) && (coordinator.sneakPeekState(for: vm.screenUUID).type != .music) && (vm.notchState == .closed))) { view in
-                  view
-                      .fixedSize()
-              }
-              .zIndex(1)
-            if vm.notchState == .open {
-                VStack {
-                    switch coordinator.currentView {
-                    case .home:
-                        NotchHomeView(
-                            albumArtNamespace: albumArtNamespace,
-                            horizontalMediaGestureFeedback: horizontalMediaGestureFeedback,
-                            isHoveringMusicArea: $isHoveringMusicArea
+                    if let closedSnapshot {
+                        ClosedNotchRenderer(
+                            snapshot: closedSnapshot,
+                            albumArtNamespace: albumArtNamespace
                         )
-                    case .shelf:
-                        ShelfView()
+                    } else {
+                        BoringHeader()
+                            .frame(height: max(24, displayClosedNotchHeight))
+                            .opacity(
+                                gestureProgress == 0
+                                    ? 1
+                                    : 1 - min(abs(gestureProgress) * 0.1, 0.3)
+                            )
                     }
                 }
-                .transition(
-                    .scale(scale: 0.8, anchor: .top)
-                    .combined(with: .opacity)
-                    .animation(.smooth(duration: 0.35))
+            }
+            .zIndex(1)
+
+            if vm.notchState == .open {
+                OpenNotchContentView(
+                    albumArtNamespace: albumArtNamespace,
+                    horizontalMediaGestureFeedback: horizontalMediaGestureFeedback,
+                    isHoveringMusicArea: $isHoveringMusicArea,
+                    gestureProgress: gestureProgress
                 )
-                .zIndex(1)
-                .allowsHitTesting(vm.notchState == .open)
-                .opacity(gestureProgress != 0 ? 1.0 - min(abs(gestureProgress) * 0.1, 0.3) : 1.0)
             }
         }
         .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], delegate: GeneralDropTargetDelegate(isTargeted: $vm.generalDropTargeting))
-    }
-
-    @ViewBuilder
-    func BoringFaceAnimation() -> some View {
-        HStack {
-            Rectangle()
-                .fill(.black)
-                .frame(width: vm.closedNotchSize.width + 20)
-            let faceScale = min(1.0, displayClosedNotchHeight / 30.0)
-            MinimalFaceFeatures(height: 24.0 * faceScale, width: 30.0 * faceScale)
-        }.frame(
-            height: displayClosedNotchHeight,
-            alignment: .center
-        )
-    }
-
-    @ViewBuilder
-    func MusicLiveActivity() -> some View {
-        HStack(spacing: 0) {
-            // Closed-mode album art: scale padding and corner radius according to cornerRadiusScaleFactor
-            let baseArtSize = displayClosedNotchHeight - 12
-            let scaledArtSize: CGFloat = {
-                if let scale = cornerRadiusScaleFactor {
-                    return displayClosedNotchHeight - 12 * scale
-                }
-                return baseArtSize
-            }()
-
-            let closedCornerRadius: CGFloat = {
-                let base = MusicPlayerImageSizes.cornerRadiusInset.closed
-                if let scale = cornerRadiusScaleFactor {
-                    return max(0, base * scale)
-                }
-                return base
-            }()
-
-            Image(nsImage: musicManager.albumArt)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .clipShape(
-                    RoundedRectangle(
-                        cornerRadius: closedCornerRadius)
-                )
-                .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
-                .frame(
-                    width: scaledArtSize,
-                    height: scaledArtSize
-                )
-
-            Rectangle()
-                .fill(.black)
-                .overlay(
-                    HStack(alignment: .top) {
-                        if coordinator.expandingView.show
-                            && coordinator.expandingView.type == .music
-                        {
-                            MarqueeText(
-                                musicManager.songTitle,
-                                color: Defaults[.coloredSpectrogram]
-                                    ? Color(nsColor: musicManager.avgColor) : Color.gray,
-                                delayDuration: 0.4,
-                                frameWidth: 100
-                            )
-                            .opacity(
-                                (coordinator.expandingView.show
-                                    && Defaults[.sneakPeekStyles] == .inline)
-                                    ? 1 : 0
-                            )
-                            Spacer(minLength: vm.closedNotchSize.width)
-                            // Song Artist
-                            Text(musicManager.artistName)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-                                .foregroundStyle(
-                                    Defaults[.coloredSpectrogram]
-                                        ? Color(nsColor: musicManager.avgColor)
-                                        : Color.gray
-                                )
-                                .opacity(
-                                    (coordinator.expandingView.show
-                                        && coordinator.expandingView.type == .music
-                                        && Defaults[.sneakPeekStyles] == .inline)
-                                        ? 1 : 0
-                                )
-                        }
-                    }
-                )
-                .frame(
-                    width: (coordinator.expandingView.show
-                        && coordinator.expandingView.type == .music
-                        && Defaults[.sneakPeekStyles] == .inline)
-                        ? 380
-                        : vm.closedNotchSize.width - 4 + (2 * liveActivityEdgeMargin)
-                )
-
-            HStack {
-                AudioSpectrumView(
-                    isPlaying: musicManager.isPlaying,
-                    tintColor: Defaults[.coloredSpectrogram]
-                    ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.5)
-                    : Color.gray
-                )
-                .frame(width: 18, height: 12)
-            }
-            .frame(
-                width: max(
-                    0,
-                    displayClosedNotchHeight - 12
-                        + gestureProgress / 2
-                ),
-                height: max(
-                    0,
-                    displayClosedNotchHeight - 12
-                ),
-                alignment: .center
-            )
-        }
-        .frame(
-            height: displayClosedNotchHeight,
-            alignment: .center
-        )
     }
 
     @ViewBuilder

--- a/boringNotch/components/Notch/ClosedNotchLayout.swift
+++ b/boringNotch/components/Notch/ClosedNotchLayout.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct ClosedNotchLayout<Leading: View, Trailing: View>: View {
+    let metrics: ClosedNotchLayoutMetrics
+
+    private let leading: Leading
+    private let trailing: Trailing
+
+    init(
+        metrics: ClosedNotchLayoutMetrics,
+        @ViewBuilder leading: () -> Leading,
+        @ViewBuilder trailing: () -> Trailing
+    ) {
+        self.metrics = metrics
+        self.leading = leading()
+        self.trailing = trailing()
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            leading
+                .frame(
+                    width: metrics.leadingWidth,
+                    height: metrics.height,
+                    alignment: .trailing
+                )
+
+            Color.clear
+                .frame(
+                    width: metrics.leadingExclusionMargin
+                        + metrics.exclusionWidth
+                        + metrics.trailingExclusionMargin,
+                    height: metrics.height
+                )
+
+            trailing
+                .frame(
+                    width: metrics.trailingWidth,
+                    height: metrics.height,
+                    alignment: .leading
+                )
+        }
+        .frame(width: metrics.totalWidth, height: metrics.height)
+    }
+}

--- a/boringNotch/components/Notch/ClosedNotchPresentation.swift
+++ b/boringNotch/components/Notch/ClosedNotchPresentation.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+enum ClosedNotchPresentation: Equatable {
+    case batteryNotification
+    case inlineOSD
+    case music
+    case idleFace
+    case idle
+}
+
+enum ClosedNotchSupplementalPresentation: Equatable {
+    case systemOSD
+    case music
+}
+
+struct ClosedNotchLayoutMetrics: Equatable {
+    let exclusionWidth: CGFloat
+    let leadingWidth: CGFloat
+    let trailingWidth: CGFloat
+    let leadingExclusionMargin: CGFloat
+    let trailingExclusionMargin: CGFloat
+    let horizontalChromeInset: CGFloat
+    let height: CGFloat
+
+    var totalWidth: CGFloat {
+        leadingWidth
+            + leadingExclusionMargin
+            + exclusionWidth
+            + trailingExclusionMargin
+            + trailingWidth
+    }
+}
+
+struct ClosedNotchPresentationInput: Equatable {
+    let closedNotchWidth: CGFloat
+    let height: CGFloat
+    let idleHeight: CGFloat
+    let inlineOSDHeight: CGFloat
+    let inlineSideWidth: CGFloat
+    let albumArtWidth: CGFloat
+    let spectrumWidth: CGFloat
+    let expandedMusicCenterWidth: CGFloat
+    let idleFaceTrailingWidth: CGFloat
+    let batteryLeadingWidth: CGFloat
+    let batteryNotificationVisible: Bool
+    let inlineOSDVisible: Bool
+    let musicVisible: Bool
+    let idleFaceVisible: Bool
+    let musicExpanded: Bool
+    let supplemental: ClosedNotchSupplementalPresentation?
+}
+
+struct ClosedNotchPresentationState: Equatable {
+    let primary: ClosedNotchPresentation
+    let supplemental: ClosedNotchSupplementalPresentation?
+    let musicExpanded: Bool
+    let metrics: ClosedNotchLayoutMetrics
+}
+
+enum ClosedNotchPresentationResolver {
+    static func resolve(_ input: ClosedNotchPresentationInput) -> ClosedNotchPresentationState {
+        let primary: ClosedNotchPresentation
+
+        if input.batteryNotificationVisible {
+            primary = .batteryNotification
+        } else if input.inlineOSDVisible {
+            primary = .inlineOSD
+        } else if input.musicVisible {
+            primary = .music
+        } else if input.idleFaceVisible {
+            primary = .idleFace
+        } else {
+            primary = .idle
+        }
+
+        let layout: (
+            leadingWidth: CGFloat,
+            trailingWidth: CGFloat,
+            leadingMargin: CGFloat,
+            trailingMargin: CGFloat,
+            chromeInset: CGFloat
+        )
+        switch primary {
+        case .batteryNotification:
+            layout = (
+                input.batteryLeadingWidth,
+                76,
+                0,
+                10,
+                cornerRadiusInsets.closed.bottom
+            )
+
+        case .inlineOSD:
+            layout = (input.inlineSideWidth, input.inlineSideWidth, 0, 0, 12)
+
+        case .music:
+            if input.musicExpanded {
+                let textSideWidth = max(
+                    0,
+                    (input.expandedMusicCenterWidth - input.closedNotchWidth) / 2
+                )
+                layout = (
+                    input.albumArtWidth + textSideWidth,
+                    textSideWidth + input.spectrumWidth,
+                    0,
+                    0,
+                    cornerRadiusInsets.closed.bottom
+                )
+            } else {
+                let centralizedEdgeMargin = max(0, liveActivityEdgeMargin - 2)
+                layout = (
+                    input.albumArtWidth,
+                    input.spectrumWidth,
+                    centralizedEdgeMargin,
+                    centralizedEdgeMargin,
+                    cornerRadiusInsets.closed.bottom
+                )
+            }
+
+        case .idleFace:
+            layout = (
+                0,
+                input.idleFaceTrailingWidth,
+                0,
+                8,
+                cornerRadiusInsets.closed.bottom
+            )
+
+        case .idle:
+            layout = (0, 0, 0, 0, 4)
+        }
+
+        let resolvedHeight: CGFloat
+        switch primary {
+        case .idle:
+            resolvedHeight = input.idleHeight
+        case .inlineOSD:
+            resolvedHeight = input.inlineOSDHeight
+        default:
+            resolvedHeight = input.height
+        }
+
+        return .init(
+            primary: primary,
+            supplemental: input.supplemental,
+            musicExpanded: primary == .music && input.musicExpanded,
+            metrics: .init(
+                exclusionWidth: input.closedNotchWidth,
+                leadingWidth: layout.leadingWidth,
+                trailingWidth: layout.trailingWidth,
+                leadingExclusionMargin: layout.leadingMargin,
+                trailingExclusionMargin: layout.trailingMargin,
+                horizontalChromeInset: layout.chromeInset,
+                height: resolvedHeight
+            )
+        )
+    }
+}

--- a/boringNotch/components/Notch/ClosedNotchPresentation.swift
+++ b/boringNotch/components/Notch/ClosedNotchPresentation.swift
@@ -6,6 +6,38 @@ enum ClosedNotchPresentation: Equatable {
     case music
     case idleFace
     case idle
+
+    var priority: ClosedNotchPresentationPriority {
+        switch self {
+        case .batteryNotification: .critical
+        case .inlineOSD: .system
+        case .music: .activity
+        case .idleFace: .ambient
+        case .idle: .idle
+        }
+    }
+}
+
+enum ClosedNotchPresentationPriority: Int, Comparable {
+    case idle
+    case ambient
+    case activity
+    case system
+    case critical
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+struct ClosedNotchPresentationCandidate: Equatable {
+    let presentation: ClosedNotchPresentation
+    let isVisible: Bool
+
+    init(_ presentation: ClosedNotchPresentation, isVisible: Bool) {
+        self.presentation = presentation
+        self.isVisible = isVisible
+    }
 }
 
 enum ClosedNotchSupplementalPresentation: Equatable {
@@ -42,10 +74,7 @@ struct ClosedNotchPresentationInput: Equatable {
     let expandedMusicCenterWidth: CGFloat
     let idleFaceTrailingWidth: CGFloat
     let batteryLeadingWidth: CGFloat
-    let batteryNotificationVisible: Bool
-    let inlineOSDVisible: Bool
-    let musicVisible: Bool
-    let idleFaceVisible: Bool
+    let candidates: [ClosedNotchPresentationCandidate]
     let musicExpanded: Bool
     let supplemental: ClosedNotchSupplementalPresentation?
 }
@@ -59,19 +88,15 @@ struct ClosedNotchPresentationState: Equatable {
 
 enum ClosedNotchPresentationResolver {
     static func resolve(_ input: ClosedNotchPresentationInput) -> ClosedNotchPresentationState {
-        let primary: ClosedNotchPresentation
+        let primary = input.candidates.reduce(nil as ClosedNotchPresentationCandidate?) {
+            selected, candidate in
+            guard candidate.isVisible else { return selected }
+            guard let selected else { return candidate }
 
-        if input.batteryNotificationVisible {
-            primary = .batteryNotification
-        } else if input.inlineOSDVisible {
-            primary = .inlineOSD
-        } else if input.musicVisible {
-            primary = .music
-        } else if input.idleFaceVisible {
-            primary = .idleFace
-        } else {
-            primary = .idle
-        }
+            return candidate.presentation.priority > selected.presentation.priority
+                ? candidate
+                : selected
+        }?.presentation ?? .idle
 
         let layout: (
             leadingWidth: CGFloat,

--- a/boringNotch/components/Notch/ClosedNotchRenderSnapshot.swift
+++ b/boringNotch/components/Notch/ClosedNotchRenderSnapshot.swift
@@ -22,6 +22,27 @@ struct ClosedNotchRenderData {
     let osd: Binding<sneakPeek>
 }
 
+struct ClosedNotchSnapshotContext {
+    let closedNotchWidth: CGFloat
+    let displayHeight: CGFloat
+    let idleHeight: CGFloat
+    let isHovering: Bool
+    let gestureProgress: CGFloat
+    let hideOnClosed: Bool
+    let showIdleFace: Bool
+    let musicLiveActivityEnabled: Bool
+    let musicPlayerIdle: Bool
+    let expandingViewVisible: Bool
+    let expandingViewType: SneakContentType
+    let sneakPeek: sneakPeek
+    let sneakPeekVisible: Bool
+    let cornerRadiusScalingEnabled: Bool
+    let inlineOSDEnabled: Bool
+    let powerStatusNotificationsEnabled: Bool
+    let sneakPeekStyle: SneakPeekStyle
+    let renderData: ClosedNotchRenderData
+}
+
 struct ClosedNotchRenderSnapshot {
     let presentation: ClosedNotchPresentationState
     let renderData: ClosedNotchRenderData
@@ -30,19 +51,105 @@ struct ClosedNotchRenderSnapshot {
     let albumArtWidth: CGFloat
     let spectrumWidth: CGFloat
 
-    init(
-        presentationInput: ClosedNotchPresentationInput,
-        renderData: ClosedNotchRenderData,
-        displayHeight: CGFloat,
-        cornerRadiusScaleFactor: CGFloat?,
-        albumArtWidth: CGFloat,
-        spectrumWidth: CGFloat
-    ) {
+    init(context: ClosedNotchSnapshotContext) {
+        let cornerScale: CGFloat? = context.cornerRadiusScalingEnabled
+            && context.displayHeight > 0
+            ? context.displayHeight / 38
+            : nil
+        let albumArtWidth = max(0, context.displayHeight - 12 * (cornerScale ?? 1))
+        let spectrumWidth = max(0, context.displayHeight - 12 + context.gestureProgress / 2)
+        let musicExpanded = context.expandingViewVisible
+            && context.expandingViewType == .music
+            && context.sneakPeekStyle == .inline
+        let batteryNotificationVisible = context.expandingViewType == .battery
+            && context.expandingViewVisible
+            && context.powerStatusNotificationsEnabled
+        let inlineOSDVisible = context.sneakPeekVisible
+            && context.inlineOSDEnabled
+            && context.sneakPeek.type != .music
+            && context.sneakPeek.type != .battery
+        let musicVisible = (!context.expandingViewVisible
+            || context.expandingViewType == .music)
+            && (context.renderData.music.isPlaying || !context.musicPlayerIdle)
+            && context.musicLiveActivityEnabled
+            && !context.hideOnClosed
+        let idleFaceVisible = !context.expandingViewVisible
+            && !context.renderData.music.isPlaying
+            && context.musicPlayerIdle
+            && context.showIdleFace
+            && !context.hideOnClosed
+
+        let supplemental: ClosedNotchSupplementalPresentation?
+        if context.sneakPeekVisible,
+           context.sneakPeek.type != .music,
+           context.sneakPeek.type != .battery,
+           !context.inlineOSDEnabled {
+            supplemental = .systemOSD
+        } else if context.sneakPeekVisible,
+                  context.sneakPeek.type == .music,
+                  !context.hideOnClosed,
+                  context.sneakPeekStyle == .standard {
+            supplemental = .music
+        } else {
+            supplemental = nil
+        }
+
+        let presentationInput = ClosedNotchPresentationInput(
+            closedNotchWidth: context.closedNotchWidth,
+            height: context.displayHeight,
+            idleHeight: context.idleHeight,
+            inlineOSDHeight: context.displayHeight + (context.isHovering ? 8 : 0),
+            inlineSideWidth: max(
+                0,
+                100 - (context.isHovering ? 0 : 12) + context.gestureProgress / 2
+            ),
+            albumArtWidth: albumArtWidth,
+            spectrumWidth: spectrumWidth,
+            expandedMusicCenterWidth: 380,
+            idleFaceTrailingWidth: 20 + 30 * min(1, context.displayHeight / 30),
+            batteryLeadingWidth: batteryNotificationVisible
+                ? context.renderData.battery.leadingWidth
+                : 0,
+            candidates: [
+                .init(.batteryNotification, isVisible: batteryNotificationVisible),
+                .init(.inlineOSD, isVisible: inlineOSDVisible),
+                .init(.music, isVisible: musicVisible),
+                .init(.idleFace, isVisible: idleFaceVisible),
+                .init(.idle, isVisible: true)
+            ],
+            musicExpanded: musicExpanded,
+            supplemental: supplemental
+        )
+
         presentation = ClosedNotchPresentationResolver.resolve(presentationInput)
-        self.renderData = renderData
-        self.displayHeight = displayHeight
-        self.cornerRadiusScaleFactor = cornerRadiusScaleFactor
+        renderData = context.renderData
+        displayHeight = context.displayHeight
+        cornerRadiusScaleFactor = cornerScale
         self.albumArtWidth = albumArtWidth
         self.spectrumWidth = spectrumWidth
+    }
+
+    var topCornerRadius: CGFloat {
+        let baseRadius = cornerRadiusInsets.closed.top
+        guard let cornerRadiusScaleFactor else {
+            return displayHeight > 0 ? baseRadius : 0
+        }
+        return max(0, baseRadius * cornerRadiusScaleFactor)
+    }
+
+    var notchShape: NotchShape {
+        let baseBottomRadius = cornerRadiusInsets.closed.bottom
+        let bottomRadius: CGFloat
+
+        if let cornerRadiusScaleFactor {
+            bottomRadius = max(0, baseBottomRadius * cornerRadiusScaleFactor)
+        } else {
+            bottomRadius = displayHeight > 0 ? baseBottomRadius : 0
+        }
+
+        return NotchShape(
+            topCornerRadius: topCornerRadius,
+            bottomCornerRadius: bottomRadius
+        )
     }
 }

--- a/boringNotch/components/Notch/ClosedNotchRenderSnapshot.swift
+++ b/boringNotch/components/Notch/ClosedNotchRenderSnapshot.swift
@@ -1,0 +1,48 @@
+import AppKit
+import SwiftUI
+
+struct ClosedNotchBatteryRenderData {
+    let statusTextKey: String
+    let level: Float
+    let isCharging: Bool
+    let isInLowPowerMode: Bool
+    let isPluggedIn: Bool
+    let maxAdapterWatts: Int
+
+    var leadingWidth: CGFloat {
+        let localizedStatus = NSLocalizedString(statusTextKey, comment: "")
+        let font = NSFont.preferredFont(forTextStyle: .subheadline)
+        return ceil((localizedStatus as NSString).size(withAttributes: [.font: font]).width)
+    }
+}
+
+struct ClosedNotchRenderData {
+    let music: ClosedNotchMusicRenderData
+    let battery: ClosedNotchBatteryRenderData
+    let osd: Binding<sneakPeek>
+}
+
+struct ClosedNotchRenderSnapshot {
+    let presentation: ClosedNotchPresentationState
+    let renderData: ClosedNotchRenderData
+    let displayHeight: CGFloat
+    let cornerRadiusScaleFactor: CGFloat?
+    let albumArtWidth: CGFloat
+    let spectrumWidth: CGFloat
+
+    init(
+        presentationInput: ClosedNotchPresentationInput,
+        renderData: ClosedNotchRenderData,
+        displayHeight: CGFloat,
+        cornerRadiusScaleFactor: CGFloat?,
+        albumArtWidth: CGFloat,
+        spectrumWidth: CGFloat
+    ) {
+        presentation = ClosedNotchPresentationResolver.resolve(presentationInput)
+        self.renderData = renderData
+        self.displayHeight = displayHeight
+        self.cornerRadiusScaleFactor = cornerRadiusScaleFactor
+        self.albumArtWidth = albumArtWidth
+        self.spectrumWidth = spectrumWidth
+    }
+}

--- a/boringNotch/components/Notch/ClosedNotchRenderer.swift
+++ b/boringNotch/components/Notch/ClosedNotchRenderer.swift
@@ -1,0 +1,143 @@
+import Defaults
+import SwiftUI
+
+struct ClosedNotchRenderer: View {
+    let snapshot: ClosedNotchRenderSnapshot
+    let albumArtNamespace: Namespace.ID
+
+    private var state: ClosedNotchPresentationState { snapshot.presentation }
+    private var renderData: ClosedNotchRenderData { snapshot.renderData }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            primaryContent
+            supplementalContent
+        }
+        .conditionalModifier(state.supplemental != nil) { view in
+            view.fixedSize()
+        }
+        .zIndex(1)
+    }
+
+    @ViewBuilder
+    private var primaryContent: some View {
+        switch state.primary {
+        case .batteryNotification:
+            ClosedNotchLayout(metrics: state.metrics) {
+                Text(LocalizedStringKey(renderData.battery.statusTextKey))
+                    .font(.subheadline)
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            } trailing: {
+                BoringBatteryView(
+                    batteryWidth: 30,
+                    isCharging: renderData.battery.isCharging,
+                    isInLowPowerMode: renderData.battery.isInLowPowerMode,
+                    isPluggedIn: renderData.battery.isPluggedIn,
+                    levelBattery: renderData.battery.level,
+                    maxAdapterWatts: renderData.battery.maxAdapterWatts,
+                    isForNotification: true
+                )
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+
+        case .inlineOSD:
+            ClosedNotchLayout(metrics: state.metrics) {
+                let sneakPeek = renderData.osd.wrappedValue
+                InlineOSDLeadingView(
+                    type: sneakPeek.type,
+                    value: sneakPeek.value,
+                    icon: sneakPeek.icon,
+                    accent: sneakPeek.accent
+                )
+            } trailing: {
+                InlineOSDTrailingView(
+                    type: renderData.osd.type,
+                    value: renderData.osd.value,
+                    accent: renderData.osd.wrappedValue.accent
+                )
+            }
+            .transition(.opacity)
+
+        case .music:
+            ClosedNotchLayout(metrics: state.metrics) {
+                MusicLiveActivityLeadingView(
+                    data: renderData.music,
+                    albumArtNamespace: albumArtNamespace,
+                    albumArtWidth: snapshot.albumArtWidth,
+                    titleWidth: max(0, state.metrics.leadingWidth - snapshot.albumArtWidth),
+                    cornerRadiusScaleFactor: snapshot.cornerRadiusScaleFactor,
+                    expanded: state.musicExpanded
+                )
+            } trailing: {
+                MusicLiveActivityTrailingView(
+                    data: renderData.music,
+                    artistWidth: max(0, state.metrics.trailingWidth - snapshot.spectrumWidth),
+                    spectrumWidth: snapshot.spectrumWidth,
+                    expanded: state.musicExpanded
+                )
+            }
+
+        case .idleFace:
+            ClosedNotchLayout(metrics: state.metrics) {
+                EmptyView()
+            } trailing: {
+                IdleNotchFaceView(displayClosedNotchHeight: snapshot.displayHeight)
+            }
+
+        case .idle:
+            Color.clear
+                .frame(width: state.metrics.totalWidth, height: state.metrics.height)
+        }
+    }
+
+    @ViewBuilder
+    private var supplementalContent: some View {
+        switch state.supplemental {
+        case .systemOSD:
+            SystemEventIndicatorModifier(
+                eventType: renderData.osd.type,
+                value: renderData.osd.value,
+                icon: renderData.osd.icon,
+                accent: renderData.osd.accent,
+                sendEventBack: updateSystemValue
+            )
+            .padding(.bottom, 10)
+            .padding(.leading, 4)
+            .padding(.trailing, 8)
+
+        case .music:
+            HStack(alignment: .center) {
+                Image(systemName: "music.note")
+
+                GeometryReader { geometry in
+                    MarqueeText(
+                        renderData.music.title + " - " + renderData.music.artist,
+                        color: Defaults[.playerColorTinting]
+                            ? Color(nsColor: renderData.music.tintColor)
+                                .ensureMinimumBrightness(factor: 0.6)
+                            : .gray,
+                        delayDuration: 1,
+                        frameWidth: geometry.size.width
+                    )
+                }
+            }
+            .foregroundStyle(.gray)
+            .padding(.bottom, 10)
+
+        case nil:
+            EmptyView()
+        }
+    }
+
+    private func updateSystemValue(_ newValue: CGFloat) {
+        switch renderData.osd.wrappedValue.type {
+        case .volume:
+            VolumeManager.shared.setAbsolute(Float32(newValue))
+        case .brightness:
+            BrightnessManager.shared.setAbsolute(value: Float32(newValue))
+        default:
+            break
+        }
+    }
+}

--- a/boringNotch/components/Notch/IdleNotchFaceView.swift
+++ b/boringNotch/components/Notch/IdleNotchFaceView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct IdleNotchFaceView: View {
+    let displayClosedNotchHeight: CGFloat
+
+    var body: some View {
+        let faceScale = min(1, displayClosedNotchHeight / 30)
+
+        MinimalFaceFeatures(
+            height: 24 * faceScale,
+            width: 30 * faceScale
+        )
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .padding(.leading, 20)
+    }
+}

--- a/boringNotch/components/Notch/MusicLiveActivityView.swift
+++ b/boringNotch/components/Notch/MusicLiveActivityView.swift
@@ -1,0 +1,97 @@
+import AppKit
+import Defaults
+import SwiftUI
+
+struct ClosedNotchMusicRenderData {
+    let albumArt: NSImage
+    let title: String
+    let artist: String
+    let tintColor: NSColor
+    let isPlaying: Bool
+}
+
+struct MusicLiveActivityLeadingView: View {
+    let data: ClosedNotchMusicRenderData
+    let albumArtNamespace: Namespace.ID
+    let albumArtWidth: CGFloat
+    let titleWidth: CGFloat
+    let cornerRadiusScaleFactor: CGFloat?
+    let expanded: Bool
+
+    var body: some View {
+        HStack(spacing: 0) {
+            albumArt
+
+            if showsExpandedText {
+                MarqueeText(
+                    data.title,
+                    color: Defaults[.coloredSpectrogram]
+                        ? Color(nsColor: data.tintColor)
+                        : .gray,
+                    delayDuration: 0.4,
+                    frameWidth: titleWidth
+                )
+                .frame(width: titleWidth)
+            }
+        }
+    }
+
+    private var albumArt: some View {
+        Image(nsImage: data.albumArt)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .clipShape(RoundedRectangle(cornerRadius: closedCornerRadius))
+            .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
+            .frame(width: albumArtWidth, height: albumArtWidth)
+    }
+
+    private var showsExpandedText: Bool {
+        expanded && titleWidth > 0
+    }
+
+    private var closedCornerRadius: CGFloat {
+        let base = MusicPlayerImageSizes.cornerRadiusInset.closed
+        guard let cornerRadiusScaleFactor else { return base }
+        return max(0, base * cornerRadiusScaleFactor)
+    }
+}
+
+struct MusicLiveActivityTrailingView: View {
+    let data: ClosedNotchMusicRenderData
+    let artistWidth: CGFloat
+    let spectrumWidth: CGFloat
+    let expanded: Bool
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if showsExpandedText {
+                Text(data.artist)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .foregroundStyle(
+                        Defaults[.coloredSpectrogram]
+                            ? Color(nsColor: data.tintColor)
+                            : .gray
+                    )
+                    .frame(width: artistWidth, alignment: .trailing)
+            }
+
+            spectrum
+        }
+    }
+
+    private var spectrum: some View {
+        AudioSpectrumView(
+            isPlaying: data.isPlaying,
+            tintColor: Defaults[.coloredSpectrogram]
+                ? Color(nsColor: data.tintColor).ensureMinimumBrightness(factor: 0.5)
+                : .gray
+        )
+        .frame(width: 18, height: 12)
+        .frame(width: spectrumWidth, alignment: .center)
+    }
+
+    private var showsExpandedText: Bool {
+        expanded && artistWidth > 0
+    }
+}

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -23,7 +23,6 @@ struct MusicPlayerView: View {
             AlbumArtView(vm: vm, albumArtNamespace: albumArtNamespace).frame(width: 120).padding(.all, 5 * (vm.notchSize.height / 190))
             MusicControlsView(horizontalMediaGestureFeedback: horizontalMediaGestureFeedback)
                 .drawingGroup()
-                .compositingGroup()
         }
         .contentShape(Rectangle())
         .onHover { hovering in
@@ -158,7 +157,12 @@ struct MusicControlsView: View {
             )
             .fontWeight(.medium)
             if Defaults[.enableLyrics] {
-                TimelineView(.animation(minimumInterval: 0.25)) { timeline in
+                TimelineView(
+                    .animation(
+                        minimumInterval: 0.25,
+                        paused: musicManager.playbackRate <= 0
+                    )
+                ) { timeline in
                     let currentElapsed: Double = {
                         guard musicManager.isPlaying else { return musicManager.elapsedTime }
                         let delta = timeline.date.timeIntervalSince(musicManager.timestampDate)
@@ -202,7 +206,12 @@ struct MusicControlsView: View {
     }
 
     private var musicSlider: some View {
-        TimelineView(.animation(minimumInterval: musicManager.playbackRate > 0 ? 0.1 : nil)) { timeline in
+        TimelineView(
+            .animation(
+                minimumInterval: 0.1,
+                paused: musicManager.playbackRate <= 0
+            )
+        ) { timeline in
             MusicSliderView(
                 sliderValue: $sliderValue,
                 duration: $musicManager.songDuration,
@@ -212,8 +221,7 @@ struct MusicControlsView: View {
                 currentDate: timeline.date,
                 timestampDate: musicManager.timestampDate,
                 elapsedTime: musicManager.elapsedTime,
-                playbackRate: musicManager.playbackRate,
-                isPlaying: musicManager.isPlaying
+                playbackUpdatesPaused: musicManager.playbackRate <= 0
             ) { newValue in
                 MusicManager.shared.seek(to: newValue)
             }
@@ -422,8 +430,6 @@ struct VolumeControlView: View {
 struct NotchHomeView: View {
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var webcamManager = WebcamManager.shared
-    @ObservedObject var batteryModel = BatteryStatusViewModel.shared
-    @ObservedObject var coordinator = BoringViewCoordinator.shared
     let albumArtNamespace: Namespace.ID
     let horizontalMediaGestureFeedback: CGFloat
     @Binding var isHoveringMusicArea: Bool
@@ -477,8 +483,7 @@ struct MusicSliderView: View {
     let currentDate: Date
     let timestampDate: Date
     let elapsedTime: Double
-    let playbackRate: Double
-    let isPlaying: Bool
+    let playbackUpdatesPaused: Bool
     var onValueChange: (Double) -> Void
 
 
@@ -508,10 +513,18 @@ struct MusicSliderView: View {
             )
             .font(.caption)
         }
-        .onChange(of: currentDate) {
-           guard !dragging, timestampDate.timeIntervalSince(lastDragged) > -1 else { return }
-            sliderValue = MusicManager.shared.estimatedPlaybackPosition(at: currentDate)
+        .onChange(of: currentDate, initial: true) { _, date in
+            updateSlider(at: date)
         }
+        .onChange(of: elapsedTime) { _, _ in
+            guard playbackUpdatesPaused else { return }
+            updateSlider(at: currentDate)
+        }
+    }
+
+    private func updateSlider(at date: Date) {
+        guard !dragging, timestampDate.timeIntervalSince(lastDragged) > -1 else { return }
+        sliderValue = MusicManager.shared.estimatedPlaybackPosition(at: date)
     }
 
     func timeString(from seconds: Double) -> String {

--- a/boringNotch/components/Notch/OpenNotchContentView.swift
+++ b/boringNotch/components/Notch/OpenNotchContentView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct OpenNotchContentView: View {
+    @EnvironmentObject private var vm: BoringViewModel
+    @ObservedObject private var coordinator = BoringViewCoordinator.shared
+
+    let albumArtNamespace: Namespace.ID
+    let horizontalMediaGestureFeedback: CGFloat
+    @Binding var isHoveringMusicArea: Bool
+    let gestureProgress: CGFloat
+
+    var body: some View {
+        VStack {
+            switch coordinator.currentView {
+            case .home:
+                NotchHomeView(
+                    albumArtNamespace: albumArtNamespace,
+                    horizontalMediaGestureFeedback: horizontalMediaGestureFeedback,
+                    isHoveringMusicArea: $isHoveringMusicArea
+                )
+            case .shelf:
+                ShelfView()
+            }
+        }
+        .transition(
+            .scale(scale: 0.8, anchor: .top)
+                .combined(with: .opacity)
+                .animation(.smooth(duration: 0.35))
+        )
+        .zIndex(1)
+        .allowsHitTesting(vm.notchState == .open)
+        .opacity(gestureProgress == 0 ? 1 : 1 - min(abs(gestureProgress) * 0.1, 0.3))
+    }
+}

--- a/boringNotch/components/Notch/OpenNotchContentView.swift
+++ b/boringNotch/components/Notch/OpenNotchContentView.swift
@@ -11,7 +11,7 @@ struct OpenNotchContentView: View {
 
     var body: some View {
         VStack {
-            switch coordinator.currentView {
+            switch selectedDestination {
             case .home:
                 NotchHomeView(
                     albumArtNamespace: albumArtNamespace,
@@ -20,6 +20,8 @@ struct OpenNotchContentView: View {
                 )
             case .shelf:
                 ShelfView()
+            case nil:
+                EmptyView()
             }
         }
         .transition(
@@ -30,5 +32,12 @@ struct OpenNotchContentView: View {
         .zIndex(1)
         .allowsHitTesting(vm.notchState == .open)
         .opacity(gestureProgress == 0 ? 1 : 1 - min(abs(gestureProgress) * 0.1, 0.3))
+    }
+
+    private var selectedDestination: NotchViews? {
+        let availableDestinations = NotchDestinationDescriptor.availableBuiltIn
+        return availableDestinations.first {
+            $0.destination == coordinator.currentView
+        }?.destination ?? availableDestinations.first?.destination
     }
 }

--- a/boringNotch/components/OSD/Views/InlineOSD.swift
+++ b/boringNotch/components/OSD/Views/InlineOSD.swift
@@ -5,100 +5,101 @@
 //  Created by Richard Kunkli on 14/09/2024.
 //
 
-import SwiftUI
 import Defaults
+import SwiftUI
 
-struct InlineOSD: View {
-    @EnvironmentObject var vm: BoringViewModel
+struct InlineOSDLeadingView: View {
+    let type: SneakContentType
+    let value: CGFloat
+    let icon: String
+    let accent: Color?
+
+    var body: some View {
+        HStack(spacing: 5) {
+            OSDIconView(eventType: type, icon: icon, value: value, accent: accent)
+
+            Text(type.localizedOSDName)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .lineLimit(1)
+                .allowsTightening(true)
+                .contentTransition(.numericText())
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct InlineOSDTrailingView: View {
     @Binding var type: SneakContentType
     @Binding var value: CGFloat
-    @Binding var icon: String
-    @Binding var accent: Color?
-    @Binding var hoverAnimation: Bool
-    @Binding var gestureProgress: CGFloat
+    let accent: Color?
+
     var body: some View {
-        HStack {
-            HStack(spacing: 5) {
-                OSDIconView(eventType: type, icon: icon, value: value, accent: accent)
-                
-                Text(Type2Name(type))
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                    .lineLimit(1)
-                    .allowsTightening(true)
-                    .contentTransition(.numericText())
-            }
-            .frame(width: 100 - (hoverAnimation ? 0 : 12) + gestureProgress / 2, height: vm.notchSize.height - (hoverAnimation ? 0 : 12), alignment: .leading)
-            
-            Rectangle()
-                .fill(.black)
-                .frame(width: vm.closedNotchSize.width - 20)
-            
-            HStack {
-                if (type == .mic) {
-                    Text(value.isZero ? "muted" : "unmuted")
-                        .foregroundStyle(.gray)
-                        .lineLimit(1)
-                        .allowsTightening(true)
-                        .multilineTextAlignment(.trailing)
-                        .frame(maxWidth: .infinity, alignment: .trailing)
-                        .contentTransition(.interpolate)
-                } else {
-                        HStack {
-                        DraggableProgressBar(value: $value, onChange: { v in
-                            if type == .volume {
-                                VolumeManager.shared.setAbsolute(Float32(v))
-                            } else if type == .brightness {
-                                BrightnessManager.shared.setAbsolute(value: Float32(v))
-                            }
-                        }, accentColor: accent, compact: true)
-                        .frame(maxWidth: .infinity)
-                        if (type == .volume && value.isZero) {
-                            Text("muted")
-                                .font(.caption)
-                                .fontWeight(.medium)
-                                .foregroundStyle(.gray)
-                                .lineLimit(1)
-                                .allowsTightening(true)
-                                .multilineTextAlignment(.trailing)
-                        } else if Defaults[.showClosedNotchOSDPercentage] {
-                            Text("\(Int(value * 100))%")
-                                .font(.caption)
-                                .fontWeight(.medium)
-                                .foregroundStyle(.gray)
-                                .lineLimit(1)
-                                .allowsTightening(true)
-                                .multilineTextAlignment(.trailing)
-                        }
-                    }
+        Group {
+            if type == .mic {
+                Text(value.isZero ? "muted" : "unmuted")
+                    .foregroundStyle(.gray)
+                    .contentTransition(.interpolate)
+            } else {
+                HStack {
+                    DraggableProgressBar(
+                        value: $value,
+                        onChange: updateSystemValue,
+                        accentColor: accent,
+                        compact: true
+                    )
+                    .frame(maxWidth: .infinity)
+
+                    valueLabel
                 }
             }
-            .padding(.trailing, 4)
-            .frame(width: 100 - (hoverAnimation ? 0 : 12) + gestureProgress / 2, height: vm.closedNotchSize.height - (hoverAnimation ? 0 : 12), alignment: .center)
         }
-        .frame(height: vm.closedNotchSize.height + (hoverAnimation ? 8 : 0), alignment: .center)
+        .lineLimit(1)
+        .allowsTightening(true)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .padding(.trailing, 4)
     }
-    
-    func Type2Name(_ type: SneakContentType) -> String {
-        switch(type) {
-            case .volume:
-                return NSLocalizedString("Volume", comment: "")
-            case .brightness:
-                return NSLocalizedString("Brightness", comment: "")
-            case .backlight:
-                return NSLocalizedString("Backlight", comment: "")
-            case .mic:
-                return NSLocalizedString("Mic", comment: "")
-            default:
-                return ""
+
+    @ViewBuilder
+    private var valueLabel: some View {
+        if type == .volume && value.isZero {
+            Text("muted")
+                .font(.caption)
+                .fontWeight(.medium)
+                .foregroundStyle(.gray)
+        } else if Defaults[.showClosedNotchOSDPercentage] {
+            Text("\(Int(value * 100))%")
+                .font(.caption)
+                .fontWeight(.medium)
+                .foregroundStyle(.gray)
+        }
+    }
+
+    private func updateSystemValue(_ newValue: CGFloat) {
+        switch type {
+        case .volume:
+            VolumeManager.shared.setAbsolute(Float32(newValue))
+        case .brightness:
+            BrightnessManager.shared.setAbsolute(value: Float32(newValue))
+        default:
+            break
         }
     }
 }
 
-#Preview {
-    InlineOSD(type: .constant(.brightness), value: .constant(0.4), icon: .constant(""), accent: .constant(nil), hoverAnimation: .constant(false), gestureProgress: .constant(0))
-        .padding(.horizontal, 8)
-        .background(Color.black)
-        .padding()
-        .environmentObject(BoringViewModel())
+private extension SneakContentType {
+    var localizedOSDName: String {
+        switch self {
+        case .volume:
+            NSLocalizedString("Volume", comment: "")
+        case .brightness:
+            NSLocalizedString("Brightness", comment: "")
+        case .backlight:
+            NSLocalizedString("Backlight", comment: "")
+        case .mic:
+            NSLocalizedString("Mic", comment: "")
+        default:
+            ""
+        }
+    }
 }

--- a/boringNotch/components/Tabs/TabButton.swift
+++ b/boringNotch/components/Tabs/TabButton.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct TabButton: View {
     let label: String
     let icon: String
-    let selected: Bool
     let onClick: () -> Void
     
     var body: some View {
@@ -19,12 +18,13 @@ struct TabButton: View {
                 .padding(.horizontal, 15)
                 .contentShape(Capsule())
         }
+        .accessibilityLabel(label)
         .buttonStyle(PlainButtonStyle())
     }
 }
 
 #Preview {
-    TabButton(label: "Home", icon: "tray.fill", selected: true) {
+    TabButton(label: "Home", icon: "tray.fill") {
         print("Tapped")
     }
 }

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -7,43 +7,68 @@
 
 import SwiftUI
 
-struct TabModel: Identifiable {
-    let id = UUID()
+struct NotchDestinationDescriptor: Identifiable {
+    var id: NotchViews { destination }
+
+    let destination: NotchViews
     let label: String
     let icon: String
-    let view: NotchViews
+    let order: Int
+    let isAvailable: Bool
 }
 
-let tabs = [
-    TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
-]
+extension NotchDestinationDescriptor {
+    static let builtIn: [Self] = [
+        .init(
+            destination: .home,
+            label: "Home",
+            icon: "house.fill",
+            order: 0,
+            isAvailable: true
+        ),
+        .init(
+            destination: .shelf,
+            label: "Shelf",
+            icon: "tray.fill",
+            order: 1,
+            isAvailable: true
+        )
+    ]
+
+    static let availableBuiltIn: [Self] = {
+        builtIn
+            .filter(\.isAvailable)
+            .sorted { $0.order < $1.order }
+    }()
+}
 
 struct TabSelectionView: View {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     @Namespace var animation
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(tabs) { tab in
-                    TabButton(label: tab.label, icon: tab.icon, selected: coordinator.currentView == tab.view) {
-                        withAnimation(.smooth) {
-                            coordinator.currentView = tab.view
-                        }
+            ForEach(NotchDestinationDescriptor.availableBuiltIn) { destination in
+                let isSelected = coordinator.currentView == destination.destination
+
+                TabButton(label: destination.label, icon: destination.icon) {
+                    withAnimation(.smooth) {
+                        coordinator.currentView = destination.destination
                     }
-                    .frame(height: 26)
-                    .foregroundStyle(tab.view == coordinator.currentView ? .white : .gray)
-                    .background {
-                        if tab.view == coordinator.currentView {
-                            Capsule()
-                                .fill(coordinator.currentView == tab.view ? Color(nsColor: .secondarySystemFill) : Color.clear)
-                                .matchedGeometryEffect(id: "capsule", in: animation)
-                        } else {
-                            Capsule()
-                                .fill(coordinator.currentView == tab.view ? Color(nsColor: .secondarySystemFill) : Color.clear)
-                                .matchedGeometryEffect(id: "capsule", in: animation)
-                                .hidden()
-                        }
+                }
+                .frame(height: 26)
+                .foregroundStyle(isSelected ? .white : .gray)
+                .background {
+                    if isSelected {
+                        Capsule()
+                            .fill(Color(nsColor: .secondarySystemFill))
+                            .matchedGeometryEffect(id: "capsule", in: animation)
+                    } else {
+                        Capsule()
+                            .fill(Color.clear)
+                            .matchedGeometryEffect(id: "capsule", in: animation)
+                            .hidden()
                     }
+                }
             }
         }
         .clipShape(Capsule())

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -18,7 +18,7 @@ public enum NotchState {
     case open
 }
 
-public enum NotchViews {
+public enum NotchViews: Hashable {
     case home
     case shelf
 }

--- a/boringNotch/models/BatteryStatusViewModel.swift
+++ b/boringNotch/models/BatteryStatusViewModel.swift
@@ -31,20 +31,23 @@ class BatteryStatusViewModel: ObservableObject {
     }
 
     var statusText: LocalizedStringKey {
+        LocalizedStringKey(statusTextKey)
+    }
+
+    var statusTextKey: String {
         switch lastStatus {
         case .plugged(let plugged):
-            return LocalizedStringKey(plugged ? "Plugged In" : "Unplugged")
+            return plugged ? "Plugged In" : "Unplugged"
         case .lowPower(let enabled):
-            let key = enabled ? "Low Power: On" : "Low Power: Off"
-            return LocalizedStringKey(key)
+            return enabled ? "Low Power: On" : "Low Power: Off"
         case .charging(let isCharging, let level):
             if isCharging {
-                return LocalizedStringKey("Charging battery")
+                return "Charging battery"
             }
             if level < 100 {
-                return LocalizedStringKey("Not charging")
+                return "Not charging"
             }
-            return LocalizedStringKey("Full charge")
+            return "Full charge"
         }
     }
 


### PR DESCRIPTION
This started as a view extraction, but the main goal is to give the notch one clear rendering path instead of letting every feature manage its own layout around the physical notch.

The closed notch now has centrally managed leading, exclusion, and trailing regions. Music, battery notifications, the inline OSD, and the idle face provide content for those regions, while the renderer owns the hardware safe space and chooses the active presentation through an ordered priority list. The same render snapshot is used for sizing, shape, and content, so those decisions cannot drift apart during an update.

I also moved the open-notch content switch out of `ContentView` and put the built-in destinations behind stable descriptors shared by the tab bar and content renderer. This is not an ExtensionKit API yet, but it leaves the first-party UI on a path that can be opened up later without another large rendering rewrite.

While doing the extraction, I removed unnecessary observation from `ContentView`, kept the compact music view's identity stable, and paused the open music timelines when playback is paused. Battery notification widths are measured from the localized text instead of relying on a fixed width, so longer labels stay on one line.

This is not intended as a visual redesign. The layout should behave the same as before; the difference is that spacing and presentation rules now live in one place.

### Testing

- Manually checked the closed idle, music, battery, volume, brightness, microphone, hover, and open/close states
- Checked transitions between Home and Shelf, including the latest transition change from `dev`
- Ran a fresh Release build after rebasing onto the latest `dev`
- Profiled open Home while playing and paused; the paused timeline no longer keeps the view continuously active, and playback uses less CPU