### PR TITLE
feat: Add Pomodoro timer with customizable settings

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -131,6 +131,9 @@
 		9A0887322C7A693000C160EA /* TabButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0887312C7A693000C160EA /* TabButton.swift */; };
 		9A0887352C7AFF8E00C160EA /* TabSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0887342C7AFF8E00C160EA /* TabSelectionView.swift */; };
 		9A987A0D2C73CA66005CA465 /* ShelfView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A987A032C73CA66005CA465 /* ShelfView.swift */; };
+		AA1000012C73CA66005CA465 /* PomodoroManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000022C73CA66005CA465 /* PomodoroManager.swift */; };
+		AA1000032C73CA66005CA465 /* PomodoroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000042C73CA66005CA465 /* PomodoroView.swift */; };
+		AA1000052C73CA66005CA465 /* PomodoroSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000062C73CA66005CA465 /* PomodoroSettingsView.swift */; };
 		9A987A102C73CA8D005CA465 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 9A987A0F2C73CA8D005CA465 /* Collections */; };
 		9AB0C6BD2C73C9CB00F7CD30 /* NotchHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */; };
 		B10348D92C74E56000475897 /* ConditionalModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10348D82C74E56000475897 /* ConditionalModifier.swift */; };
@@ -315,6 +318,9 @@
 		9A0887312C7A693000C160EA /* TabButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabButton.swift; sourceTree = "<group>"; };
 		9A0887342C7AFF8E00C160EA /* TabSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSelectionView.swift; sourceTree = "<group>"; };
 		9A987A032C73CA66005CA465 /* ShelfView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShelfView.swift; sourceTree = "<group>"; };
+		AA1000022C73CA66005CA465 /* PomodoroManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = boringNotch/managers/PomodoroManager.swift; sourceTree = "<group>"; };
+		AA1000042C73CA66005CA465 /* PomodoroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = boringNotch/components/Pomodoro/PomodoroView.swift; sourceTree = "<group>"; };
+		AA1000062C73CA66005CA465 /* PomodoroSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = boringNotch/components/Settings/PomodoroSettingsView.swift; sourceTree = "<group>"; };
 		9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotchHomeView.swift; sourceTree = "<group>"; };
 		AFAD1670A870402D88BFFE47 /* AudioOutputRouteResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioOutputRouteResolver.swift; sourceTree = "<group>"; };
 		B10348D82C74E56000475897 /* ConditionalModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalModifier.swift; sourceTree = "<group>"; };
@@ -1084,6 +1090,9 @@
 				1471A8592C6281BD0058408D /* BoringNotchWindow.swift in Sources */,
 				14CEF4182C5CAED300855D72 /* ContentView.swift in Sources */,
 				9A987A0D2C73CA66005CA465 /* ShelfView.swift in Sources */,
+				AA1000012C73CA66005CA465 /* PomodoroManager.swift in Sources */,
+				AA1000032C73CA66005CA465 /* PomodoroView.swift in Sources */,
+				AA1000052C73CA66005CA465 /* PomodoroSettingsView.swift in Sources */,
 				1132E5142E777B920068732D /* YouTubeMusicNetworking.swift in Sources */,
 				1132E5122E777B6E0068732D /* YouTubeMusicModels.swift in Sources */,
 				11CFC65F2E097F2F00748C80 /* OnboardingView.swift in Sources */,
@@ -1503,7 +1512,7 @@
 			repositoryURL = "https://github.com/airbnb/lottie-spm.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.6.1;
