### PR TITLE
Add missing NSCalendars/NSRemindersFullAccessUsageDescription keys

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -1350,9 +1350,11 @@
 				INFOPLIST_KEY_LSBackgroundOnly = NO;
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "This app uses AppleEvents to control music";
+				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "This app uses the calendar to display your calendar events";
 				INFOPLIST_KEY_NSCalendarsUsageDescription = "This app uses the calendar to display your calendar events";
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app uses the camera to display a live camera view";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSRemindersFullAccessUsageDescription = "This app uses Reminders to display your scheduled reminder in the calendar";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "This app uses Reminders to display your scheduled reminder in the calendar";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1416,9 +1418,11 @@
 				INFOPLIST_KEY_LSBackgroundOnly = NO;
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "This app uses AppleEvents to control music";
+				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "This app uses the calendar to display your calendar events";
 				INFOPLIST_KEY_NSCalendarsUsageDescription = "This app uses the calendar to display your calendar events";
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app uses the camera to display a live camera view";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSRemindersFullAccessUsageDescription = "This app uses Reminders to display your scheduled reminder in the calendar";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "This app uses Reminders to display your scheduled reminder in the calendar";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## Problem

Calendar and Reminders permissions can never be granted on macOS 14+. The app is missing the `FullAccess` usage description keys that EventKit requires.

The code requests **full** access:

```
$ strings -a boringNotch.app/Contents/MacOS/boringNotch | grep requestFullAccess
requestFullAccessToEvents
requestFullAccessToReminders
```

But the shipped `Info.plist` only declares the legacy keys:

```
$ plutil -p boringNotch.app/Contents/Info.plist | grep -iE "Calendars|Reminders"
"NSCalendarsUsageDescription" => "This app uses the calendar to display your calendar events"
"NSRemindersUsageDescription" => "This app uses Reminders to display your scheduled reminder in the calendar"
```

The target is built against the macOS 15.5 SDK (`DTSDKName = macosx15.5`, `LSMinimumSystemVersion = 14.0`). For apps linked on or after macOS 14, `NSCalendarsUsageDescription` is ignored — `requestFullAccessToEvents` requires `NSCalendarsFullAccessUsageDescription`, and `requestFullAccessToReminders` requires `NSRemindersFullAccessUsageDescription`.

The result on v2.7.3: the access request fails silently, **no permission prompt is ever shown**, and the app never appears in System Settings → Privacy & Security → Calendars. The calendar view stays empty even with fully synced accounts in Calendar.app.

Only `INFOPLIST_KEY_NSCalendarsUsageDescription` and `INFOPLIST_KEY_NSRemindersUsageDescription` are set in `project.pbxproj`, so the required keys never reach the built bundle.

## Fix

Add `INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription` and `INFOPLIST_KEY_NSRemindersFullAccessUsageDescription` to both the Debug and Release configurations, reusing the existing descriptions.

The legacy keys are kept, so the change is purely additive. Four added lines, no code changes and no translation changes.

## Testing

`xcodebuild -scheme boringNotch -configuration Debug` → **BUILD SUCCEEDED**, and the resulting bundle now carries all four keys:

```
$ plutil -p Build/Products/Debug/boringNotch.app/Contents/Info.plist | grep -iE "Calendars|Reminders"
"NSCalendarsFullAccessUsageDescription" => "This app uses the calendar to display your calendar events"
"NSCalendarsUsageDescription" => "This app uses the calendar to display your calendar events"
"NSRemindersFullAccessUsageDescription" => "This app uses Reminders to display your scheduled reminder in the calendar"
"NSRemindersUsageDescription" => "This app uses Reminders to display your scheduled reminder in the calendar"
```

No screenshots: this changes build settings only, there is no UI change.

Reproduced on macOS 26.0 (Darwin 25.6.0), MacBook Air M2, boringNotch 2.7.3.
