### PR TITLE
Refactor Shelf rendering and interaction handling

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1100292A2E8691B400035A57 /* FileShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110029292E8691B400035A57 /* FileShareView.swift */; };
 		1100292E2E86940F00035A57 /* QuickShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1100292D2E86940F00035A57 /* QuickShareService.swift */; };
 		1113ABC52E80E27000EC13B2 /* ShelfItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1113ABC32E80E27000EC13B2 /* ShelfItemView.swift */; };
+		A1F000012F00000100000001 /* ShelfItemInteractionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F000022F00000100000001 /* ShelfItemInteractionView.swift */; };
 		1113ABC62E80E27000EC13B2 /* ShelfPersistenceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1113ABBE2E80E27000EC13B2 /* ShelfPersistenceService.swift */; };
 		1113ABC82E80E27000EC13B2 /* ShelfItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1113ABB72E80E27000EC13B2 /* ShelfItem.swift */; };
 		1113ABCA2E80E27000EC13B2 /* ShelfSelectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1113ABC02E80E27000EC13B2 /* ShelfSelectionModel.swift */; };
@@ -208,6 +209,7 @@
 		1113ABBE2E80E27000EC13B2 /* ShelfPersistenceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelfPersistenceService.swift; sourceTree = "<group>"; };
 		1113ABC02E80E27000EC13B2 /* ShelfSelectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelfSelectionModel.swift; sourceTree = "<group>"; };
 		1113ABC32E80E27000EC13B2 /* ShelfItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelfItemView.swift; sourceTree = "<group>"; };
+		A1F000022F00000100000001 /* ShelfItemInteractionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelfItemInteractionView.swift; sourceTree = "<group>"; };
 		1113ABCF2E80E6BB00EC13B2 /* ThumbnailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailService.swift; sourceTree = "<group>"; };
 		111BE9942ECF2DEF0079DD4E /* DragDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragDetector.swift; sourceTree = "<group>"; };
 		111BEA602ED09B1B0079DD4E /* NSScreen+UUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScreen+UUID.swift"; sourceTree = "<group>"; };
@@ -430,6 +432,7 @@
 				11F747CD2EC75CEA00F841DB /* DragPreviewView.swift */,
 				110029292E8691B400035A57 /* FileShareView.swift */,
 				1113ABC32E80E27000EC13B2 /* ShelfItemView.swift */,
+				A1F000022F00000100000001 /* ShelfItemInteractionView.swift */,
 				9A987A032C73CA66005CA465 /* ShelfView.swift */,
 			);
 			path = Views;
@@ -1028,6 +1031,7 @@
 				B1C974342C642B6D0000E707 /* MarqueeTextView.swift in Sources */,
 				14288DE82C6E01C800B9F80C /* ProgressIndicator.swift in Sources */,
 				1113ABC52E80E27000EC13B2 /* ShelfItemView.swift in Sources */,
