### PR TITLE
feat(calendar): join meetings directly from the notch

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07FE456E7AEA085D9FCA6D97 /* MeetingLinkDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B2A5E5F4D28F1DD9CD0B09 /* MeetingLinkDetector.swift */; };
 		1100290C2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1100290B2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift */; };
 		110029272E84FD4C00035A57 /* TemporaryFileStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110029262E84FD4C00035A57 /* TemporaryFileStorageService.swift */; };
 		1100292A2E8691B400035A57 /* FileShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110029292E8691B400035A57 /* FileShareView.swift */; };
@@ -123,6 +124,7 @@
 		14E9FEAE2C7325770062E83F /* Button+Bouncing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E9FEAD2C7325770062E83F /* Button+Bouncing.swift */; };
 		14FC6E502C7DED5600C7BEA5 /* DataTypes+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FC6E4F2C7DED5600C7BEA5 /* DataTypes+Extensions.swift */; };
 		201C3E071A104384B8629328 /* AudioOutputRouteResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFAD1670A870402D88BFFE47 /* AudioOutputRouteResolver.swift */; };
+		3C1B922F0813671B2886CF43 /* MeetingLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA22021D89A9E4FF88A618D /* MeetingLink.swift */; };
 		507266DB2C908E2E00A2D00D /* HoverButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507266DA2C908E2E00A2D00D /* HoverButton.swift */; };
 		5917FD112E57891600E87F1C /* MediaKeyInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5917FD102E57891600E87F1C /* MediaKeyInterceptor.swift */; };
 		5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */; };
@@ -307,6 +309,7 @@
 		14E9FEA92C70BF610062E83F /* DownloadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadView.swift; sourceTree = "<group>"; };
 		14E9FEAD2C7325770062E83F /* Button+Bouncing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Button+Bouncing.swift"; sourceTree = "<group>"; };
 		14FC6E4F2C7DED5600C7BEA5 /* DataTypes+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataTypes+Extensions.swift"; sourceTree = "<group>"; };
+		3CA22021D89A9E4FF88A618D /* MeetingLink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeetingLink.swift; sourceTree = "<group>"; };
 		507266DA2C908E2E00A2D00D /* HoverButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverButton.swift; sourceTree = "<group>"; };
 		5917FD102E57891600E87F1C /* MediaKeyInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaKeyInterceptor.swift; sourceTree = "<group>"; };
 		5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationRelauncher.swift; sourceTree = "<group>"; };
@@ -337,12 +340,13 @@
 		B1D6FD422C6603730015F173 /* SoftwareUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdater.swift; sourceTree = "<group>"; };
 		B1F0A0012E60000100000001 /* BrightnessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrightnessManager.swift; sourceTree = "<group>"; };
 		B1FEB4982C7686630066EBBC /* PanGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanGesture.swift; sourceTree = "<group>"; };
+		B9B2A5E5F4D28F1DD9CD0B09 /* MeetingLinkDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeetingLinkDetector.swift; sourceTree = "<group>"; };
 		F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCaptureManager.swift; sourceTree = "<group>"; };
 		F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryActivityManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		11F7485C2EC9AABA00F841DB /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		11F7485C2EC9AABA00F841DB /* Exceptions for "BoringNotchXPCHelper" folder in "BoringNotchXPCHelper" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -352,8 +356,29 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		112FB72F2CCF12CC0015238C /* private */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = private; sourceTree = "<group>"; };
-		11F748502EC9AABA00F841DB /* BoringNotchXPCHelper */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (11F7485C2EC9AABA00F841DB /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = BoringNotchXPCHelper; sourceTree = "<group>"; };
+		112FB72F2CCF12CC0015238C /* private */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = private;
+			sourceTree = "<group>";
+		};
+		11F748502EC9AABA00F841DB /* BoringNotchXPCHelper */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				11F7485C2EC9AABA00F841DB /* Exceptions for "BoringNotchXPCHelper" folder in "BoringNotchXPCHelper" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = BoringNotchXPCHelper;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -469,6 +494,7 @@
 			isa = PBXGroup;
 			children = (
 				116398952DF5D6C00052E6AF /* CalendarServiceProviding.swift */,
