### PR TITLE
Refactor drop interaction state out of BoringViewModel

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		14D570C02C5EA5870011E668 /* AnimatedFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570BF2C5EA5870011E668 /* AnimatedFace.swift */; };
 		14D570C62C5F38210011E668 /* BoringHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570C52C5F38210011E668 /* BoringHeader.swift */; };
 		14D570C92C5F38890011E668 /* BoringViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570C82C5F38890011E668 /* BoringViewModel.swift */; };
+		C0D300012F60000100000001 /* DropInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300022F60000100000001 /* DropInteractionState.swift */; };
 		14D570CB2C5F4B2C0011E668 /* BatteryStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570CA2C5F4B2C0011E668 /* BatteryStatusViewModel.swift */; };
 		14D570CD2C5F4BB70011E668 /* BoringBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570CC2C5F4BB70011E668 /* BoringBattery.swift */; };
 		14D570D22C5F6C6A0011E668 /* BoringExtrasMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570D12C5F6C6A0011E668 /* BoringExtrasMenu.swift */; };
@@ -301,6 +302,7 @@
 		14D570BF2C5EA5870011E668 /* AnimatedFace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedFace.swift; sourceTree = "<group>"; };
 		14D570C52C5F38210011E668 /* BoringHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringHeader.swift; sourceTree = "<group>"; };
 		14D570C82C5F38890011E668 /* BoringViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringViewModel.swift; sourceTree = "<group>"; };
+		C0D300022F60000100000001 /* DropInteractionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropInteractionState.swift; sourceTree = "<group>"; };
 		14D570CA2C5F4B2C0011E668 /* BatteryStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryStatusViewModel.swift; sourceTree = "<group>"; };
 		14D570CC2C5F4BB70011E668 /* BoringBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringBattery.swift; sourceTree = "<group>"; };
 		14D570D12C5F6C6A0011E668 /* BoringExtrasMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringExtrasMenu.swift; sourceTree = "<group>"; };
@@ -728,6 +730,7 @@
 				1163988C2DF5CAB40052E6AF /* EventModel.swift */,
 				B19016232CC15B4D00E3F12E /* Constants.swift */,
 				14D570C82C5F38890011E668 /* BoringViewModel.swift */,
+				C0D300022F60000100000001 /* DropInteractionState.swift */,
 				14D570CA2C5F4B2C0011E668 /* BatteryStatusViewModel.swift */,
 				1153BD902D986DB300979FB0 /* PlaybackState.swift */,
 			);
@@ -1055,6 +1058,7 @@
 				B1A78C822C8BA08100BD51B0 /* FullscreenMediaDetection.swift in Sources */,
 				14E9FEAE2C7325770062E83F /* Button+Bouncing.swift in Sources */,
 				14D570C92C5F38890011E668 /* BoringViewModel.swift in Sources */,