+				A1F000012F00000100000001 /* ShelfItemInteractionView.swift in Sources */,
 				1113ABC62E80E27000EC13B2 /* ShelfPersistenceService.swift in Sources */,
 				11DB26662EDD0BE1001EA0CF /* LyricsService.swift in Sources */,
 				1113ABC82E80E27000EC13B2 /* ShelfItem.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -408,7 +408,10 @@ struct ContentView: View {
                             isHoveringMusicArea: $isHoveringMusicArea
                         )
                     case .shelf:
-                        ShelfView()
+                        ShelfView(
+                            dropInteraction: vm.dropInteraction,
+                            animation: vm.animation
+                        )
                     }
                 }
                 .transition(

--- a/boringNotch/components/Shelf/Services/QuickLookService.swift
+++ b/boringNotch/components/Shelf/Services/QuickLookService.swift
@@ -6,8 +6,10 @@
 //
 
 import Foundation
+import Combine
 import UniformTypeIdentifiers
 import SwiftUI
+import QuickLook
 import QuickLookUI
 import AppKit
 
@@ -21,6 +23,15 @@ final class QuickLookService: ObservableObject {
     private var previewPanel: QLPreviewPanel?
     private var accessingURLs: [URL] = []
     private var previewPanelObserver: Any?
+    private var selectionCancellable: AnyCancellable?
+
+    init() {
+        selectionCancellable = ShelfSelectionModel.shared.$selectedIDs
+            .dropFirst()
+            .sink { [weak self] selectedIDs in
+                self?.updateFromShelfSelection(selectedIDs: selectedIDs)
+            }
+    }
 
     func show(urls: [URL], selectFirst: Bool = true, slideshow: Bool = false) {
         guard !urls.isEmpty else { return }
@@ -82,6 +93,25 @@ final class QuickLookService: ObservableObject {
         guard isQuickLookOpen else { return }
         show(urls: urls, selectFirst: true)
     }
+
+    private func updateFromShelfSelection(selectedIDs: Set<UUID>) {
+        guard isQuickLookOpen && !selectedIDs.isEmpty else { return }
+
+        let urls: [URL] = ShelfStateViewModel.shared.items.compactMap { item in
+            guard selectedIDs.contains(item.id) else { return nil }
+            if let fileURL = item.fileURL {
+                return fileURL
+            }
+            if case .link(let url) = item.kind {
+                return url
+            }
+            return nil
+        }
+
+        if !urls.isEmpty {
+            updateSelection(urls: urls)
+        }
+    }
 }
 
 extension QuickLookService {
@@ -114,4 +144,3 @@ extension View {
         self.modifier(QuickLookPresenter(service: service))
     }
 }
-

--- a/boringNotch/components/Shelf/Services/QuickLookService.swift
+++ b/boringNotch/components/Shelf/Services/QuickLookService.swift
@@ -95,7 +95,11 @@ final class QuickLookService: ObservableObject {
     }
 
     private func updateFromShelfSelection(selectedIDs: Set<UUID>) {
-        guard isQuickLookOpen && !selectedIDs.isEmpty else { return }
+        guard isQuickLookOpen else { return }
+        guard !selectedIDs.isEmpty else {
+            hide()
+            return
+        }
 
         let urls: [URL] = ShelfStateViewModel.shared.items.compactMap { item in
             guard selectedIDs.contains(item.id) else { return nil }

--- a/boringNotch/components/Shelf/ViewModels/ShelfItemViewModel.swift
+++ b/boringNotch/components/Shelf/ViewModels/ShelfItemViewModel.swift
@@ -64,10 +64,7 @@ final class ShelfItemViewModel: ObservableObject {
     init(item: ShelfItem) {
         self.item = item
         self.draftTitle = item.displayName
-        Task { await loadThumbnail() }
     }
-
-    var isSelected: Bool { selection.isSelected(item.id) }
 
     func loadThumbnail() async {
         guard let url = item.fileURL else { return }

--- a/boringNotch/components/Shelf/ViewModels/ShelfSelectionModel.swift
+++ b/boringNotch/components/Shelf/ViewModels/ShelfSelectionModel.swift
@@ -7,22 +7,30 @@
 
 import Foundation
 import Combine
-
-private let _shelfTypeAnchor: Bool = {
-    _ = String(describing: ShelfItem.self)
-    return true
-}()
+import Observation
 
 @MainActor
 final class ShelfSelectionModel: ObservableObject {
     static let shared = ShelfSelectionModel()
 
     @Published private(set) var selectedIDs: Set<UUID> = []
+    private var itemStates: [UUID: WeakSelectionState] = [:]
 
     // Anchor for shift-range selection
     private var lastAnchorID: UUID? = nil
 
     func isSelected(_ id: UUID) -> Bool { selectedIDs.contains(id) }
+
+    func state(for id: UUID) -> ShelfItemSelectionState {
+        pruneUnusedItemStates()
+        if let state = itemStates[id]?.value {
+            return state
+        }
+
+        let state = ShelfItemSelectionState(isSelected: selectedIDs.contains(id))
+        itemStates[id] = WeakSelectionState(state)
+        return state
+    }
 
     var hasSelection: Bool { !selectedIDs.isEmpty }
 
@@ -36,16 +44,18 @@ final class ShelfSelectionModel: ObservableObject {
     }
 
     func selectSingle(_ item: ShelfItem) {
-        selectedIDs = [item.id]
+        updateSelection(to: [item.id])
         lastAnchorID = item.id
     }
 
     func toggle(_ item: ShelfItem) {
-        if selectedIDs.contains(item.id) {
-            selectedIDs.remove(item.id)
+        var newSelection = selectedIDs
+        if newSelection.contains(item.id) {
+            newSelection.remove(item.id)
         } else {
-            selectedIDs.insert(item.id)
+            newSelection.insert(item.id)
         }
+        updateSelection(to: newSelection)
         lastAnchorID = item.id
     }
 
@@ -60,12 +70,28 @@ final class ShelfSelectionModel: ObservableObject {
         let lower = min(startIndex, endIndex)
         let upper = max(startIndex, endIndex)
         let rangeIDs = allItems[lower...upper].map { $0.id }
-        selectedIDs = Set(rangeIDs)
+        updateSelection(to: Set(rangeIDs))
     }
 
     func clear() {
-        selectedIDs.removeAll()
+        updateSelection(to: [])
         lastAnchorID = nil
+    }
+
+    private func updateSelection(to newSelection: Set<UUID>) {
+        guard newSelection != selectedIDs else { return }
+
+        let changedIDs = selectedIDs.symmetricDifference(newSelection)
+        selectedIDs = newSelection
+
+        for id in changedIDs {
+            itemStates[id]?.value?.isSelected = newSelection.contains(id)
+        }
+        pruneUnusedItemStates()
+    }
+
+    private func pruneUnusedItemStates() {
+        itemStates = itemStates.filter { $0.value.value != nil }
     }
 
     // Keep anchor sane if items array changed drastically (optional helper)
@@ -83,5 +109,23 @@ final class ShelfSelectionModel: ObservableObject {
 
     func endDrag() {
         isDragging = false
+    }
+}
+
+private final class WeakSelectionState {
+    weak var value: ShelfItemSelectionState?
+
+    init(_ value: ShelfItemSelectionState) {
+        self.value = value
+    }
+}
+
+@Observable
+@MainActor
+final class ShelfItemSelectionState {
+    fileprivate(set) var isSelected: Bool
+
+    init(isSelected: Bool) {
+        self.isSelected = isSelected
     }
 }

--- a/boringNotch/components/Shelf/Views/FileShareView.swift
+++ b/boringNotch/components/Shelf/Views/FileShareView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct FileShareView: View {
-    @EnvironmentObject private var vm: BoringViewModel
+    let dropInteraction: DropInteractionState
     @StateObject private var quickShare = QuickShareService.shared
     @Default(.quickShareProvider) var quickShareProvider: String
 
@@ -24,13 +24,13 @@ struct FileShareView: View {
     }
 
     var body: some View {
-        @Bindable var dropInteraction = vm.dropInteraction
+        @Bindable var interaction = dropInteraction
 
         dropArea
             .background(NSViewHost(view: $hostView))
-            .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data, .image], isTargeted: $dropInteraction.dropZoneTargeting) { providers in
+            .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data, .image], isTargeted: $interaction.dropZoneTargeting) { providers in
                 interactionNonce = .init()
-                dropInteraction.dropEvent = true
+                interaction.dropEvent = true
                 Task { await handleDrop(providers) }
                 return true
             }
@@ -50,7 +50,7 @@ struct FileShareView: View {
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
                         .stroke(
-                            vm.dropInteraction.dropZoneTargeting
+                            dropInteraction.dropZoneTargeting
                                 ? Color.accentColor.opacity(0.9)
                                 : Color.white.opacity(0.1),
                             style: StrokeStyle(lineWidth: 3, lineCap: .round, dash: [10])
@@ -63,7 +63,7 @@ struct FileShareView: View {
                 ZStack {
                     Circle()
                         .fill(Color.white.opacity(
-                            vm.dropInteraction.dropZoneTargeting ? 0.11 : 0.09
+                            dropInteraction.dropZoneTargeting ? 0.11 : 0.09
                         ))
                         .frame(width: 55, height: 55)
                     Group {
@@ -77,12 +77,12 @@ struct FileShareView: View {
                     }
                     .frame(width: 34, height: 34)
                         .foregroundStyle(
-                            vm.dropInteraction.dropZoneTargeting ? Color.accentColor : Color.gray
+                            dropInteraction.dropZoneTargeting ? Color.accentColor : Color.gray
                         )
                         .scaleEffect(
-                            vm.dropInteraction.dropZoneTargeting ? 1.06 : 1.0
+                            dropInteraction.dropZoneTargeting ? 1.06 : 1.0
                         )
-                        .animation(.spring(response: 0.36, dampingFraction: 0.7), value: vm.dropInteraction.dropZoneTargeting)
+                        .animation(.spring(response: 0.36, dampingFraction: 0.7), value: dropInteraction.dropZoneTargeting)
                 }
 
                 Text(selectedProvider.id)

--- a/boringNotch/components/Shelf/Views/ShelfItemInteractionView.swift
+++ b/boringNotch/components/Shelf/Views/ShelfItemInteractionView.swift
@@ -1,0 +1,186 @@
+//
+//  ShelfItemInteractionView.swift
+//  boringNotch
+//
+
+import AppKit
+import Defaults
+import SwiftUI
+
+protocol ShelfItemInteractionSurface: AnyObject {}
+
+/// A narrow AppKit bridge for Shelf pointer and native drag interactions.
+struct ShelfItemInteractionView<DragPreview: View>: NSViewRepresentable {
+    let item: ShelfItem
+    let viewModel: ShelfItemViewModel
+    @ViewBuilder let dragPreview: () -> DragPreview
+    let onPrimaryClick: (NSEvent, NSView) -> Void
+    let onContextClick: (NSEvent, NSView) -> Void
+
+    func makeNSView(context: Context) -> InteractionView {
+        let view = InteractionView()
+        update(view)
+        return view
+    }
+
+    func updateNSView(_ nsView: InteractionView, context: Context) {
+        update(nsView)
+    }
+
+    private func update(_ view: InteractionView) {
+        view.item = item
+        view.dragPreviewProvider = renderDragPreview
+        view.onPrimaryClick = onPrimaryClick
+        view.onContextClick = onContextClick
+    }
+
+    private func renderDragPreview() -> NSImage {
+        let renderer = ImageRenderer(content: dragPreview())
+        renderer.scale = NSScreen.main?.backingScaleFactor ?? 2
+        return renderer.nsImage ?? viewModel.thumbnail ?? item.icon
+    }
+
+    final class InteractionView: NSView, NSDraggingSource, ShelfItemInteractionSurface {
+        var item: ShelfItem!
+        var dragPreviewProvider: (() -> NSImage)?
+        var onPrimaryClick: ((NSEvent, NSView) -> Void)?
+        var onContextClick: ((NSEvent, NSView) -> Void)?
+
+        private let dragThreshold: CGFloat = 3
+        private var mouseDownEvent: NSEvent?
+        private var draggedURLs: [URL] = []
+        private var draggedItems: [ShelfItem] = []
+
+        override func rightMouseDown(with event: NSEvent) {
+            onContextClick?(event, self)
+        }
+
+        override func mouseDown(with event: NSEvent) {
+            mouseDownEvent = event
+            onPrimaryClick?(event, self)
+        }
+
+        override func mouseDragged(with event: NSEvent) {
+            guard let mouseDownEvent else {
+                super.mouseDragged(with: event)
+                return
+            }
+
+            let dragDistance = hypot(
+                event.locationInWindow.x - mouseDownEvent.locationInWindow.x,
+                event.locationInWindow.y - mouseDownEvent.locationInWindow.y
+            )
+
+            guard dragDistance > dragThreshold else {
+                super.mouseDragged(with: event)
+                return
+            }
+
+            startDragSession(with: event)
+            self.mouseDownEvent = nil
+        }
+
+        private func startDragSession(with event: NSEvent) {
+            let selectedItems = ShelfSelectionModel.shared.selectedItems(
+                in: ShelfStateViewModel.shared.items
+            )
+            let itemsToDrag = selectedItems.count > 1
+                && selectedItems.contains(where: { $0.id == item.id })
+                ? selectedItems
+                : [item]
+
+            draggedItems = itemsToDrag
+            let draggingItems = itemsToDrag.compactMap(makeDraggingItem)
+
+            guard !draggingItems.isEmpty else { return }
+            beginDraggingSession(with: draggingItems, event: event, source: self)
+        }
+
+        private func makeDraggingItem(for item: ShelfItem) -> NSDraggingItem? {
+            guard let writer = pasteboardWriter(for: item) else { return nil }
+
+            let draggingItem = NSDraggingItem(pasteboardWriter: writer)
+            let image = dragPreviewProvider?() ?? item.icon
+            draggingItem.setDraggingFrame(
+                NSRect(origin: .zero, size: image.size),
+                contents: image
+            )
+            return draggingItem
+        }
+
+        private func pasteboardWriter(for item: ShelfItem) -> (any NSPasteboardWriting)? {
+            switch item.kind {
+            case .file:
+                guard let url = ShelfStateViewModel.shared.resolveAndUpdateBookmark(for: item) else {
+                    let fallback = NSPasteboardItem()
+                    fallback.setString(item.displayName, forType: .string)
+                    return fallback
+                }
+
+                if url.startAccessingSecurityScopedResource() {
+                    draggedURLs.append(url)
+                    NSLog("🔐 Started security-scoped access for drag: \(url.path)")
+                }
+                return url as NSURL
+
+            case .text(let string):
+                let pasteboardItem = NSPasteboardItem()
+                pasteboardItem.setString(string, forType: .string)
+                return pasteboardItem
+
+            case .link(let url):
+                let pasteboardItem = NSPasteboardItem()
+                pasteboardItem.setString(url.absoluteString, forType: .URL)
+                pasteboardItem.setString(url.absoluteString, forType: .string)
+                return pasteboardItem
+            }
+        }
+
+        func draggingSession(
+            _ session: NSDraggingSession,
+            sourceOperationMaskFor context: NSDraggingContext
+        ) -> NSDragOperation {
+            if Defaults[.copyOnDrag] {
+                return .copy
+            }
+
+            switch context {
+            case .outsideApplication:
+                return [.copy, .move]
+            case .withinApplication:
+                return [.copy, .move, .generic]
+            @unknown default:
+                return .copy
+            }
+        }
+
+        func draggingSession(_ session: NSDraggingSession, willBeginAt screenPoint: NSPoint) {
+            ShelfSelectionModel.shared.beginDrag()
+        }
+
+        func draggingSession(
+            _ session: NSDraggingSession,
+            endedAt screenPoint: NSPoint,
+            operation: NSDragOperation
+        ) {
+            ShelfSelectionModel.shared.endDrag()
+
+            for url in draggedURLs {
+                url.stopAccessingSecurityScopedResource()
+                NSLog("🔐 Stopped security-scoped access after drag: \(url.path)")
+            }
+            draggedURLs.removeAll()
+
+            if Defaults[.autoRemoveShelfItems] && !operation.isEmpty {
+                for item in draggedItems {
+                    ShelfStateViewModel.shared.remove(item)
+                }
+            }
+            draggedItems.removeAll()
+        }
+
+        func ignoreModifierKeys(for session: NSDraggingSession) -> Bool {
+            false
+        }
+    }
+}

--- a/boringNotch/components/Shelf/Views/ShelfItemView.swift
+++ b/boringNotch/components/Shelf/Views/ShelfItemView.swift
@@ -5,74 +5,67 @@
 //  Created by Alexander on 2025-09-24.
 //
 
-import AppKit
 import SwiftUI
-import Defaults
-
-import QuickLook
 
 struct ShelfItemView: View {
     let item: ShelfItem
-    @EnvironmentObject var vm: BoringViewModel
-    @ObservedObject var selection = ShelfSelectionModel.shared
+    let quickLookService: QuickLookService
+    let dropInteraction: DropInteractionState
     @StateObject private var viewModel: ShelfItemViewModel
-    @EnvironmentObject private var quickLookService: QuickLookService
-    @State private var showStack = false
+    @State private var selectionState: ShelfItemSelectionState
     @State private var debouncedDropTarget = false
 
-    private var isSelected: Bool { viewModel.isSelected }
-    private var shouldHideDuringDrag: Bool { selection.isDragging && selection.isSelected(item.id) && false }
+    private var isSelected: Bool { selectionState.isSelected }
+
+    private var highlight: HighlightPresentation {
+        if debouncedDropTarget {
+            HighlightPresentation(
+                fill: Color.accentColor.opacity(0.25),
+                stroke: Color.accentColor.opacity(0.9),
+                lineWidth: 3
+            )
+        } else if isSelected {
+            HighlightPresentation(
+                fill: Color.accentColor.opacity(0.15),
+                stroke: Color.accentColor.opacity(0.8),
+                lineWidth: 2
+            )
+        } else {
+            HighlightPresentation(fill: .clear, stroke: .clear, lineWidth: 1)
+        }
+    }
     
-    init(item: ShelfItem) {
+    init(
+        item: ShelfItem,
+        quickLookService: QuickLookService,
+        dropInteraction: DropInteractionState
+    ) {
         self.item = item
+        self.quickLookService = quickLookService
+        self.dropInteraction = dropInteraction
         _viewModel = StateObject(wrappedValue: ShelfItemViewModel(item: item))
+        _selectionState = State(initialValue: ShelfSelectionModel.shared.state(for: item.id))
     }
 
     var body: some View {
-        ZStack {
-            if !shouldHideDuringDrag {
-                VStack(alignment: .center, spacing: 2) {
-                    iconView
-                    textView
-                }
-                .frame(width: 105)
-                .padding(.vertical, 10)
-                .padding(.horizontal, 5)
-                .background(backgroundView)
-                .contentShape(Rectangle())
-                .animation(.easeInOut(duration: 0.1), value: debouncedDropTarget)
-                .animation(.easeInOut(duration: 0.1), value: isSelected)
-
-                DraggableClickHandler(
-                    item: item,
-                    viewModel: viewModel,
-                    dragPreviewContent: {
-                        DragPreviewView(thumbnail: viewModel.thumbnail ?? item.icon, displayName: item.displayName)
-                    },
-                    onRightClick: viewModel.handleRightClick,
-                    onClick: { event, nsview in
-                        viewModel.handleClick(event: event, view: nsview)
-                    }
-                )
-            } else {
-                Color.clear
-                    .frame(width: 105)
-                    .padding(.vertical, 10)
-                    .padding(.horizontal, 5)
-            }
-        }
+        itemContent
         .onChange(of: viewModel.isDropTargeted) { _, targeted in
-            vm.dropInteraction.dragDetectorTargeting = targeted
-            // Debounce drop target state changes
-            Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(50))
-                debouncedDropTarget = targeted
+            dropInteraction.dragDetectorTargeting = targeted
+        }
+        .task(id: viewModel.isDropTargeted) {
+            let targeted = viewModel.isDropTargeted
+            do {
+                try await Task.sleep(for: .milliseconds(50))
+            } catch {
+                return
             }
+            guard !Task.isCancelled else { return }
+            debouncedDropTarget = targeted
+        }
+        .task(id: item.id) {
+            await viewModel.loadThumbnail()
         }
         .onAppear {
-            Task { 
-                await viewModel.loadThumbnail()
-            }
             viewModel.onQuickLookRequest = { urls in
                 quickLookService.show(urls: urls, selectFirst: true)
             }
@@ -80,6 +73,34 @@ struct ShelfItemView: View {
     }
 
     // MARK: - View Components
+
+    private var itemContent: some View {
+        VStack(alignment: .center, spacing: 2) {
+            iconView
+            textView
+        }
+        .frame(width: 105)
+        .padding(.vertical, 10)
+        .padding(.horizontal, 5)
+        .background(backgroundView)
+        .contentShape(Rectangle())
+        .animation(.easeInOut(duration: 0.1), value: debouncedDropTarget)
+        .animation(.easeInOut(duration: 0.1), value: isSelected)
+        .overlay {
+            ShelfItemInteractionView(
+                item: item,
+                viewModel: viewModel,
+                dragPreview: {
+                    DragPreviewView(
+                        thumbnail: viewModel.thumbnail ?? item.icon,
+                        displayName: item.displayName
+                    )
+                },
+                onPrimaryClick: viewModel.handleClick,
+                onContextClick: viewModel.handleRightClick
+            )
+        }
+    }
 
     private var iconView: some View {
         Image(nsImage: viewModel.thumbnail ?? item.icon)
@@ -102,245 +123,19 @@ struct ShelfItemView: View {
 
     private var backgroundView: some View {
         RoundedRectangle(cornerRadius: 12, style: .continuous)
-            .fill(backgroundColor)
+            .fill(highlight.fill)
             .overlay(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .strokeBorder(
-                        strokeColor,
-                        lineWidth: strokeWidth
+                        highlight.stroke,
+                        lineWidth: highlight.lineWidth
                     )
             )
     }
 
-    private var backgroundColor: Color {
-        if debouncedDropTarget {
-            return Color.accentColor.opacity(0.25)
-        } else if isSelected {
-            return Color.accentColor.opacity(0.15)
-        } else {
-            return Color.clear
-        }
-    }
-
-    private var strokeColor: Color {
-        if debouncedDropTarget {
-            return Color.accentColor.opacity(0.9)
-        } else if isSelected {
-            return Color.accentColor.opacity(0.8)
-        } else {
-            return Color.clear
-        }
-    }
-
-    private var strokeWidth: CGFloat {
-        if debouncedDropTarget {
-            return 3
-        } else if isSelected {
-            return 2
-        } else {
-            return 1
-        }
-    }
-}
-
-// MARK: - Draggable Click Handler with NSDraggingSource
-private struct DraggableClickHandler<Content: View>: NSViewRepresentable {
-    let item: ShelfItem
-    let viewModel: ShelfItemViewModel
-    @ViewBuilder let dragPreviewContent: () -> Content
-    let onRightClick: (NSEvent, NSView) -> Void
-    let onClick: (NSEvent, NSView) -> Void
-    
-    func makeNSView(context: Context) -> DraggableClickView {
-        let view = DraggableClickView()
-        view.item = item
-        view.viewModel = viewModel
-        view.getDragPreview = {
-            self.renderDragPreview()
-        }
-        view.onRightClick = onRightClick
-        view.onClick = onClick
-        return view
-    }
-    
-    func updateNSView(_ nsView: DraggableClickView, context: Context) {
-        nsView.item = item
-        nsView.viewModel = viewModel
-        // Update the closure to capture latest state if needed, though usually content closure is enough
-        nsView.getDragPreview = {
-            self.renderDragPreview()
-        }
-        nsView.onRightClick = onRightClick
-        nsView.onClick = onClick
-    }
-    
-    private func renderDragPreview() -> NSImage {
-        let content = dragPreviewContent()
-        let renderer = ImageRenderer(content: content)
-        renderer.scale = NSScreen.main?.backingScaleFactor ?? 2.0
-        
-        if let nsImage = renderer.nsImage {
-            return nsImage
-        }
-        
-        // Fallback to icon if rendering fails
-        return viewModel.thumbnail ?? item.icon
-    }
-    
-    final class DraggableClickView: NSView, NSDraggingSource {
-        var item: ShelfItem!
-        weak var viewModel: ShelfItemViewModel?
-        var getDragPreview: (() -> NSImage)?
-        var onRightClick: ((NSEvent, NSView) -> Void)?
-        var onClick: ((NSEvent, NSView) -> Void)?
-
-        private var mouseDownEvent: NSEvent?
-        private let dragThreshold: CGFloat = 3.0
-        private var draggedURLs: [URL] = []
-        private var draggedItems: [ShelfItem] = []
-        
-        override func rightMouseDown(with event: NSEvent) {
-            onRightClick?(event, self)
-        }
-        
-        override func mouseDown(with event: NSEvent) {
-            mouseDownEvent = event
-            onClick?(event, self)
-        }
-        
-        override func mouseDragged(with event: NSEvent) {
-            guard let mouseDownEvent = mouseDownEvent else {
-                super.mouseDragged(with: event)
-                return
-            }
-            
-            let dragDistance = hypot(
-                event.locationInWindow.x - mouseDownEvent.locationInWindow.x,
-                event.locationInWindow.y - mouseDownEvent.locationInWindow.y
-            )
-            
-            if dragDistance > dragThreshold {
-                startDragSession(with: event)
-                self.mouseDownEvent = nil
-            } else {
-                super.mouseDragged(with: event)
-            }
-        }
-        
-        private func startDragSession(with event: NSEvent) {
-            // Prepare dragging items
-            let selectedItems = ShelfSelectionModel.shared.selectedItems(in: ShelfStateViewModel.shared.items)
-            let itemsToDrag: [ShelfItem]
-
-            if selectedItems.count > 1 && selectedItems.contains(where: { $0.id == item.id }) {
-                itemsToDrag = selectedItems
-            } else {
-                itemsToDrag = [item]
-            }
-
-            // Store items being dragged for auto-remove feature
-            draggedItems = itemsToDrag
-
-            // Create dragging items for AppKit
-            var draggingItems: [NSDraggingItem] = []
-
-            for dragItem in itemsToDrag {
-                if let pasteboardWriter = pasteboardWriter(for: dragItem) {
-                    let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardWriter)
-
-                    // Use the drag preview image - generated on demand
-                    let image = getDragPreview?() ?? dragItem.icon
-                    let imageFrame = NSRect(
-                        x: 0,
-                        y: 0,
-                        width: image.size.width,
-                        height: image.size.height
-                    )
-                    draggingItem.setDraggingFrame(imageFrame, contents: image)
-
-                    draggingItems.append(draggingItem)
-                }
-            }
-
-            guard !draggingItems.isEmpty else { return }
-
-            beginDraggingSession(with: draggingItems, event: event, source: self)
-        }
-        
-        private func pasteboardWriter(for item: ShelfItem) -> (any NSPasteboardWriting)? {
-            switch item.kind {
-            case .file:
-                guard let url = ShelfStateViewModel.shared.resolveAndUpdateBookmark(for: item) else {
-                    let fallback = NSPasteboardItem()
-                    fallback.setString(item.displayName, forType: .string)
-                    return fallback
-                }
-
-                // Start accessing security-scoped resource and keep it active during drag
-                if url.startAccessingSecurityScopedResource() {
-                    draggedURLs.append(url)
-                    NSLog("🔐 Started security-scoped access for drag: \(url.path)")
-                }
-
-                return url as NSURL
-
-            case .text(let string):
-                let pasteboardItem = NSPasteboardItem()
-                pasteboardItem.setString(string, forType: .string)
-                return pasteboardItem
-
-            case .link(let url):
-                let pasteboardItem = NSPasteboardItem()
-                pasteboardItem.setString(url.absoluteString, forType: .URL)
-                pasteboardItem.setString(url.absoluteString, forType: .string)
-                return pasteboardItem
-            }
-        }
-        
-        // MARK: - NSDraggingSource
-        
-        func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
-            // When copyOnDrag is enabled, only allow copy operations
-            if Defaults[.copyOnDrag] {
-                return [.copy]
-            }
-            
-            switch context {
-            case .outsideApplication:
-                return [.copy, .move]
-            case .withinApplication:
-                return [.copy, .move, .generic]
-            @unknown default:
-                return [.copy]
-            }
-        }
-        
-        func draggingSession(_ session: NSDraggingSession, willBeginAt screenPoint: NSPoint) {
-            ShelfSelectionModel.shared.beginDrag()
-        }
-        
-        
-        func draggingSession(_ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation) {
-            ShelfSelectionModel.shared.endDrag()
-
-            // Stop accessing security-scoped resources after drag completes
-            for url in draggedURLs {
-                url.stopAccessingSecurityScopedResource()
-                NSLog("🔐 Stopped security-scoped access after drag: \(url.path)")
-            }
-            draggedURLs.removeAll()
-
-            // Auto-remove items from shelf if enabled and drag succeeded
-            if Defaults[.autoRemoveShelfItems] && !operation.isEmpty {
-                for item in draggedItems {
-                    ShelfStateViewModel.shared.remove(item)
-                }
-            }
-            draggedItems.removeAll()
-        }
-        
-        func ignoreModifierKeys(for session: NSDraggingSession) -> Bool {
-            return false
-        }
+    private struct HighlightPresentation {
+        let fill: Color
+        let stroke: Color
+        let lineWidth: CGFloat
     }
 }

--- a/boringNotch/components/Shelf/Views/ShelfView.swift
+++ b/boringNotch/components/Shelf/Views/ShelfView.swift
@@ -10,78 +10,60 @@ import AppKit
 import Defaults
 
 struct ShelfView: View {
-    @EnvironmentObject var vm: BoringViewModel
+    let dropInteraction: DropInteractionState
+    let animation: Animation?
     @StateObject var tvm = ShelfStateViewModel.shared
-    @StateObject var selection = ShelfSelectionModel.shared
-    @StateObject private var quickLookService = QuickLookService()
+
     private let spacing: CGFloat = 8
 
-    var body: some View {
-        @Bindable var dropInteraction = vm.dropInteraction
+    private var displayedItems: [ShelfItem] {
+        Defaults[.reverseShelfOrdering] ? Array(tvm.items.reversed()) : tvm.items
+    }
 
-        HStack(spacing: 12) {
-            FileShareView()
-                .aspectRatio(1, contentMode: .fit)
-                .environmentObject(vm)
-            panel
-                .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], isTargeted: $dropInteraction.dragDetectorTargeting) { providers in
-                    handleDrop(providers: providers)
-                }
+    var body: some View {
+        @Bindable var interaction = dropInteraction
+
+        ShelfQuickLookHost { quickLookService in
+            HStack(spacing: 12) {
+                FileShareView(dropInteraction: dropInteraction)
+                    .aspectRatio(1, contentMode: .fit)
+                panel(quickLookService: quickLookService)
+                    .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], isTargeted: $interaction.dragDetectorTargeting) { providers in
+                        handleDrop(providers: providers)
+                    }
+            }
         }
-        // Bind Quick Look to shelf selection
-        .onChange(of: selection.selectedIDs) {
-            updateQuickLookSelection()
-        }
-        .quickLookPresenter(using: quickLookService)
     }
     
     private func handleDrop(providers: [NSItemProvider]) -> Bool {
-        guard !selection.isDragging else { return false }
-        vm.dropInteraction.dropEvent = true
-        ShelfStateViewModel.shared.load(providers)
+        guard !ShelfSelectionModel.shared.isDragging else { return false }
+        dropInteraction.dropEvent = true
+        tvm.load(providers)
         return true
     }
     
-    private func updateQuickLookSelection() {
-        guard quickLookService.isQuickLookOpen && !selection.selectedIDs.isEmpty else { return }
-        
-        let selectedItems = selection.selectedItems(in: tvm.items)
-        let urls: [URL] = selectedItems.compactMap { item in
-            if let fileURL = item.fileURL {
-                return fileURL
-            }
-            if case .link(let url) = item.kind {
-                return url
-            }
-            return nil
-        }
-        
-        if !urls.isEmpty {
-            quickLookService.updateSelection(urls: urls)
-        }
-    }
-
-    var panel: some View {
+    private func panel(quickLookService: QuickLookService) -> some View {
         RoundedRectangle(cornerRadius: 16)
             .stroke(
-                vm.dropInteraction.dragDetectorTargeting
+                dropInteraction.dragDetectorTargeting
                     ? Color.accentColor.opacity(0.9)
                     : Color.white.opacity(0.1),
                 style: StrokeStyle(lineWidth: 3, lineCap: .round, dash: [10])
             )
             .overlay {
-                content
-                    .padding()
+                ZStack {
+                    ShelfBackgroundInteractionView()
+                    content(quickLookService: quickLookService)
+                        .padding()
+                }
             }
             .transaction { transaction in
-                transaction.animation = vm.animation
+                transaction.animation = animation
             }
-            .contentShape(Rectangle())
-            .onTapGesture { selection.clear() }
     }
 
-    var content: some View {
-        @Bindable var dropInteraction = vm.dropInteraction
+    private func content(quickLookService: QuickLookService) -> some View {
+        @Bindable var interaction = dropInteraction
 
         return Group {
             if tvm.isEmpty {
@@ -100,21 +82,97 @@ struct ShelfView: View {
             } else {
                 ScrollView(.horizontal) {
                     LazyHStack(spacing: spacing) {
-                        ForEach(Defaults[.reverseShelfOrdering] ? tvm.items.reversed() : tvm.items) { item in
-                            ShelfItemView(item: item)
-                                .environmentObject(quickLookService)
+                        ForEach(displayedItems) { item in
+                            ShelfItemView(
+                                item: item,
+                                quickLookService: quickLookService,
+                                dropInteraction: dropInteraction
+                            )
                         }
                     }
                 }
                 .padding(-spacing)
                 .scrollIndicators(.never)
-                .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], isTargeted: $dropInteraction.dragDetectorTargeting) { providers in
+                .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], isTargeted: $interaction.dragDetectorTargeting) { providers in
                     handleDrop(providers: providers)
                 }
             }
         }
         .onAppear {
-            ShelfStateViewModel.shared.cleanupInvalidItems()
+            tvm.cleanupInvalidItems()
         }
+    }
+}
+
+private struct ShelfBackgroundInteractionView: NSViewRepresentable {
+    func makeNSView(context: Context) -> BackgroundView {
+        BackgroundView()
+    }
+
+    func updateNSView(_ nsView: BackgroundView, context: Context) {}
+
+    static func dismantleNSView(_ nsView: BackgroundView, coordinator: ()) {
+        nsView.stopMonitoring()
+    }
+
+    final class BackgroundView: NSView {
+        private var eventMonitor: Any?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            stopMonitoring()
+
+            guard window != nil else { return }
+            eventMonitor = NSEvent.addLocalMonitorForEvents(
+                matching: .leftMouseDown
+            ) { [weak self] event in
+                self?.handle(event)
+                return event
+            }
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            nil
+        }
+
+        func stopMonitoring() {
+            guard let eventMonitor else { return }
+            NSEvent.removeMonitor(eventMonitor)
+            self.eventMonitor = nil
+        }
+
+        private func handle(_ event: NSEvent) {
+            guard let window,
+                  event.window === window,
+                  bounds.contains(convert(event.locationInWindow, from: nil)),
+                  let contentView = window.contentView
+            else { return }
+
+            let hitPoint = contentView.convert(event.locationInWindow, from: nil)
+            guard !isShelfItemInteraction(contentView.hitTest(hitPoint)) else { return }
+
+            ShelfSelectionModel.shared.clear()
+        }
+
+        private func isShelfItemInteraction(_ hitView: NSView?) -> Bool {
+            var view = hitView
+            while let currentView = view {
+                if currentView is any ShelfItemInteractionSurface {
+                    return true
+                }
+                view = currentView.superview
+            }
+            return false
+        }
+    }
+}
+
+private struct ShelfQuickLookHost<Content: View>: View {
+    @State private var service = QuickLookService()
+    @ViewBuilder let content: (QuickLookService) -> Content
+
+    var body: some View {
+        content(service)
+            .quickLookPresenter(using: service)
     }
 }


### PR DESCRIPTION
## Summary

- Add explicit background/item hit testing to prevent item selection from clearing immediately.
- Preserve click, double-click, context-menu, and multi-item drag behavior through a narrow AppKit interaction bridge.
- Scope selection observation to per-item `@Observable` state.
- Remove `BoringViewModel` observation from Shelf children; pass focused drop-interaction and animation dependencies explicitly.
- Isolate Quick Look selection synchronization.