+				B9B2A5E5F4D28F1DD9CD0B09 /* MeetingLinkDetector.swift */,
 			);
 			path = Providers;
 			sourceTree = "<group>";
@@ -730,6 +756,7 @@
 				14D570C82C5F38890011E668 /* BoringViewModel.swift */,
 				14D570CA2C5F4B2C0011E668 /* BatteryStatusViewModel.swift */,
 				1153BD902D986DB300979FB0 /* PlaybackState.swift */,
+				3CA22021D89A9E4FF88A618D /* MeetingLink.swift */,
 			);
 			path = models;
 			sourceTree = "<group>";
@@ -861,8 +888,6 @@
 				11F748502EC9AABA00F841DB /* BoringNotchXPCHelper */,
 			);
 			name = BoringNotchXPCHelper;
-			packageProductDependencies = (
-			);
 			productName = BoringNotchXPCHelper;
 			productReference = 11F7484F2EC9AABA00F841DB /* BoringNotchXPCHelper.xpc */;
 			productType = "com.apple.product-type.xpc-service";
@@ -1120,6 +1145,8 @@
 				1100290C2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift in Sources */,
 				11CFC6632E09918400748C80 /* MusicControllerSelectionView.swift in Sources */,
 				B1F0A0022E60000100000001 /* BrightnessManager.swift in Sources */,
+				3C1B922F0813671B2886CF43 /* MeetingLink.swift in Sources */,
+				07FE456E7AEA085D9FCA6D97 /* MeetingLinkDetector.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -170,6 +170,13 @@
 			remoteGlobalIDString = 11F7484E2EC9AABA00F841DB;
 			remoteInfo = BoringNotchXPCHelper;
 		};
+		A5167216301F85B40018095A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 14CEF40A2C5CAED200855D72 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 14CEF4112C5CAED300855D72;
+			remoteInfo = boringNotch;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -319,6 +326,7 @@
 		9A0887342C7AFF8E00C160EA /* TabSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSelectionView.swift; sourceTree = "<group>"; };
 		9A987A032C73CA66005CA465 /* ShelfView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShelfView.swift; sourceTree = "<group>"; };
 		9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotchHomeView.swift; sourceTree = "<group>"; };
+		A5167212301F85B40018095A /* boringNotchTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = boringNotchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AFAD1670A870402D88BFFE47 /* AudioOutputRouteResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioOutputRouteResolver.swift; sourceTree = "<group>"; };
 		B10348D82C74E56000475897 /* ConditionalModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalModifier.swift; sourceTree = "<group>"; };
 		B10F84A22C6C9596009F3026 /* TestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView.swift; sourceTree = "<group>"; };
@@ -346,7 +354,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		11F7485C2EC9AABA00F841DB /* Exceptions for "BoringNotchXPCHelper" folder in "BoringNotchXPCHelper" target */ = {
+		11F7485C2EC9AABA00F841DB /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -356,29 +364,9 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		112FB72F2CCF12CC0015238C /* private */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = private;
-			sourceTree = "<group>";
-		};
-		11F748502EC9AABA00F841DB /* BoringNotchXPCHelper */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				11F7485C2EC9AABA00F841DB /* Exceptions for "BoringNotchXPCHelper" folder in "BoringNotchXPCHelper" target */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = BoringNotchXPCHelper;
-			sourceTree = "<group>";
-		};
+		112FB72F2CCF12CC0015238C /* private */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = private; sourceTree = "<group>"; };
+		11F748502EC9AABA00F841DB /* BoringNotchXPCHelper */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (11F7485C2EC9AABA00F841DB /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = BoringNotchXPCHelper; sourceTree = "<group>"; };
+		A5167213301F85B40018095A /* boringNotchTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = boringNotchTests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -406,6 +394,13 @@
 				B19016222CC15B3D00E3F12E /* Defaults in Frameworks */,
 				111BE95D2ECD71E10079DD4E /* AsyncXPCConnection in Frameworks */,
 				B1628B922CC260C0003D8DF3 /* SwiftUIIntrospect in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A516720F301F85B40018095A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -666,6 +661,7 @@
 				112B0EB62E30DD0F00562D6C /* mediaremote-adapter */,
 				14CEF4142C5CAED300855D72 /* boringNotch */,
 				11F748502EC9AABA00F841DB /* BoringNotchXPCHelper */,