+				C0D300012F60000100000001 /* DropInteractionState.swift in Sources */,
 				14D570BC2C5E98EB0011E668 /* generic.swift in Sources */,
 				118EBE272E92DE8400D54B5A /* NSMenu+AssociatedObject.swift in Sources */,
 				B1CE8CFE2C6F659400DD9871 /* KeyboardShortcutsHelper.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -114,6 +114,8 @@ struct ContentView: View {
     private var displayClosedNotchHeight: CGFloat { isNotchHeightZero ? 10 : vm.effectiveClosedNotchHeight }
 
     var body: some View {
+        @Bindable var dropInteraction = vm.dropInteraction
+
         // Calculate scale based on gesture progress only
         let gestureScale: CGFloat = {
             guard gestureProgress != 0 else { return 1.0 }
@@ -158,7 +160,9 @@ struct ContentView: View {
                         handleHover(hovering)
                     }
                     .onTapGesture {
-                        doOpen()
+                        if vm.notchState == .closed {
+                            doOpen()
+                        }
                     }
                     .conditionalModifier(Defaults[.enableGestures]) { view in
                         view
@@ -250,7 +254,7 @@ struct ContentView: View {
         .background(dragDetector)
         .preferredColorScheme(.dark)
         .environmentObject(vm)
-        .onChange(of: vm.anyDropZoneTargeting) { _, isTargeted in
+        .onChange(of: dropInteraction.anyDropZoneTargeting) { _, isTargeted in
             anyDropDebounceTask?.cancel()
 
             if isTargeted {
@@ -266,12 +270,12 @@ struct ContentView: View {
                 try? await Task.sleep(for: .milliseconds(500))
                 guard !Task.isCancelled else { return }
 
-                if vm.dropEvent {
-                    vm.dropEvent = false
+                if dropInteraction.dropEvent {
+                    dropInteraction.dropEvent = false
                     return
                 }
 
-                vm.dropEvent = false
+                dropInteraction.dropEvent = false
                 if !SharingStateManager.shared.preventNotchClose {
                     vm.close()
                 }
@@ -281,6 +285,8 @@ struct ContentView: View {
 
     @ViewBuilder
     func NotchLayout() -> some View {
+        @Bindable var dropInteraction = vm.dropInteraction
+
         VStack(alignment: .leading) {
             VStack(alignment: .leading) {
                 if coordinator.helloAnimationRunning {
@@ -415,7 +421,7 @@ struct ContentView: View {
                 .opacity(gestureProgress != 0 ? 1.0 - min(abs(gestureProgress) * 0.1, 0.3) : 1.0)
             }
         }
-        .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], delegate: GeneralDropTargetDelegate(isTargeted: $vm.generalDropTargeting))
+        .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], delegate: GeneralDropTargetDelegate(isTargeted: $dropInteraction.generalDropTargeting))
     }
 
     @ViewBuilder
@@ -541,12 +547,14 @@ struct ContentView: View {
 
     @ViewBuilder
     var dragDetector: some View {
+        @Bindable var dropInteraction = vm.dropInteraction
+
         if Defaults[.boringShelf] && vm.notchState == .closed {
             Color.clear
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .contentShape(Rectangle())
-        .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], isTargeted: $vm.dragDetectorTargeting) { providers in
-            vm.dropEvent = true
+        .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], isTargeted: $dropInteraction.dragDetectorTargeting) { providers in
+            dropInteraction.dropEvent = true
             ShelfStateViewModel.shared.load(providers)
             return true
         }

--- a/boringNotch/components/Shelf/Views/FileShareView.swift
+++ b/boringNotch/components/Shelf/Views/FileShareView.swift
@@ -24,11 +24,13 @@ struct FileShareView: View {
     }
 
     var body: some View {
+        @Bindable var dropInteraction = vm.dropInteraction
+
         dropArea
             .background(NSViewHost(view: $hostView))
-            .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data, .image], isTargeted: $vm.dropZoneTargeting) { providers in
+            .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data, .image], isTargeted: $dropInteraction.dropZoneTargeting) { providers in
                 interactionNonce = .init()
-                vm.dropEvent = true
+                dropInteraction.dropEvent = true
                 Task { await handleDrop(providers) }
                 return true
             }
@@ -48,7 +50,7 @@ struct FileShareView: View {
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
                         .stroke(
-                            vm.dropZoneTargeting
+                            vm.dropInteraction.dropZoneTargeting
                                 ? Color.accentColor.opacity(0.9)
                                 : Color.white.opacity(0.1),
                             style: StrokeStyle(lineWidth: 3, lineCap: .round, dash: [10])
@@ -61,7 +63,7 @@ struct FileShareView: View {
                 ZStack {
                     Circle()
                         .fill(Color.white.opacity(
-                            vm.dropZoneTargeting ? 0.11 : 0.09
+                            vm.dropInteraction.dropZoneTargeting ? 0.11 : 0.09
                         ))
                         .frame(width: 55, height: 55)
                     Group {
@@ -75,12 +77,12 @@ struct FileShareView: View {
                     }
                     .frame(width: 34, height: 34)
                         .foregroundStyle(
-                            vm.dropZoneTargeting ? Color.accentColor : Color.gray
+                            vm.dropInteraction.dropZoneTargeting ? Color.accentColor : Color.gray
                         )
                         .scaleEffect(
-                            vm.dropZoneTargeting ? 1.06 : 1.0
+                            vm.dropInteraction.dropZoneTargeting ? 1.06 : 1.0
                         )
-                        .animation(.spring(response: 0.36, dampingFraction: 0.7), value: vm.dropZoneTargeting)
+                        .animation(.spring(response: 0.36, dampingFraction: 0.7), value: vm.dropInteraction.dropZoneTargeting)
                 }
 
                 Text(selectedProvider.id)

--- a/boringNotch/components/Shelf/Views/ShelfItemView.swift
+++ b/boringNotch/components/Shelf/Views/ShelfItemView.swift
@@ -62,7 +62,7 @@ struct ShelfItemView: View {
             }
         }
         .onChange(of: viewModel.isDropTargeted) { _, targeted in
-            vm.dragDetectorTargeting = targeted
+            vm.dropInteraction.dragDetectorTargeting = targeted
             // Debounce drop target state changes
             Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(50))

--- a/boringNotch/components/Shelf/Views/ShelfView.swift
+++ b/boringNotch/components/Shelf/Views/ShelfView.swift
@@ -17,12 +17,14 @@ struct ShelfView: View {
     private let spacing: CGFloat = 8
 
     var body: some View {
+        @Bindable var dropInteraction = vm.dropInteraction
+
         HStack(spacing: 12) {
             FileShareView()
                 .aspectRatio(1, contentMode: .fit)
                 .environmentObject(vm)
             panel
-                .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], isTargeted: $vm.dragDetectorTargeting) { providers in
+                .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], isTargeted: $dropInteraction.dragDetectorTargeting) { providers in
                     handleDrop(providers: providers)
                 }
         }
@@ -35,7 +37,7 @@ struct ShelfView: View {
     
     private func handleDrop(providers: [NSItemProvider]) -> Bool {
         guard !selection.isDragging else { return false }
-        vm.dropEvent = true
+        vm.dropInteraction.dropEvent = true
         ShelfStateViewModel.shared.load(providers)
         return true
     }
@@ -62,7 +64,7 @@ struct ShelfView: View {
     var panel: some View {
         RoundedRectangle(cornerRadius: 16)
             .stroke(
-                vm.dragDetectorTargeting
+                vm.dropInteraction.dragDetectorTargeting
                     ? Color.accentColor.opacity(0.9)
                     : Color.white.opacity(0.1),
                 style: StrokeStyle(lineWidth: 3, lineCap: .round, dash: [10])
@@ -79,7 +81,9 @@ struct ShelfView: View {
     }
 
     var content: some View {
-        Group {
+        @Bindable var dropInteraction = vm.dropInteraction
+
+        return Group {
             if tvm.isEmpty {
                 VStack(spacing: 10) {
                     Image(systemName: "tray.and.arrow.down")
@@ -104,7 +108,7 @@ struct ShelfView: View {
                 }
                 .padding(-spacing)
                 .scrollIndicators(.never)
-                .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], isTargeted: $vm.dragDetectorTargeting) { providers in
+                .onDrop(of: [.fileURL, .url, .utf8PlainText, .plainText, .data], isTargeted: $dropInteraction.dragDetectorTargeting) { providers in
                     handleDrop(providers: providers)
                 }
             }

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -15,14 +15,9 @@ class BoringViewModel: NSObject, ObservableObject {
 
     let animationLibrary: BoringAnimations = .init()
     let animation: Animation?
+    let dropInteraction = DropInteractionState()
 
     @Published private(set) var notchState: NotchState = .closed
-
-    @Published var dragDetectorTargeting: Bool = false
-    @Published var generalDropTargeting: Bool = false
-    @Published var dropZoneTargeting: Bool = false
-    @Published var dropEvent: Bool = false
-    @Published var anyDropZoneTargeting: Bool = false
     var cancellables: Set<AnyCancellable> = []
     
     @Published var hideOnClosed: Bool = true
@@ -58,13 +53,6 @@ class BoringViewModel: NSObject, ObservableObject {
         notchSize = getClosedNotchSize(screenUUID: screenUUID)
         closedNotchSize = notchSize
 
-        Publishers.CombineLatest3($dropZoneTargeting, $dragDetectorTargeting, $generalDropTargeting)
-            .map { shelf, drag, general in
-                shelf || drag || general
-            }
-            .assign(to: \.anyDropZoneTargeting, on: self)
-            .store(in: &cancellables)
-        
         setupDetectorObserver()
     }
     
@@ -196,7 +184,7 @@ class BoringViewModel: NSObject, ObservableObject {
 
     @discardableResult
     func open() -> Bool {
-        guard !coordinator.firstLaunch else { return false }
+        guard !coordinator.firstLaunch, notchState != .open else { return false }
 
         self.notchSize = openNotchSize
         self.notchState = .open

--- a/boringNotch/models/DropInteractionState.swift
+++ b/boringNotch/models/DropInteractionState.swift
@@ -1,0 +1,18 @@
+//
+//  DropInteractionState.swift
+//  boringNotch
+//
+
+import Observation
+
+@Observable
+final class DropInteractionState {
+    var dragDetectorTargeting = false
+    var generalDropTargeting = false
+    var dropZoneTargeting = false
+    var dropEvent = false
+
+    var anyDropZoneTargeting: Bool {
+        dragDetectorTargeting || generalDropTargeting || dropZoneTargeting
+    }
+}


### PR DESCRIPTION
## Summary

- Extract Shelf/notch drop targeting into a focused `@Observable` `DropInteractionState`.
- Derive aggregate targeting without republishing it through `BoringViewModel`.
- Make opening idempotent and ignore the parent open tap while the notch is already open.