### PR TITLE
fix(media): resolve stale artwork in browser private browsing and helper processes(fix for macOS 26.5.2)

### DIFF
--- a/boringNotch/helpers/AppIcons.swift
+++ b/boringNotch/helpers/AppIcons.swift
@@ -36,10 +36,29 @@ struct AppIcons {
     
 }
 
+func normalizeBundleIdentifier(_ bundleID: String) -> String {
+    let lower = bundleID.lowercased()
+    
+    // Handle WebKit / Safari rendering helper processes
+    if lower.contains("safari") || lower.contains("webkit") {
+        return "com.apple.Safari"
+    }
+    
+    // General rule for Chromium/Electron helper processes
+    // e.g., "com.google.Chrome.helper" -> "com.google.Chrome"
+    let components = bundleID.components(separatedBy: ".")
+    if let helperIndex = components.firstIndex(where: { $0.lowercased() == "helper" }) {
+        return components[0..<helperIndex].joined(separator: ".")
+    }
+    
+    return bundleID
+}
+
 func AppIcon(for bundleID: String) -> Image {
     let workspace = NSWorkspace.shared
+    let normalizedID = normalizeBundleIdentifier(bundleID)
     
-    if let appURL = workspace.urlForApplication(withBundleIdentifier: bundleID) {
+    if let appURL = workspace.urlForApplication(withBundleIdentifier: normalizedID) {
         let appIcon = workspace.icon(forFile: appURL.path)
         return Image(nsImage: appIcon)
     }
@@ -50,8 +69,9 @@ func AppIcon(for bundleID: String) -> Image {
 
 func AppIconAsNSImage(for bundleID: String) -> NSImage? {
     let workspace = NSWorkspace.shared
+    let normalizedID = normalizeBundleIdentifier(bundleID)
     
-    if let appURL = workspace.urlForApplication(withBundleIdentifier: bundleID) {
+    if let appURL = workspace.urlForApplication(withBundleIdentifier: normalizedID) {
         let appIcon = workspace.icon(forFile: appURL.path)
         appIcon.size = NSSize(width: 256, height: 256)
         return appIcon

--- a/boringNotch/helpers/AppIcons.swift
+++ b/boringNotch/helpers/AppIcons.swift
@@ -39,8 +39,13 @@ struct AppIcons {
 func normalizeBundleIdentifier(_ bundleID: String) -> String {
     let lower = bundleID.lowercased()
     
+    // Handle Safari Technology Preview rendering helper processes
+    if lower.hasPrefix("com.apple.safaritechnologypreview.") {
+        return "com.apple.SafariTechnologyPreview"
+    }
+    
     // Handle WebKit / Safari rendering helper processes
-    if lower.contains("safari") || lower.contains("webkit") {
+    if lower.hasPrefix("com.apple.webkit.") || lower.hasPrefix("com.apple.safari.") {
         return "com.apple.Safari"
     }
     

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -219,6 +219,9 @@ class MusicManager: ObservableObject {
                 if let appIconImage = AppIconAsNSImage(for: state.bundleIdentifier) {
                     self.usingAppIconForArtwork = true
                     self.updateAlbumArt(newAlbumArt: appIconImage)
+                } else {
+                    self.usingAppIconForArtwork = false
+                    self.updateAlbumArt(newAlbumArt: defaultImage)
                 }
             }
             self.artworkData = state.artwork


### PR DESCRIPTION
Fixes #1394

### Why We Need This
In macOS (specifically on macOS 26.5.2 Tahoe with updated WebKit process isolation), media played inside Safari Private Browsing or browser helper processes is attributed to sandboxed subprocess identifiers (such as `com.apple.WebKit.WebContent` or `.helper` processes). 

Because `com.apple.WebKit.WebContent` is a background helper framework rather than an application bundle, `AppIconAsNSImage` failed to resolve an app icon for the browser, causing stale artwork from a previously played track (e.g., Apple Music or Spotify) to remain stuck on screen.

### What Was Changed
1. **Bundle Identifier Normalization** (`AppIcons.swift`): Added a `normalizeBundleIdentifier` helper function to map WebKit subprocess identifiers (`com.apple.WebKit.WebContent`, etc.) and Chromium/Electron helper processes back to their main application bundle identifiers (e.g., `com.apple.Safari`).
2. **Default Artwork Fallback** (`MusicManager.swift`): Added a fallback in `MusicManager.swift` so that if no artwork metadata and no app icon can be resolved for a media session, the artwork is explicitly reset to the default placeholder image (`defaultImage`), ensuring stale artwork is never left stuck on screen.

---

### How Was This Tested
1. Played a track in Apple Music/Spotify until artwork appeared in the Boring Notch.
2. Opened a YouTube video in a **Safari Private Browsing** window (`com.apple.WebKit.WebContent` session).
3. Verified that the old Apple Music album cover was cleared and the Notch correctly resolved and displayed the **Safari app icon**.