+				A5167213301F85B40018095A /* boringNotchTests */,
 				14CEF4132C5CAED300855D72 /* Products */,
 				14D031EC2C689DB70096E6A1 /* Frameworks */,
 			);
@@ -676,6 +672,7 @@
 			children = (
 				14CEF4122C5CAED300855D72 /* boringNotch.app */,
 				11F7484F2EC9AABA00F841DB /* BoringNotchXPCHelper.xpc */,
+				A5167212301F85B40018095A /* boringNotchTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -929,6 +926,29 @@
 			productReference = 14CEF4122C5CAED300855D72 /* boringNotch.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A5167211301F85B40018095A /* boringNotchTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A516721A301F85B40018095A /* Build configuration list for PBXNativeTarget "boringNotchTests" */;
+			buildPhases = (
+				A516720E301F85B40018095A /* Sources */,
+				A516720F301F85B40018095A /* Frameworks */,
+				A5167210301F85B40018095A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A5167217301F85B40018095A /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A5167213301F85B40018095A /* boringNotchTests */,
+			);
+			name = boringNotchTests;
+			packageProductDependencies = (
+			);
+			productName = boringNotchTests;
+			productReference = A5167212301F85B40018095A /* boringNotchTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -936,7 +956,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1640;
+				LastSwiftUpdateCheck = 2660;
 				LastUpgradeCheck = 1640;
 				TargetAttributes = {
 					11F7484E2EC9AABA00F841DB = {
@@ -945,6 +965,10 @@
 					14CEF4112C5CAED300855D72 = {
 						CreatedOnToolsVersion = 15.4;
 						LastSwiftMigration = 1640;
+					};
+					A5167211301F85B40018095A = {
+						CreatedOnToolsVersion = 26.6;
+						TestTargetID = 14CEF4112C5CAED300855D72;
 					};
 				};
 			};
@@ -976,6 +1000,7 @@
 			targets = (
 				14CEF4112C5CAED300855D72 /* boringNotch */,
 				11F7484E2EC9AABA00F841DB /* BoringNotchXPCHelper */,
+				A5167211301F85B40018095A /* boringNotchTests */,
 			);
 		};
 /* End PBXProject section */
@@ -998,6 +1023,13 @@
 				112B0EB92E30DD0F00562D6C /* mediaremote-adapter.pl in Resources */,
 				B17266E12C6532560031BA0D /* Localizable.xcstrings in Resources */,
 				14A7E5972C65FD31008C1BE9 /* boring.m4a in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A5167210301F85B40018095A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1150,6 +1182,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A516720E301F85B40018095A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -1157,6 +1196,11 @@
 			isa = PBXTargetDependency;
 			target = 11F7484E2EC9AABA00F841DB /* BoringNotchXPCHelper */;
 			targetProxy = 11F748592EC9AABA00F841DB /* PBXContainerItemProxy */;
+		};
+		A5167217301F85B40018095A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 14CEF4112C5CAED300855D72 /* boringNotch */;
+			targetProxy = A5167216301F85B40018095A /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1468,6 +1512,46 @@
 			};
 			name = Release;
 		};
+		A5167218301F85B40018095A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.qareai.boringNotchTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/boringNotch.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/boringNotch";
+			};
+			name = Debug;
+		};
+		A5167219301F85B40018095A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.qareai.boringNotchTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/boringNotch.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/boringNotch";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1494,6 +1578,15 @@
 			buildConfigurations = (
 				14CEF4222C5CAED400855D72 /* Debug */,
 				14CEF4232C5CAED400855D72 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A516721A301F85B40018095A /* Build configuration list for PBXNativeTarget "boringNotchTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A5167218301F85B40018095A /* Debug */,
+				A5167219301F85B40018095A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -6147,6 +6147,9 @@
         }
       }
     },
