### PR TITLE
ci: pin legacy Xcode 16 runner

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,7 +28,9 @@ jobs:
           - ^16
         scheme:
           - boringNotch
-    runs-on: macos-latest
+    # macos-latest now resolves to macos-26, which does not ship Xcode 16.
+    # Keep this legacy main-branch build on an image with the requested toolchain.
+    runs-on: macos-15
     steps:
     - name: Code Checkout
       # TODO: pin to immutable SHA


### PR DESCRIPTION
## Summary

- Pin the legacy Xcode 16 build to `macos-15`.
- Keep the newer `dev` branch matrix unchanged.

`macos-latest` now resolves to `macos-26`, which does not include Xcode 16, so the existing `^16` build failed before compilation.

## Verification

- `actionlint .github/workflows/cicd.yml` passes.
- `git diff --check` passes.