+				minimumVersion = 4.5.2;
 			};
 		};
 		14D032182C68F32E0096E6A1 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */ = {
@@ -1519,23 +1528,23 @@
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
 				kind = exactVersion;
-				version = 2.9.4;
+				version = 2.9.1;
 			};
 		};
 		9A987A0E2C73CA8D005CA465 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-collections.git";
 			requirement = {
-				kind = exactVersion;
-				version = 1.6.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.2;
 			};
 		};
 		9A987A112C73CAA1005CA465 /* XCRemoteSwiftPackageReference "Pow" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/EmergeTools/Pow";
 			requirement = {
-				kind = exactVersion;
-				version = 1.0.6;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.4;
 			};
 		};
 		B1628B902CC260C0003D8DF3 /* XCRemoteSwiftPackageReference "swiftui-introspect" */ = {
@@ -1551,16 +1560,16 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
 			requirement = {
-				kind = exactVersion;
-				version = 3.0.1;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.2.4;
 			};
 		};
 		B19016202CC15B3D00E3F12E /* XCRemoteSwiftPackageReference "Defaults" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sindresorhus/Defaults";
 			requirement = {
-				kind = exactVersion;
-				version = 9.0.9;
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.0.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/boringNotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/boringNotch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/Defaults",
       "state" : {
-        "revision" : "00a7465a0668a87fa159e779b9d80f1f9652357e",
-        "version" : "9.0.9"
+        "revision" : "8192b0986611e105355a9433e99bf5c79469fbbd",
+        "version" : "9.0.6"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
       "state" : {
-        "revision" : "49c3fc04ea827f816df67843bfcc57286b47ff06",
-        "version" : "3.0.1"
+        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
+        "version" : "2.4.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-spm.git",
       "state" : {
-        "revision" : "0aff16288f8dc1e3dab35cbf5cf45979673fd3df",
-        "version" : "4.6.1"
+        "revision" : "04f2fd18cc9404a0a0917265a449002674f24ec9",
+        "version" : "4.5.2"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/EmergeTools/Pow",
       "state" : {
-        "revision" : "1b4b1dda28c50b95f0872927ee2226fe8b58950e",
-        "version" : "1.0.6"
+        "revision" : "a504eb6d144bcf49f4f33029a2795345cb39e6b4",
+        "version" : "1.0.5"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
-        "version" : "2.9.4"
+        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
+        "version" : "2.9.1"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
-        "version" : "1.6.0"
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
-        "version" : "603.0.2"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -281,7 +281,7 @@ struct ContentView: View {
 
     @ViewBuilder
     func NotchLayout() -> some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading) {
                 if coordinator.helloAnimationRunning {
                     Spacer()
@@ -403,6 +403,8 @@ struct ContentView: View {
                         )
                     case .shelf:
                         ShelfView()
+                    case .pomodoro:
+                        PomodoroView()
                     }
                 }
                 .transition(
@@ -415,6 +417,7 @@ struct ContentView: View {
                 .opacity(gestureProgress != 0 ? 1.0 - min(abs(gestureProgress) * 0.1, 0.3) : 1.0)
             }
         }
+        .frame(maxHeight: vm.notchState == .open ? .infinity : nil, alignment: .top)
         .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], delegate: GeneralDropTargetDelegate(isTargeted: $vm.generalDropTargeting))
     }
 

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -16,7 +16,7 @@ struct BoringHeader: View {
     var body: some View {
         HStack(spacing: 0) {
             HStack {
-                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
+                if (!tvm.isEmpty || coordinator.alwaysShowTabs) {
                     TabSelectionView()
                 } else if vm.notchState == .open {
                     EmptyView()

--- a/boringNotch/components/Pomodoro/PomodoroView.swift
+++ b/boringNotch/components/Pomodoro/PomodoroView.swift
@@ -1,0 +1,256 @@
+//
+//  PomodoroView.swift
+//  boringNotch
+//
+
+import Defaults
+import SwiftUI
+
+struct PomodoroView: View {
+    @ObservedObject var manager = PomodoroManager.shared
+    @EnvironmentObject var vm: BoringViewModel
+
+    private var phaseColor: Color {
+        switch manager.phase {
+        case .work:
+            return Color.red
+        case .shortBreak:
+            return Color.green
+        case .longBreak:
+            return Color.blue
+        }
+    }
+
+    private var formattedTime: String {
+        let totalSeconds = max(0, Int(manager.timeRemaining))
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 22) {
+            // Left: Large Circular Progress Ring & Digital Timer
+            ZStack {
+                // Background Ring Track
+                Circle()
+                    .stroke(Color.white.opacity(0.1), lineWidth: 7)
+
+                // Animated Gradient Progress Ring
+                Circle()
+                    .trim(from: 0, to: CGFloat(manager.progressRatio))
+                    .stroke(
+                        AngularGradient(
+                            gradient: Gradient(colors: [phaseColor.opacity(0.7), phaseColor]),
+                            center: .center
+                        ),
+                        style: StrokeStyle(lineWidth: 7, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                    .animation(.linear(duration: 0.5), value: manager.progressRatio)
+
+                // Timer Digital Countdown & Phase Info
+                VStack(spacing: 2) {
+                    Text(formattedTime)
+                        .font(.system(size: 26, weight: .bold, design: .rounded))
+                        .foregroundStyle(.white)
+                        .monospacedDigit()
+
+                    HStack(spacing: 4) {
+                        Image(systemName: manager.phase.icon)
+                            .font(.system(size: 10))
+                        Text(manager.phaseDisplayName(for: manager.phase))
+                            .font(.system(size: 11, weight: .semibold, design: .rounded))
+                    }
+                    .foregroundStyle(phaseColor)
+                }
+            }
+            .frame(width: 104, height: 104)
+
+            // Right: Full-width Controls, Phase Bar & Analytics Cards
+            VStack(alignment: .leading, spacing: 10) {
+                // Row 1: Phase Selector Bar
+                HStack(spacing: 8) {
+                    ForEach(PomodoroPhase.allCases) { phase in
+                        Button {
+                            withAnimation(.smooth) {
+                                manager.selectPhase(phase)
+                            }
+                        } label: {
+                            HStack(spacing: 5) {
+                                Image(systemName: phase.icon)
+                                    .font(.system(size: 10))
+                                Text(manager.phaseDisplayName(for: phase))
+                                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(
+                                manager.phase == phase
+                                    ? phaseColor.opacity(0.22)
+                                    : Color.white.opacity(0.06)
+                            )
+                            .foregroundStyle(
+                                manager.phase == phase
+                                    ? phaseColor
+                                    : Color.gray
+                            )
+                            .clipShape(Capsule())
+                            .overlay(
+                                Capsule()
+                                    .stroke(manager.phase == phase ? phaseColor.opacity(0.5) : Color.clear, lineWidth: 1)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+
+                // Row 2: Play/Pause, Quick +5m/-5m Tweak Controls & Actions
+                HStack(spacing: 12) {
+                    // Reset Button
+                    Button {
+                        withAnimation(.smooth) {
+                            manager.reset()
+                        }
+                    } label: {
+                        Image(systemName: "arrow.counterclockwise")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.8))
+                            .frame(width: 30, height: 30)
+                            .background(Color.white.opacity(0.08))
+                            .clipShape(Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .help("Reset Timer")
+
+                    // Play / Pause Main Button
+                    Button {
+                        withAnimation(.smooth) {
+                            manager.togglePlayPause()
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: manager.state == .running ? "pause.fill" : "play.fill")
+                                .font(.system(size: 14, weight: .bold))
+                            Text(manager.state == .running ? "Pause" : (manager.state == .paused ? "Resume" : "Start"))
+                                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                        }
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 7)
+                        .background(phaseColor)
+                        .foregroundStyle(.white)
+                        .clipShape(Capsule())
+                        .shadow(color: phaseColor.opacity(0.4), radius: 5, x: 0, y: 2)
+                    }
+                    .buttonStyle(.plain)
+
+                    // Skip Button
+                    Button {
+                        withAnimation(.smooth) {
+                            manager.skip()
+                        }
+                    } label: {
+                        Image(systemName: "forward.fill")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.8))
+                            .frame(width: 30, height: 30)
+                            .background(Color.white.opacity(0.08))
+                            .clipShape(Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .help("Skip Phase")
+
+                    // Power User Quick Adjustments: +5m / -5m
+                    HStack(spacing: 4) {
+                        Button("-5m") {
+                            withAnimation(.smooth) {
+                                manager.addMinutes(-5)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.gray)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(Color.white.opacity(0.06))
+                        .clipShape(Capsule())
+
+                        Button("+5m") {
+                            withAnimation(.smooth) {
+                                manager.addMinutes(5)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 11, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.gray)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(Color.white.opacity(0.06))
+                        .clipShape(Capsule())
+                    }
+
+                    Spacer(minLength: 4)
+
+                    // Settings Quick Button
+                    Button {
+                        DispatchQueue.main.async {
+                            SettingsWindowController.shared.showWindow(selectedTab: .pomodoro)
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "slider.horizontal.3")
+                                .font(.system(size: 12))
+                            Text("Customize")
+                                .font(.system(size: 11, weight: .medium, design: .rounded))
+                        }
+                        .foregroundStyle(.gray)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(Color.white.opacity(0.06))
+                        .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                // Row 3: Full-width Stats & Progress Cards
+                HStack(spacing: 10) {
+                    // Stat 1: Completed Sessions vs Goal
+                    HStack(spacing: 6) {
+                        Text("🍅")
+                            .font(.system(size: 12))
+                        let target = Defaults[.pomodoroTargetSessions]
+                        Text("Goal: \(manager.completedSessionsCount) / \(target) sessions")
+                            .font(.system(size: 11, weight: .medium, design: .rounded))
+                            .foregroundStyle(.white.opacity(0.9))
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(Color.white.opacity(0.05))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                    // Stat 2: Long Break Progress
+                    HStack(spacing: 6) {
+                        Image(systemName: "cup.and.saucer")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.gray)
+                        let interval = max(1, Defaults[.pomodoroLongBreakInterval])
+                        let rem = manager.completedSessionsCount % interval
+                        let sessionsUntilLong = interval - rem
+                        Text("Next Long Break: in \(sessionsUntilLong) session\(sessionsUntilLong == 1 ? "" : "s")")
+                            .font(.system(size: 11, weight: .medium, design: .rounded))
+                            .foregroundStyle(.gray)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(Color.white.opacity(0.05))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 14)
+        .padding(.bottom, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/boringNotch/components/Settings/PomodoroSettingsView.swift
+++ b/boringNotch/components/Settings/PomodoroSettingsView.swift
@@ -3,6 +3,7 @@
 //  boringNotch
 //
 
+import AppKit
 import Defaults
 import SwiftUI
 
@@ -179,7 +180,10 @@ struct PomodoroSettingsView: View {
                             .font(.system(size: 13, weight: .medium))
                             .foregroundStyle(.secondary)
                             .frame(width: 145, alignment: .leading)
-                        TextField("", value: $longBreakInterval, formatter: NumberFormatter())
+                        TextField("", value: Binding(
+                            get: { max(1, longBreakInterval) },
+                            set: { longBreakInterval = max(1, $0) }
+                        ), formatter: NumberFormatter())
                             .labelsHidden()
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 60)
@@ -194,7 +198,10 @@ struct PomodoroSettingsView: View {
                             .font(.system(size: 13, weight: .medium))
                             .foregroundStyle(.secondary)
                             .frame(width: 145, alignment: .leading)
-                        TextField("", value: $targetSessions, formatter: NumberFormatter())
+                        TextField("", value: Binding(
+                            get: { max(1, targetSessions) },
+                            set: { targetSessions = max(1, $0) }
+                        ), formatter: NumberFormatter())
                             .labelsHidden()
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 60)

--- a/boringNotch/components/Settings/PomodoroSettingsView.swift
+++ b/boringNotch/components/Settings/PomodoroSettingsView.swift
@@ -1,0 +1,264 @@
+//
+//  PomodoroSettingsView.swift
+//  boringNotch
+//
+
+import Defaults
+import SwiftUI
+
+struct PomodoroSettingsView: View {
+    @Default(.pomodoroWorkDuration) var workDuration
+    @Default(.pomodoroShortBreakDuration) var shortBreakDuration
+    @Default(.pomodoroLongBreakDuration) var longBreakDuration
+    @Default(.pomodoroLongBreakInterval) var longBreakInterval
+    @Default(.pomodoroWorkName) var workName
+    @Default(.pomodoroShortBreakName) var shortBreakName
+    @Default(.pomodoroLongBreakName) var longBreakName
+    @Default(.pomodoroTargetSessions) var targetSessions
+    @Default(.pomodoroSoundName) var soundName
+    @Default(.pomodoroAutoStartBreaks) var autoStartBreaks
+    @Default(.pomodoroAutoStartWork) var autoStartWork
+    @Default(.pomodoroSoundEnabled) var soundEnabled
+
+    let availableSounds = ["Glass", "Basso", "Blow", "Bottle", "Frog", "Hero", "Morse", "Ping", "Pop", "Tink"]
+
+    private var currentPresetName: String {
+        let w = Int(workDuration / 60)
+        let s = Int(shortBreakDuration / 60)
+        let l = Int(longBreakDuration / 60)
+
+        if w == 25 && s == 5 && l == 15 { return "Classic" }
+        if w == 50 && s == 10 && l == 20 { return "Extended" }
+        if w == 90 && s == 15 && l == 30 { return "DeepWork" }
+        if w == 15 && s == 3 && l == 10 { return "Sprint" }
+        return "Custom"
+    }
+
+    private func applyPresetByName(_ name: String) {
+        switch name {
+        case "Classic":
+            applyPreset(w: 25, s: 5, l: 15)
+        case "Extended":
+            applyPreset(w: 50, s: 10, l: 20)
+        case "DeepWork":
+            applyPreset(w: 90, s: 15, l: 30)
+        case "Sprint":
+            applyPreset(w: 15, s: 3, l: 10)
+        default:
+            break
+        }
+    }
+
+    private func applyPreset(w: Int, s: Int, l: Int) {
+        workDuration = TimeInterval(w * 60)
+        shortBreakDuration = TimeInterval(s * 60)
+        longBreakDuration = TimeInterval(l * 60)
+        PomodoroManager.shared.resetTimeToPhase()
+    }
+
+    var body: some View {
+        Form {
+            Section("Preset Workflows") {
+                Picker("Preset Workflow", selection: Binding(
+                    get: { currentPresetName },
+                    set: { applyPresetByName($0) }
+                )) {
+                    Text("Custom").tag("Custom")
+                    Text("Classic Pomodoro (25 / 5 / 15 min)").tag("Classic")
+                    Text("Extended Focus (50 / 10 / 20 min)").tag("Extended")
+                    Text("Deep Work (90 / 15 / 30 min)").tag("DeepWork")
+                    Text("Quick Sprint (15 / 3 / 10 min)").tag("Sprint")
+                }
+                .tint(.effectiveAccent)
+            }
+
+            Section("Custom Phase Labels") {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack {
+                        Text("Work:")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 90, alignment: .leading)
+                        TextField("", text: $workName, prompt: Text("Work Phase Name"))
+                            .labelsHidden()
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    HStack {
+                        Text("Short Break:")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 90, alignment: .leading)
+                        TextField("", text: $shortBreakName, prompt: Text("Short Break Name"))
+                            .labelsHidden()
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    HStack {
+                        Text("Long Break:")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 90, alignment: .leading)
+                        TextField("", text: $longBreakName, prompt: Text("Long Break Name"))
+                            .labelsHidden()
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    HStack {
+                        Spacer()
+                        Button("Save") {
+                            PomodoroManager.shared.objectWillChange.send()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .tint(.effectiveAccent)
+                    }
+                    .padding(.top, 2)
+                }
+                .padding(.vertical, 4)
+            }
+
+            Section("Durations & Goals") {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack {
+                        Text("Work Duration:")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 145, alignment: .leading)
+                        TextField("", value: Binding(
+                            get: { Int(workDuration / 60) },
+                            set: { workDuration = TimeInterval(max(1, min(180, $0)) * 60) }
+                        ), formatter: NumberFormatter())
+                        .labelsHidden()
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 60)
+                        .multilineTextAlignment(.trailing)
+                        Text("min")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack {
+                        Text("Short Break Duration:")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 145, alignment: .leading)
+                        TextField("", value: Binding(
+                            get: { Int(shortBreakDuration / 60) },
+                            set: { shortBreakDuration = TimeInterval(max(1, min(60, $0)) * 60) }
+                        ), formatter: NumberFormatter())
+                        .labelsHidden()
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 60)
+                        .multilineTextAlignment(.trailing)
+                        Text("min")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack {
+                        Text("Long Break Duration:")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 145, alignment: .leading)
+                        TextField("", value: Binding(
+                            get: { Int(longBreakDuration / 60) },
+                            set: { longBreakDuration = TimeInterval(max(1, min(120, $0)) * 60) }
+                        ), formatter: NumberFormatter())
+                        .labelsHidden()
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 60)
+                        .multilineTextAlignment(.trailing)
+                        Text("min")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack {
+                        Text("Long Break Interval:")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 145, alignment: .leading)
+                        TextField("", value: $longBreakInterval, formatter: NumberFormatter())
+                            .labelsHidden()
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 60)
+                            .multilineTextAlignment(.trailing)
+                        Text("sessions")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack {
+                        Text("Daily Target Goal:")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 145, alignment: .leading)
+                        TextField("", value: $targetSessions, formatter: NumberFormatter())
+                            .labelsHidden()
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 60)
+                            .multilineTextAlignment(.trailing)
+                        Text("sessions")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack {
+                        Spacer()
+                        Button("Save") {
+                            PomodoroManager.shared.resetTimeToPhase()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .tint(.effectiveAccent)
+                    }
+                    .padding(.top, 2)
+                }
+                .padding(.vertical, 4)
+            }
+
+            Section("Notifications & Audio Alert") {
+                Toggle("Play Completion Sound", isOn: $soundEnabled)
+                    .tint(.effectiveAccent)
+
+                if soundEnabled {
+                    Picker("Chime Sound", selection: $soundName) {
+                        ForEach(availableSounds, id: \.self) { sound in
+                            Text(sound).tag(sound)
+                        }
+                    }
+
+                    Button("Preview Chime Sound") {
+                        NSSound(named: NSSound.Name(soundName))?.play()
+                    }
+                }
+
+                Toggle("Auto-start Breaks", isOn: $autoStartBreaks)
+                    .tint(.effectiveAccent)
+                Toggle("Auto-start Work Sessions", isOn: $autoStartWork)
+                    .tint(.effectiveAccent)
+            }
+
+            Section {
+                Button("Reset All Preferences to Defaults") {
+                    workDuration = 25 * 60
+                    shortBreakDuration = 5 * 60
+                    longBreakDuration = 15 * 60
+                    longBreakInterval = 4
+                    workName = "Work"
+                    shortBreakName = "Short Break"
+                    longBreakName = "Long Break"
+                    targetSessions = 8
+                    soundName = "Glass"
+                    autoStartBreaks = false
+                    autoStartWork = false
+                    soundEnabled = true
+                    PomodoroManager.shared.reset()
+                }
+                .foregroundStyle(.red)
+            }
+        }
+        .formStyle(.grouped)
+    }
+}

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -9,7 +9,7 @@ import Sparkle
 import SwiftUI
 import SwiftUIIntrospect
 
-private enum SettingsTab: String, CaseIterable, Identifiable {
+enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case appearance
     case media
@@ -18,6 +18,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
     case battery
     case shelf
     case mirror
+    case pomodoro
     case shortcuts
     case advanced
     case about
@@ -34,6 +35,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .battery: "Battery"
         case .shelf: "Shelf"
         case .mirror: "Mirror"
+        case .pomodoro: "Pomodoro"
         case .shortcuts: "Shortcuts"
         case .advanced: "Advanced"
         case .about: "About"
@@ -50,6 +52,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .battery: "battery.100.bolt"
         case .shelf: "books.vertical"
         case .mirror: "camera"
+        case .pomodoro: "timer"
         case .shortcuts: "keyboard"
         case .advanced: "gearshape.2"
         case .about: "info.circle"
@@ -58,18 +61,19 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
 }
 
 struct SettingsView: View {
-    @State private var selectedTab: SettingsTab = .general
+    @ObservedObject var windowController: SettingsWindowController
     @State private var accentColorUpdateTrigger = UUID()
 
     let updaterController: SPUStandardUpdaterController?
 
-    init(updaterController: SPUStandardUpdaterController? = nil) {
+    init(windowController: SettingsWindowController = .shared, updaterController: SPUStandardUpdaterController? = nil) {
+        self.windowController = windowController
         self.updaterController = updaterController
     }
 
     var body: some View {
         NavigationSplitView {
-            List(selection: $selectedTab) {
+            List(selection: $windowController.selectedTab) {
                 ForEach(SettingsTab.allCases) { tab in
                     Label(tab.title, systemImage: tab.systemImage)
                         .tag(tab)
@@ -81,7 +85,7 @@ struct SettingsView: View {
             .navigationSplitViewColumnWidth(200)
         } detail: {
             Group {
-                switch selectedTab {
+                switch windowController.selectedTab {
                 case .general:
                     GeneralSettings()
                 case .appearance:
@@ -98,6 +102,8 @@ struct SettingsView: View {
                     Shelf()
                 case .mirror:
                     MirrorSettings()
+                case .pomodoro:
+                    PomodoroSettingsView()
                 case .shortcuts:
                     Shortcuts()
                 case .advanced:
@@ -106,7 +112,6 @@ struct SettingsView: View {
                     if let controller = updaterController {
                         About(updaterController: controller)
                     } else {
-                        // Fallback with a default controller
                         About(
                             updaterController: SPUStandardUpdaterController(
                                 startingUpdater: false, updaterDelegate: nil,

--- a/boringNotch/components/Settings/SettingsWindowController.swift
+++ b/boringNotch/components/Settings/SettingsWindowController.swift
@@ -10,10 +10,11 @@ import SwiftUI
 import Defaults
 import Sparkle
 
-class SettingsWindowController: NSWindowController {
+class SettingsWindowController: NSWindowController, ObservableObject {
     static let shared = SettingsWindowController()
     private var updaterController: SPUStandardUpdaterController?
-    
+    @Published var selectedTab: SettingsTab = .general
+
     private init() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 700, height: 600),
@@ -58,7 +59,7 @@ class SettingsWindowController: NSWindowController {
         window.identifier = NSUserInterfaceItemIdentifier("BoringNotchSettingsWindow")
         
         // Create the SwiftUI content
-        let settingsView = SettingsView(updaterController: updaterController)
+        let settingsView = SettingsView(windowController: self, updaterController: updaterController)
         let hostingView = NSHostingView(rootView: settingsView)
         window.contentView = hostingView
         
@@ -66,7 +67,8 @@ class SettingsWindowController: NSWindowController {
         window.delegate = self
     }
     
-    func showWindow() {
+    func showWindow(selectedTab: SettingsTab = .general) {
+        self.selectedTab = selectedTab
         // Set app to regular mode first
         NSApp.setActivationPolicy(.regular)
         
@@ -92,11 +94,7 @@ class SettingsWindowController: NSWindowController {
         }
     }
     
-    override func close() {
-        super.close()
-        relinquishFocus()
-    }
-    
+
     private func relinquishFocus() {
         window?.orderOut(nil)
         
@@ -115,8 +113,7 @@ extension SettingsWindowController: NSWindowDelegate {
     }
     
     func windowDidBecomeKey(_ notification: Notification) {
-        // Ensure app is in regular mode when window becomes key
-        NSApp.setActivationPolicy(.regular)
+        // Window is now key — activation policy already set in showWindow()
     }
     
     func windowDidResignKey(_ notification: Notification) {

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -16,7 +16,8 @@ struct TabModel: Identifiable {
 
 let tabs = [
     TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
+    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf),
+    TabModel(label: "Pomodoro", icon: "timer", view: .pomodoro)
 ]
 
 struct TabSelectionView: View {

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -5,6 +5,7 @@
 //  Created by Hugo Persson on 2024-08-25.
 //
 
+import Defaults
 import SwiftUI
 
 struct TabModel: Identifiable {
@@ -22,10 +23,21 @@ let tabs = [
 
 struct TabSelectionView: View {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @Default(.boringShelf) var boringShelf
     @Namespace var animation
+
+    var activeTabs: [TabModel] {
+        tabs.filter { tab in
+            if tab.view == .shelf {
+                return boringShelf
+            }
+            return true
+        }
+    }
+
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(tabs) { tab in
+            ForEach(activeTabs) { tab in
                     TabButton(label: tab.label, icon: tab.icon, selected: coordinator.currentView == tab.view) {
                         withAnimation(.smooth) {
                             coordinator.currentView = tab.view

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -21,6 +21,7 @@ public enum NotchState {
 public enum NotchViews {
     case home
     case shelf
+    case pomodoro
 }
 
 enum DownloadIndicatorStyle: String, Defaults.Serializable {

--- a/boringNotch/managers/PomodoroManager.swift
+++ b/boringNotch/managers/PomodoroManager.swift
@@ -1,0 +1,259 @@
+//
+//  PomodoroManager.swift
+//  boringNotch
+//
+
+import AppKit
+import Combine
+import Defaults
+import Foundation
+import UserNotifications
+
+public enum PomodoroPhase: String, CaseIterable, Identifiable, Codable {
+    case work = "Work"
+    case shortBreak = "Short Break"
+    case longBreak = "Long Break"
+
+    public var id: String { self.rawValue }
+
+    var icon: String {
+        switch self {
+        case .work: return "briefcase.fill"
+        case .shortBreak: return "cup.and.saucer.fill"
+        case .longBreak: return "bed.double.fill"
+        }
+    }
+}
+
+public enum PomodoroState: String, Codable {
+    case idle
+    case running
+    case paused
+}
+
+@MainActor
+public class PomodoroManager: ObservableObject {
+    public static let shared = PomodoroManager()
+
+    @Published public var phase: PomodoroPhase = .work {
+        didSet {
+            if state == .idle {
+                resetTimeToPhase()
+            }
+        }
+    }
+
+    @Published public var state: PomodoroState = .idle
+    @Published public var timeRemaining: TimeInterval = 25 * 60
+    @Published public var completedSessionsCount: Int = 0
+
+    private var timerCancellable: AnyCancellable?
+
+    private init() {
+        self.timeRemaining = targetDuration(for: .work)
+        setupNotificationPermissions()
+    }
+
+    public var targetDuration: TimeInterval {
+        targetDuration(for: phase)
+    }
+
+    public func targetDuration(for phase: PomodoroPhase) -> TimeInterval {
+        switch phase {
+        case .work:
+            return Defaults[.pomodoroWorkDuration]
+        case .shortBreak:
+            return Defaults[.pomodoroShortBreakDuration]
+        case .longBreak:
+            return Defaults[.pomodoroLongBreakDuration]
+        }
+    }
+
+    public var progressRatio: Double {
+        let total = targetDuration
+        guard total > 0 else { return 0 }
+        let elapsed = total - timeRemaining
+        return max(0, min(1, elapsed / total))
+    }
+
+    public func start() {
+        guard state != .running else { return }
+        if state == .idle {
+            timeRemaining = targetDuration
+        }
+        state = .running
+        startTimer()
+    }
+
+    public func pause() {
+        guard state == .running else { return }
+        state = .paused
+        stopTimer()
+    }
+
+    public func resume() {
+        guard state == .paused else { return }
+        state = .running
+        startTimer()
+    }
+
+    public func togglePlayPause() {
+        switch state {
+        case .running:
+            pause()
+        case .paused:
+            resume()
+        case .idle:
+            start()
+        }
+    }
+
+    public func reset() {
+        stopTimer()
+        state = .idle
+        resetTimeToPhase()
+    }
+
+    public func skip() {
+        stopTimer()
+        advanceToNextPhase(didCompleteCurrent: false)
+    }
+
+    public func selectPhase(_ newPhase: PomodoroPhase) {
+        stopTimer()
+        phase = newPhase
+        state = .idle
+        resetTimeToPhase()
+    }
+
+    public func resetTimeToPhase() {
+        timeRemaining = targetDuration(for: phase)
+    }
+
+    private func startTimer() {
+        stopTimer()
+        timerCancellable = Timer.publish(every: 1.0, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                self?.tick()
+            }
+    }
+
+    private func stopTimer() {
+        timerCancellable?.cancel()
+        timerCancellable = nil
+    }
+
+    private func tick() {
+        guard state == .running else { return }
+
+        if timeRemaining > 1 {
+            timeRemaining -= 1
+        } else {
+            timeRemaining = 0
+            handlePhaseCompletion()
+        }
+    }
+
+    public func addMinutes(_ mins: Int) {
+        let addedSeconds = TimeInterval(mins * 60)
+        timeRemaining = max(10, timeRemaining + addedSeconds)
+    }
+
+    public func phaseDisplayName(for phase: PomodoroPhase) -> String {
+        switch phase {
+        case .work:
+            let name = Defaults[.pomodoroWorkName]
+            return name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Work" : name
+        case .shortBreak:
+            let name = Defaults[.pomodoroShortBreakName]
+            return name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Short Break" : name
+        case .longBreak:
+            let name = Defaults[.pomodoroLongBreakName]
+            return name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Long Break" : name
+        }
+    }
+
+    public func applyPreset(workMinutes: Int, shortBreakMinutes: Int, longBreakMinutes: Int) {
+        Defaults[.pomodoroWorkDuration] = TimeInterval(workMinutes * 60)
+        Defaults[.pomodoroShortBreakDuration] = TimeInterval(shortBreakMinutes * 60)
+        Defaults[.pomodoroLongBreakDuration] = TimeInterval(longBreakMinutes * 60)
+        resetTimeToPhase()
+    }
+
+    private func handlePhaseCompletion() {
+        stopTimer()
+
+        // Sound alert
+        if Defaults[.pomodoroSoundEnabled] {
+            let soundName = Defaults[.pomodoroSoundName]
+            NSSound(named: NSSound.Name(soundName))?.play()
+        }
+
+        let completedPhase = phase
+        let isWorkPhase = (completedPhase == .work)
+
+        if isWorkPhase {
+            completedSessionsCount += 1
+            sendNotification(
+                title: "Pomodoro Completed! 🍅",
+                body: "Great job! Time to take a break."
+            )
+        } else {
+            sendNotification(
+                title: "Break Finished! ⚡️",
+                body: "Ready to focus on your next work session?"
+            )
+        }
+
+        advanceToNextPhase(didCompleteCurrent: true)
+    }
+
+    private func advanceToNextPhase(didCompleteCurrent: Bool) {
+        let longBreakInterval = Defaults[.pomodoroLongBreakInterval]
+
+        if phase == .work {
+            if completedSessionsCount > 0 && (completedSessionsCount % longBreakInterval == 0) {
+                phase = .longBreak
+            } else {
+                phase = .shortBreak
+            }
+
+            resetTimeToPhase()
+
+            if didCompleteCurrent && Defaults[.pomodoroAutoStartBreaks] {
+                start()
+            } else {
+                state = .idle
+            }
+        } else {
+            phase = .work
+            resetTimeToPhase()
+
+            if didCompleteCurrent && Defaults[.pomodoroAutoStartWork] {
+                start()
+            } else {
+                state = .idle
+            }
+        }
+    }
+
+    private func setupNotificationPermissions() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+    }
+
+    private func sendNotification(title: String, body: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = UNNotificationSound.default
+
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+    }
+}

--- a/boringNotch/managers/PomodoroManager.swift
+++ b/boringNotch/managers/PomodoroManager.swift
@@ -212,7 +212,7 @@ public class PomodoroManager: NSObject, ObservableObject, UNUserNotificationCent
     }
 
     private func advanceToNextPhase(didCompleteCurrent: Bool) {
-        let longBreakInterval = Defaults[.pomodoroLongBreakInterval]
+        let longBreakInterval = max(1, Defaults[.pomodoroLongBreakInterval])
 
         if phase == .work {
             if completedSessionsCount > 0 && (completedSessionsCount % longBreakInterval == 0) {
@@ -248,7 +248,6 @@ public class PomodoroManager: NSObject, ObservableObject, UNUserNotificationCent
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
-        content.sound = UNNotificationSound.default
 
         let request = UNNotificationRequest(
             identifier: UUID().uuidString,
@@ -266,6 +265,6 @@ public class PomodoroManager: NSObject, ObservableObject, UNUserNotificationCent
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
         // Force notifications to show as visual banner alerts even if app is focused
-        completionHandler([.banner, .sound])
+        completionHandler([.banner])
     }
 }

--- a/boringNotch/managers/PomodoroManager.swift
+++ b/boringNotch/managers/PomodoroManager.swift
@@ -32,7 +32,7 @@ public enum PomodoroState: String, Codable {
 }
 
 @MainActor
-public class PomodoroManager: ObservableObject {
+public class PomodoroManager: NSObject, ObservableObject, UNUserNotificationCenterDelegate {
     public static let shared = PomodoroManager()
 
     @Published public var phase: PomodoroPhase = .work {
@@ -49,9 +49,11 @@ public class PomodoroManager: ObservableObject {
 
     private var timerCancellable: AnyCancellable?
 
-    private init() {
+    private override init() {
+        super.init()
         self.timeRemaining = targetDuration(for: .work)
         setupNotificationPermissions()
+        UNUserNotificationCenter.current().delegate = self
     }
 
     public var targetDuration: TimeInterval {
@@ -255,5 +257,15 @@ public class PomodoroManager: ObservableObject {
         )
 
         UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+    nonisolated public func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        // Force notifications to show as visual banner alerts even if app is focused
+        completionHandler([.banner, .sound])
     }
 }

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -279,6 +279,20 @@ extension Defaults.Keys {
     
     // MARK: Battery
     static let showPowerStatusNotifications = Key<Bool>("showPowerStatusNotifications", default: true)
+    
+    // MARK: Pomodoro
+    static let pomodoroWorkDuration = Key<TimeInterval>("pomodoroWorkDuration", default: 25 * 60)
+    static let pomodoroShortBreakDuration = Key<TimeInterval>("pomodoroShortBreakDuration", default: 5 * 60)
+    static let pomodoroLongBreakDuration = Key<TimeInterval>("pomodoroLongBreakDuration", default: 15 * 60)
+    static let pomodoroLongBreakInterval = Key<Int>("pomodoroLongBreakInterval", default: 4)
+    static let pomodoroWorkName = Key<String>("pomodoroWorkName", default: "Work")
+    static let pomodoroShortBreakName = Key<String>("pomodoroShortBreakName", default: "Short Break")
+    static let pomodoroLongBreakName = Key<String>("pomodoroLongBreakName", default: "Long Break")
+    static let pomodoroTargetSessions = Key<Int>("pomodoroTargetSessions", default: 8)
+    static let pomodoroSoundName = Key<String>("pomodoroSoundName", default: "Glass")
+    static let pomodoroAutoStartBreaks = Key<Bool>("pomodoroAutoStartBreaks", default: false)
+    static let pomodoroAutoStartWork = Key<Bool>("pomodoroAutoStartWork", default: false)
+    static let pomodoroSoundEnabled = Key<Bool>("pomodoroSoundEnabled", default: true)
     static let showBatteryIndicator = Key<Bool>("showBatteryIndicator", default: true)
     static let showBatteryPercentage = Key<Bool>("showBatteryPercentage", default: true)
     static let showPowerStatusIcons = Key<Bool>("showPowerStatusIcons", default: true)


### PR DESCRIPTION
### Summary

Adds a fully integrated Pomodoro timer to Boring Notch.

### Why Do We Need This
The Pomodoro technique is one of the most popular time-management methods for maintaining focus and productivity. Since Boring Notch acts as an easily accessible interactive overlay at the top of the screen, it is the perfect home for a Pomodoro timer. 
Adding this feature provides users with:
1. **At-a-glance focus tracking** right from their screen notch without requiring a full third-party app window.
2. **Reduced screen clutter** by utilizing the notch area to control focus intervals.
3. **Frictionless workflow control** through quick hover access and customizable presets built directly into the system settings.
---
### What Was Changed
- **PomodoroManager**: Created a main state machine managing timer logic, phases (Work, Short Break, Long Break), daily target analytics, and sound/notification alerts.
- **PomodoroView**: Built a notch-optimized interface displaying an animated circular progress ring, countdown clock, phase selector bar, session metrics, and control shortcuts (Play, Pause, Skip, Reset, and ±5m timing adjustments).
- **Settings & Preferences**:
  - Integrated custom configurations (work/break durations, target sessions, phase names, audio chime alerts, autostart rules) using `Defaults` in `Constants.swift`.
  - Added a dedicated "Pomodoro" tab interface to `SettingsView` and `PomodoroSettingsView`.
- **System Stability Fixes**: Refactored `SettingsWindowController` window dismissal handling to resolve a crash loop caused by duplicate activation policy transitions.
- **Xcode Compatibility**: Downgraded Package.resolved and project version configurations to ensure compatibility with standard Xcode releases (16.x / Swift 6.1).
---
### Testing

- Built successfully
- Verified timer countdown
- Verified pause/resume/reset
- Verified settings persistence
- Verified notifications
---
### Features
- **Visual Circular Progress Ring**: An elegant, animated circle tracking the current phase duration, dynamically themed 
 (🔴 Work, 🟢 Short Break, 🔵 Long Break).
- **Productivity Workflows (Presets)**: Includes built-in workflows:
  - *Classic Pomodoro*: 25m work / 5m short break / 15m long break.
  - *Extended Focus*: 50m work / 10m short break / 20m long break.
  - *Deep Work*: 90m work / 15m short break / 30m long break.
  - *Quick Sprint*: 15m work / 3m short break / 10m long break.
- **Customizable Intervals**: Custom duration controls for each session type.
- **Customizable Labels**: Ability to personalize names for each phase (e.g., "Coding", "Tea Break", "Nap").
- **Smart Control Shortcuts**: Play, pause, skip, and reset actions, plus quick time-tweak adjustments (+5 mins / -5 mins) inside the notch widget.
- **Analytics & Goal Tracking**: Keep track of focus sessions completed toward a daily target goal, with automatic calculations for when the next long break is due.
- **Sound Alerts & Notifications**: Sends macOS system notifications on completion and plays your choice of audio alert (Glass, Basso, Morse, etc.).
- **Auto-Start Modes**: Options to automatically transition and start the next work session or break phase.

---
### Images
<img width="596" height="184" alt="image" src="https://github.com/user-attachments/assets/002ee970-c239-4da8-a926-2ca82ff7f565" />
<img width="599" height="191" alt="image" src="https://github.com/user-attachments/assets/4e86d6ab-37dc-42e4-95f3-9bf30acbfcf1" />
<img width="701" height="600" alt="image" src="https://github.com/user-attachments/assets/9a023f4c-73f2-42d4-a951-087e1e01a82f" />
<img width="697" height="339" alt="image" src="https://github.com/user-attachments/assets/7c730d0d-5b64-469d-a0bd-92e3c8e79460" />