### PR TITLE
Add Dock icon visibility setting

### DIFF
--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -6,11 +6,19 @@
 //
 
 import AVFoundation
+import AppKit
 import Combine
 import Defaults
 import KeyboardShortcuts
 import Sparkle
 import SwiftUI
+
+extension NSApplication {
+    @discardableResult
+    func applyDockIconPreference() -> Bool {
+        setActivationPolicy(Defaults[.hideDockIcon] ? .accessory : .regular)
+    }
+}
 
 @main
 struct DynamicNotchApp: App {
@@ -312,6 +320,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.applyDockIconPreference()
 
         NotificationCenter.default.addObserver(
             self,

--- a/boringNotch/components/Settings/SettingsWindowController.swift
+++ b/boringNotch/components/Settings/SettingsWindowController.swift
@@ -67,8 +67,7 @@ class SettingsWindowController: NSWindowController {
     }
     
     func showWindow() {
-        // Set app to regular mode first
-        NSApp.setActivationPolicy(.regular)
+        NSApp.applyDockIconPreference()
         
         // If window is already visible, bring it to front properly
         if window?.isVisible == true {
@@ -100,8 +99,7 @@ class SettingsWindowController: NSWindowController {
     private func relinquishFocus() {
         window?.orderOut(nil)
         
-        // Set app back to accessory mode immediately
-        NSApp.setActivationPolicy(.accessory)
+        NSApp.applyDockIconPreference()
     }
 }
 
@@ -115,8 +113,7 @@ extension SettingsWindowController: NSWindowDelegate {
     }
     
     func windowDidBecomeKey(_ notification: Notification) {
-        // Ensure app is in regular mode when window becomes key
-        NSApp.setActivationPolicy(.regular)
+        NSApp.applyDockIconPreference()
     }
     
     func windowDidResignKey(_ notification: Notification) {

--- a/boringNotch/components/Settings/Views/GeneralSettingsView.swift
+++ b/boringNotch/components/Settings/Views/GeneralSettingsView.swift
@@ -19,6 +19,7 @@ struct GeneralSettings: View {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
 
     @Default(.appLanguage) var appLanguage
+    @Default(.hideDockIcon) var hideDockIcon
     @Default(.mirrorShape) var mirrorShape
     @Default(.gestureSensitivity) var gestureSensitivity
     @Default(.minimumHoverDuration) var minimumHoverDuration
@@ -43,6 +44,12 @@ struct GeneralSettings: View {
                     Text("Show menu bar icon")
                 }
                 .tint(.effectiveAccent)
+                Defaults.Toggle(key: .hideDockIcon) {
+                    Text("Hide icon in Dock")
+                }
+                .onChange(of: hideDockIcon) {
+                    NSApp.applyDockIconPreference()
+                }
                 LaunchAtLogin.Toggle() {
                     Text("Launch at login")
                 }

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -138,7 +138,7 @@ class BoringViewModel: NSObject, ObservableObject {
 
         case .denied, .restricted:
             DispatchQueue.main.async {
-                NSApp.setActivationPolicy(.regular)
+                NSApp.applyDockIconPreference()
                 NSApp.activate(ignoringOtherApps: true)
 
                 let alert = NSAlert()
@@ -153,7 +153,7 @@ class BoringViewModel: NSObject, ObservableObject {
                     }
                 }
 
-                NSApp.setActivationPolicy(.accessory)
+                NSApp.applyDockIconPreference()
                 NSApp.deactivate()
             }
 

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -208,6 +208,7 @@ extension Defaults.Keys {
     // MARK: General
     static let appLanguage = Key<AppLanguage>("appLanguage", default: .system)
     static let menubarIcon = Key<Bool>("menubarIcon", default: true)
+    static let hideDockIcon = Key<Bool>("hideDockIcon", default: true)
     static let showOnAllDisplays = Key<Bool>("showOnAllDisplays", default: false)
     static let automaticallySwitchDisplay = Key<Bool>("automaticallySwitchDisplay", default: true)
     static let releaseName = Key<String>("releaseName", default: "Flying Rabbit 🐇🪽")


### PR DESCRIPTION
## Summary

- Add a default-on “Hide icon in Dock” setting under General → System features.
- Apply the preference at launch and whenever activation policy changes, including while Settings is open.
- Preserve the existing menu-bar-only default while allowing users to show the Dock icon when desired.

## Verification

- Built successfully with Xcode 26.6 using the macOS Debug target.
- Confirmed the built app retains LSUIElement = true.
- Confirmed no existing Dock visibility setting was present in the upstream dev branch.