+    "Copy Meeting Link" : {
+
+    },
     "Copy items on drag" : {
       "localizations" : {
         "de" : {
@@ -11900,6 +11903,12 @@
         }
       }
     },
+    "Join %@ meeting" : {
+
+    },
+    "Join meeting when tapping an event" : {
+
+    },
     "Keep Boring Notch Updated" : {
       "comment" : "A title for a view that allows users to configure Boring Notch's update preferences.",
       "localizations" : {
@@ -16243,6 +16252,9 @@
           }
         }
       }
+    },
+    "Open in Calendar" : {
+
     },
     "Open notch on hover" : {
       "localizations" : {

--- a/boringNotch/Providers/CalendarServiceProviding.swift
+++ b/boringNotch/Providers/CalendarServiceProviding.swift
@@ -149,7 +149,12 @@ extension EventModel {
             participants: .init(from: event),
             timeZone: calendar.isSubscribed || calendar.isDelegate ? nil : event.timeZone,
             hasRecurrenceRules: event.hasRecurrenceRules || event.isDetached,
-            priority: nil
+            priority: nil,
+            meetingLink: MeetingLinkDetector.detect(
+                url: event.url,
+                location: event.location,
+                notes: event.notes
+            )
         )
     }
     
@@ -173,7 +178,8 @@ extension EventModel {
             participants: [],
             timeZone: calendar.isSubscribed || calendar.isDelegate ? nil : reminder.timeZone,
             hasRecurrenceRules: reminder.hasRecurrenceRules,
-            priority: .init(from: reminder.priority)
+            priority: .init(from: reminder.priority),
+            meetingLink: nil
         )
     }
 }

--- a/boringNotch/Providers/MeetingLinkDetector.swift
+++ b/boringNotch/Providers/MeetingLinkDetector.swift
@@ -1,0 +1,49 @@
+//
+//  MeetingLinkDetector.swift
+//  boringNotch
+//
+
+import Foundation
+
+/// Finds a video-meeting join URL on a calendar event.
+///
+/// EventKit exposes no public API for conference links, so the URL is recovered by
+/// parsing the event's own text fields. Detection is deliberately conservative:
+/// only known provider hosts count, and the structured fields outrank free text so
+/// an unrelated link in a long description cannot beat the organiser's own values.
+enum MeetingLinkDetector {
+
+    /// Field priority: `url` then `location` then `notes`. First classified match wins.
+    static func detect(url: URL?, location: String?, notes: String?) -> MeetingLink? {
+        if let url, let link = classify(url) { return link }
+        if let location, let link = firstLink(in: location) { return link }
+        if let notes, let link = firstLink(in: notes) { return link }
+        return nil
+    }
+
+    /// First recognised meeting URL in a block of free text.
+    static func firstLink(in text: String) -> MeetingLink? {
+        guard !text.isEmpty,
+              let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        else { return nil }
+
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        var found: MeetingLink?
+        detector.enumerateMatches(in: text, options: [], range: range) { match, _, stop in
+            guard let url = match?.url, let link = classify(url) else { return }
+            found = link
+            stop.pointee = true
+        }
+        return found
+    }
+
+    /// Maps a URL to a provider, or nil if the host is not a known meeting service.
+    static func classify(_ url: URL) -> MeetingLink? {
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = url.host(),
+              let provider = MeetingProvider.provider(forHost: host)
+        else { return nil }
+        return MeetingLink(url: url, provider: provider)
+    }
+}

