### PR TITLE
Use session-scoped event tap for media controls

### DIFF
--- a/boringNotch/observers/MediaKeyInterceptor.swift
+++ b/boringNotch/observers/MediaKeyInterceptor.swift
@@ -80,7 +80,7 @@ final class MediaKeyInterceptor {
 
         let mask = CGEventMask(1 << kSystemDefinedEventType.rawValue)
         eventTap = CGEvent.tapCreate(
-            tap: .cghidEventTap,
+            tap: .cgSessionEventTap,
             place: .headInsertEventTap,
             options: .defaultTap,
             eventsOfInterest: mask,


### PR DESCRIPTION
## Summary

- Use `.cgSessionEventTap` instead of `.cghidEventTap` for media-key interception.
- Preserve the existing active filter and Accessibility authorization flow.
- Allow HID and remote-control events to enter the login session at the documented event-tap boundary.

## Why

The HID-scoped tap intercepts events as they enter the window server, while the session-scoped tap is specifically documented for HID and remote-control events entering a login session. This should provide more reliable behaviour, but it will now conflict with other apps that intercept these events, like Lunar or BetterDisplay.