### PR TITLE
Fix artwork disappearing on diff-only Now Playing updates

### DIFF
--- a/boringNotch/MediaControllers/NowPlayingController.swift
+++ b/boringNotch/MediaControllers/NowPlayingController.swift
@@ -290,6 +290,8 @@ final class NowPlayingController: ObservableObject, MediaControllerProtocol {
             )
         } else if !diff {
             newPlaybackState.artwork = nil
+        } else {
+            newPlaybackState.artwork = self.playbackState.artwork
         }
 
         if let dateString = payload.timestamp,


### PR DESCRIPTION
## Summary
- Fixes #1425

Media artwork in the notch was disappearing shortly after playback started, then reappearing on the next track change. The Now Playing adapter periodically sends lightweight `diff: true` updates (e.g. elapsed-time ticks) that omit `artworkData` to save bandwidth. Every other field in `NowPlayingController.handleAdapterUpdate(_:)` (title, artist, shuffle, repeat mode, etc.) already carries its previous value forward when a diff update has no new value for that field, but the `artwork` branch was missing that case — so it fell through to `nil` on every diff-only tick until the next full update repopulated it.

## What changed
- `boringNotch/MediaControllers/NowPlayingController.swift`: added the missing `else` branch to `artwork` handling, matching the existing pattern used by the other fields, so artwork is preserved across diff-only updates and only cleared on a genuine full update with no artwork.

## Test plan
- [x] `xcodebuild -project boringNotch.xcodeproj -scheme boringNotch -configuration Debug -destination 'platform=macOS' build` — BUILD SUCCEEDED
- [x] Manual verification: play media from a source that sends periodic diff updates and confirm artwork stays visible past 30s of continuous playback (reviewer/reporter confirmation welcome)