### PR TITLE
Add shelf removal controls for the selection and the whole shelf

### DIFF
--- a/boringNotch/components/Shelf/ViewModels/ShelfStateViewModel.swift
+++ b/boringNotch/components/Shelf/ViewModels/ShelfStateViewModel.swift
@@ -57,6 +57,24 @@ final class ShelfStateViewModel: ObservableObject {
         items.removeAll { $0.id == item.id }
     }
 
+    /// Removes several items in one pass, so the shelf is persisted once rather than per item.
+    func remove(_ itemsToRemove: [ShelfItem]) {
+        guard !itemsToRemove.isEmpty else { return }
+        let ids = Set(itemsToRemove.map(\.id))
+        for item in itemsToRemove {
+            item.cleanupStoredData()
+        }
+        items.removeAll { ids.contains($0.id) }
+    }
+
+    func removeAll() {
+        guard !items.isEmpty else { return }
+        for item in items {
+            item.cleanupStoredData()
+        }
+        items = []
+    }
+
     func updateBookmark(for item: ShelfItem, bookmark: Data) {
         guard let idx = items.firstIndex(where: { $0.id == item.id }) else { return }
         if case .file = items[idx].kind {

--- a/boringNotch/components/Shelf/Views/ShelfView.swift
+++ b/boringNotch/components/Shelf/Views/ShelfView.swift
@@ -15,6 +15,7 @@ struct ShelfView: View {
     @StateObject var selection = ShelfSelectionModel.shared
     @StateObject private var quickLookService = QuickLookService()
     private let spacing: CGFloat = 8
+    @State private var isHoveringPanel = false
 
     var body: some View {
         HStack(spacing: 12) {
@@ -71,11 +72,65 @@ struct ShelfView: View {
                 content
                     .padding()
             }
+            .overlay(alignment: .topTrailing) {
+                removalButton
+                    .padding(6)
+                    .opacity(showRemovalButton ? 1 : 0)
+                    .animation(.easeInOut(duration: 0.12), value: showRemovalButton)
+            }
             .transaction { transaction in
                 transaction.animation = vm.animation
             }
             .contentShape(Rectangle())
             .onTapGesture { selection.clear() }
+            .onHover { hovering in
+                isHoveringPanel = hovering
+            }
+    }
+
+    private var selectionCount: Int {
+        selection.selectedItems(in: tvm.items).count
+    }
+
+    /// Stays visible whenever there is a selection, since the button is then the only way to
+    /// remove exactly those items. With no selection it keeps out of the way until hover: the
+    /// panel is only as wide as the open notch, so a permanent control here would sit over
+    /// the last item's tile.
+    private var showRemovalButton: Bool {
+        !tvm.isEmpty && (isHoveringPanel || selectionCount > 0)
+    }
+
+    /// Scoped to the selection when there is one, and to the whole shelf otherwise, so the
+    /// visible control never removes more than the user just asked for.
+    private var removalButton: some View {
+        let count = selectionCount
+        let isSelectionScoped = count > 0
+        let title = isSelectionScoped ? "Remove Selected (\(count))" : "Clear All"
+
+        return Button {
+            if isSelectionScoped {
+                let selected = selection.selectedItems(in: tvm.items)
+                selection.clear()
+                tvm.remove(selected)
+            } else {
+                selection.clear()
+                tvm.removeAll()
+            }
+        } label: {
+            HStack(spacing: 3) {
+                Image(systemName: "trash")
+                Text(title)
+            }
+            .font(.system(size: 10, weight: .medium))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 4)
+            .background(Capsule().fill(Color.black.opacity(0.65)))
+            .overlay(Capsule().strokeBorder(Color.white.opacity(0.2), lineWidth: 0.5))
+        }
+        .buttonStyle(.plain)
+        .help(title)
+        .accessibilityLabel(Text(title))
     }
 
     var content: some View {


### PR DESCRIPTION
Relates to #1248 — delivers the Clear All half. The keyboard half is deliberately not implemented; reasoning below so nobody repeats the attempt.

## What

Removing shelf items required a right-click and "Remove" on each one, which #1248 describes as tedious when clearing several at once.

This adds one control to the shelf panel, scoped to whatever is selected:

- **With a selection** — reads `Remove Selected (n)` and removes only those items. It stays visible, because it is then the only way to act on that selection.
- **With no selection** — reads `Clear All`, revealed on hover so it does not permanently sit over the last item's tile. The panel is only as wide as the open notch.

Bulk removal is added on the view model (`remove(_: [ShelfItem])`, `removeAll()`) so the shelf is persisted once per operation rather than once per item.

Two files, +73 lines, no new dependencies, no translation changes.

## Screenshots

**No selection** — `Clear All`, revealed on hovering the panel:

<img width="720" alt="Shelf panel with three items and a Clear All button in the top-right corner" src="https://raw.githubusercontent.com/pcruiher08/boring.notch/pr-assets/shot-clearall.png">

**Two items selected** — the same control becomes `Remove Selected (2)` and acts only on those two:

<img width="720" alt="Shelf panel with two of three items selected and the button reading Remove Selected (2)" src="https://raw.githubusercontent.com/pcruiher08/boring.notch/pr-assets/shot-remove-selected.png">

## Why the control is scoped, rather than always "Clear All"

An earlier revision showed only `Clear All`. With multi-select already supported that turned out to be a trap: select three of eight items, and the single visible button silently removes all eight. Scoping both the label and the action to the current selection means the visible control never removes more than was just asked for.

## On the keyboard half of #1248

#1248 asks for two things: Delete/Backspace on the selection, and a Clear All button. This PR delivers the second and skips the first. The reasoning, in case it saves someone else the detour:

`BoringNotchSkyLightWindow` sets `canBecomeKey = false`, so nothing inside the notch can receive a `keyDown`. The seemingly obvious fix — take key focus while the shelf has a selection, since the window is a `.nonactivatingPanel` and can hold key status without activating the app — was implemented and tested. It is a one-way door: `resignKey()` is only a notification hook, which AppKit calls to *tell* a window it has lost key status. Calling it does not hand key status to anything else, so the panel keeps the keyboard indefinitely and the user's keystrokes stop reaching the frontmost app. Confirmed by testing, then reverted.

The mechanism that would work is a consuming `CGEvent` tap, as `MediaKeyInterceptor` already does. That requires Accessibility authorization, which seemed a steep price to pay for removing a shelf item, so I would rather you decide than spend that permission unilaterally. Happy to add it if you would prefer.

## Testing — please read, I have not run this exact branch

`dev` requires Xcode 26, which I do not have (I am on 15.2 / Xcode 16.3). I could not build or run this branch locally at all.

Rather than submit untested behaviour, I backported the identical change onto a `main`-based build, which does compile on Xcode 16.3, and tested it there:

- multi-select, then `Remove Selected (n)` removes exactly the selection and nothing else
- with no selection, `Clear All` empties the shelf
- the button is not swallowed by the panel's existing tap-to-clear-selection gesture

**The screenshots above are from that backported build, not from this branch.** The shelf code being exercised is the same — the cherry-pick onto `dev` applied cleanly — but I want to be explicit that the artefact I ran is not the artefact I am asking you to merge.

This branch itself is verified by CI only: green on all three matrix legs (Xcode `^26`/macos-26, `~26.0`/macos-15, `^27`/xcode-27). That confirms it compiles on your toolchain; it does not confirm behaviour.

If you would rather have behaviour confirmation on `dev` proper before considering this, say so and I will get onto a machine that can build it.

## Notes

Touches only `ShelfView.swift` and `ShelfStateViewModel.swift`, so no overlap with #1261 (`ShelfView`/`FileShareView`, different regions), #1303, or #1465.
