### PR TITLE
feat: add daily planning and review

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+    name: "BoringNotchDailyPlanning",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "DailyPlanningCore", targets: ["DailyPlanningCore"])
+    ],
+    targets: [
+        .target(
+            name: "DailyPlanningCore",
+            path: "boringNotch/features/DailyPlanning/Core"
+        ),
+        .testTarget(
+            name: "DailyPlanningCoreTests",
+            dependencies: ["DailyPlanningCore"],
+            path: "boringNotchTests"
+        ),
+    ]
+)

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DA1100012F60000000000001 /* DailyPlanningCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1100022F60000000000002 /* DailyPlanningCore.swift */; };
+		DA1100032F60000000000003 /* DailyPlanningManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1100042F60000000000004 /* DailyPlanningManager.swift */; };
+		DA1100052F60000000000005 /* DailyPlanningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1100062F60000000000006 /* DailyPlanningView.swift */; };
 		1100290C2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1100290B2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift */; };
 		110029272E84FD4C00035A57 /* TemporaryFileStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110029262E84FD4C00035A57 /* TemporaryFileStorageService.swift */; };
 		1100292A2E8691B400035A57 /* FileShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110029292E8691B400035A57 /* FileShareView.swift */; };
@@ -196,6 +199,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		DA1100022F60000000000002 /* DailyPlanningCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPlanningCore.swift; sourceTree = "<group>"; };
+		DA1100042F60000000000004 /* DailyPlanningManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPlanningManager.swift; sourceTree = "<group>"; };
+		DA1100062F60000000000006 /* DailyPlanningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPlanningView.swift; sourceTree = "<group>"; };
 		1100290B2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSItemProvider+LoadHelpers.swift"; sourceTree = "<group>"; };
 		110029262E84FD4C00035A57 /* TemporaryFileStorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryFileStorageService.swift; sourceTree = "<group>"; };
 		110029292E8691B400035A57 /* FileShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileShareView.swift; sourceTree = "<group>"; };
@@ -387,6 +393,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		DA1100072F60000000000007 /* DailyPlanning */ = {
+			isa = PBXGroup;
+			children = (
+				DA1100082F60000000000008 /* Core */,
+				DA1100042F60000000000004 /* DailyPlanningManager.swift */,
+				DA1100062F60000000000006 /* DailyPlanningView.swift */,
+			);
+			path = "features/DailyPlanning";
+			sourceTree = "<group>";
+		};
+		DA1100082F60000000000008 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				DA1100022F60000000000002 /* DailyPlanningCore.swift */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
 		1113ABB82E80E27000EC13B2 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -657,6 +681,7 @@
 		14CEF4142C5CAED300855D72 /* boringNotch */ = {
 			isa = PBXGroup;
 			children = (
+				DA1100072F60000000000007 /* DailyPlanning */,
 				11F748672EC9AC9600F841DB /* XPCHelperClient */,
 				116398942DF5D6B40052E6AF /* Providers */,
 				14288DE22C6E016F00B9F80C /* observers */,
@@ -990,6 +1015,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA1100012F60000000000001 /* DailyPlanningCore.swift in Sources */,
+				DA1100032F60000000000003 /* DailyPlanningManager.swift in Sources */,
+				DA1100052F60000000000005 /* DailyPlanningView.swift in Sources */,
 				115C12EC2ED3D003009754CA /* OpenNotchOSD.swift in Sources */,
 				14C08BB92C8DE4B1000F8AA0 /* BoringCalendar.swift in Sources */,
 				5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentView: View {
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var brightnessManager = BrightnessManager.shared
     @ObservedObject var volumeManager = VolumeManager.shared
+    @ObservedObject var dailyPlanningManager = DailyPlanningManager.shared
     @State private var hoverTask: Task<Void, Never>?
     @State private var isHovering: Bool = false
     @State private var anyDropDebounceTask: Task<Void, Never>?
@@ -338,9 +339,14 @@ struct ContentView: View {
                       } else if !coordinator.expandingView.show && vm.notchState == .closed && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {
                           BoringFaceAnimation()
                        } else if vm.notchState == .open {
-                           BoringHeader()
-                               .frame(height: max(24, displayClosedNotchHeight))
-                               .opacity(gestureProgress != 0 ? 1.0 - min(abs(gestureProgress) * 0.1, 0.3) : 1.0)
+                           if dailyPlanningManager.isPresenting || dailyPlanningManager.isFinishingSession {
+                               Color.clear
+                                   .frame(height: max(24, displayClosedNotchHeight))
+                           } else {
+                               BoringHeader()
+                                   .frame(height: max(24, displayClosedNotchHeight))
+                                   .opacity(gestureProgress != 0 ? 1.0 - min(abs(gestureProgress) * 0.1, 0.3) : 1.0)
+                           }
                        }
                         // New case to enable compact notch on external displays
                         else if !vm.hasNotch {
@@ -403,6 +409,8 @@ struct ContentView: View {
                         )
                     case .shelf:
                         ShelfView()
+                    case .dailyPlanning:
+                        DailyPlanningView()
                     }
                 }
                 .transition(

--- a/boringNotch/Providers/CalendarServiceProviding.swift
+++ b/boringNotch/Providers/CalendarServiceProviding.swift
@@ -14,6 +14,8 @@ protocol CalendarServiceProviding {
     func requestAccess(to type: EKEntityType) async throws -> Bool
     func calendars() async -> [CalendarModel]
     func events(from start: Date, to end: Date, calendars: [String]) async -> [EventModel]
+    func reminders(from start: Date, to end: Date) async -> [EventModel]
+    func setReminderCompleted(reminderID: String, completed: Bool) async
 }
 
 class CalendarService: CalendarServiceProviding {
@@ -79,6 +81,13 @@ class CalendarService: CalendarServiceProviding {
         }
         
         return events.sorted { $0.start < $1.start }
+    }
+
+    func reminders(from start: Date, to end: Date) async -> [EventModel] {
+        guard hasAccess(to: .reminder) else { return [] }
+        let reminderCalendars = store.calendars(for: .reminder)
+        return await fetchReminders(from: start, to: end, calendars: reminderCalendars)
+            .sorted { $0.start < $1.start }
     }
     
     private func fetchReminders(from start: Date, to end: Date, calendars: [EKCalendar]) async -> [EventModel] {

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -76,6 +76,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var whatsNewWindow: NSWindow?
     var timer: Timer?
     var closeNotchTask: Task<Void, Never>?
+    var dailyWorkflowDismissTask: Task<Void, Never>?
     private var previousScreens: [NSScreen]?
     private var onboardingWindowController: NSWindowController?
     private var screenLockedObserver: Any?
@@ -366,6 +367,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         })
 
+        observers.append(NotificationCenter.default.addObserver(
+            forName: .dailyWorkflowNeedsPresentation, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.presentDailyWorkflow()
+            }
+        })
+
+        observers.append(NotificationCenter.default.addObserver(
+            forName: .dailyWorkflowDidFinish, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.dismissDailyWorkflow()
+            }
+        })
+
         // Use closure-based observers for DistributedNotificationCenter and keep tokens for removal
         screenLockedObserver = DistributedNotificationCenter.default().addObserver(
             forName: NSNotification.Name(rawValue: "com.apple.screenIsLocked"),
@@ -465,6 +482,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         setupDragDetectors()
 
+        Task { @MainActor in
+            DailyPlanningManager.shared.start()
+        }
+
         if coordinator.firstLaunch {
             DispatchQueue.main.async {
                 self.showOnboardingWindow()
@@ -483,6 +504,41 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // make sure OSD subsystems are in the right state now that initial
         // notch windows have been created/cleaned up
         coordinator.applyOSDSources()
+    }
+
+    @MainActor
+    private func presentDailyWorkflow() {
+        guard DailyPlanningManager.shared.isPresenting else { return }
+
+        closeNotchTask?.cancel()
+        closeNotchTask = nil
+        dailyWorkflowDismissTask?.cancel()
+        dailyWorkflowDismissTask = nil
+        coordinator.currentView = .dailyPlanning
+
+        if Defaults[.showOnAllDisplays] {
+            let preferredViewModel = viewModels[coordinator.selectedScreenUUID] ?? viewModels.values.first
+            _ = preferredViewModel?.open()
+        } else {
+            _ = vm.open()
+        }
+    }
+
+    @MainActor
+    private func dismissDailyWorkflow() {
+        vm.close()
+        viewModels.values.forEach { $0.close() }
+
+        dailyWorkflowDismissTask?.cancel()
+        dailyWorkflowDismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 550_000_000)
+            guard !Task.isCancelled, let self else { return }
+
+            // The daily view stays empty until every notch window has finished closing.
+            self.coordinator.currentView = .home
+            DailyPlanningManager.shared.completeFinishingSession()
+            self.dailyWorkflowDismissTask = nil
+        }
     }
 
     func playWelcomeSound() {
@@ -594,6 +650,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // windows might have been added/removed during the earlier logic –
         // update the OSD subsystems accordingly.
         coordinator.applyOSDSources()
+
+        if DailyPlanningManager.shared.isPresenting {
+            Task { @MainActor in
+                self.presentDailyWorkflow()
+            }
+        }
     }
 
     @objc func togglePopover(_ sender: Any?) {

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -12,11 +12,14 @@ struct BoringHeader: View {
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @ObservedObject var dailyPlanningManager = DailyPlanningManager.shared
     @StateObject var tvm = ShelfStateViewModel.shared
     var body: some View {
         HStack(spacing: 0) {
             HStack {
-                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
+                if dailyPlanningManager.isPresenting {
+                    EmptyView()
+                } else if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
                     TabSelectionView()
                 } else if vm.notchState == .open {
                     EmptyView()

--- a/boringNotch/components/Settings/Views/CalendarSettingsView.swift
+++ b/boringNotch/components/Settings/Views/CalendarSettingsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct CalendarSettings: View {
     @ObservedObject private var calendarManager = CalendarManager.shared
+    @ObservedObject private var dailyPlanningManager = DailyPlanningManager.shared
     @Default(.showCalendar) var showCalendar: Bool
     @Default(.hideCompletedReminders) var hideCompletedReminders
     @Default(.hideAllDayEvents) var hideAllDayEvents
@@ -44,6 +45,45 @@ struct CalendarSettings: View {
                         Text(day.localizedString).tag(day)
                     }
                 }
+            }
+            Section(header: Text("Daily Planning & Review")) {
+                Toggle(
+                    "Morning planning",
+                    isOn: Binding(
+                        get: { dailyPlanningManager.preferences.morningPlanningEnabled },
+                        set: { dailyPlanningManager.setEnabled($0, for: .morningPlanning) }
+                    )
+                )
+                DatePicker(
+                    "Planning time",
+                    selection: Binding(
+                        get: { dailyPlanningManager.configuredTime(for: .morningPlanning) },
+                        set: { dailyPlanningManager.setTime($0, for: .morningPlanning) }
+                    ),
+                    displayedComponents: .hourAndMinute
+                )
+                .disabled(!dailyPlanningManager.preferences.morningPlanningEnabled)
+
+                Toggle(
+                    "Evening review",
+                    isOn: Binding(
+                        get: { dailyPlanningManager.preferences.eveningReviewEnabled },
+                        set: { dailyPlanningManager.setEnabled($0, for: .eveningReview) }
+                    )
+                )
+                DatePicker(
+                    "Review time",
+                    selection: Binding(
+                        get: { dailyPlanningManager.configuredTime(for: .eveningReview) },
+                        set: { dailyPlanningManager.setTime($0, for: .eveningReview) }
+                    ),
+                    displayedComponents: .hourAndMinute
+                )
+                .disabled(!dailyPlanningManager.preferences.eveningReviewEnabled)
+
+                Text("Sessions open in the notch and stay there until you finish them. Times are stored on this Mac.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
             Section(header: Text("Calendars")) {
                 if calendarManager.calendarAuthorizationStatus != .fullAccess {

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -21,6 +21,7 @@ public enum NotchState {
 public enum NotchViews {
     case home
     case shelf
+    case dailyPlanning
 }
 
 enum DownloadIndicatorStyle: String, Defaults.Serializable {

--- a/boringNotch/features/DailyPlanning/Core/DailyPlanningCore.swift
+++ b/boringNotch/features/DailyPlanning/Core/DailyPlanningCore.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+enum DailyWorkflowKind: String, Codable, CaseIterable, Equatable {
+    case morningPlanning
+    case eveningReview
+}
+
+struct DailyWorkflowPreferences: Codable, Equatable {
+    var morningPlanningEnabled: Bool
+    var morningPlanningMinutes: Int
+    var eveningReviewEnabled: Bool
+    var eveningReviewMinutes: Int
+
+    static let `default` = DailyWorkflowPreferences(
+        morningPlanningEnabled: false,
+        morningPlanningMinutes: 8 * 60,
+        eveningReviewEnabled: false,
+        eveningReviewMinutes: 20 * 60
+    )
+
+    func isEnabled(_ kind: DailyWorkflowKind) -> Bool {
+        switch kind {
+        case .morningPlanning: morningPlanningEnabled
+        case .eveningReview: eveningReviewEnabled
+        }
+    }
+
+    func minutesAfterMidnight(for kind: DailyWorkflowKind) -> Int {
+        switch kind {
+        case .morningPlanning: morningPlanningMinutes
+        case .eveningReview: eveningReviewMinutes
+        }
+    }
+}
+
+struct DailyWorkflowDay: Codable, Equatable {
+    let era: Int
+    let year: Int
+    let month: Int
+    let day: Int
+
+    init(date: Date, calendar: Calendar) {
+        let components = calendar.dateComponents([.era, .year, .month, .day], from: date)
+        era = components.era ?? 1
+        year = components.year ?? 0
+        month = components.month ?? 0
+        day = components.day ?? 0
+    }
+}
+
+struct DailyWorkflowCompletionState: Codable, Equatable {
+    private var morningPlanningDay: DailyWorkflowDay?
+    private var eveningReviewDay: DailyWorkflowDay?
+
+    init(
+        morningPlanningDay: DailyWorkflowDay? = nil,
+        eveningReviewDay: DailyWorkflowDay? = nil
+    ) {
+        self.morningPlanningDay = morningPlanningDay
+        self.eveningReviewDay = eveningReviewDay
+    }
+
+    func isCompleted(_ kind: DailyWorkflowKind, on date: Date, calendar: Calendar) -> Bool {
+        let expectedDay = DailyWorkflowDay(date: date, calendar: calendar)
+        switch kind {
+        case .morningPlanning: return morningPlanningDay == expectedDay
+        case .eveningReview: return eveningReviewDay == expectedDay
+        }
+    }
+
+    mutating func markCompleted(_ kind: DailyWorkflowKind, on date: Date, calendar: Calendar) {
+        let completedDay = DailyWorkflowDay(date: date, calendar: calendar)
+        switch kind {
+        case .morningPlanning: morningPlanningDay = completedDay
+        case .eveningReview: eveningReviewDay = completedDay
+        }
+    }
+}
+
+struct DailyReminderItem: Equatable, Identifiable {
+    let id: String
+    let title: String
+    let dueDate: Date
+    let isCompleted: Bool
+    let listTitle: String
+}
+
+struct DailyReminderSections: Equatable {
+    let all: [DailyReminderItem]
+    let completed: [DailyReminderItem]
+    let incomplete: [DailyReminderItem]
+
+    init(items: [DailyReminderItem], sessionDate: Date, calendar: Calendar) {
+        let day = calendar.dateInterval(of: .day, for: sessionDate)
+        let filtered =
+            items
+            .filter { item in
+                guard let day else { return false }
+                return day.contains(item.dueDate)
+            }
+            .sorted {
+                if $0.dueDate == $1.dueDate {
+                    return $0.title.localizedStandardCompare($1.title) == .orderedAscending
+                }
+                return $0.dueDate < $1.dueDate
+            }
+
+        all = filtered
+        completed = filtered.filter(\.isCompleted)
+        incomplete = filtered.filter { !$0.isCompleted }
+    }
+}
+
+enum DailyWorkflowSchedule {
+    static func dueWorkflow(
+        at date: Date,
+        preferences: DailyWorkflowPreferences,
+        completionState: DailyWorkflowCompletionState,
+        calendar: Calendar = .current
+    ) -> DailyWorkflowKind? {
+        for kind in DailyWorkflowKind.allCases where preferences.isEnabled(kind) {
+            guard !completionState.isCompleted(kind, on: date, calendar: calendar) else {
+                continue
+            }
+            guard
+                let trigger = triggerDate(
+                    for: kind, on: date, preferences: preferences, calendar: calendar)
+            else {
+                continue
+            }
+            if trigger <= date {
+                return kind
+            }
+        }
+        return nil
+    }
+
+    static func nextEvaluation(
+        after date: Date,
+        preferences: DailyWorkflowPreferences,
+        completionState: DailyWorkflowCompletionState,
+        calendar: Calendar = .current
+    ) -> Date? {
+        let candidates = DailyWorkflowKind.allCases.compactMap { kind -> Date? in
+            guard preferences.isEnabled(kind) else { return nil }
+
+            if !completionState.isCompleted(kind, on: date, calendar: calendar),
+                let today = triggerDate(
+                    for: kind, on: date, preferences: preferences, calendar: calendar),
+                today > date
+            {
+                return today
+            }
+
+            guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: date) else {
+                return nil
+            }
+            return triggerDate(
+                for: kind, on: tomorrow, preferences: preferences, calendar: calendar)
+        }
+
+        return candidates.min()
+    }
+
+    static func triggerDate(
+        for kind: DailyWorkflowKind,
+        on date: Date,
+        preferences: DailyWorkflowPreferences,
+        calendar: Calendar = .current
+    ) -> Date? {
+        let minutes = min(max(preferences.minutesAfterMidnight(for: kind), 0), 23 * 60 + 59)
+        return calendar.date(
+            byAdding: .minute,
+            value: minutes,
+            to: calendar.startOfDay(for: date)
+        )
+    }
+}
+
+final class DailyWorkflowPreferencesStore {
+    private enum Key {
+        static let preferences = "dailyWorkflow.preferences.v1"
+        static let completionState = "dailyWorkflow.completionState.v1"
+    }
+
+    private let defaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func loadPreferences() -> DailyWorkflowPreferences {
+        decode(DailyWorkflowPreferences.self, forKey: Key.preferences) ?? .default
+    }
+
+    func savePreferences(_ preferences: DailyWorkflowPreferences) throws {
+        try encode(preferences, forKey: Key.preferences)
+    }
+
+    func loadCompletionState() -> DailyWorkflowCompletionState {
+        decode(DailyWorkflowCompletionState.self, forKey: Key.completionState) ?? .init()
+    }
+
+    func saveCompletionState(_ state: DailyWorkflowCompletionState) throws {
+        try encode(state, forKey: Key.completionState)
+    }
+
+    private func encode<T: Encodable>(_ value: T, forKey key: String) throws {
+        defaults.set(try encoder.encode(value), forKey: key)
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
+        guard let data = defaults.data(forKey: key) else { return nil }
+        return try? decoder.decode(type, from: data)
+    }
+}

--- a/boringNotch/features/DailyPlanning/DailyPlanningManager.swift
+++ b/boringNotch/features/DailyPlanning/DailyPlanningManager.swift
@@ -1,0 +1,314 @@
+import EventKit
+import Foundation
+import SwiftUI
+
+extension Notification.Name {
+    static let dailyWorkflowNeedsPresentation = Notification.Name("DailyWorkflowNeedsPresentation")
+    static let dailyWorkflowDidFinish = Notification.Name("DailyWorkflowDidFinish")
+}
+
+struct DailyWorkflowSession: Equatable, Identifiable {
+    let kind: DailyWorkflowKind
+    let date: Date
+
+    var id: String {
+        "\(kind.rawValue)-\(date.timeIntervalSinceReferenceDate)"
+    }
+}
+
+enum DailyPlanningContentState: Equatable {
+    case idle
+    case loading
+    case loaded(DailyReminderSections)
+    case permissionDenied
+    case failure(String)
+}
+
+@MainActor
+final class DailyPlanningManager: ObservableObject {
+    static let shared = DailyPlanningManager()
+
+    @Published private(set) var preferences: DailyWorkflowPreferences
+    @Published private(set) var activeSession: DailyWorkflowSession?
+    @Published private(set) var contentState: DailyPlanningContentState = .idle
+    @Published private(set) var isFinishingSession = false
+    @Published private(set) var updatingReminderIDs: Set<String> = []
+
+    var isPresenting: Bool { activeSession != nil }
+
+    private let store: DailyWorkflowPreferencesStore
+    private let calendarService: CalendarServiceProviding
+    private var completionState: DailyWorkflowCompletionState
+    private var timer: Timer?
+    private var evaluationTask: Task<Void, Never>?
+    private var eventStoreObserver: NSObjectProtocol?
+    private var hasStarted = false
+
+    init(
+        store: DailyWorkflowPreferencesStore = DailyWorkflowPreferencesStore(),
+        calendarService: CalendarServiceProviding = CalendarService()
+    ) {
+        self.store = store
+        self.calendarService = calendarService
+        preferences = store.loadPreferences()
+        completionState = store.loadCompletionState()
+    }
+
+    deinit {
+        timer?.invalidate()
+        evaluationTask?.cancel()
+        if let eventStoreObserver {
+            NotificationCenter.default.removeObserver(eventStoreObserver)
+        }
+    }
+
+    func start() {
+        guard !hasStarted else {
+            presentActiveSessionIfNeeded()
+            return
+        }
+        hasStarted = true
+        eventStoreObserver = NotificationCenter.default.addObserver(
+            forName: .EKEventStoreChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                guard self?.activeSession != nil else { return }
+                await self?.reloadActiveSession(showLoadingIndicator: false)
+            }
+        }
+        evaluate()
+    }
+
+    func presentActiveSessionIfNeeded() {
+        guard activeSession != nil else { return }
+        NotificationCenter.default.post(name: .dailyWorkflowNeedsPresentation, object: nil)
+    }
+
+    func setEnabled(_ isEnabled: Bool, for kind: DailyWorkflowKind) {
+        updatePreferences { preferences in
+            switch kind {
+            case .morningPlanning:
+                preferences.morningPlanningEnabled = isEnabled
+            case .eveningReview:
+                preferences.eveningReviewEnabled = isEnabled
+            }
+        }
+    }
+
+    func setTime(_ date: Date, for kind: DailyWorkflowKind, calendar: Calendar = .current) {
+        let components = calendar.dateComponents([.hour, .minute], from: date)
+        let minutes = (components.hour ?? 0) * 60 + (components.minute ?? 0)
+        updatePreferences { preferences in
+            switch kind {
+            case .morningPlanning:
+                preferences.morningPlanningMinutes = minutes
+            case .eveningReview:
+                preferences.eveningReviewMinutes = minutes
+            }
+        }
+    }
+
+    func configuredTime(
+        for kind: DailyWorkflowKind, on date: Date = Date(), calendar: Calendar = .current
+    ) -> Date {
+        DailyWorkflowSchedule.triggerDate(
+            for: kind,
+            on: date,
+            preferences: preferences,
+            calendar: calendar
+        ) ?? calendar.startOfDay(for: date)
+    }
+
+    func beginFinishingActiveSession() {
+        guard activeSession != nil, !isFinishingSession else { return }
+        isFinishingSession = true
+    }
+
+    func finalizeActiveSession() {
+        guard let session = activeSession else { return }
+
+        var updatedCompletion = completionState
+        updatedCompletion.markCompleted(session.kind, on: session.date, calendar: .current)
+
+        do {
+            try store.saveCompletionState(updatedCompletion)
+        } catch {
+            contentState = .failure("Your completion could not be saved. Please try again.")
+            isFinishingSession = false
+            return
+        }
+
+        completionState = updatedCompletion
+        activeSession = nil
+        contentState = .idle
+        NotificationCenter.default.post(name: .dailyWorkflowDidFinish, object: nil)
+    }
+
+    func completeFinishingSession() {
+        guard isFinishingSession else { return }
+
+        isFinishingSession = false
+        evaluate()
+    }
+
+    func setReminderCompleted(reminderID: String, completed: Bool) async {
+        guard activeSession != nil,
+            !isFinishingSession,
+            !updatingReminderIDs.contains(reminderID)
+        else {
+            return
+        }
+
+        updatingReminderIDs.insert(reminderID)
+        updateReminderCompletionLocally(reminderID: reminderID, completed: completed)
+        await calendarService.setReminderCompleted(reminderID: reminderID, completed: completed)
+        await reloadActiveSession(showLoadingIndicator: false)
+        updatingReminderIDs.remove(reminderID)
+    }
+
+    func reloadActiveSession(showLoadingIndicator: Bool = true) async {
+        guard let session = activeSession else { return }
+        if showLoadingIndicator {
+            contentState = .loading
+        }
+
+        let status = EKEventStore.authorizationStatus(for: .reminder)
+        let hasAccess: Bool
+        switch status {
+        case .notDetermined:
+            hasAccess = (try? await calendarService.requestAccess(to: .reminder)) == true
+        case .fullAccess, .authorized:
+            hasAccess = true
+        case .denied, .restricted, .writeOnly:
+            hasAccess = false
+        @unknown default:
+            hasAccess = false
+        }
+
+        guard hasAccess else {
+            contentState = .permissionDenied
+            return
+        }
+
+        let calendar = Calendar.current
+        guard let interval = calendar.dateInterval(of: .day, for: session.date) else {
+            contentState = .failure("Today’s reminder window could not be calculated.")
+            return
+        }
+
+        let events = await calendarService.reminders(from: interval.start, to: interval.end)
+        guard activeSession == session else { return }
+
+        let items = events.compactMap { event -> DailyReminderItem? in
+            guard case .reminder(let isCompleted) = event.type else { return nil }
+            return DailyReminderItem(
+                id: event.id,
+                title: event.title,
+                dueDate: event.start,
+                isCompleted: isCompleted,
+                listTitle: event.calendar.title
+            )
+        }
+        contentState = .loaded(
+            DailyReminderSections(
+                items: items,
+                sessionDate: session.date,
+                calendar: calendar
+            ))
+    }
+
+    private func updateReminderCompletionLocally(reminderID: String, completed: Bool) {
+        guard let session = activeSession, case .loaded(let sections) = contentState else { return }
+
+        let updatedItems = sections.all.map { item in
+            guard item.id == reminderID else { return item }
+            return DailyReminderItem(
+                id: item.id,
+                title: item.title,
+                dueDate: item.dueDate,
+                isCompleted: completed,
+                listTitle: item.listTitle
+            )
+        }
+
+        withAnimation(.easeInOut(duration: 0.15)) {
+            contentState = .loaded(
+                DailyReminderSections(
+                    items: updatedItems,
+                    sessionDate: session.date,
+                    calendar: .current
+                )
+            )
+        }
+    }
+
+    private func updatePreferences(_ update: (inout DailyWorkflowPreferences) -> Void) {
+        var updatedPreferences = preferences
+        update(&updatedPreferences)
+        updatedPreferences.morningPlanningMinutes = clampedMinutes(
+            updatedPreferences.morningPlanningMinutes)
+        updatedPreferences.eveningReviewMinutes = clampedMinutes(
+            updatedPreferences.eveningReviewMinutes)
+
+        do {
+            try store.savePreferences(updatedPreferences)
+            preferences = updatedPreferences
+            evaluate()
+        } catch {
+            contentState = .failure("Your schedule could not be saved. Please try again.")
+        }
+    }
+
+    private func clampedMinutes(_ minutes: Int) -> Int {
+        min(max(minutes, 0), 23 * 60 + 59)
+    }
+
+    private func evaluate(at date: Date = Date()) {
+        evaluationTask?.cancel()
+        evaluationTask = Task { [weak self] in
+            await self?.evaluateNow(at: date)
+        }
+    }
+
+    private func evaluateNow(at date: Date) async {
+        timer?.invalidate()
+        timer = nil
+
+        if activeSession != nil {
+            presentActiveSessionIfNeeded()
+            return
+        }
+
+        if let kind = DailyWorkflowSchedule.dueWorkflow(
+            at: date,
+            preferences: preferences,
+            completionState: completionState,
+            calendar: .current
+        ) {
+            activeSession = DailyWorkflowSession(kind: kind, date: date)
+            contentState = .loading
+            NotificationCenter.default.post(name: .dailyWorkflowNeedsPresentation, object: nil)
+            await reloadActiveSession()
+            return
+        }
+
+        guard
+            let nextDate = DailyWorkflowSchedule.nextEvaluation(
+                after: date,
+                preferences: preferences,
+                completionState: completionState,
+                calendar: .current
+            )
+        else { return }
+
+        let timer = Timer(fire: nextDate, interval: 0, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                self?.evaluate()
+            }
+        }
+        self.timer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+}

--- a/boringNotch/features/DailyPlanning/DailyPlanningView.swift
+++ b/boringNotch/features/DailyPlanning/DailyPlanningView.swift
@@ -1,0 +1,201 @@
+import AppKit
+import SwiftUI
+
+struct DailyPlanningView: View {
+    @ObservedObject private var manager = DailyPlanningManager.shared
+
+    var body: some View {
+        ZStack {
+            if !manager.isFinishingSession {
+                VStack(spacing: 8) {
+                    header
+                    content
+                }
+                .transition(.opacity)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.bottom, 8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(.easeOut(duration: 0.12), value: manager.isFinishingSession)
+        .task(id: manager.isFinishingSession) {
+            guard manager.isFinishingSession else { return }
+
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            guard !Task.isCancelled else { return }
+            manager.finalizeActiveSession()
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: sessionKind == .eveningReview ? "moon.stars.fill" : "sunrise.fill")
+                .foregroundStyle(sessionKind == .eveningReview ? .indigo : .orange)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(sessionKind == .eveningReview ? "Evening Review" : "Today’s Plan")
+                    .font(.headline)
+                if let date = manager.activeSession?.date {
+                    Text(date.formatted(date: .abbreviated, time: .omitted))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            Button(sessionKind == .eveningReview ? "Finish Review" : "Finish Planning") {
+                manager.beginFinishingActiveSession()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch manager.contentState {
+        case .idle, .loading:
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Loading today’s reminders…")
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxHeight: .infinity)
+
+        case .permissionDenied:
+            HStack(spacing: 12) {
+                Image(systemName: "exclamationmark.lock.fill")
+                    .foregroundStyle(.orange)
+                Text("Allow Reminders access to use daily planning and review.")
+                    .font(.callout)
+                Spacer()
+                Button("Open Settings") {
+                    guard
+                        let url = URL(
+                            string:
+                                "x-apple.systempreferences:com.apple.preference.security?Privacy_Reminders"
+                        )
+                    else {
+                        return
+                    }
+                    NSWorkspace.shared.open(url)
+                }
+                .controlSize(.small)
+            }
+            .frame(maxHeight: .infinity)
+
+        case .failure(let message):
+            Label(message, systemImage: "exclamationmark.triangle.fill")
+                .font(.callout)
+                .foregroundStyle(.orange)
+                .frame(maxHeight: .infinity)
+
+        case .loaded(let sections):
+            if sections.all.isEmpty {
+                Label("No reminders are due today.", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.secondary)
+                    .frame(maxHeight: .infinity)
+            } else if sessionKind == .eveningReview {
+                eveningSections(sections)
+            } else {
+                reminderList(sections.all, emptyMessage: "Nothing planned")
+            }
+        }
+    }
+
+    private var sessionKind: DailyWorkflowKind {
+        manager.activeSession?.kind ?? .morningPlanning
+    }
+
+    private func eveningSections(_ sections: DailyReminderSections) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            reminderSection(
+                title: "Still open",
+                count: sections.incomplete.count,
+                symbol: "circle",
+                color: .orange,
+                items: sections.incomplete
+            )
+            Divider()
+            reminderSection(
+                title: "Completed",
+                count: sections.completed.count,
+                symbol: "checkmark.circle.fill",
+                color: .green,
+                items: sections.completed
+            )
+        }
+    }
+
+    private func reminderSection(
+        title: String,
+        count: Int,
+        symbol: String,
+        color: Color,
+        items: [DailyReminderItem]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 4) {
+                Image(systemName: symbol).foregroundStyle(color)
+                Text("\(title) · \(count)")
+                    .font(.caption.bold())
+            }
+            reminderList(items, emptyMessage: "None")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func reminderList(_ items: [DailyReminderItem], emptyMessage: String) -> some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 3) {
+                if items.isEmpty {
+                    Text(emptyMessage)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                } else {
+                    ForEach(items) { item in
+                        reminderRow(item)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func reminderRow(_ item: DailyReminderItem) -> some View {
+        HStack(spacing: 6) {
+            Button {
+                Task {
+                    await manager.setReminderCompleted(
+                        reminderID: item.id,
+                        completed: !item.isCompleted
+                    )
+                }
+            } label: {
+                Image(systemName: item.isCompleted ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(item.isCompleted ? .green : .secondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(
+                manager.isFinishingSession || manager.updatingReminderIDs.contains(item.id)
+            )
+            Text(item.title.isEmpty ? "Untitled reminder" : item.title)
+                .font(.caption)
+                .lineLimit(1)
+                .strikethrough(item.isCompleted)
+            Spacer(minLength: 4)
+            Text(item.listTitle)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 5))
+        .animation(.easeInOut(duration: 0.15), value: item.isCompleted)
+    }
+}
+
+#Preview {
+    DailyPlanningView()
+        .frame(width: 616, height: 142)
+        .preferredColorScheme(.dark)
+}

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -209,7 +209,7 @@ class BoringViewModel: NSObject, ObservableObject {
 
     func close() {
         // Do not close while a share picker or sharing service is active
-        if SharingStateManager.shared.preventNotchClose {
+        if SharingStateManager.shared.preventNotchClose || DailyPlanningManager.shared.isPresenting {
             return
         }
         self.notchSize = getClosedNotchSize(screenUUID: self.screenUUID)
@@ -221,12 +221,16 @@ class BoringViewModel: NSObject, ObservableObject {
         }
         self.edgeAutoOpenActive = false
 
-        // Set the current view to shelf if it contains files and the user enables openShelfByDefault
-        // Otherwise, if the user has not enabled openLastShelfByDefault, set the view to home
-        if Defaults[.boringShelf] && !ShelfStateViewModel.shared.isEmpty && Defaults[.openShelfByDefault] {
-            coordinator.currentView = .shelf
-        } else if !coordinator.openLastTabByDefault {
-            coordinator.currentView = .home
+        // Keep the daily workflow selected, but empty, until its close animation completes.
+        // Switching to the default tab here would show calendar or music content mid-animation.
+        if !DailyPlanningManager.shared.isFinishingSession {
+            // Set the current view to shelf if it contains files and the user enables openShelfByDefault
+            // Otherwise, if the user has not enabled openLastShelfByDefault, set the view to home
+            if Defaults[.boringShelf] && !ShelfStateViewModel.shared.isEmpty && Defaults[.openShelfByDefault] {
+                coordinator.currentView = .shelf
+            } else if !coordinator.openLastTabByDefault {
+                coordinator.currentView = .home
+            }
         }
     }
 

--- a/boringNotchTests/DailyPlanningCoreTests.swift
+++ b/boringNotchTests/DailyPlanningCoreTests.swift
@@ -1,0 +1,293 @@
+import XCTest
+
+@testable import DailyPlanningCore
+
+final class DailyPlanningCoreTests: XCTestCase {
+  private var calendar: Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    return calendar
+  }
+
+  private func date(
+    year: Int = 2026,
+    month: Int = 8,
+    day: Int = 8,
+    hour: Int,
+    minute: Int = 0
+  ) -> Date {
+    calendar.date(
+      from: DateComponents(
+        year: year,
+        month: month,
+        day: day,
+        hour: hour,
+        minute: minute
+      ))!
+  }
+
+  func testMorningSessionBecomesDueAfterConfiguredTime() {
+    let preferences = DailyWorkflowPreferences(
+      morningPlanningEnabled: true,
+      morningPlanningMinutes: 8 * 60,
+      eveningReviewEnabled: false,
+      eveningReviewMinutes: 20 * 60
+    )
+
+    XCTAssertNil(
+      DailyWorkflowSchedule.dueWorkflow(
+        at: date(hour: 7, minute: 59),
+        preferences: preferences,
+        completionState: .init(),
+        calendar: calendar
+      ))
+    XCTAssertEqual(
+      DailyWorkflowSchedule.dueWorkflow(
+        at: date(hour: 8),
+        preferences: preferences,
+        completionState: .init(),
+        calendar: calendar
+      ), .morningPlanning)
+  }
+
+  func testReminderSectionsFilterToSessionDayAndSeparateCompletion() {
+    let items = [
+      DailyReminderItem(
+        id: "open", title: "Open", dueDate: date(hour: 9), isCompleted: false,
+        listTitle: "Work"),
+      DailyReminderItem(
+        id: "done", title: "Done", dueDate: date(hour: 10), isCompleted: true,
+        listTitle: "Home"),
+      DailyReminderItem(
+        id: "tomorrow", title: "Tomorrow", dueDate: date(day: 9, hour: 9),
+        isCompleted: false,
+        listTitle: "Work"),
+    ]
+
+    let sections = DailyReminderSections(
+      items: items, sessionDate: date(hour: 12), calendar: calendar)
+
+    XCTAssertEqual(sections.all.map(\.id), ["open", "done"])
+    XCTAssertEqual(sections.incomplete.map(\.id), ["open"])
+    XCTAssertEqual(sections.completed.map(\.id), ["done"])
+  }
+
+  func testCompletedSessionIsSuppressedForThatDay() {
+    let preferences = DailyWorkflowPreferences(
+      morningPlanningEnabled: true,
+      morningPlanningMinutes: 8 * 60,
+      eveningReviewEnabled: false,
+      eveningReviewMinutes: 20 * 60
+    )
+    var completion = DailyWorkflowCompletionState()
+    completion.markCompleted(.morningPlanning, on: date(hour: 9), calendar: calendar)
+
+    XCTAssertNil(
+      DailyWorkflowSchedule.dueWorkflow(
+        at: date(hour: 10),
+        preferences: preferences,
+        completionState: completion,
+        calendar: calendar
+      ))
+    XCTAssertEqual(
+      DailyWorkflowSchedule.dueWorkflow(
+        at: date(day: 9, hour: 10),
+        preferences: preferences,
+        completionState: completion,
+        calendar: calendar
+      ), .morningPlanning)
+  }
+
+  func testMorningTakesPriorityWhenBothSessionsAreOverdue() {
+    let preferences = DailyWorkflowPreferences(
+      morningPlanningEnabled: true,
+      morningPlanningMinutes: 8 * 60,
+      eveningReviewEnabled: true,
+      eveningReviewMinutes: 20 * 60
+    )
+
+    XCTAssertEqual(
+      DailyWorkflowSchedule.dueWorkflow(
+        at: date(hour: 21),
+        preferences: preferences,
+        completionState: .init(),
+        calendar: calendar
+      ), .morningPlanning)
+  }
+
+  func testChangingTimeChangesNextEvaluation() {
+    let early = DailyWorkflowPreferences(
+      morningPlanningEnabled: true,
+      morningPlanningMinutes: 8 * 60,
+      eveningReviewEnabled: false,
+      eveningReviewMinutes: 20 * 60
+    )
+    let later = DailyWorkflowPreferences(
+      morningPlanningEnabled: true,
+      morningPlanningMinutes: 9 * 60,
+      eveningReviewEnabled: false,
+      eveningReviewMinutes: 20 * 60
+    )
+
+    XCTAssertEqual(
+      DailyWorkflowSchedule.nextEvaluation(
+        after: date(hour: 7),
+        preferences: early,
+        completionState: .init(),
+        calendar: calendar
+      ), date(hour: 8))
+    XCTAssertEqual(
+      DailyWorkflowSchedule.nextEvaluation(
+        after: date(hour: 7),
+        preferences: later,
+        completionState: .init(),
+        calendar: calendar
+      ), date(hour: 9))
+  }
+
+  func testChangingEveningTimeChangesNextEvaluation() {
+    var completion = DailyWorkflowCompletionState()
+    completion.markCompleted(.morningPlanning, on: date(hour: 12), calendar: calendar)
+
+    let early = DailyWorkflowPreferences(
+      morningPlanningEnabled: true,
+      morningPlanningMinutes: 8 * 60,
+      eveningReviewEnabled: true,
+      eveningReviewMinutes: 20 * 60
+    )
+    let later = DailyWorkflowPreferences(
+      morningPlanningEnabled: true,
+      morningPlanningMinutes: 8 * 60,
+      eveningReviewEnabled: true,
+      eveningReviewMinutes: 21 * 60
+    )
+
+    XCTAssertEqual(
+      DailyWorkflowSchedule.nextEvaluation(
+        after: date(hour: 19),
+        preferences: early,
+        completionState: completion,
+        calendar: calendar
+      ), date(hour: 20))
+    XCTAssertEqual(
+      DailyWorkflowSchedule.nextEvaluation(
+        after: date(hour: 19),
+        preferences: later,
+        completionState: completion,
+        calendar: calendar
+      ), date(hour: 21))
+  }
+
+  func testMovingPendingTriggerIntoPastMakesSessionDueImmediately() {
+    let future = DailyWorkflowPreferences(
+      morningPlanningEnabled: true,
+      morningPlanningMinutes: 10 * 60,
+      eveningReviewEnabled: false,
+      eveningReviewMinutes: 20 * 60
+    )
+    let movedEarlier = DailyWorkflowPreferences(
+      morningPlanningEnabled: true,
+      morningPlanningMinutes: 8 * 60,
+      eveningReviewEnabled: false,
+      eveningReviewMinutes: 20 * 60
+    )
+
+    XCTAssertNil(
+      DailyWorkflowSchedule.dueWorkflow(
+        at: date(hour: 9),
+        preferences: future,
+        completionState: .init(),
+        calendar: calendar
+      ))
+    XCTAssertEqual(
+      DailyWorkflowSchedule.dueWorkflow(
+        at: date(hour: 9),
+        preferences: movedEarlier,
+        completionState: .init(),
+        calendar: calendar
+      ), .morningPlanning)
+  }
+
+  func testPreferencesAndCompletionPersistAcrossStoreInstances() throws {
+    let suiteName = "DailyPlanningCoreTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    let preferences = DailyWorkflowPreferences(
+      morningPlanningEnabled: true,
+      morningPlanningMinutes: 7 * 60 + 30,
+      eveningReviewEnabled: true,
+      eveningReviewMinutes: 21 * 60
+    )
+    var completion = DailyWorkflowCompletionState()
+    completion.markCompleted(.eveningReview, on: date(hour: 22), calendar: calendar)
+
+    let writer = DailyWorkflowPreferencesStore(defaults: defaults)
+    try writer.savePreferences(preferences)
+    try writer.saveCompletionState(completion)
+
+    let reader = DailyWorkflowPreferencesStore(defaults: defaults)
+    XCTAssertEqual(reader.loadPreferences(), preferences)
+    XCTAssertEqual(reader.loadCompletionState(), completion)
+  }
+
+  func testMissedMorningTriggerIsRecoveredAfterStoreReload() throws {
+    let suiteName = "DailyPlanningCoreTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    let writer = DailyWorkflowPreferencesStore(defaults: defaults)
+    try writer.savePreferences(
+      DailyWorkflowPreferences(
+        morningPlanningEnabled: true,
+        morningPlanningMinutes: 8 * 60,
+        eveningReviewEnabled: false,
+        eveningReviewMinutes: 20 * 60
+      ))
+
+    let relaunchedStore = DailyWorkflowPreferencesStore(defaults: defaults)
+    XCTAssertEqual(
+      DailyWorkflowSchedule.dueWorkflow(
+        at: date(hour: 10),
+        preferences: relaunchedStore.loadPreferences(),
+        completionState: relaunchedStore.loadCompletionState(),
+        calendar: calendar
+      ), .morningPlanning)
+  }
+
+  func testEveningBecomesDueAfterOverdueMorningIsCompleted() {
+    let preferences = DailyWorkflowPreferences(
+      morningPlanningEnabled: true,
+      morningPlanningMinutes: 8 * 60,
+      eveningReviewEnabled: true,
+      eveningReviewMinutes: 20 * 60
+    )
+    var completion = DailyWorkflowCompletionState()
+    completion.markCompleted(.morningPlanning, on: date(hour: 21), calendar: calendar)
+
+    XCTAssertEqual(
+      DailyWorkflowSchedule.dueWorkflow(
+        at: date(hour: 21),
+        preferences: preferences,
+        completionState: completion,
+        calendar: calendar
+      ), .eveningReview)
+  }
+
+  func testDisabledSessionsNeverBecomeDue() {
+    XCTAssertNil(
+      DailyWorkflowSchedule.dueWorkflow(
+        at: date(hour: 23),
+        preferences: .default,
+        completionState: .init(),
+        calendar: calendar
+      ))
+    XCTAssertNil(
+      DailyWorkflowSchedule.nextEvaluation(
+        after: date(hour: 23),
+        preferences: .default,
+        completionState: .init(),
+        calendar: calendar
+      ))
+  }
+}


### PR DESCRIPTION
## Summary

Adds configurable morning planning and evening review workflows backed by native Apple Reminders.

- Shows today’s due reminders in a notch-based morning plan.
- Shows completed and incomplete reminders in an evening review.
- Allows completing and reopening reminders directly from the workflow.
- Keeps the workflow open until Finish, then clears its content before the notch closes.

## Why

The app previously had calendar reminder visibility but no guided daily planning or end-of-day review experience. This adds scheduled, persistent workflows while keeping the user in control of when the notch dismisses.

## Validation

- `swift test --disable-sandbox` — 11 tests passed.
- Debug `xcodebuild` completed successfully.
