### PR TITLE
Downsample album artwork before computing its average colour

### DIFF
--- a/boringNotch/extensions/NSImage+Extensions.swift
+++ b/boringNotch/extensions/NSImage+Extensions.swift
@@ -25,10 +25,19 @@ extension NSImage {
                 return
             }
             
-            let width = cgImage.width
-            let height = cgImage.height
+            // Downsample before averaging. Album artwork is routinely 1000x1000
+            // or larger, which means allocating a multi-megabyte scratch buffer
+            // and running a million-iteration loop to produce a single colour.
+            // CoreGraphics area-averages while scaling, so a small box yields
+            // the same average to well within a single 8-bit colour step.
+            let maxDimension = 64
+            let srcWidth = max(1, cgImage.width)
+            let srcHeight = max(1, cgImage.height)
+            let scale = min(1.0, Double(maxDimension) / Double(max(srcWidth, srcHeight)))
+            let width = max(1, Int((Double(srcWidth) * scale).rounded()))
+            let height = max(1, Int((Double(srcHeight) * scale).rounded()))
             let totalPixels = width * height
-            
+
             guard let context = CGContext(data: nil,
                                           width: width,
                                           height: height,


### PR DESCRIPTION
## What

`NSImage.averageColor(completion:)` decodes album artwork at full resolution and sums every pixel on the CPU to produce a single `NSColor`. This patch scales the image into a 64px box first.

## Why

Album art is routinely 1000x1000 or larger. Each track change allocates a scratch buffer of `width * height * 4` bytes and runs a loop over every pixel — roughly 4 MB and a million iterations to compute one colour that drives the spectrogram tint and player accent.

CoreGraphics area-averages while scaling, so the downsampled buffer carries the same information for this purpose.

## Correctness

I compared the new implementation against the existing one on generated test images, including a high-frequency checkerboard as a worst case for downsampling:

| Image | Worst per-channel delta |
|---|---|
| Gradient 1000px | 0.17 / 255 |
| Checkerboard 1200px | 0.00 / 255 |
| Dark + accent 800px | 0.96 / 255 |
| Tiny 40px | 0.00 / 255 |

Worst case is under one displayable 8-bit colour step. Images already smaller than 64px take `scale = 1.0` and are byte-identical to before.

## Measured

| Artwork | Before | After |
|---|---|---|
| 600x600 | 0.16 ms / 1406 KB | 0.01 ms / 16 KB |
| 1000x1000 | 0.44 ms / 3906 KB | 0.01 ms / 16 KB |
| 1400x1400 | 1.05 ms / 7656 KB | 0.01 ms / 16 KB |

The scratch buffer is now constant-size regardless of artwork resolution.

## Notes

- Branched from `dev` per CONTRIBUTING. `xcodebuild` succeeds.
- Behaviour is otherwise unchanged — no API, call-site, or feature changes.
- Found while profiling high idle CPU on v2.7.3 (see #1260). The dominant cause there was the `AnimatedFace` blink timer, which `dev` has already fixed; this is a separate, smaller allocation win that still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)