### PR TITLE
Raise the notch window level while open so other menu bar panels do not cover it

### DIFF
--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -281,6 +281,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 .environmentObject(viewModel)
         )
 
+        // Keep the open notch above other menu bar extras' expanded panels
+        window.observeNotchState(of: viewModel)
+
         window.orderFrontRegardless()
         NotchSpaceManager.shared.notchSpace.windows.insert(window)
 

--- a/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
@@ -32,8 +32,14 @@ extension SkyLightOperator {
 }
 
 class BoringNotchSkyLightWindow: NSPanel {
+    /// Level used while the notch is closed: just above the menu bar.
+    static let baseLevel: NSWindow.Level = .mainMenu + 3
+    /// Level used while the notch is open. Menu bar extras expand their panels at or around
+    /// `.popUpMenu`, which sits well above `baseLevel` and would otherwise cover the notch.
+    static let expandedLevel: NSWindow.Level = .popUpMenu + 1
+
     private var isSkyLightEnabled: Bool = false
-    
+
     override init(
         contentRect: NSRect,
         styleMask: NSWindow.StyleMask,
@@ -58,7 +64,7 @@ class BoringNotchSkyLightWindow: NSPanel {
         titlebarAppearsTransparent = true
         backgroundColor = .clear
         isMovable = false
-        level = .mainMenu + 3
+        level = Self.baseLevel
         hasShadow = false
         isReleasedWhenClosed = false
         
@@ -123,6 +129,32 @@ class BoringNotchSkyLightWindow: NSPanel {
         }
     }
     
+    // MARK: - Window level
+
+    /// Raises the window above other menu bar extras' expanded panels while the notch is open,
+    /// and drops it back to `baseLevel` when it closes so the closed notch keeps its normal
+    /// ordering relative to the rest of the system UI.
+    func observeNotchState(of viewModel: BoringViewModel) {
+        viewModel.$notchState
+            .removeDuplicates()
+            .sink { [weak self] state in
+                self?.setExpanded(state == .open)
+            }
+            .store(in: &observers)
+    }
+
+    private func setExpanded(_ expanded: Bool) {
+        let newLevel = expanded ? Self.expandedLevel : Self.baseLevel
+        guard level != newLevel else { return }
+        level = newLevel
+
+        // Raising the level does not by itself reorder the window above panels that were
+        // ordered in front of it while it sat at the lower level.
+        if expanded {
+            orderFrontRegardless()
+        }
+    }
+
     func enableSkyLight() {
         if !isSkyLightEnabled {
             SkyLightOperator.shared.delegateWindow(self)


### PR DESCRIPTION
## What

The notch window sat at `.mainMenu + 3` (level 27) at all times. Other menu bar extras expand their panels at or around `.popUpMenu` (level 101), well above that, so a neighbouring panel that was already expanded would draw over the notch when it opened on hover.

`BoringNotchSkyLightWindow` now moves to `.popUpMenu + 1` (102) while the notch is open, and returns to `.mainMenu + 3` when it closes. The closed notch therefore keeps its existing ordering relative to the rest of the system UI, and only the actively-open notch is elevated.

It also calls `orderFrontRegardless()` on the way up: raising the level alone does not reorder the window above windows that were placed in front of it while it sat lower.

## Testing — measured on a `main`-based build, not on this branch

Up front: `dev` requires Xcode 26 and I am on 15.2 / Xcode 16.3, so I could not build or run this branch locally. The measurements below were taken from the same change applied to a `main`-based build. The window-level code is identical between the two; the cherry-pick onto `dev` applied cleanly. This branch itself is verified by CI compile only.

Window levels read directly from the window server (`CGWindowListCopyWindowInfo` / `kCGWindowLayer`) while hovering the notch:

```
CLOSED        window=61122  layer=27   size=640x210
HOVERED       window=61122  layer=102  size=640x210
CLOSED-AGAIN  window=61122  layer=27   size=640x210
```

Transitions in both directions with no stuck-elevated state. The menu bar status item (layer 25) is unaffected.

CI green on all three matrix legs (Xcode `^26`/macos-26, `~26.0`/macos-15, `^27`/xcode-27).

I have used measured window levels rather than a screen recording here, since a z-order change is difficult to show convincingly on video and the layer values are the actual thing being asserted. Happy to add a recording if you would like one.

## Design notes

- The two levels are named constants (`baseLevel`, `expandedLevel`) rather than inline literals, since the value now matters in more than one place.
- The subscription is stored in the window's existing `observers` set, so it is torn down with the window, including by the existing `cleanupObservers()` on `willClose`.
- Only the open state is elevated. Elevating unconditionally would change the closed notch's relationship to other system UI for no benefit.

## Trade-off worth a maintainer's opinion

This cuts both ways by design: if a user has another menu bar extra's dropdown open and then hovers the notch, that dropdown is now covered by the notch rather than the reverse. That is the fix working as intended, but you may have a view on which should win.

## Deliberately not changed

`BoringNotchWindow` still hard-codes `level = .mainMenu + 3`. Nothing instantiates it — `createBoringNotchWindow` only ever builds the SkyLight variant — so I left it alone rather than changing code I could not exercise.

#926 (menu bar icons under the notch not clickable) is adjacent but pre-existing and not addressed here: the notch was already above status items (layer 25) at level 27, so this change does not alter that relationship.

No translation changes.