--- a/boringNotch/components/Calendar/BoringCalendar.swift
+++ b/boringNotch/components/Calendar/BoringCalendar.swift
@@ -585,6 +585,7 @@ struct EventListView: View {
     let events: [EventModel]
     @Default(.autoScrollToNextEvent) private var autoScrollToNextEvent
     @Default(.showFullEventTitles) private var showFullEventTitles
+    @State private var hoveredEventID: String?
 
 
     static func filteredEvents(events: [EventModel]) -> [EventModel] {
@@ -629,15 +630,38 @@ struct EventListView: View {
             List {
                 ForEach(filteredEvents) { event in
                     Button(action: {
-                        if let url = event.calendarAppURL() {
+                        if let link = event.meetingLink, Defaults[.joinMeetingOnEventTap] {
+                            openURL(link.url)
+                        } else if let url = event.calendarAppURL() {
                             openURL(url)
                         }
                     }) {
-                        eventRow(event)
+                        eventRow(event, isHovered: hoveredEventID == event.id)
                     }
                     .id(event.id)
                     .padding(.leading, -5)
                     .buttonStyle(PlainButtonStyle())
+                    .onHover { hovering in
+                        // Guarded: moving between adjacent rows fires the new row's
+                        // enter before the old row's exit, so an unguarded nil would
+                        // clear the wrong row.
+                        if hovering {
+                            hoveredEventID = event.id
+                        } else if hoveredEventID == event.id {
+                            hoveredEventID = nil
+                        }
+                    }
+                    .contextMenu {
+                        if let url = event.calendarAppURL() {
+                            Button("Open in Calendar") { openURL(url) }
+                        }
+                        if let link = event.meetingLink {
+                            Button("Copy Meeting Link") {
+                                NSPasteboard.general.clearContents()
+                                NSPasteboard.general.setString(link.url.absoluteString, forType: .string)
+                            }
+                        }
+                    }
                     .listRowSeparator(.automatic)
                     .listRowSeparatorTint(.gray.opacity(0.2))
                     .listRowBackground(Color.clear)
@@ -657,7 +681,7 @@ struct EventListView: View {
         Spacer(minLength: 0)
     }
 
-    private func eventRow(_ event: EventModel) -> some View {
+    private func eventRow(_ event: EventModel, isHovered: Bool) -> some View {
         if event.type.isReminder {
             let isCompleted: Bool
             if case .reminder(let completed) = event.type {
@@ -733,6 +757,27 @@ struct EventListView: View {
                         }
                     }
                     Spacer(minLength: 0)
+
+                    // Joinable indicator. The 16pt frame lives on the Group, not the
+                    // Image, so the column holds its width whether or not a glyph is
+                    // drawn — otherwise the time column goes ragged between rows.
+                    Group {
+                        if let link = event.meetingLink {
+                            Image(systemName: "video.fill")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(isHovered ? Color.effectiveAccent : .white.opacity(0.5))
+                                .padding(3)
+                                .background(
+                                    Capsule().fill(isHovered ? Color.gray.opacity(0.2) : .clear)
+                                )
+                                .animation(.smooth(duration: 0.3), value: isHovered)
+                                .accessibilityLabel("Join \(link.provider.displayName) meeting")
+                        } else {
+                            Color.clear
+                        }
+                    }
+                    .frame(width: 16)
+
                     VStack(alignment: .trailing, spacing: 4) {
                         if event.isAllDay {
                             Text("All-day")

--- a/boringNotch/components/Settings/Views/CalendarSettingsView.swift
+++ b/boringNotch/components/Settings/Views/CalendarSettingsView.swift
@@ -35,6 +35,9 @@ struct CalendarSettings: View {
             Defaults.Toggle(key: .showFullEventTitles) {
                 Text("Always show full event titles")
             }
+            Defaults.Toggle(key: .joinMeetingOnEventTap) {
+                Text("Join meeting when tapping an event")
+            }
             Defaults.Toggle(key: .calendarWeekView) {
                 Text("Weekly view")
             }

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -322,6 +322,7 @@ extension Defaults.Keys {
     static let autoScrollToNextEvent = Key<Bool>("autoScrollToNextEvent", default: true)
     static let calendarWeekView = Key<Bool>("calendarWeekView", default: false)
     static let weekStartDay = Key<WeekStartDay>("weekStartDay", default: .system)
+    static let joinMeetingOnEventTap = Key<Bool>("joinMeetingOnEventTap", default: true)
     
     // MARK: Fullscreen Media Detection
     static let hideNotchOption = Key<HideNotchOption>("hideNotchOption", default: .nowPlayingOnly)

--- a/boringNotch/models/EventModel.swift
+++ b/boringNotch/models/EventModel.swift
@@ -24,6 +24,9 @@ struct EventModel: Equatable, Identifiable {
     let timeZone: TimeZone?
     let hasRecurrenceRules: Bool
     let priority: Priority?
+    /// Video-meeting join link recovered from the event's own fields, if any.
+    /// Resolved once at fetch time — never on the view path.
+    let meetingLink: MeetingLink?
 }
 
 enum AttendanceStatus: Comparable {

--- a/boringNotch/models/MeetingLink.swift
+++ b/boringNotch/models/MeetingLink.swift
@@ -1,0 +1,58 @@
+//
+//  MeetingLink.swift
+//  boringNotch
+//
+
+import Foundation
+
+/// A video-conferencing service recognised on calendar events.
+enum MeetingProvider: String, Codable, CaseIterable, Sendable {
+    case googleMeet
+    case zoom
+    case teams
+    case webex
+    case whereby
+    case jitsi
+
+    /// Human-readable name, used in the accessibility label.
+    var displayName: String {
+        switch self {
+        case .googleMeet: return "Google Meet"
+        case .zoom: return "Zoom"
+        case .teams: return "Microsoft Teams"
+        case .webex: return "Webex"
+        case .whereby: return "Whereby"
+        case .jitsi: return "Jitsi"
+        }
+    }
+
+    /// Host suffixes that identify this provider. A host matches when it equals a
+    /// suffix exactly or ends with "." + suffix, so `acme.zoom.us` matches `zoom.us`
+    /// while `notzoom.us` does not.
+    var hostSuffixes: [String] {
+        switch self {
+        case .googleMeet: return ["meet.google.com", "hangouts.google.com"]
+        case .zoom: return ["zoom.us", "zoomgov.com"]
+        case .teams: return ["teams.microsoft.com", "teams.live.com"]
+        case .webex: return ["webex.com"]
+        case .whereby: return ["whereby.com"]
+        case .jitsi: return ["meet.jit.si"]
+        }
+    }
+
+    static func provider(forHost host: String) -> MeetingProvider? {
+        let host = host.lowercased()
+        for provider in MeetingProvider.allCases {
+            for suffix in provider.hostSuffixes where host == suffix || host.hasSuffix("." + suffix) {
+                return provider
+            }
+        }
+        return nil
+    }
+}
+
+/// A join URL discovered on a calendar event, plus the service it belongs to.
+struct MeetingLink: Equatable, Codable, Sendable {
+    let url: URL
+    let provider: MeetingProvider
+}

--- a/boringNotchTests/MeetingLinkDetectorTests.swift
+++ b/boringNotchTests/MeetingLinkDetectorTests.swift
@@ -1,0 +1,120 @@
+//
+//  MeetingLinkDetectorTests.swift
+//  boringNotchTests
+//
+
+import XCTest
+
+@testable import boringNotch
+
+final class MeetingLinkDetectorTests: XCTestCase {
+
+    private func detect(url: String? = nil, location: String? = nil, notes: String? = nil) -> MeetingLink? {
+        MeetingLinkDetector.detect(
+            url: url.flatMap(URL.init(string:)),
+            location: location,
+            notes: notes
+        )
+    }
+
+    // MARK: - Provider recognition
+
+    func testGoogleMeetInNotes() {
+        let link = detect(notes: "Join with Google Meet: https://meet.google.com/abc-defg-hij\nOr dial in")
+        XCTAssertEqual(link?.provider, .googleMeet)
+        XCTAssertEqual(link?.url.host(), "meet.google.com")
+    }
+
+    func testZoomInLocation() {
+        XCTAssertEqual(detect(location: "https://zoom.us/j/1234567890?pwd=xYz")?.provider, .zoom)
+    }
+
+    func testZoomVanitySubdomain() {
+        let link = detect(location: "https://acme.zoom.us/j/999")
+        XCTAssertEqual(link?.provider, .zoom)
+        XCTAssertEqual(link?.url.host(), "acme.zoom.us")
+    }
+
+    func testTeamsAcrossNewlines() {
+        let link = detect(notes: """
+            Click here to join the meeting
+            https://teams.microsoft.com/l/meetup-join/19%3ameeting_abc
+            Learn more
+            """)
+        XCTAssertEqual(link?.provider, .teams)
+    }
+
+    func testWebexSubdomain() {
+        XCTAssertEqual(detect(location: "https://acme.webex.com/meet/x")?.provider, .webex)
+    }
+
+    func testJitsi() {
+        XCTAssertEqual(detect(location: "https://meet.jit.si/StandUp")?.provider, .jitsi)
+    }
+
+    func testWhereby() {
+        XCTAssertEqual(detect(location: "https://whereby.com/team")?.provider, .whereby)
+    }
+
+    // MARK: - Field priority
+
+    func testURLFieldBeatsLocation() {
+        let link = detect(url: "https://meet.google.com/aaa-bbbb-ccc", location: "https://zoom.us/j/111")
+        XCTAssertEqual(link?.provider, .googleMeet)
+    }
+
+    func testLocationBeatsNotes() {
+        let link = detect(location: "https://zoom.us/j/222",
+                          notes: "Old link https://meet.google.com/zzz-yyyy-xxx")
+        XCTAssertEqual(link?.provider, .zoom)
+    }
+
+    func testFirstKnownLinkWinsWithinAField() {
+        let link = detect(notes: "https://example.com/x then https://whereby.com/team then https://zoom.us/j/1")
+        XCTAssertEqual(link?.provider, .whereby)
+    }
+
+    // MARK: - Rejection
+
+    func testUnknownHostIgnored() {
+        XCTAssertNil(detect(notes: "Agenda: https://docs.google.com/document/d/abc123/edit"))
+    }
+
+    func testLookalikeHostRejected() {
+        XCTAssertNil(detect(location: "https://notzoom.us/j/1"))
+    }
+
+    func testNonHTTPSchemeRejected() {
+        XCTAssertNil(detect(url: "mailto:someone@zoom.us"))
+    }
+
+    func testAllFieldsNil() {
+        XCTAssertNil(detect())
+    }
+
+    func testEmptyStrings() {
+        XCTAssertNil(detect(location: "", notes: ""))
+    }
+
+    // MARK: - Real-world regression
+
+    /// Verbatim Google Calendar invite boilerplate. It contains two decoy links
+    /// after the join link — the tel.meet dial-in page and the support.google.com
+    /// help article — either of which a naive "first URL" parser would pick.
+    /// Verified against live Google Calendar data on 2026-08-02.
+    func testRealGoogleInviteBoilerplate() {
+        let link = detect(notes: """
+            -::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-
+            Join with Google Meet: https://meet.google.com/qms-wgjc-ygk
+            Or dial: (US) +1 402-989-0231 PIN: 757713660#
+            More phone numbers: https://tel.meet/qms-wgjc-ygk?pin=7644906875876&hs=7
+
+            Learn more about Meet at: https://support.google.com/a/users/answer/9282720
+
+            Please do not edit this section.
+            -::~:~::~:~:~:~:~:~:~:
+            """)
+        XCTAssertEqual(link?.provider, .googleMeet)
+        XCTAssertEqual(link?.url.absoluteString, "https://meet.google.com/qms-wgjc-ygk")
+    }
+}


### PR DESCRIPTION
## What this adds

Tapping a calendar event in the notch currently opens Apple Calendar. When that event is a video meeting, this makes it open the meeting instead — one click from the notch straight into the call.

Events that have a detected meeting link show a small video glyph. Apple Calendar stays reachable from the row's context menu, and the whole thing can be turned off in settings.

## Why the link is parsed rather than read from EventKit

There is no public EventKit API for conference links. `EKEvent` exposes no conference property, and the `EKVirtualConference*` family is provider-side plumbing — it is for apps that *create* conferences for Calendar, not for reading one off a synced event. Apple's own Calendar uses private machinery for its Join button, which isn't an option for a sandboxed, Sparkle-updated app.

The link is however present in fields EventKit does expose. Google's CalDAV sync writes the Meet URL into the event description; Zoom links commonly land in `location`; some organisers use `url`. `EventModel` already carried all three, so no changes to the calendar service layer were needed — only detection.

## How detection works

`MeetingLinkDetector` is a pure function over three optional strings — no EventKit, no SwiftUI — which is what makes it unit-testable in isolation.

- `NSDataDetector` extracts candidate URLs, which are then classified by **host suffix** against a static table
- Matching is on host components, so `acme.zoom.us` matches while `notzoom.us` does not
- Field priority is **`url` → `location` → `notes`**, so an unrelated link in a long description can't outrank the organiser's structured fields
- Unknown hosts return `nil` — there is deliberately no generic URL fallback

Providers: Google Meet, Zoom, Teams, Webex, Whereby, Jitsi. Adding another is one line in the table.

Detection runs **once per event at fetch time**, not on the SwiftUI view path — events are only rebuilt on date change and `EKEventStoreChanged`.

This matters more than it might look. A real Google invite contains three links: the Meet URL, a `tel.meet` dial-in page, and a `support.google.com` help article. A naive "first URL in the notes" approach can easily send the user to a help page instead of their meeting.

## Interaction design

The **row** remains the click target; the glyph is an indicator and never receives clicks. That avoids asking the user to acquire a small target inside a surface that dismisses itself on hover-out.

The glyph is always visible on joinable rows (dim), brightening on hover, rather than appearing only on hover. Two reasons: with roughly three rows visible, hover-only marks turn "which of these can I join?" into a serial hover-hunt; and a target that appears only *after* you're hovering adds a second acquisition step on a self-dismissing surface. This also matches the existing idiom in `HoverButton`, where the icon is permanent and only the capsule background animates in.

The glyph column reserves 16pt whether or not a glyph is drawn, so the right-aligned time column stays consistent between rows.

## Accessibility

Resting opacity is pinned at 50% white — **5.28:1** against the black notch, clearing the WCAG 1.4.11 3:1 floor for non-text indicators. (The row's usual secondary grey, dimmed to a comparable weight, measures 2.10:1 and fails, which is why this uses white.) The glyph carries an `accessibilityLabel` naming the provider, since it is otherwise a purely visual signal.

## Settings

One new key, `joinMeetingOnEventTap`, defaulting to **on**, in the Calendar pane. With it off, tapping an event opens Apple Calendar exactly as before while the glyphs remain visible. Happy to flip the default to `false` if you'd prefer the behaviour change be opt-in.

## Tests

Adds `boringNotchTests` — the first test target in the project. 16 cases covering provider recognition, field priority, lookalike-host rejection, non-HTTP scheme rejection and empty input, using `@testable import` so they exercise the shipping types rather than a recompiled copy.

Includes a regression test built from verbatim Google Calendar invite boilerplate, decoy links and all. Verified against live Google Calendar data: 8/8 Meet events detected, 3/3 non-meetings ignored, no false positives.

If you'd rather not take a test target in this PR, I can drop it and land the feature alone.

## Notes for review

- **Translations are untouched.** The `Localizable.xcstrings` change adds four *new English source keys* with empty bodies and modifies zero translated values, so the Crowdin sync can pick them up on `dev`. They were inserted in place rather than via `xcstringstool sync`, which re-sorts the whole catalogue and produced a 6,475-line diff for four strings.
- **No network calls**, and no event data leaves the machine. Detection is local string parsing.
- Built and tested against `dev` on macOS 26.5 with Xcode 26.6.
- Deep links (`zoommtg://`, `msteams://`) are deliberately out of scope — the https URL already hands off to the native app via the browser and works when the app isn't installed. Easy follow-up if wanted.

<img width="865" height="239" alt="2026-08-03_03-55-08" src="https://github.com/user-attachments/assets/85caebca-ad7b-4e30-b706-19e504d22a0f" />

