### PR TITLE
Add Claude Code agent control from the notch

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -23,6 +23,8 @@ struct ContentView: View {
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var brightnessManager = BrightnessManager.shared
     @ObservedObject var volumeManager = VolumeManager.shared
+    @ObservedObject private var agentVM = AIAgentViewModel.shared
+    @State private var agentOpenedNotch = false
     @State private var hoverTask: Task<Void, Never>?
     @State private var isHovering: Bool = false
     @State private var anyDropDebounceTask: Task<Void, Never>?
@@ -113,6 +115,32 @@ struct ContentView: View {
 
     private var displayClosedNotchHeight: CGFloat { isNotchHeightZero ? 10 : vm.effectiveClosedNotchHeight }
 
+    // MARK: Agent surface expansion
+
+    /// Extra room the notch gets on agent surfaces, so approval cards and
+    /// the chat panel are actually usable instead of cramped. Both keep the
+    /// standard notch width — only the height grows.
+    static let agentApprovalExtraSize = CGSize(width: 0, height: 120)
+    static let agentChatExtraSize = CGSize(width: 0, height: 320)
+
+    private var agentSurfaceExpanded: Bool {
+        vm.notchState == .open
+            && (coordinator.currentView == .agentApproval || coordinator.currentView == .agent)
+    }
+
+    private var effectiveOpenSize: CGSize {
+        guard agentSurfaceExpanded else { return vm.notchSize }
+        let extra = coordinator.currentView == .agent ? Self.agentChatExtraSize : Self.agentApprovalExtraSize
+        return CGSize(width: openNotchSize.width + extra.width,
+                      height: openNotchSize.height + extra.height)
+    }
+
+    private var effectiveWindowSize: CGSize {
+        agentSurfaceExpanded
+            ? CGSize(width: effectiveOpenSize.width, height: effectiveOpenSize.height + shadowPadding)
+            : windowSize
+    }
+
     var body: some View {
         @Bindable var dropInteraction = vm.dropInteraction
 
@@ -149,7 +177,7 @@ struct ContentView: View {
                     .opacity((isNotchHeightZero && vm.notchState == .closed) ? 0.01 : 1)
                 
                 mainLayout
-                    .frame(height: vm.notchState == .open ? vm.notchSize.height : nil)
+                    .frame(height: vm.notchState == .open ? effectiveOpenSize.height : nil)
                     .conditionalModifier(true) { view in
                         return view
                             .animation(vm.notchState == .open ? StandardAnimations.open : StandardAnimations.close, value: vm.notchState)
@@ -164,13 +192,13 @@ struct ContentView: View {
                             doOpen()
                         }
                     }
-                    .conditionalModifier(Defaults[.enableGestures]) { view in
+                    .conditionalModifier(Defaults[.enableGestures] && !agentSurfaceExpanded) { view in
                         view
                             .panGesture(direction: .down) { translation, phase in
                                 handleDownGesture(translation: translation, phase: phase)
                             }
                     }
-                    .conditionalModifier(Defaults[.closeGestureEnabled] && Defaults[.enableGestures]) { view in
+                    .conditionalModifier(Defaults[.closeGestureEnabled] && Defaults[.enableGestures] && !agentSurfaceExpanded) { view in
                         view
                             .panGesture(direction: .up) { translation, phase in
                                 handleUpGesture(translation: translation, phase: phase)
@@ -187,16 +215,7 @@ struct ContentView: View {
                     }
                     .onReceive(NotificationCenter.default.publisher(for: .sharingDidFinish)) { _ in
                         if vm.notchState == .open && !isHovering && !vm.isBatteryPopoverActive {
-                            hoverTask?.cancel()
-                            hoverTask = Task {
-                                try? await Task.sleep(for: .milliseconds(100))
-                                guard !Task.isCancelled else { return }
-                                await MainActor.run {
-                                    if self.vm.notchState == .open && !self.isHovering && !self.vm.isBatteryPopoverActive && !SharingStateManager.shared.preventNotchClose {
-                                        self.vm.close()
-                                    }
-                                }
-                            }
+                            scheduleAutoClose()
                         }
                     }
                     .onChange(of: vm.notchState) { _, newState in
@@ -206,18 +225,15 @@ struct ContentView: View {
                             }
                         }
                     }
-                    .onChange(of: vm.isBatteryPopoverActive) {
-                        if !vm.isBatteryPopoverActive && !isHovering && vm.notchState == .open && !SharingStateManager.shared.preventNotchClose {
-                            hoverTask?.cancel()
-                            hoverTask = Task {
-                                try? await Task.sleep(for: .milliseconds(100))
-                                guard !Task.isCancelled else { return }
-                                await MainActor.run {
-                                    if !self.vm.isBatteryPopoverActive && !self.isHovering && self.vm.notchState == .open && !SharingStateManager.shared.preventNotchClose {
-                                        self.vm.close()
-                                    }
-                                }
-                            }
+                    .onChange(of: agentVM.hasActiveAgentCard) { _, active in
+                        handleAgentCardActivity(active)
+                    }
+                    .onChange(of: coordinator.currentView) { _, view in
+                        updateAgentKeyFocus(view)
+                    }
+                    .onChange(of: vm.isBatteryPopoverActive) { _, active in
+                        if !active && !isHovering && vm.notchState == .open && !SharingStateManager.shared.preventNotchClose {
+                            scheduleAutoClose()
                         }
                     }
                     .sensoryFeedback(.alignment, trigger: haptics)
@@ -242,9 +258,10 @@ struct ContentView: View {
             }
         }
         .padding(.bottom, 8)
-        .frame(maxWidth: windowSize.width, maxHeight: windowSize.height, alignment: .top)
+        .frame(maxWidth: effectiveWindowSize.width, maxHeight: effectiveWindowSize.height, alignment: .top)
         .ignoresSafeArea(.all)
         .compositingGroup()
+        .background(NotchWindowResizer(targetSize: effectiveWindowSize))
         .scaleEffect(
             x: gestureScale,
             y: gestureScale,
@@ -412,6 +429,10 @@ struct ContentView: View {
                             dropInteraction: vm.dropInteraction,
                             animation: vm.animation
                         )
+                    case .agent:
+                        AIAgentPanel()
+                    case .agentApproval:
+                        AgentApprovalView()
                     }
                 }
                 .transition(
@@ -577,11 +598,59 @@ struct ContentView: View {
 
     // MARK: - Hover Management
 
+    /// Claude needs a decision: open the notch on the approval surface (if
+    /// auto-open is on); close it again once the cards clear.
+    private func handleAgentCardActivity(_ active: Bool) {
+        if active {
+            guard Defaults[.aiAgentAutoOpen] else { return }
+            let wasOpen = vm.notchState == .open
+            agentOpenedNotch = true
+            withAnimation(animationSpring) {
+                if !wasOpen { vm.open() }
+                coordinator.currentView = .agentApproval
+            }
+        } else if agentOpenedNotch {
+            agentOpenedNotch = false
+            guard !isHovering else { return }
+            withAnimation(animationSpring) {
+                vm.close()
+            }
+        }
+    }
+
+    /// Only the agent surfaces host text fields; the panel stays
+    /// key-incapable everywhere else so the notch never steals keyboard
+    /// focus from the active app.
+    private func updateAgentKeyFocus(_ view: NotchViews) {
+        BoringNotchSkyLightWindow.allowsKeyFocus = (view == .agent || view == .agentApproval)
+    }
+
+    /// Shared auto-close path: wait a beat, then close the notch if nothing
+    /// (hover, popover, sharing) still needs it open. Extracted from three
+    /// identical inline tasks — the body's modifier chain otherwise grows
+    /// past what the type-checker tolerates.
+    private func scheduleAutoClose() {
+        hoverTask?.cancel()
+        hoverTask = Task {
+            try? await Task.sleep(for: .milliseconds(100))
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                if self.vm.notchState == .open && !self.isHovering && !self.vm.isBatteryPopoverActive && !SharingStateManager.shared.preventNotchClose {
+                    self.vm.close()
+                }
+            }
+        }
+    }
+
     private func handleHover(_ hovering: Bool) {
         if coordinator.firstLaunch { return }
         hoverTask?.cancel()
-        
+
         if hovering {
+            // Borderless panels inherit whatever cursor the window below the
+            // notch had when the mouse entered — reset to the standard arrow.
+            DispatchQueue.main.async { NSCursor.arrow.set() }
+
             withAnimation(animationSpring) {
                 isHovering = true
             }
@@ -805,4 +874,35 @@ struct GeneralDropTargetDelegate: DropDelegate {
     return ContentView()
         .environmentObject(vm)
         .frame(width: vm.notchSize.width, height: vm.notchSize.height)
+}
+
+/// Keeps the notch panel's size in sync with the SwiftUI content: when an
+/// agent surface asks for extra room the (borderless, fixed-size) window
+/// itself grows — anchored to the top edge and horizontally centered — and
+/// shrinks back when the surface goes away.
+private struct NotchWindowResizer: NSViewRepresentable {
+    let targetSize: CGSize
+
+    func makeNSView(context: Context) -> NSView {
+        NSView()
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        guard let window = view.window else { return }
+        let current = window.frame.size
+        guard abs(current.width - targetSize.width) > 0.5
+              || abs(current.height - targetSize.height) > 0.5 else { return }
+
+        var frame = window.frame
+        frame.size = targetSize
+        frame.origin.x -= (targetSize.width - current.width) / 2 // stay centered
+        frame.origin.y -= (targetSize.height - current.height)   // keep the top edge fixed
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.35
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            context.allowsImplicitAnimation = true
+            window.setFrame(frame, display: true)
+        }
+    }
 }

--- a/boringNotch/boringNotch.entitlements
+++ b/boringNotch/boringNotch.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
 	<key>com.apple.security.device.audio-input</key>

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -463,7 +463,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             adjustWindowPosition(changeAlpha: true)
         }
 
-setupDragDetectors()
+        setupDragDetectors()
 
         // Start the Claude Code bridge and install the hook integration
         AIAgentViewModel.shared.activate()

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -463,7 +463,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             adjustWindowPosition(changeAlpha: true)
         }
 
-        setupDragDetectors()
+setupDragDetectors()
+
+        // Start the Claude Code bridge and install the hook integration
+        AIAgentViewModel.shared.activate()
 
         if coordinator.firstLaunch {
             DispatchQueue.main.async {

--- a/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
@@ -138,14 +138,20 @@ class BoringNotchSkyLightWindow: NSPanel {
     }
     
     private var observers: Set<AnyCancellable> = []
-    
+
     private func cleanupObservers() {
         Task { @MainActor in
             self.observers.forEach { $0.cancel() }
             self.observers.removeAll()
         }
     }
-    
-    override var canBecomeKey: Bool { false }
+
+    // The notch panel is non-activating and normally never takes key focus —
+    // but text fields on the agent surfaces (chat input, question's custom
+    // answer) need key status to receive keystrokes. ContentView flips this
+    // while an agent surface with an input is on screen.
+    static var allowsKeyFocus = false
+
+    override var canBecomeKey: Bool { Self.allowsKeyFocus }
     override var canBecomeMain: Bool { false }
 }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -17,6 +17,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
     case osd
     case battery
     case shelf
+    case agent
     case mirror
     case shortcuts
     case advanced
@@ -33,6 +34,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .osd: "OSD"
         case .battery: "Battery"
         case .shelf: "Shelf"
+        case .agent: "AI Agent"
         case .mirror: "Mirror"
         case .shortcuts: "Shortcuts"
         case .advanced: "Advanced"
@@ -49,6 +51,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .osd: "dial.medium.fill"
         case .battery: "battery.100.bolt"
         case .shelf: "books.vertical"
+        case .agent: "brain"
         case .mirror: "camera"
         case .shortcuts: "keyboard"
         case .advanced: "gearshape.2"
@@ -96,6 +99,8 @@ struct SettingsView: View {
                     Charge()
                 case .shelf:
                     Shelf()
+                case .agent:
+                    AIAgentSettingsView()
                 case .mirror:
                     MirrorSettings()
                 case .shortcuts:

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Defaults
 
 struct TabModel: Identifiable {
     let id = UUID()
@@ -16,15 +17,17 @@ struct TabModel: Identifiable {
 
 let tabs = [
     TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
+    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf),
+    TabModel(label: "Agent", icon: "brain", view: .agent)
 ]
 
 struct TabSelectionView: View {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @Default(.aiAgentEnabled) var agentEnabled
     @Namespace var animation
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(tabs) { tab in
+            ForEach(tabs.filter { $0.view != .agent || agentEnabled }) { tab in
                     TabButton(label: tab.label, icon: tab.icon, selected: coordinator.currentView == tab.view) {
                         withAnimation(.smooth) {
                             coordinator.currentView = tab.view

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -21,6 +21,8 @@ public enum NotchState {
 public enum NotchViews {
     case home
     case shelf
+    case agent
+    case agentApproval
 }
 
 enum DownloadIndicatorStyle: String, Defaults.Serializable {

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -348,4 +348,23 @@ extension Defaults.Keys {
     }
 
     static let didClearLegacyURLCacheV1 = Key<Bool>("didClearLegacyURLCache_v1", default: false)
+
+    // MARK: AI Agent control (Claude Code)
+    static let aiAgentEnabled = Key<Bool>("aiAgentEnabled", default: true)
+    static let aiAgentAutoOpen = Key<Bool>("aiAgentAutoOpen", default: true)
+    static let aiAgentNotifyOnDone = Key<Bool>("aiAgentNotifyOnDone", default: true)
+    /// System sound (NSSound name) played when a card needs the user, and
+    /// when a task finishes.
+    static let aiAgentArrivalSound = Key<String>("aiAgentArrivalSound", default: "Ping")
+    static let aiAgentDoneSound = Key<String>("aiAgentDoneSound", default: "Glass")
+    static let aiAgentClaudeBinary = Key<String>("aiAgentClaudeBinary", default: "")
+    static let aiAgentWorkspace = Key<String>("aiAgentWorkspace", default: "")
+    static let aiAgentModel = Key<String>("aiAgentModel", default: "")
+    /// When on, tool calls in every Claude Code session (terminal included)
+    /// hold for a decision from the notch. Off by default: terminal sessions
+    /// keep Claude Code's own permission prompts.
+    static let aiAgentHoldExternalTools = Key<Bool>("aiAgentHoldExternalTools", default: false)
+    /// Prompts queued for busy sessions ([sessionID: [prompt]] as JSON) so
+    /// they survive an app relaunch.
+    static let aiAgentQueuedPrompts = Key<Data>("aiAgentQueuedPrompts", default: Data())
 }

--- a/boringNotch/private/AIAgent/AIAgentFullView.swift
+++ b/boringNotch/private/AIAgent/AIAgentFullView.swift
@@ -1,0 +1,276 @@
+//
+//  AIAgentFullView.swift
+//  boringNotch
+//
+//  Full desktop window for driving Claude Code: session sidebar,
+//  transcript, prompt input, and inline approve/deny of permission
+//  and question prompts — the Vibe Island-style cockpit.
+//
+
+import SwiftUI
+import Defaults
+
+struct AIAgentFullView: View {
+    @ObservedObject private var vm = AIAgentViewModel.shared
+    @State private var draft = ""
+
+    var body: some View {
+        HStack(spacing: 0) {
+            sessionSidebar
+                .frame(minWidth: 220, maxWidth: 260)
+                .background(AgentPalette.ink)
+
+            Divider().overlay(Color.white.opacity(0.08))
+
+            VStack(spacing: 0) {
+                transcript
+                Divider().overlay(Color.white.opacity(0.08))
+                promptBar
+            }
+        }
+        .frame(minWidth: 720, minHeight: 480)
+    }
+
+    // MARK: Sidebar
+
+    private var sessionSidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Sessions")
+                    .font(.headline)
+                    .foregroundStyle(AgentPalette.paper)
+                Spacer()
+                Button { Task { await vm.startNewSession() } } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(14)
+
+            Divider().overlay(Color.white.opacity(0.08))
+
+            List(vm.sessions, selection: Binding(
+                get: { vm.selectedSessionID },
+                set: { if let id = $0 { vm.openChat(sessionID: id) } }
+            )) { session in
+                SessionFullRow(session: session)
+                    .padding(.vertical, 2)
+            }
+            .listStyle(.sidebar)
+            .scrollContentBackground(.hidden)
+        }
+    }
+
+    // MARK: Transcript
+
+    private var transcript: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 10) {
+                    ForEach(vm.messages) { message in
+                        ChatBubbleFull(message: message)
+                            .id(message.id)
+                    }
+
+                    if !vm.pendingPermissions.isEmpty {
+                        ForEach(vm.pendingPermissions) { request in
+                            PermissionCardFull(request: request)
+                        }
+                    }
+
+                    if !vm.pendingQuestions.isEmpty {
+                        ForEach(vm.pendingQuestions) { request in
+                            QuestionCardFull(request: request)
+                        }
+                    }
+
+                    if vm.sending {
+                        HStack {
+                            AgentStateDot(color: AgentPalette.running, pulsing: true, size: 7)
+                            Text("Agent is working…")
+                                .font(.caption)
+                                .foregroundStyle(AgentPalette.paperSecondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(14)
+            }
+            .onChange(of: vm.messages.count + vm.pendingPermissions.count + vm.pendingQuestions.count) {
+                if let last = vm.messages.last {
+                    withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+                }
+            }
+        }
+    }
+
+    // MARK: Prompt bar
+
+    private var promptBar: some View {
+        HStack(spacing: 10) {
+            TextField("Send a prompt to your agent…", text: $draft, onCommit: send)
+                .textFieldStyle(.roundedBorder)
+                .disabled(vm.sending)
+            Button(action: send) {
+                Image(systemName: "paperplane.fill")
+                    .font(.system(size: 13, weight: .semibold))
+            }
+            .disabled(draft.trimmingCharacters(in: .whitespaces).isEmpty || vm.sending)
+            Button(action: { vm.interrupt() }) {
+                Image(systemName: "stop.fill")
+                    .font(.system(size: 13, weight: .semibold))
+            }
+            .help("Interrupt")
+        }
+        .padding(12)
+    }
+
+    private func send() {
+        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        draft = ""
+        Task { await vm.sendPrompt(text) }
+    }
+}
+
+// MARK: - Session full row
+
+private struct SessionFullRow: View {
+    let session: AgentSession
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 8) {
+                AgentStateDot(color: AgentPalette.tint(for: session.phase), size: 8)
+                Text(session.displayTitle)
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(AgentPalette.paper)
+                    .lineLimit(1)
+            }
+
+            if let model = session.modelRef {
+                Text(model)
+                    .font(.caption2)
+                    .foregroundStyle(AgentPalette.paperSecondary)
+            }
+        }
+        .padding(.vertical, 3)
+    }
+}
+
+// MARK: - Full transcript bubble
+
+private struct ChatBubbleFull: View {
+    let message: AgentChatMessage
+
+    var body: some View {
+        HStack {
+            if message.role == .user { Spacer() }
+            VStack(alignment: message.role == .user ? .trailing : .leading, spacing: 3) {
+                Text(message.role == .user ? "You" : "Agent")
+                    .font(.caption2)
+                    .foregroundStyle(AgentPalette.paperSecondary)
+                Text(message.text)
+                    .textSelection(.enabled)
+                    .padding(12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .fill(message.role == .user
+                                ? Color.accentColor.opacity(0.22)
+                                : Color(nsColor: .secondarySystemFill))
+                    )
+            }
+            if message.role == .assistant { Spacer() }
+        }
+    }
+}
+
+// MARK: - Full permission card
+
+private struct PermissionCardFull: View {
+    @ObservedObject private var vm = AIAgentViewModel.shared
+    let request: AgentPendingPermission
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(request.title, systemImage: "hand.raised.fill")
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.orange)
+            if !request.detail.isEmpty {
+                Text(request.detail)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(AgentPalette.paperSecondary)
+            }
+            HStack(spacing: 10) {
+                Button("Approve") { vm.approve(permission: request) }
+                    .buttonStyle(.borderedProminent)
+                Button("Always") { vm.approve(permission: request, always: true) }
+                    .buttonStyle(.bordered)
+                Button("Deny") { vm.deny(permission: request) }
+                    .buttonStyle(.bordered)
+                    .tint(.red)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(RoundedRectangle(cornerRadius: 14).fill(Color.orange.opacity(0.12)))
+    }
+}
+
+// MARK: - Full question card
+
+private struct QuestionCardFull: View {
+    @ObservedObject private var vm = AIAgentViewModel.shared
+    let request: AgentPendingQuestion
+    @State private var customAnswer = ""
+    @State private var submitting = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Question", systemImage: "questionmark.circle.fill")
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.blue)
+
+            ForEach(request.questions) { q in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(q.question).font(.callout)
+                    if !q.options.isEmpty {
+                        HStack(spacing: 8) {
+                            ForEach(q.options) { opt in
+                                Button {
+                                    vm.answer(question: request, answers: [[opt.label]])
+                                } label: {
+                                    Text(opt.label)
+                                        .font(.callout.weight(.medium))
+                                        .padding(.horizontal, 14)
+                                        .padding(.vertical, 6)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .disabled(submitting)
+                            }
+                        }
+                    }
+                    HStack {
+                        TextField("Type your answer…", text: $customAnswer, onCommit: submitCustom)
+                            .textFieldStyle(.roundedBorder)
+                        Button("Send") { submitCustom() }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(customAnswer.trimmingCharacters(in: .whitespaces).isEmpty)
+                    }
+                }
+                .padding(.horizontal, 12)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(RoundedRectangle(cornerRadius: 14).fill(Color.blue.opacity(0.12)))
+    }
+
+    private func submitCustom() {
+        let text = customAnswer.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        customAnswer = ""
+        vm.answer(question: request, answers: [[text]])
+    }
+}

--- a/boringNotch/private/AIAgent/AIAgentPanel.swift
+++ b/boringNotch/private/AIAgent/AIAgentPanel.swift
@@ -1,0 +1,429 @@
+//
+//  AIAgentPanel.swift
+//  boringNotch
+//
+//  The Agent tab inside the open notch: sessions list ↔ chat view.
+//  Compact, fast, keyboard-navigable. 640×190 notch constraint.
+//
+
+import SwiftUI
+import Defaults
+
+struct AIAgentPanel: View {
+    @ObservedObject private var vm = AIAgentViewModel.shared
+    @State private var draft = ""
+    @State private var showNewSessionAlert = false
+    @Namespace private var animation
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+
+            Divider().overlay(Color.white.opacity(0.08))
+
+            if vm.sessions.isEmpty {
+                emptyState
+            } else if vm.selectedSessionID == nil {
+                sessionsList
+            } else {
+                chatView
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(AgentPalette.ink)
+        .onAppear { vm.activate() }
+    }
+
+    // MARK: Header
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            // Status dot + label
+            HStack(spacing: 6) {
+                AgentStateDot(
+                    color: vm.connected ? (vm.connected ? .green : .yellow) : .gray,
+                    pulsing: vm.connected && vm.sessions.contains { $0.phase == .busy },
+                    size: 8
+                )
+                Text(vm.connected ? "Claude Code" : (vm.claudeMissing ? "Claude Code missing" : "Claude Code"))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(vm.connected ? AgentPalette.paper : AgentPalette.paperFaint)
+            }
+
+            Spacer()
+
+            // Session picker menu (when in list mode)
+            if vm.selectedSessionID == nil && !vm.sessions.isEmpty {
+                Menu {
+                    ForEach(vm.sessions) { session in
+                        Button {
+                            vm.openChat(sessionID: session.id)
+                        } label: {
+                            HStack {
+                                AgentStateDot(color: AgentPalette.tint(for: session.phase), size: 6)
+                                Text(session.displayTitle)
+                                    .font(.system(size: 11, weight: .medium))
+                                if let model = session.modelRef {
+                                    Text(model)
+                                        .font(.system(size: 9, design: .monospaced))
+                                        .foregroundStyle(AgentPalette.paperFaint)
+                                }
+                            }
+                        }
+                    }
+                    Divider()
+                    Button { Task { await vm.startNewSession() } } label: {
+                        Label("New Session", systemImage: "plus")
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 9, weight: .semibold))
+                        Text("Sessions")
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    }
+                    .foregroundStyle(AgentPalette.paper)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(Capsule().fill(Color.white.opacity(0.06)))
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+            }
+
+            // New session
+            if vm.selectedSessionID == nil {
+                Button { Task { await vm.startNewSession() } } label: {
+                    Image(systemName: "plus.bubble")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(AgentPalette.paper)
+                        .frame(width: 26, height: 26)
+                        .background(Circle().fill(Color.white.opacity(0.07)))
+                }
+                .buttonStyle(.plain)
+                .help("New session")
+            }
+
+            // Model picker — always visible while a session is open so the
+            // user can change the model; label falls back to "Select model".
+            if vm.selectedSessionID != nil {
+                Menu {
+                    if vm.availableModels.isEmpty {
+                        Text("Loading models…")
+                            .font(.system(size: 11))
+                            .foregroundStyle(AgentPalette.paperFaint)
+                    }
+                    ForEach(vm.availableModels) { m in
+                        Button { Task { await vm.switchModel(m) } } label: {
+                            HStack {
+                                Text(m.name ?? m.id).font(.system(size: 11))
+                                if let ref = vm.selectedSession?.modelRef, m.ref == ref {
+                                    Image(systemName: "checkmark")
+                                }
+                            }
+                        }
+                    }
+                } label: {
+                    Text(vm.selectedModel?.name ?? vm.selectedSession?.modelRef ?? "Select model")
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundStyle(AgentPalette.paper)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(Color.white.opacity(0.06)))
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+            }
+
+            // Back button (from chat to list)
+            if vm.selectedSessionID != nil {
+                Button { vm.closeChat() } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(AgentPalette.paper)
+                        .frame(width: 26, height: 26)
+                        .background(Circle().fill(Color.white.opacity(0.07)))
+                }
+                .buttonStyle(.plain)
+                .help("Back to sessions")
+            }
+        }
+    }
+
+    // MARK: Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "brain.head.profile")
+                .font(.system(size: 28))
+                .foregroundStyle(AgentPalette.paperFaint)
+
+            if vm.claudeMissing {
+                Text("Claude Code CLI not found")
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(AgentPalette.paperSecondary)
+                Text("Install it with:\nnpm install -g @anthropic-ai/claude-code")
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(AgentPalette.paperFaint)
+                    .multilineTextAlignment(.center)
+            } else if vm.needsAuth {
+                Text("Claude Code needs authentication")
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(AgentPalette.paperSecondary)
+                Button {
+                    ClaudeCodeAuthOpener.openTerminalLogin()
+                } label: {
+                    Label("Authenticate", systemImage: "person.badge.key.fill")
+                        .font(.system(size: 11, weight: .medium))
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .tint(AgentPalette.completed)
+            } else if vm.sessions.isEmpty {
+                Text("No sessions yet")
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(AgentPalette.paperSecondary)
+                Button { Task { await vm.startNewSession() } } label: {
+                    Label("Create Session", systemImage: "plus.bubble")
+                        .font(.system(size: 11, weight: .medium))
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .tint(AgentPalette.completed)
+            } else {
+                Text(vm.connected ? "All caught up" : "Start Claude Code in any project to connect")
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(AgentPalette.paperSecondary)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: Sessions list
+
+    private var sessionsList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(vm.sessions) { session in
+                    SessionRow(session: session, isSelected: false) {
+                        vm.openChat(sessionID: session.id)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 2)
+                    .background(
+                        Rectangle()
+                            .fill(Color.white.opacity(0.02))
+                            .overlay(Rectangle().fill(Color.white.opacity(0.04)).frame(height: 0.5), alignment: .bottom)
+                    )
+                    .onTapGesture { vm.openChat(sessionID: session.id) }
+                }
+            }
+            .padding(.horizontal, 2)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: Chat view
+
+    private var chatView: some View {
+        VStack(spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 8) {
+                        ForEach(vm.messages) { message in
+                            ChatBubble(message: message)
+                                .id(message.id)
+                        }
+                        if vm.chatLoading || vm.sending || vm.selectedSession?.phase == .busy {
+                            HStack(spacing: 6) {
+                                Spacer()
+                                AgentStateDot(
+                                    color: vm.selectedSession?.phase == .busy
+                                        ? AgentPalette.running : AgentPalette.waiting,
+                                    pulsing: true, size: 7)
+                                Text(vm.selectedSession?.phase == .busy
+                                     ? "Claude is thinking…"
+                                     : (vm.sending ? "Sending…" : "Loading…"))
+                                    .font(.system(size: 10, design: .monospaced))
+                                    .foregroundStyle(AgentPalette.paperFaint)
+                                Spacer()
+                            }
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 8)
+                            .transition(.opacity)
+                        }
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                }
+                .onChange(of: vm.messages.count) { _, _ in
+                    if let last = vm.messages.last {
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            proxy.scrollTo(last.id, anchor: .bottom)
+                        }
+                    }
+                }
+                .onChange(of: vm.sending) { _, new in
+                    if new, let last = vm.messages.last {
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            proxy.scrollTo(last.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+
+            Divider().overlay(Color.white.opacity(0.08))
+
+            // Input bar
+            HStack(spacing: 8) {
+                TextField(vm.sending || vm.isSessionRunning ? "Working…" : "Message…", text: $draft, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(AgentPalette.paper)
+                    .lineLimit(1...4)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 7)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(Color.white.opacity(0.06))
+                            .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .strokeBorder(Color.white.opacity(0.07), lineWidth: 1))
+                    )
+                    .disabled(vm.sending || vm.isSessionRunning)
+                    .onSubmit { send() }
+
+                if vm.sending || vm.isSessionRunning {
+                    Button { vm.interrupt() } label: {
+                        Image(systemName: "stop.fill")
+                            .font(.system(size: 11, weight: .bold))
+                            .foregroundStyle(AgentPalette.waitingApproval)
+                            .frame(width: 30, height: 30)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Interrupt")
+                } else {
+                    Button { send() } label: {
+                        Image(systemName: "paperplane.fill")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(AgentPalette.paper)
+                            .frame(width: 30, height: 30)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+        }
+    }
+
+    private func send() {
+        guard !vm.sending else { return }
+        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        draft = ""
+        Task { await vm.sendPrompt(text) }
+    }
+}
+
+// MARK: - Session Row
+
+private struct SessionRow: View {
+    let session: AgentSession
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            AgentStateDot(
+                color: AgentPalette.tint(for: session.phase),
+                pulsing: session.phase == .busy || session.phase == .waitingApproval || session.phase == .waitingAnswer,
+                size: 8
+            )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(session.displayTitle)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(AgentPalette.paper)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                HStack(spacing: 6) {
+                    if let tool = session.lastTool {
+                        AgentChip(text: tool, tint: AgentPalette.paperFaint)
+                    }
+                    if let model = session.modelRef {
+                        AgentChip(text: model.hasPrefix("claude/") ? String(model.dropFirst("claude/".count)) : model,
+                                  tint: AgentPalette.paperFaint)
+                    }
+                    if session.phase == .waitingApproval {
+                        AgentChip(text: "needs you", tint: AgentPalette.waitingApproval)
+                    } else if session.phase == .waitingAnswer {
+                        AgentChip(text: "question", tint: AgentPalette.waitingAnswer)
+                    }
+                    Text(AgentAge.string(from: session.updatedAt))
+                        .font(.system(size: 9, design: .monospaced))
+                        .foregroundStyle(AgentPalette.paperFaint)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(AgentPalette.paperFaint)
+        }
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Chat Bubble
+
+private struct ChatBubble: View {
+    let message: AgentChatMessage
+
+    var body: some View {
+        if message.role == .system {
+            HStack {
+                Spacer()
+                Text(message.text)
+                    .font(.system(size: 9.5, design: .monospaced))
+                    .foregroundStyle(AgentPalette.paperFaint)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(Capsule().fill(Color.white.opacity(0.05)))
+                Spacer()
+            }
+        } else {
+            HStack {
+                if message.role == .user { Spacer(minLength: 40) }
+
+                VStack(alignment: message.role == .user ? .trailing : .leading, spacing: 2) {
+                    if message.role != .error {
+                        Text(message.role == .user ? "You" : "Agent")
+                            .font(.system(size: 9, weight: .medium, design: .monospaced))
+                            .foregroundStyle(AgentPalette.paperFaint)
+                    }
+                    Text(message.text)
+                        .font(.system(size: 11))
+                        .foregroundStyle(message.role == .user ? AgentPalette.paper : AgentPalette.paper.opacity(0.95))
+                        .textSelection(.enabled)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 7)
+                        .background(
+                            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                                .fill(message.role == .user
+                                    ? Color.white.opacity(0.12)
+                                    : Color.white.opacity(0.05))
+                        )
+                }
+
+                if message.role == .assistant || message.role == .error { Spacer(minLength: 40) }
+            }
+        }
+    }
+}

--- a/boringNotch/private/AIAgent/AIAgentSettingsView.swift
+++ b/boringNotch/private/AIAgent/AIAgentSettingsView.swift
@@ -1,0 +1,215 @@
+//
+//  AIAgentSettingsView.swift
+//  boringNotch
+//
+//  Settings pane for the Claude Code integration. Matches boring.notch's
+//  SettingsView style with grouped sections and clean visual hierarchy.
+//
+
+import SwiftUI
+import Defaults
+
+struct AIAgentSettingsView: View {
+    @Default(.aiAgentEnabled) var enabled
+    @Default(.aiAgentAutoOpen) var autoOpen
+    @Default(.aiAgentNotifyOnDone) var notifyOnDone
+    @Default(.aiAgentModel) var defaultModel
+    @Default(.aiAgentWorkspace) var workspace
+    @Default(.aiAgentClaudeBinary) var claudeBinaryOverride
+    @Default(.aiAgentHoldExternalTools) var holdExternalTools
+    @Default(.aiAgentArrivalSound) var arrivalSound
+    @Default(.aiAgentDoneSound) var doneSound
+    @ObservedObject private var vm = AIAgentViewModel.shared
+    @State private var hooksInstalled = AgentHookInstaller.isInstalled()
+    @State private var killSwitch = AgentHookInstaller.killSwitchEnabled
+
+    var body: some View {
+        Form {
+            // Enable section
+            Section {
+                Toggle("Enable Agent tab", isOn: $enabled)
+                    .tint(.effectiveAccent)
+                    .onChange(of: enabled) { _, newValue in
+                        if newValue {
+                            AIAgentViewModel.shared.activate()
+                        } else {
+                            AIAgentViewModel.shared.deactivate()
+                        }
+                    }
+                Text("Adds an Agent tab to the notch with your Claude Code sessions, and lets you approve edits and answer questions straight from the notch.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            // Claude Code environment
+            Section("Claude Code") {
+                environmentRow(
+                    label: "CLI",
+                    ok: !vm.claudeMissing,
+                    okText: "Found at \(vm.claudeBinary)",
+                    failText: "Not found — install with: npm install -g @anthropic-ai/claude-code")
+
+                environmentRow(
+                    label: "Authentication",
+                    ok: !vm.needsAuth,
+                    okText: "Signed in",
+                    failText: "Not signed in")
+
+                if vm.needsAuth, !vm.claudeMissing {
+                    Button("Authenticate in Terminal…") {
+                        ClaudeCodeAuthOpener.openTerminalLogin()
+                    }
+                    .controlSize(.small)
+                }
+
+                HStack {
+                    Circle()
+                        .fill(vm.connected ? Color.green : Color.orange)
+                        .frame(width: 8, height: 8)
+                    Text(vm.connected
+                         ? "Bridge connected — \(vm.instances.count) live session\(vm.instances.count == 1 ? "" : "s")"
+                         : "Bridge idle — no live Claude Code sessions")
+                        .font(.callout)
+                        .foregroundStyle(vm.connected ? .primary : .secondary)
+                    Spacer()
+                    Button("Restart Bridge") { AIAgentViewModel.shared.restart() }
+                        .controlSize(.small)
+                }
+                .padding(.vertical, 2)
+            }
+
+            // Hook integration
+            Section("Terminal Integration") {
+                HStack {
+                    Image(systemName: hooksInstalled ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
+                        .foregroundStyle(hooksInstalled ? Color.green : .orange)
+                    Text(hooksInstalled
+                         ? "Hooks installed in ~/.claude — the notch sees every session"
+                         : "Hooks not installed")
+                        .font(.callout)
+                    Spacer()
+                    Button("Reinstall") {
+                        AgentHookInstaller.install()
+                        hooksInstalled = AgentHookInstaller.isInstalled()
+                    }
+                    .controlSize(.small)
+                }
+
+                Toggle("Pause notch hooks (kill switch)", isOn: $killSwitch)
+                    .tint(.effectiveAccent)
+                    .onChange(of: killSwitch) { _, newValue in
+                        AgentHookInstaller.killSwitchEnabled = newValue
+                    }
+                Text("Pauses the integration without uninstalling: Claude Code behaves exactly as if the notch were gone. Approvals fall back to the normal terminal prompts.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Toggle("Auto-open notch for approvals & updates", isOn: $autoOpen)
+                    .tint(.effectiveAccent)
+                Toggle("Notify when Claude finishes a task", isOn: $notifyOnDone)
+                    .tint(.effectiveAccent)
+                Toggle("Approve terminal prompts from the notch", isOn: $holdExternalTools)
+                    .tint(.effectiveAccent)
+                Text("Off: terminal sessions keep Claude Code's normal approval prompts, and the notch only decides for sessions it drives. On: tool calls in every session wait for your decision here (up to 30s).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            // Sounds
+            Section("Sounds") {
+                soundPickerRow(label: "Claude needs you", binding: $arrivalSound)
+                soundPickerRow(label: "Task finished", binding: $doneSound)
+            }
+
+            // Default model
+            Section("Default Model") {
+                Picker("Model", selection: $defaultModel) {
+                    Text("Claude Code default").tag("")
+                    ForEach(vm.availableModels) { m in
+                        Text(m.name ?? m.id).tag(m.ref)
+                    }
+                }
+                if !defaultModel.isEmpty {
+                    Text("Used for new sessions created from the notch.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            // Workspace
+            Section("Workspace") {
+                TextField("Default directory for new sessions", text: $workspace)
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+                Text("Leave empty to use your home directory.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            // Advanced
+            Section("Advanced") {
+                TextField("Claude binary path (auto-detected)", text: $claudeBinaryOverride)
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+                Text("Leave empty to auto-detect. Changes apply after reopening the Agent tab.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            // Actions
+            Section {
+                Button("Open Agent Window") {
+                    AIAgentWindowController.shared.showWindow()
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+            hooksInstalled = AgentHookInstaller.isInstalled()
+        }
+    }
+
+    private func soundPickerRow(label: String, binding: Binding<String>) -> some View {
+        HStack {
+            Picker(label, selection: binding) {
+                ForEach(Self.systemSounds, id: \.self) { sound in
+                    Text(sound).tag(sound)
+                }
+            }
+            Button {
+                NSSound(named: NSSound.Name(binding.wrappedValue))?.play()
+            } label: {
+                Image(systemName: "play.circle")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Preview sound")
+        }
+    }
+
+    static let systemSounds = [
+        "Basso", "Blow", "Bottle", "Frog", "Funk", "Glass", "Hero",
+        "Morse", "Ping", "Pop", "Purr", "Sosumi", "Submarine", "Tink",
+    ]
+
+    @ViewBuilder
+    private func environmentRow(label: String, ok: Bool, okText: String, failText: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: ok ? "checkmark.circle.fill" : "xmark.circle.fill")
+                .foregroundStyle(ok ? Color.green : .orange)
+                .frame(width: 16)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(label)
+                    .font(.callout.weight(.medium))
+                Text(ok ? okText : failText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/boringNotch/private/AIAgent/AIAgentViewModel.swift
+++ b/boringNotch/private/AIAgent/AIAgentViewModel.swift
@@ -1,0 +1,830 @@
+//
+//  AIAgentViewModel.swift
+//  boringNotch
+//
+//  Central state for the Claude Code integration: live sessions from
+//  ~/.claude/projects transcripts, hook-driven approval/question cards,
+//  chat driving through headless `claude -p` runs, and model switching.
+//
+
+import Foundation
+import Combine
+import Defaults
+import AppKit
+import SwiftUI
+
+// MARK: - Session model
+
+struct AgentSession: Identifiable, Equatable {
+    enum Phase: Equatable {
+        case busy
+        case idle
+        case waitingApproval
+        case waitingAnswer
+        case errored
+    }
+
+    enum Source: Equatable {
+        case managed    // driven from the notch (headless claude -p runs)
+        case external   // user's own terminal session, observed via hooks/transcripts
+    }
+
+    let id: String
+    var directory: String?
+    var title: String
+    var phase: Phase = .idle
+    var source: Source = .external
+    var lastPrompt: String?
+    var lastReply: String?
+    var lastTool: String?
+    var modelRef: String?
+    var updatedAt = Date()
+    var needsFirstPrompt = false
+
+    var project: String {
+        guard let dir = directory, !dir.isEmpty else { return "claude" }
+        return (dir as NSString).lastPathComponent
+    }
+
+    var displayTitle: String {
+        let t = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        if t.isEmpty {
+            return lastPrompt.map { String($0.prefix(48)) } ?? "Session \(id.suffix(6))"
+        }
+        return String(t.prefix(64))
+    }
+
+    static func == (lhs: AgentSession, rhs: AgentSession) -> Bool {
+        lhs.id == rhs.id && lhs.phase == rhs.phase && lhs.title == rhs.title
+    }
+}
+
+// MARK: - Done notification card
+
+struct AgentDoneCard: Identifiable, Equatable {
+    let id = UUID()
+    let sessionID: String
+    var title: String
+    var reply: String
+    var isAttention = false
+    var createdAt = Date()
+}
+
+// MARK: - Model picker entry
+
+struct AgentModel: Identifiable, Equatable {
+    let id: String
+    let providerID: String
+    let name: String?
+
+    var ref: String { "\(providerID)/\(id)" }
+}
+
+// MARK: - View model
+
+@MainActor
+final class AIAgentViewModel: ObservableObject, AgentBridgeDelegate {
+    static let shared = AIAgentViewModel()
+
+    let bridge = AgentBridgeServer()
+
+    // Environment
+    @Published private(set) var instances: [AgentInstanceInfo] = []
+    @Published private(set) var connected = false
+    @Published private(set) var everConnected = false
+    @Published private(set) var claudeBinary = ""
+    @Published private(set) var authState: ClaudeAuthState = .needsAuth
+
+    // Sessions
+    @Published private(set) var sessions: [AgentSession] = []
+    @Published var selectedSessionID: String?
+
+    // Pending user action
+    @Published private(set) var pendingPermissions: [AgentPendingPermission] = []
+    @Published private(set) var pendingQuestions: [AgentPendingQuestion] = []
+    @Published private(set) var doneCards: [AgentDoneCard] = []
+    @Published var cardDismissedIDs: Set<String> = []
+
+    // Chat state
+    @Published private(set) var messages: [AgentChatMessage] = []
+    @Published private(set) var chatLoading = false
+    @Published private(set) var sending = false
+    @Published private(set) var availableModels: [AgentModel] = []
+    /// Prompts typed while the session is busy in the terminal, keyed by
+    /// session; flushed automatically the moment the session goes idle.
+    /// Persisted so an app relaunch doesn't eat messages waiting to send.
+    @Published private(set) var queuedPrompts: [String: [String]] = AIAgentViewModel.restoreQueuedPrompts() {
+        didSet { persistQueuedPrompts() }
+    }
+
+    private var runners: [String: ClaudeCodeRunner] = [:]
+    private var refreshTimer: Timer?
+    private var slowTimer: Timer?
+    private var reloadDebounce: Task<Void, Never>?
+    private var doneCardCleanupTask: Task<Void, Never>?
+    private var started = false
+    private var scanInFlight = false
+
+    var hasPendingApproval: Bool {
+        !pendingPermissions.isEmpty || !pendingQuestions.isEmpty
+    }
+
+    /// The card that should take over the open notch surface, if any.
+    var activePermission: AgentPendingPermission? {
+        pendingPermissions.first { !cardDismissedIDs.contains($0.id) }
+    }
+
+    var activeQuestion: AgentPendingQuestion? {
+        pendingQuestions.first { !cardDismissedIDs.contains($0.id) }
+    }
+
+    var activeDoneCard: AgentDoneCard? {
+        doneCards.first
+    }
+
+    /// True while a card worth interrupting the user for is on screen —
+    /// drives the notch auto-open and its vertical expansion.
+    var hasActiveAgentCard: Bool {
+        activePermission != nil || activeQuestion != nil || activeDoneCard != nil
+    }
+
+    /// Attention sound for a card arriving in the notch. Both sounds are
+    /// user-configurable in the agent settings (system sounds by name).
+    private func playArrivalSound(done: Bool) {
+        let name = done ? Defaults[.aiAgentDoneSound] : Defaults[.aiAgentArrivalSound]
+        NSSound(named: NSSound.Name(name))?.play()
+    }
+
+    var selectedSession: AgentSession? {
+        sessions.first { $0.id == selectedSessionID }
+    }
+
+    var needsAuth: Bool { authState == .needsAuth }
+    var claudeMissing: Bool { claudeBinary.isEmpty }
+
+    // MARK: Lifecycle
+
+    func activate() {
+        guard Defaults[.aiAgentEnabled] else { return }
+        guard !started else { return }
+        started = true
+
+        let ok = bridge.start(delegate: self)
+        if !ok {
+            NSLog("[Agent] failed to start bridge server")
+        }
+        AgentHookInstaller.ensureInstalled()
+        refreshEnvironment()
+        loadModels()
+        refreshSessions()
+        startTimers()
+    }
+
+    func deactivate() {
+        stopTimers()
+        bridge.stop()
+        started = false
+    }
+
+    func restart() {
+        deactivate()
+        activate()
+    }
+
+    private func startTimers() {
+        refreshTimer?.invalidate()
+        slowTimer?.invalidate()
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.refreshSessions() }
+        }
+        slowTimer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.refreshEnvironment()
+                Task { @MainActor [weak self] in self?.loadModels() }
+            }
+        }
+    }
+
+    private func stopTimers() {
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+        slowTimer?.invalidate()
+        slowTimer = nil
+    }
+
+    private func refreshEnvironment() {
+        claudeBinary = ClaudeCodeRunner.resolveBinary()
+        authState = ClaudeCodeRunner.authState()
+    }
+
+    // MARK: Sessions refresh (from transcripts + live state)
+
+    /// Runs the transcript scan off the main thread — it stats every session
+    /// file and re-reads changed ones — then applies the result on the main
+    /// actor. Overlapping scans are skipped; the next timer tick picks up.
+    private func refreshSessions() {
+        guard !scanInFlight else { return }
+        scanInFlight = true
+        Task.detached(priority: .utility) { [weak self] in
+            let summaries = TranscriptStore.scan()
+            await MainActor.run { [weak self] in
+                self?.applyScan(summaries)
+                self?.scanInFlight = false
+            }
+        }
+    }
+
+    private func applyScan(_ summaries: [TranscriptStore.Summary]) {
+        let now = Date()
+
+        for summary in summaries {
+            var phase: AgentSession.Phase = .idle
+            if pendingPermissions.contains(where: { $0.sessionID == summary.id }) {
+                phase = .waitingApproval
+            } else if pendingQuestions.contains(where: { $0.sessionID == summary.id }) {
+                phase = .waitingAnswer
+            } else if runners[summary.id] != nil || now.timeIntervalSince(summary.updatedAt) < 25 {
+                phase = .busy
+            }
+
+            if let i = sessions.firstIndex(where: { $0.id == summary.id }) {
+                sessions[i].directory = summary.directory.isEmpty ? sessions[i].directory : summary.directory
+                if let t = summary.title, !t.isEmpty { sessions[i].title = t }
+                if let m = summary.model { sessions[i].modelRef = Self.modelRef(forModel: m) }
+                if let p = summary.lastPrompt { sessions[i].lastPrompt = p }
+                if let r = summary.lastReply { sessions[i].lastReply = r }
+                if sessions[i].phase != .errored { sessions[i].phase = phase }
+                sessions[i].updatedAt = summary.updatedAt
+            } else {
+                sessions.append(AgentSession(
+                    id: summary.id,
+                    directory: summary.directory.isEmpty ? nil : summary.directory,
+                    title: summary.title ?? "",
+                    phase: phase,
+                    source: .external,
+                    lastPrompt: summary.lastPrompt,
+                    lastReply: summary.lastReply,
+                    lastTool: nil,
+                    modelRef: summary.model.map { Self.modelRef(forModel: $0) },
+                    updatedAt: summary.updatedAt))
+            }
+        }
+
+        // Drop transcript-only sessions that disappeared from disk.
+        let diskIDs = Set(summaries.map(\.id))
+        sessions.removeAll { session in
+            session.needsFirstPrompt ? false : (!diskIDs.contains(session.id) && runners[session.id] == nil)
+        }
+
+        sortSessions()
+
+        // Safety net for queued prompts: the normal trigger is the bridge's
+        // Stop event, but a Stop can get lost (app relaunch, dropped hook
+        // POST). When the periodic scan sees an idle session that still has
+        // a queue, drain it instead of letting the messages strand.
+        for id in queuedPrompts.keys {
+            guard let s = sessions.first(where: { $0.id == id }),
+                  s.phase != .busy, s.phase != .waitingApproval, s.phase != .waitingAnswer,
+                  runners[id] == nil else { continue }
+            flushQueuedPrompt(for: id)
+        }
+
+        connected = !instances.isEmpty || !runners.isEmpty
+    }
+
+    private func sortSessions() {
+        func rank(_ s: AgentSession) -> Int {
+            switch s.phase {
+            case .waitingApproval, .waitingAnswer: return 0
+            case .busy: return 1
+            case .errored: return 2
+            case .idle: return 3
+            }
+        }
+        sessions.sort { a, b in
+            let ra = rank(a), rb = rank(b)
+            if ra != rb { return ra < rb }
+            return a.updatedAt > b.updatedAt
+        }
+    }
+
+    // MARK: AgentBridgeDelegate
+
+    func bridge(didRegisterInstance info: AgentInstanceInfo) {
+        everConnected = true
+        if !instances.contains(where: { $0.id == info.id }) {
+            instances.append(info)
+        }
+        connected = true
+    }
+
+    func bridge(didReceiveEvent event: AgentEvent, sessionID: String) {
+        everConnected = true
+        connected = true
+
+        switch event {
+        case .sessionStarted(_, let directory):
+            upsertSession(id: sessionID) { s in
+                s.directory = directory ?? s.directory
+                if s.phase == .errored { s.phase = .idle }
+            }
+
+        case .sessionEnded:
+            // The session transcript persists; mark idle and refresh.
+            upsertSession(id: sessionID) { s in
+                if s.phase != .waitingApproval && s.phase != .waitingAnswer {
+                    s.phase = .idle
+                }
+            }
+            scheduleChatReload()
+
+        case .promptSubmitted(_, let text):
+            upsertSession(id: sessionID) { s in
+                s.lastPrompt = text
+                s.phase = .busy
+            }
+            scheduleChatReload()
+
+        case .toolUsed(_, let tool, let detail):
+            upsertSession(id: sessionID) { s in
+                s.lastTool = tool
+                if let d = detail, !d.isEmpty { s.lastReply = d }
+            }
+
+        case .stopped(_, let reply):
+            var shouldNotify = false
+            upsertSession(id: sessionID) { s in
+                if s.phase == .busy { shouldNotify = true }
+                s.phase = .idle
+                if let reply, !reply.isEmpty { s.lastReply = reply }
+            }
+            if shouldNotify, Defaults[.aiAgentNotifyOnDone] {
+                presentDoneCard(for: sessionID, reply: reply ?? "", attention: false)
+            }
+            scheduleChatReload()
+            flushQueuedPrompt(for: sessionID)
+
+        case .attention(_, let message):
+            upsertSession(id: sessionID) { s in
+                s.phase = .waitingApproval
+            }
+            if Defaults[.aiAgentNotifyOnDone] {
+                presentDoneCard(for: sessionID, reply: message, attention: true)
+            }
+
+        case .errored(_, let message):
+            upsertSession(id: sessionID) { s in
+                s.phase = .errored
+                s.lastReply = message
+            }
+        }
+    }
+
+    func bridge(didReceivePermission permission: AgentPendingPermission) {
+        pendingPermissions.removeAll { $0.id == permission.id }
+        pendingPermissions.append(permission)
+        upsertSession(id: permission.sessionID) { s in
+            s.phase = .waitingApproval
+        }
+        playArrivalSound(done: false)
+    }
+
+    func bridge(didReceiveQuestion question: AgentPendingQuestion) {
+        pendingQuestions.removeAll { $0.id == question.id }
+        pendingQuestions.append(question)
+        upsertSession(id: question.sessionID) { s in
+            s.phase = .waitingAnswer
+        }
+        playArrivalSound(done: false)
+    }
+
+    func bridgeDidExpire(requestID: String) {
+        pendingPermissions.removeAll { $0.id == requestID }
+        pendingQuestions.removeAll { $0.id == requestID }
+        cardDismissedIDs.remove(requestID)
+    }
+
+    func bridgeStateSnapshot() -> AgentJSON {
+        .object([
+            "sessions": .array(sessions.map { s in
+                .object([
+                    "id": .string(s.id),
+                    "project": .string(s.project),
+                    "title": .string(s.displayTitle),
+                    "phase": .string(String(describing: s.phase)),
+                    "source": .string(String(describing: s.source)),
+                    "model": .string(s.modelRef ?? ""),
+                    "lastTool": .string(s.lastTool ?? ""),
+                    "updatedAt": .number(s.updatedAt.timeIntervalSince1970),
+                ])
+            }),
+            "pendingPermissions": .array(pendingPermissions.map { p in
+                .object([
+                    "id": .string(p.id),
+                    "sessionID": .string(p.sessionID),
+                    "tool": .string(p.tool),
+                    "detail": .string(p.detail),
+                ])
+            }),
+            "pendingQuestions": .array(pendingQuestions.map { q in
+                .object([
+                    "id": .string(q.id),
+                    "sessionID": .string(q.sessionID),
+                    "questions": .array(q.questions.map { .string($0.question) }),
+                ])
+            }),
+            "instances": .number(Double(instances.count)),
+            "runningRuns": .number(Double(runners.count)),
+            "connected": .bool(connected),
+            "claudeBinary": .string(claudeBinary),
+            "needsAuth": .bool(needsAuth),
+        ])
+    }
+
+    // MARK: Session store helpers
+
+    private func upsertSession(id: String, mutate: (inout AgentSession) -> Void) {
+        if let i = sessions.firstIndex(where: { $0.id == id }) {
+            mutate(&sessions[i])
+            sessions[i].updatedAt = Date()
+        } else {
+            var s = AgentSession(id: id, directory: nil, title: "")
+            mutate(&s)
+            s.updatedAt = Date()
+            sessions.append(s)
+        }
+        sortSessions()
+    }
+
+    // MARK: Cards
+
+    private func presentDoneCard(for sessionID: String, reply: String, attention: Bool) {
+        // Dedupe: hooks (Stop) and the managed runner can both report completion.
+        if doneCards.contains(where: { $0.sessionID == sessionID }) { return }
+        let title = sessions.first { $0.id == sessionID }?.displayTitle ?? "Claude Code"
+        let card = AgentDoneCard(
+            sessionID: sessionID,
+            title: attention ? "Claude needs you" : title,
+            reply: attention ? "Attention: \(reply)" : reply,
+            isAttention: attention)
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+            doneCards.append(card)
+        }
+        playArrivalSound(done: true)
+        scheduleDoneCardCleanup()
+    }
+
+    private func scheduleDoneCardCleanup() {
+        doneCardCleanupTask?.cancel()
+        doneCardCleanupTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(12))
+            guard !Task.isCancelled else { return }
+            self?.dismissOldestDoneCard()
+        }
+    }
+
+    func dismissOldestDoneCard() {
+        withAnimation(.easeOut(duration: 0.2)) {
+            if !doneCards.isEmpty { doneCards.removeFirst() }
+        }
+    }
+
+    func dismissCard(_ id: String) {
+        cardDismissedIDs.insert(id)
+        // A dismissed permission card falls through to Claude Code's normal
+        // permission flow (the terminal prompt still works).
+        bridge.fallThrough(requestID: id)
+    }
+
+    // MARK: Answering permissions / questions
+
+    func approve(permission: AgentPendingPermission, always: Bool = false) {
+        if always {
+            // Same tool in this session skips future cards.
+            bridge.allowAlways(sessionID: permission.sessionID, tool: permission.tool)
+        }
+        pendingPermissions.removeAll { $0.id == permission.id }
+        cardDismissedIDs.remove(permission.id)
+        bridge.respond(requestID: permission.id, decision: .allow)
+        upsertSession(id: permission.sessionID) { s in
+            if s.phase == .waitingApproval { s.phase = .busy }
+        }
+    }
+
+    func deny(permission: AgentPendingPermission) {
+        pendingPermissions.removeAll { $0.id == permission.id }
+        cardDismissedIDs.remove(permission.id)
+        bridge.respond(
+            requestID: permission.id,
+            decision: .deny(reason: "Denied from Boring Notch"))
+        upsertSession(id: permission.sessionID) { s in
+            if s.phase == .waitingApproval { s.phase = .idle }
+        }
+    }
+
+    func answer(question: AgentPendingQuestion, answers: [[String]]) {
+        pendingQuestions.removeAll { $0.id == question.id }
+        cardDismissedIDs.remove(question.id)
+        bridge.respond(requestID: question.id, decision: .answers(answers))
+        upsertSession(id: question.sessionID) { s in
+            if s.phase == .waitingAnswer { s.phase = .busy }
+        }
+    }
+
+    // MARK: Chat
+
+    func openChat(sessionID: String) {
+        selectedSessionID = sessionID
+        messages = []
+        chatLoading = true
+        Task {
+            await loadMessages()
+            chatLoading = false
+        }
+        // Refresh the session's model from its transcript.
+        if let session = sessions.first(where: { $0.id == sessionID }) {
+            let dir = session.directory
+            Task {
+                if let model = TranscriptStore.currentModel(sessionID: sessionID, directory: dir) {
+                    await MainActor.run {
+                        if let i = sessions.firstIndex(where: { $0.id == sessionID }) {
+                            sessions[i].modelRef = Self.modelRef(forModel: model)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func closeChat() {
+        selectedSessionID = nil
+        messages = []
+    }
+
+    private func scheduleChatReload() {
+        guard selectedSessionID != nil else { return }
+        reloadDebounce?.cancel()
+        reloadDebounce = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(250))
+            guard !Task.isCancelled else { return }
+            await self?.loadMessages()
+        }
+    }
+
+    func loadMessages() async {
+        guard let sessionID = selectedSessionID,
+              let session = sessions.first(where: { $0.id == sessionID }) else { return }
+        // Parsing a fresh transcript can mean reading megabytes — keep it off
+        // the main thread.
+        var parsed = await Task.detached(priority: .userInitiated) {
+            TranscriptStore.messages(sessionID: sessionID, directory: session.directory)
+        }.value
+        // The queue lives outside the transcript, so re-render it after every
+        // reload or it would flicker away on the next refresh.
+        if let queue = queuedPrompts[sessionID], !queue.isEmpty {
+            parsed += queue.enumerated().map { index, text in
+                AgentChatMessage(id: "qmsg-\(index)-\(text)", role: .user, text: text)
+            }
+            parsed.append(AgentChatMessage(
+                id: "qnote-\(queue.count)",
+                role: .system,
+                text: queue.count == 1
+                    ? "1 message queued — sends when Claude finishes the current turn."
+                    : "\(queue.count) messages queued — send when Claude finishes the current turn."))
+        }
+        if parsed != messages {
+            messages = parsed
+        }
+        chatLoading = false
+    }
+
+    func sendPrompt(_ raw: String) async {
+        let text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, let sessionID = selectedSessionID else { return }
+        await performSend(text, sessionID: sessionID)
+    }
+
+    /// Sends one prompt into a specific session — whether it's the chat the
+    /// user has open or a background session flushing its queue. Returns
+    /// false when the send was refused (another send in flight), so callers
+    /// can requeue instead of dropping the message.
+    @discardableResult
+    private func performSend(_ text: String, sessionID: String) async -> Bool {
+        guard !text.isEmpty else { return false }
+        guard !sending else { return false }
+        guard runners[sessionID] == nil else { return false }
+
+        let session = sessions.first { $0.id == sessionID }
+        let directory = session?.directory
+            ?? (Defaults[.aiAgentWorkspace].isEmpty ? NSHomeDirectory() : Defaults[.aiAgentWorkspace])
+
+        // A session that is running in the user's terminal cannot accept a
+        // headless resume — it would fork the conversation away from the
+        // transcript the chat follows. Queue the message instead; the Stop
+        // hook flushes it the moment the session goes idle.
+        if session?.phase == .busy, runners[sessionID] == nil {
+            queuePrompt(text, sessionID: sessionID)
+            return true
+        }
+
+        // Echo the user's bubble right away — the transcript only gains the
+        // matching entry once the run starts writing.
+        if selectedSessionID == sessionID {
+            messages.append(AgentChatMessage(
+                id: "echo-\(UUID().uuidString)", role: .user, text: text))
+        }
+
+        // A notch-created session has no transcript yet: the first run
+        // creates it with --session-id.
+        let isNew = session?.needsFirstPrompt ?? (TranscriptStore.transcriptURL(for: sessionID, directory: directory) == nil)
+        if let i = sessions.firstIndex(where: { $0.id == sessionID }) {
+            sessions[i].needsFirstPrompt = false
+            sessions[i].lastPrompt = text
+            sessions[i].phase = .busy
+            sessions[i].source = .managed
+        } else {
+            var s = AgentSession(id: sessionID, directory: directory, title: "")
+            s.lastPrompt = text
+            s.phase = .busy
+            s.source = .managed
+            sessions.append(s)
+            sortSessions()
+        }
+
+        sending = true
+        defer { sending = false }
+
+        let runner = ClaudeCodeRunner()
+        runners[sessionID] = runner
+        // Managed runs decide their tool approvals from the notch; the
+        // bridge only holds requests for sessions marked here.
+        bridge.markManaged(sessionID: sessionID)
+
+        let model = runnerModelAlias(for: sessionID)
+        await runner.run(
+            prompt: text,
+            sessionID: sessionID,
+            isNewSession: isNew,
+            directory: directory,
+            model: model) { [weak self] event in
+            guard let self else { return }
+            switch event {
+            case .assistantText:
+                self.scheduleChatReload()
+            case .toolUsed(let name, let detail):
+                self.upsertSession(id: sessionID) { s in
+                    s.lastTool = name
+                    if let d = detail, !d.isEmpty { s.lastReply = d }
+                }
+                self.scheduleChatReload()
+            case .finished(let reply, let isError, let message):
+                self.runners[sessionID] = nil
+                self.bridge.clearManaged(sessionID: sessionID)
+                self.upsertSession(id: sessionID) { s in
+                    s.phase = isError ? .errored : .idle
+                    if isError, let message { s.lastReply = message }
+                }
+                self.scheduleChatReload()
+                if isError, let message {
+                    self.messages.append(AgentChatMessage(
+                        id: "err-\(UUID().uuidString)", role: .error, text: "⚠️ \(message)"))
+                } else if let reply, !reply.isEmpty, Defaults[.aiAgentNotifyOnDone] {
+                    self.presentDoneCard(for: sessionID, reply: reply, attention: false)
+                }
+            }
+        }
+        await loadMessages()
+        return true
+    }
+
+    // MARK: Queue persistence
+
+    private func persistQueuedPrompts() {
+        Defaults[.aiAgentQueuedPrompts] = (try? JSONEncoder().encode(queuedPrompts)) ?? Data()
+    }
+
+    private static func restoreQueuedPrompts() -> [String: [String]] {
+        let data = Defaults[.aiAgentQueuedPrompts]
+        guard !data.isEmpty,
+              let map = try? JSONDecoder().decode([String: [String]].self, from: data) else { return [:] }
+        return map
+    }
+
+    /// Files a prompt to send once the busy session goes idle.
+    private func queuePrompt(_ text: String, sessionID: String) {
+        queuedPrompts[sessionID, default: []].append(text)
+        if selectedSessionID == sessionID {
+            messages.append(AgentChatMessage(
+                id: "echo-\(UUID().uuidString)", role: .user, text: text))
+            messages.append(AgentChatMessage(
+                id: "queued-\(UUID().uuidString)",
+                role: .system,
+                text: "Queued — sends as soon as Claude finishes the current turn."))
+        }
+    }
+
+    private func flushQueuedPrompt(for sessionID: String) {
+        guard var queue = queuedPrompts[sessionID], !queue.isEmpty else { return }
+        let next = queue.removeFirst()
+        queuedPrompts[sessionID] = queue.isEmpty ? nil : queue
+        Task { [weak self] in
+            // Give the session's own .finished bookkeeping a beat to land,
+            // then send. If another send is in flight, requeue for the next
+            // idle instead of dropping the message.
+            try? await Task.sleep(for: .milliseconds(250))
+            guard let self else { return }
+            if await !self.performSend(next, sessionID: sessionID) {
+                self.queuedPrompts[sessionID, default: []].insert(next, at: 0)
+            }
+        }
+    }
+
+    func interrupt() {
+        guard let sessionID = selectedSessionID else { return }
+        runners[sessionID]?.interrupt()
+        upsertSession(id: sessionID) { s in
+            if s.phase == .busy { s.phase = .idle }
+        }
+    }
+
+    func startNewSession() async {
+        let id = UUID().uuidString
+        let directory = Defaults[.aiAgentWorkspace].isEmpty ? NSHomeDirectory() : Defaults[.aiAgentWorkspace]
+        var s = AgentSession(id: id, directory: directory, title: "")
+        s.source = .managed
+        s.needsFirstPrompt = true
+        if !Defaults[.aiAgentModel].isEmpty {
+            s.modelRef = Defaults[.aiAgentModel]
+        }
+        sessions.append(s)
+        sortSessions()
+        openChat(sessionID: id)
+    }
+
+    var isSessionRunning: Bool {
+        guard let id = selectedSessionID else { return false }
+        return runners[id] != nil
+    }
+
+    // MARK: Models
+
+    /// The Claude Code model aliases, the models routed through the user's
+    /// own provider setup, plus whatever they set as default in settings.json.
+    private func loadModels() {
+        var items: [AgentModel] = [
+            AgentModel(id: "sonnet", providerID: "claude", name: "Sonnet"),
+            AgentModel(id: "opus", providerID: "claude", name: "Opus"),
+            AgentModel(id: "haiku", providerID: "claude", name: "Haiku"),
+            AgentModel(id: "opusplan", providerID: "claude", name: "Opus Plan"),
+            AgentModel(id: "glm-5.3-flash:cloud", providerID: "claude", name: "GLM 5.3 Flash (1M ctx)"),
+            AgentModel(id: "glm-5.2:cloud", providerID: "claude", name: "GLM 5.2 (1M ctx)"),
+            AgentModel(id: "minimax-m3:cloud", providerID: "claude", name: "MiniMax M3 (1M ctx)"),
+            AgentModel(id: "gemma4:26b", providerID: "claude", name: "Gemma 4 26B (local)"),
+        ]
+        // The user's configured default model (settings.json "model").
+        let settingsURL = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/settings.json")
+        if let data = FileManager.default.contents(atPath: settingsURLPath),
+           let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let configured = obj["model"] as? String, !configured.isEmpty {
+            if !items.contains(where: { $0.id == configured }) {
+                items.append(AgentModel(id: configured, providerID: "claude", name: "Default (settings)"))
+            }
+        }
+        availableModels = items
+    }
+
+    private var settingsURLPath: String {
+        (NSHomeDirectory() as NSString).appendingPathComponent(".claude/settings.json")
+    }
+
+    func switchModel(_ model: AgentModel) async {
+        guard let sessionID = selectedSessionID else { return }
+        if let i = sessions.firstIndex(where: { $0.id == sessionID }) {
+            sessions[i].modelRef = model.ref
+        }
+    }
+
+    /// Maps a stored "claude/<alias>" ref to the value passed to `--model`.
+    private func runnerModelAlias(for sessionID: String) -> String? {
+        guard let session = sessions.first(where: { $0.id == sessionID }),
+              let ref = session.modelRef, !ref.isEmpty else { return nil }
+        let alias = ref.hasPrefix("claude/") ? String(ref.dropFirst("claude/".count)) : ref
+        // Only pass models the CLI actually accepts. Transcripts record names
+        // like "glm-5.3-flash" while the router only knows "glm-5.3-flash:cloud" —
+        // an unrecognized alias 404s the whole run, so for anything outside the
+        // known list send without --model and let the session keep its model.
+        guard availableModels.contains(where: { $0.id == alias }) else { return nil }
+        return alias
+    }
+
+    var selectedModel: AgentModel? {
+        guard let session = selectedSession, let ref = session.modelRef else { return nil }
+        return availableModels.first { $0.ref == ref }
+    }
+
+    /// Human-readable model name for a stored ref (e.g. transcript model ids).
+    static func modelRef(forModel model: String) -> String {
+        if model.contains("/") { return model }
+        return "claude/\(model)"
+    }
+}

--- a/boringNotch/private/AIAgent/AIAgentWindowController.swift
+++ b/boringNotch/private/AIAgent/AIAgentWindowController.swift
@@ -1,0 +1,84 @@
+//
+//  AIAgentWindowController.swift
+//  boringNotch
+//
+//  Hosts the full agent desktop window. Mirrors SettingsWindowController
+//  but reuses the shared AIAgentViewModel for consistent state.
+//
+
+import AppKit
+import SwiftUI
+
+final class AIAgentWindowController: NSWindowController {
+    static let shared = AIAgentWindowController()
+
+    private init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 820, height: 580),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        super.init(window: window)
+        setupWindow()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupWindow() {
+        guard let window else { return }
+        window.title = "Boring Notch · Claude Code"
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.toolbarStyle = .unified
+        window.isMovableByWindowBackground = true
+        window.collectionBehavior = [.managed, .participatesInCycle, .fullScreenAuxiliary]
+        window.hidesOnDeactivate = false
+        window.isRestorable = true
+        window.identifier = NSUserInterfaceItemIdentifier("BoringNotchAIAgentWindow")
+        window.minSize = NSSize(width: 700, height: 460)
+
+        let hostingView = NSHostingView(rootView: AIAgentFullView())
+        window.contentView = hostingView
+        window.delegate = self
+    }
+
+    func showWindow() {
+        NSApp.setActivationPolicy(.regular)
+        if window?.isVisible == true {
+            NSApp.activate(ignoringOtherApps: true)
+            window?.orderFrontRegardless()
+            window?.makeKeyAndOrderFront(nil)
+            return
+        }
+        window?.orderFrontRegardless()
+        window?.makeKeyAndOrderFront(nil)
+        window?.center()
+        NSApp.activate(ignoringOtherApps: true)
+        DispatchQueue.main.async { [weak self] in
+            self?.window?.makeKeyAndOrderFront(nil)
+        }
+    }
+
+    override func close() {
+        super.close()
+        relinquishFocus()
+    }
+
+    private func relinquishFocus() {
+        window?.orderOut(nil)
+        NSApp.setActivationPolicy(.accessory)
+    }
+}
+
+extension AIAgentWindowController: NSWindowDelegate {
+    func windowWillClose(_ notification: Notification) {
+        relinquishFocus()
+    }
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        NSApp.setActivationPolicy(.regular)
+    }
+}

--- a/boringNotch/private/AIAgent/AgentBridgeServer.swift
+++ b/boringNotch/private/AIAgent/AgentBridgeServer.swift
@@ -1,0 +1,703 @@
+//
+//  AgentBridgeServer.swift
+//  boringNotch
+//
+//  HTTP localhost bridge the Claude Code hook scripts talk to.
+//  boring-decide.sh POSTs the raw PreToolUse hook payload; for tools the
+//  user should decide on, the response is held open until the user answers
+//  from the notch (or the hold times out and we fall through to Claude
+//  Code's normal permission flow). Event-only hooks (SessionStart, Stop,
+//  Notification, …) are fire-and-forget.
+//
+//  Why TCP/HTTP: the app talks to external processes; localhost TCP works
+//  across that boundary and is covered by the network.server /
+//  network.client entitlements. The app scans a small fixed port range for
+//  a free port; the hook scripts scan the same range to discover it. HTTP
+//  (instead of raw TCP lines) lets the hooks be plain `curl` one-liners.
+//
+//  Endpoints:
+//    GET  /v1/health   → {"ok":true}
+//    GET  /v1/state    → debug snapshot (sessions, pending cards)
+//    POST /v1/hook     → raw Claude Code hook payload
+//    POST /v1/respond  → {requestID, decision: allow|deny|answer, reason?, answers?}
+//
+
+import Foundation
+import Defaults
+import os.log
+
+private let agentBridgeLog = OSLog(subsystem: "com.boringnotch.agent", category: "bridge")
+
+private func blog(_ msg: String) {
+    os_log("%{public}@", log: agentBridgeLog, type: .info, msg)
+}
+
+// MARK: - Delegate (main actor)
+
+@MainActor
+protocol AgentBridgeDelegate: AnyObject {
+    func bridge(didRegisterInstance info: AgentInstanceInfo)
+    func bridge(didReceiveEvent event: AgentEvent, sessionID: String)
+    func bridge(didReceivePermission permission: AgentPendingPermission)
+    func bridge(didReceiveQuestion question: AgentPendingQuestion)
+    /// A held request timed out without an answer — drop the card.
+    func bridgeDidExpire(requestID: String)
+    /// Debug snapshot for GET /v1/state.
+    func bridgeStateSnapshot() -> AgentJSON
+}
+
+// MARK: - Server
+
+final class AgentBridgeServer: @unchecked Sendable {
+    /// Scan this small range for a free localhost port. Keep in sync with
+    /// the PORT_RANGE in the hook scripts.
+    static let portBase = 8742
+    static let portRange: [Int] = Array(portBase..<(portBase + 11))
+    static let bridgeHost = "127.0.0.1"
+
+    /// How long a PreToolUse decision may sit unanswered before we fall
+    /// through to Claude Code's normal permission flow.
+    static let holdTimeout: TimeInterval = 30
+
+    private weak var delegate: (any AgentBridgeDelegate)?
+    private var listenFD: Int32 = -1
+    private var running = false
+    private let workQueue = DispatchQueue(label: "boringnotch.agent-bridge", attributes: .concurrent)
+
+    // Sessions the notch itself spawned (managed `claude -p` runs). Only
+    // their tool requests hold for a notch decision; external terminal
+    // sessions pass through instantly so Claude Code's own permission flow
+    // is never delayed.
+    private let managedLock = NSLock()
+    private var managedSessions: Set<String> = []
+
+    // Held PreToolUse requests awaiting a user decision.
+    private let heldLock = NSLock()
+    private var heldRequests: [String: HeldRequest] = [:]
+    // Tools the user approved with "Always", per session — no card next time.
+    private var alwaysAllowedTools: [String: Set<String>] = [:]
+
+    final class HeldRequest {
+        let id: String
+        let sessionID: String
+        private let lock = NSLock()
+        private var resumed = false
+        private var body: String?
+
+        init(id: String, sessionID: String) {
+            self.id = id
+            self.sessionID = sessionID
+        }
+
+        /// Resumes exactly once with the response body for the hook.
+        func fulfill(_ responseBody: String) -> Bool {
+            lock.lock()
+            if resumed {
+                lock.unlock()
+                return false
+            }
+            resumed = true
+            body = responseBody
+            lock.unlock()
+            return true
+        }
+
+        var response: String? {
+            lock.lock()
+            defer { lock.unlock() }
+            return body
+        }
+    }
+
+    func start(delegate: any AgentBridgeDelegate) -> Bool {
+        self.delegate = delegate
+        stop()
+
+        var boundFD: Int32 = -1
+        var chosenPort = 0
+        for port in Self.portRange {
+            let fd = socket(AF_INET, SOCK_STREAM, 0)
+            guard fd >= 0 else {
+                blog("socket() failed: errno \(errno)")
+                return false
+            }
+
+            var yes: Int32 = 1
+            setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+
+            var addr = sockaddr_in()
+            addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+            addr.sin_family = sa_family_t(AF_INET)
+            addr.sin_port = in_port_t(port).bigEndian
+            addr.sin_addr.s_addr = inet_addr(Self.bridgeHost)
+
+            let bindResult = withUnsafePointer(to: &addr) { ptr -> Int32 in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                    bind(fd, sa, socklen_t(MemoryLayout<sockaddr>.size))
+                }
+            }
+            if bindResult != 0 {
+                close(fd)
+                continue
+            }
+            if listen(fd, 32) != 0 {
+                close(fd)
+                continue
+            }
+
+            boundFD = fd
+            chosenPort = port
+            break
+        }
+
+        guard boundFD >= 0 else {
+            blog("could not bind any bridge port in range \(Self.portBase)-\(Self.portBase + Self.portRange.count - 1)")
+            return false
+        }
+
+        listenFD = boundFD
+        running = true
+        blog("bridge listening on \(Self.bridgeHost):\(chosenPort)")
+        Thread.detachNewThread { [weak self] in
+            self?.acceptLoop()
+        }
+        return true
+    }
+
+    func stop() {
+        running = false
+        if listenFD >= 0 {
+            close(listenFD)
+            listenFD = -1
+        }
+        heldLock.lock()
+        let all = Array(heldRequests.values)
+        heldRequests.removeAll()
+        heldLock.unlock()
+        // Fail open: anything still held falls through.
+        for held in all { _ = held.fulfill("") }
+        blog("bridge stopped")
+    }
+
+    // MARK: Accept + request reading
+
+    private func acceptLoop() {
+        while running {
+            var clientAddr = sockaddr()
+            var len = socklen_t(MemoryLayout<sockaddr>.size)
+            let client = accept(listenFD, &clientAddr, &len)
+            if client < 0 {
+                if running { usleep(50_000) }
+                continue
+            }
+            configureSocket(client)
+            workQueue.async { [weak self] in
+                self?.handleConnection(client)
+            }
+        }
+    }
+
+    private func configureSocket(_ fd: Int32) {
+        var yes: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &yes, socklen_t(MemoryLayout<Int32>.size))
+        // Long enough to cover the hold timeout with margin.
+        var timeout = timeval(tv_sec: 300, tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+    }
+
+    private func handleConnection(_ fd: Int32) {
+        defer { close(fd) }
+
+        var buffer = Data()
+        var scratch = [UInt8](repeating: 0, count: 65_536)
+        let headerEndMarker = Data("\r\n\r\n".utf8)
+
+        while running {
+            let n = read(fd, &scratch, scratch.count)
+            if n <= 0 { return }
+            buffer.append(contentsOf: scratch[0..<n])
+
+            guard let headerRange = buffer.range(of: headerEndMarker) else {
+                if buffer.count > 1_048_576 { return } // absurd header, drop
+                continue
+            }
+
+            // Header block (request line + headers).
+            let headerData = buffer.subdata(in: buffer.startIndex..<headerRange.lowerBound)
+            guard let headerText = String(data: headerData, encoding: .utf8),
+                  let request = parseRequestHead(headerText) else {
+                _ = tryWrite(fd, response(status: "400 Bad Request", body: "{\"error\":\"bad request\"}"))
+                return
+            }
+
+            // Body bytes: whatever already arrived after the marker, then
+            // keep reading until Content-Length is satisfied.
+            var body = buffer.subdata(in: headerRange.upperBound..<buffer.endIndex)
+            while body.count < request.contentLength {
+                let r = read(fd, &scratch, scratch.count)
+                if r <= 0 { break }
+                body.append(contentsOf: scratch[0..<r])
+            }
+            if body.count > request.contentLength {
+                body = body.prefix(request.contentLength)
+            }
+
+            let responseBody = route(request: request, body: Data(body))
+            _ = tryWrite(fd, responseBody)
+            return // Connection: close — one request per connection
+        }
+    }
+
+    private struct HTTPRequest {
+        let method: String
+        let path: String
+        let contentLength: Int
+    }
+
+    private func parseRequestHead(_ text: String) -> HTTPRequest? {
+        var lines = text.components(separatedBy: "\r\n")
+        guard !lines.isEmpty else { return nil }
+        let requestLine = lines.removeFirst()
+        let parts = requestLine.split(separator: " ")
+        guard parts.count >= 2 else { return nil }
+        let method = String(parts[0]).uppercased()
+        let path = String(parts[1])
+        var contentLength = 0
+        for line in lines {
+            let pair = line.split(separator: ":", maxSplits: 1)
+            guard pair.count == 2 else { continue }
+            if pair[0].trimmingCharacters(in: .whitespaces).lowercased() == "content-length" {
+                contentLength = Int(pair[1].trimmingCharacters(in: .whitespaces)) ?? 0
+            }
+        }
+        return HTTPRequest(method: method, path: path, contentLength: max(0, contentLength))
+    }
+
+    private func decodeBody(_ body: Data) -> AgentJSON? {
+        guard !body.isEmpty else { return .object([:]) }
+        return try? JSONDecoder().decode(AgentJSON.self, from: body)
+    }
+
+    // MARK: Routing
+
+    private func route(request: HTTPRequest, body: Data) -> String {
+        switch (request.method, request.path) {
+        case ("GET", "/v1/health"):
+            return response(status: "200 OK", body: "{\"ok\":true,\"agent\":\"claude-code\"}")
+        case ("GET", "/v1/state"):
+            return stateResponse()
+        case ("POST", "/v1/hook"):
+            guard let payload = decodeBody(body) else {
+                return response(status: "400 Bad Request", body: "{\"error\":\"invalid json\"}")
+            }
+            return handleHook(payload)
+        case ("POST", "/v1/respond"):
+            guard let payload = decodeBody(body) else {
+                return response(status: "400 Bad Request", body: "{\"error\":\"invalid json\"}")
+            }
+            handleRespond(payload)
+            return response(status: "200 OK", body: "{\"ok\":true}")
+        default:
+            return response(status: "404 Not Found", body: "{}")
+        }
+    }
+
+    private func stateResponse() -> String {
+        let box = SnapshotBox()
+        let sem = DispatchSemaphore(value: 0)
+        Task { @MainActor [weak self] in
+            box.value = self?.delegate?.bridgeStateSnapshot() ?? .null
+            sem.signal()
+        }
+        _ = sem.wait(timeout: .now() + 3)
+        guard let data = try? JSONEncoder().encode(box.value) else {
+            return response(status: "500 Internal Server Error", body: "{}")
+        }
+        return response(status: "200 OK", body: String(data: data, encoding: .utf8) ?? "{}")
+    }
+
+    private final class SnapshotBox: @unchecked Sendable {
+        var value: AgentJSON = .null
+    }
+
+    // MARK: Hook dispatch
+
+    /// Handles a raw Claude Code hook payload. Returns the full HTTP response
+    /// (hookSpecificOutput JSON or empty body for fall-through).
+    private func handleHook(_ payload: AgentJSON) -> String {
+        guard let eventName = payload["hook_event_name"]?.string else {
+            return response(status: "400 Bad Request", body: "{}")
+        }
+        let sessionID = payload["session_id"]?.string ?? "unknown"
+        let directory = payload["cwd"]?.string
+        let transcriptPath = payload["transcript_path"]?.string
+
+        switch eventName {
+        case "SessionStart":
+            notifyMain(.sessionStarted(sessionID: sessionID, directory: directory))
+            registerInstance(sessionID: sessionID, directory: directory)
+            return response(status: "200 OK", body: "")
+
+        case "UserPromptSubmit":
+            let text = payload["prompt"]?.string ?? ""
+            notifyMain(.promptSubmitted(sessionID: sessionID, text: text))
+            return response(status: "200 OK", body: "")
+
+        case "PreToolUse":
+            return handlePreToolUse(payload, sessionID: sessionID, directory: directory)
+
+        case "Stop":
+            let reply = transcriptPath.flatMap { Self.lastAssistantReply(from: $0) }
+            notifyMain(.stopped(sessionID: sessionID, reply: reply))
+            return response(status: "200 OK", body: "")
+
+        case "SessionEnd":
+            notifyMain(.sessionEnded(sessionID: sessionID))
+            return response(status: "200 OK", body: "")
+
+        case "Notification":
+            let message = payload["message"]?.string ?? "Claude needs your attention"
+            notifyMain(.attention(sessionID: sessionID, message: message))
+            return response(status: "200 OK", body: "")
+
+        default:
+            return response(status: "200 OK", body: "")
+        }
+    }
+
+    private func handlePreToolUse(_ payload: AgentJSON, sessionID: String, directory: String?) -> String {
+        let tool = payload["tool_name"]?.string ?? ""
+        let input = payload["tool_input"]
+        let detail = Self.describe(tool: tool, input: input)
+
+        // Every tool use is surfaced as activity.
+        notifyMain(.toolUsed(sessionID: sessionID, tool: tool, detail: detail))
+
+        // Only notch-driven sessions (or, when opted in, every session) hold
+        // for a decision here. External terminal sessions return immediately
+        // so their normal permission flow never waits on the notch.
+        guard isManaged(sessionID) || Defaults[.aiAgentHoldExternalTools] else {
+            return response(status: "200 OK", body: "")
+        }
+
+        // "Always allow" from an earlier card skips the hold for this tool.
+        heldLock.lock()
+        let autoAllowed = alwaysAllowedTools[sessionID]?.contains(tool) ?? false
+        heldLock.unlock()
+        if autoAllowed {
+            return response(status: "200 OK", body: Self.hookOutput(
+                permissionDecision: "allow",
+                reason: "Auto-approved (Always allow set in Boring Notch)"))
+        }
+
+        // AskUserQuestion → held question card with option buttons.
+        if tool == "AskUserQuestion" {
+            let questions = (input?["questions"]?.array ?? []).compactMap(AgentQuestionItem.parse)
+            guard !questions.isEmpty else { return response(status: "200 OK", body: "") }
+
+            let requestID = "q-" + UUID().uuidString.prefix(8)
+            let held = HeldRequest(id: requestID, sessionID: sessionID)
+            heldLock.lock()
+            heldRequests[requestID] = held
+            heldLock.unlock()
+
+            let question = AgentPendingQuestion(
+                id: requestID,
+                sessionID: sessionID,
+                questions: questions,
+                directory: directory,
+                arrivedAt: Date())
+            Task { @MainActor [weak delegate] in
+                delegate?.bridge(didReceiveQuestion: question)
+            }
+            blog("held question \(requestID) (session \(sessionID.prefix(8)))")
+            let heldBody = waitOn(held) ?? ""
+            return response(status: "200 OK", body: heldBody)
+        }
+
+        // Mutating tools → held permission card. Read-only tools pass
+        // straight through so cards never become noise.
+        guard Self.isDecisionTool(tool) else {
+            return response(status: "200 OK", body: "")
+        }
+
+        let requestID = "p-" + UUID().uuidString.prefix(8)
+        let held = HeldRequest(id: requestID, sessionID: sessionID)
+        heldLock.lock()
+        heldRequests[requestID] = held
+        heldLock.unlock()
+
+        let permission = AgentPendingPermission(
+            id: requestID,
+            sessionID: sessionID,
+            tool: tool,
+            title: Self.title(for: tool),
+            detail: detail,
+            input: input,
+            directory: directory,
+            arrivedAt: Date())
+        Task { @MainActor [weak delegate] in
+            delegate?.bridge(didReceivePermission: permission)
+        }
+        blog("held permission \(requestID) (\(tool)) for session \(sessionID.prefix(8))")
+        let heldBody = waitOn(held) ?? ""
+        return response(status: "200 OK", body: heldBody)
+    }
+
+    // MARK: User responses
+
+    /// Marks a session as notch-driven so its tool requests hold for a
+    /// decision from the notch.
+    func markManaged(sessionID: String) {
+        managedLock.lock()
+        managedSessions.insert(sessionID)
+        managedLock.unlock()
+    }
+
+    func clearManaged(sessionID: String) {
+        managedLock.lock()
+        managedSessions.remove(sessionID)
+        managedLock.unlock()
+    }
+
+    private func isManaged(_ sessionID: String) -> Bool {
+        managedLock.lock()
+        defer { managedLock.unlock() }
+        return managedSessions.contains(sessionID)
+    }
+
+    /// In-process answer path used by the view model (cards in the notch).
+    func respond(requestID: String, decision: AgentDecision) {
+        var payload: [String: AgentJSON] = ["requestID": .string(requestID)]
+        switch decision {
+        case .allow:
+            payload["decision"] = .string("allow")
+        case .deny(let reason):
+            payload["decision"] = .string("deny")
+            if let reason { payload["reason"] = .string(reason) }
+        case .answers(let answers):
+            payload["decision"] = .string("answer")
+            payload["answers"] = .array(answers.map { .array($0.map(AgentJSON.string)) })
+        }
+        handleRespond(.object(payload))
+    }
+
+    /// Marks a tool as always-allowed within a session (the "Always" button).
+    func allowAlways(sessionID: String, tool: String) {
+        heldLock.lock()
+        alwaysAllowedTools[sessionID, default: []].insert(tool)
+        heldLock.unlock()
+    }
+
+    private func handleRespond(_ payload: AgentJSON) {
+        guard let requestID = payload["requestID"]?.string else { return }
+        heldLock.lock()
+        let held = heldRequests.removeValue(forKey: requestID)
+        heldLock.unlock()
+        guard let held else { return }
+
+        let decision = payload["decision"]?.string ?? "deny"
+        let body: String
+        switch decision {
+        case "allow":
+            body = Self.hookOutput(permissionDecision: "allow", reason: "Approved from Boring Notch")
+        case "answer":
+            let answers = (payload["answers"]?.array ?? [])
+                .map { $0.array?.compactMap(\.string) ?? [] }
+            body = Self.hookOutput(permissionDecision: "deny", reason: Self.answerReason(answers: answers))
+        default:
+            let reason = payload["reason"]?.string ?? "Denied from Boring Notch"
+            body = Self.hookOutput(permissionDecision: "deny", reason: reason)
+        }
+
+        if held.fulfill(body) {
+            blog("responded \(decision) to \(requestID)")
+        }
+    }
+
+    /// Called when a card is dismissed without a decision — we fall through
+    /// so Claude Code's normal permission flow still applies.
+    func fallThrough(requestID: String) {
+        heldLock.lock()
+        let held = heldRequests.removeValue(forKey: requestID)
+        heldLock.unlock()
+        _ = held?.fulfill("")
+    }
+
+    // MARK: Helpers
+
+    private func registerInstance(sessionID: String, directory: String?) {
+        let info = AgentInstanceInfo(
+            id: sessionID,
+            directory: directory ?? "~",
+            pid: nil,
+            managed: false,
+            lastSeen: Date())
+        Task { @MainActor [weak delegate] in
+            delegate?.bridge(didRegisterInstance: info)
+        }
+    }
+
+    private func notifyMain(_ event: AgentEvent) {
+        let sessionID: String
+        switch event {
+        case .sessionStarted(let s, _), .sessionEnded(let s), .promptSubmitted(let s, _),
+             .toolUsed(let s, _, _), .stopped(let s, _), .attention(let s, _), .errored(let s, _):
+            sessionID = s
+        }
+        Task { @MainActor [weak delegate] in
+            delegate?.bridge(didReceiveEvent: event, sessionID: sessionID)
+        }
+    }
+
+    /// Blocks this connection's worker until the held request is fulfilled or
+    /// times out. Returns the response body ("" = fall through).
+    private func waitOn(_ held: HeldRequest) -> String? {
+        let deadline = Date().addingTimeInterval(Self.holdTimeout)
+        while Date() < deadline {
+            if let body = held.response { return body }
+            usleep(200_000)
+        }
+        // Expire: remove and tell the delegate to drop the card.
+        heldLock.lock()
+        heldRequests.removeValue(forKey: held.id)
+        heldLock.unlock()
+        held.fulfill("")
+        Task { @MainActor [weak delegate] in
+            delegate?.bridgeDidExpire(requestID: held.id)
+        }
+        return ""
+    }
+
+    private func tryWrite(_ fd: Int32, _ data: String) -> Bool {
+        guard let payload = data.data(using: .utf8) else { return false }
+        return payload.withUnsafeBytes { raw -> Bool in
+            guard let base = raw.baseAddress else { return false }
+            var sent = 0
+            let total = payload.count
+            while sent < total {
+                let n = write(fd, base + sent, total - sent)
+                if n <= 0 { return false }
+                sent += n
+            }
+            return true
+        }
+    }
+
+    private func response(status: String, body: String) -> String {
+        let bodyBytes = body.data(using: .utf8)?.count ?? 0
+        return "HTTP/1.1 \(status)\r\n" +
+            "Content-Type: application/json\r\n" +
+            "Content-Length: \(bodyBytes)\r\n" +
+            "Connection: close\r\n" +
+            "\r\n" + body
+    }
+
+    // MARK: Hook output + tool classification
+
+    /// Builds the PreToolUse hookSpecificOutput JSON Claude Code expects.
+    static func hookOutput(permissionDecision decision: String, reason: String) -> String {
+        let escaped = jsonEscaped(reason)
+        return "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\"," +
+            "\"permissionDecision\":\"\(decision)\",\"permissionDecisionReason\":\"\(escaped)\"}}"
+    }
+
+    /// ASCII-safe JSON string escaping for shell transport.
+    static func jsonEscaped(_ s: String) -> String {
+        var out = ""
+        out.reserveCapacity(s.count)
+        for scalar in s.unicodeScalars {
+            switch scalar {
+            case "\"": out += "\\\""
+            case "\\": out += "\\\\"
+            case "\n": out += "\\n"
+            case "\r": out += "\\r"
+            case "\t": out += "\\t"
+            default:
+                if scalar.value < 0x20 {
+                    out += String(format: "\\u%04x", scalar.value)
+                } else if scalar.value > 0x7E {
+                    for unit in String(scalar).utf16 {
+                        out += String(format: "\\u%04x", unit)
+                    }
+                } else {
+                    out.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        return out
+    }
+
+    /// Tools the user should decide on from the notch. Read-only tools pass
+    /// straight through so the card never becomes noise.
+    static let decisionTools: Set<String> = [
+        "Bash", "Write", "Edit", "MultiEdit", "NotebookEdit",
+        "WebFetch", "WebSearch", "Task", "Agent",
+    ]
+
+    static func isDecisionTool(_ tool: String) -> Bool {
+        decisionTools.contains(tool)
+    }
+
+    static func title(for tool: String) -> String {
+        switch tool {
+        case "Bash": return "Bash command"
+        case "Write": return "Write file"
+        case "Edit", "MultiEdit": return "Edit file"
+        case "NotebookEdit": return "Edit notebook"
+        case "WebFetch": return "Fetch URL"
+        case "WebSearch": return "Web search"
+        case "Task", "Agent": return "Launch subagent"
+        default: return tool
+        }
+    }
+
+    /// Short human detail for a tool input (command line / file path / URL).
+    static func describe(tool: String, input: AgentJSON?) -> String {
+        guard let input else { return "" }
+        if let cmd = input["command"]?.string, !cmd.isEmpty { return cmd }
+        if let file = input["file_path"]?.string, !file.isEmpty { return file }
+        if let url = input["url"]?.string, !url.isEmpty { return url }
+        if let query = input["query"]?.string, !query.isEmpty { return query }
+        if let prompt = input["prompt"]?.string, !prompt.isEmpty { return prompt }
+        return ""
+    }
+
+    /// Human-readable reason carrying the user's AskUserQuestion answers.
+    static func answerReason(answers: [[String]]) -> String {
+        var parts: [String] = []
+        for (i, answer) in answers.enumerated() where !answer.isEmpty {
+            let joined = answer.joined(separator: ", ")
+            parts.append("Q\(i + 1): \(joined)")
+        }
+        let body = parts.isEmpty ? "answered" : parts.joined(separator: "; ")
+        return "The user answered via Boring Notch: \(body). " +
+            "Treat this as the user's answer and proceed with it. Do not ask again."
+    }
+
+    /// Best-effort last assistant reply from a session transcript, for the
+    /// Stop-hook done card. Reads only the tail of the transcript.
+    static func lastAssistantReply(from transcriptPath: String) -> String? {
+        let url = URL(fileURLWithPath: transcriptPath)
+        let stat = TranscriptStore.fileStat(url)
+        guard let (_, tail) = TranscriptStore.readHeadAndTail(url: url, size: stat.size) else {
+            return nil
+        }
+        var reply: String?
+        for line in tail.split(separator: "\n", omittingEmptySubsequences: true).reversed() {
+            guard line.contains("\"type\":\"assistant\""),
+                  let lineData = line.data(using: .utf8),
+                  let obj = try? JSONDecoder().decode(AgentJSON.self, from: lineData),
+                  let content = obj["message"]?["content"]?.array else { continue }
+            let textBlocks = content.filter { $0["type"]?.string == "text" }
+                .compactMap { $0["text"]?.string }
+                .joined(separator: "\n\n")
+            if !textBlocks.isEmpty {
+                reply = textBlocks
+                break
+            }
+        }
+        return reply.map { String($0.prefix(600)) }
+    }
+}

--- a/boringNotch/private/AIAgent/AgentHookInstaller.swift
+++ b/boringNotch/private/AIAgent/AgentHookInstaller.swift
@@ -1,0 +1,276 @@
+//
+//  AgentHookInstaller.swift
+//  boringNotch
+//
+//  Installs the Claude Code integration into ~/.claude:
+//    - two hook scripts under ~/.claude/hooks/boring-notch/ that forward
+//      hook payloads to the bridge (HTTP), and
+//    - hook registrations merged into ~/.claude/settings.json so every
+//      Claude Code session (interactive terminal or headless) reports to
+//      the notch and can be approved/answered from it.
+//
+//  Everything fails open: if the scripts or the app are missing, Claude
+//  Code continues completely unaffected.
+//
+
+import Foundation
+
+enum AgentHookInstaller {
+    static var claudeDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude", isDirectory: true)
+    }
+
+    static var hooksDirectory: URL {
+        claudeDirectory.appendingPathComponent("hooks/boring-notch", isDirectory: true)
+    }
+
+    static var settingsFileURL: URL {
+        claudeDirectory.appendingPathComponent("settings.json")
+    }
+
+    static var disabledFileURL: URL {
+        hooksDirectory.appendingPathComponent("DISABLED")
+    }
+
+    static let notifyScriptName = "boring-notify.sh"
+    static let decideScriptName = "boring-decide.sh"
+
+    /// Ports must match AgentBridgeServer.portRange.
+    private static let portList = (8742...8752).map(String.init).joined(separator: " ")
+
+    static var installedScripts: [String] { [notifyScriptName, decideScriptName] }
+
+    // MARK: - Script sources
+
+    /// Fire-and-forget hook forwarder (SessionStart, UserPromptSubmit, Stop,
+    /// Notification, SessionEnd).
+    static let notifyScript = ##"""
+    #!/bin/sh
+    # Boring Notch <-> Claude Code: forwards hook payloads to the notch
+    # bridge. Fire-and-forget: fails silently when the notch is not running.
+    [ -f "$HOME/.claude/hooks/boring-notch/DISABLED" ] && exit 0
+    T=$(mktemp "${TMPDIR:-/tmp}/boring-hook.XXXXXX") || exit 0
+    O=$(mktemp "${TMPDIR:-/tmp}/boring-out.XXXXXX") || { rm -f "$T"; exit 0; }
+    cat > "$T" 2>/dev/null
+    [ -s "$T" ] || { rm -f "$T" "$O"; exit 0; }
+    for P in __PORTS__; do
+      curl -s -m 3 -o "$O" -X POST "http://127.0.0.1:$P/v1/hook" \
+        -H 'Content-Type: application/json' --data-binary @"$T" 2>/dev/null
+      RC=$?
+      [ "$RC" -eq 0 ] && { rm -f "$T" "$O"; exit 0; }
+      # 28 = the bridge accepted but never answered: the app is up but
+      # stuck, so scanning the remaining ports (same app) is pointless.
+      [ "$RC" -eq 28 ] && break
+    done
+    rm -f "$T" "$O"
+    exit 0
+    """##.replacingOccurrences(of: "__PORTS__", with: portList)
+
+    /// PreToolUse bridge: holds until the user decides from the notch, then
+    /// prints the hookSpecificOutput JSON. Prints nothing to fall through.
+    /// The 40s cap matches the bridge's 30s hold with margin — if the app
+    /// is up but unresponsive, this fails open instead of hanging the tool
+    /// call for minutes.
+    static let decideScript = ##"""
+    #!/bin/sh
+    # Boring Notch <-> Claude Code PreToolUse bridge. Prints the notch's
+    # decision JSON on stdout; prints nothing to fall through to Claude
+    # Code's normal permission flow. Fails open on any error.
+    [ -f "$HOME/.claude/hooks/boring-notch/DISABLED" ] && exit 0
+    T=$(mktemp "${TMPDIR:-/tmp}/boring-hook.XXXXXX") || exit 0
+    O=$(mktemp "${TMPDIR:-/tmp}/boring-out.XXXXXX") || { rm -f "$T"; exit 0; }
+    cat > "$T" 2>/dev/null
+    [ -s "$T" ] || { rm -f "$T" "$O"; exit 0; }
+    for P in __PORTS__; do
+      curl -s -m 40 -o "$O" -X POST "http://127.0.0.1:$P/v1/hook" \
+        -H 'Content-Type: application/json' --data-binary @"$T" 2>/dev/null
+      RC=$?
+      [ "$RC" -eq 0 ] && { [ -s "$O" ] && cat "$O"; rm -f "$T" "$O"; exit 0; }
+      [ "$RC" -eq 28 ] && break
+    done
+    rm -f "$T" "$O"
+    exit 0
+    """##.replacingOccurrences(of: "__PORTS__", with: portList)
+
+    // MARK: Install / uninstall
+
+    static func ensureInstalled() {
+        if !isInstalled() {
+            install()
+        }
+    }
+
+    static func isInstalled() -> Bool {
+        scriptsInstalled() && settingsConfigured()
+    }
+
+    @discardableResult
+    static func install() -> Bool {
+        let scripts = installScripts()
+        let config = installSettingsHooks()
+        NSLog("[Agent] hook install: scripts=\(scripts) settings=\(config)")
+        return scripts && config
+    }
+
+    static func uninstall() {
+        for name in installedScripts {
+            try? FileManager.default.removeItem(at: hooksDirectory.appendingPathComponent(name))
+        }
+        removeSettingsHooks()
+        NSLog("[Agent] hooks uninstalled")
+    }
+
+    // MARK: Scripts
+
+    @discardableResult
+    static func installScripts() -> Bool {
+        do {
+            try FileManager.default.createDirectory(at: hooksDirectory, withIntermediateDirectories: true)
+            for (name, source) in [(notifyScriptName, notifyScript), (decideScriptName, decideScript)] {
+                let url = hooksDirectory.appendingPathComponent(name)
+                try source.write(to: url, atomically: true, encoding: .utf8)
+                try FileManager.default.setAttributes(
+                    [.posixPermissions: 0o755], ofItemAtPath: url.path)
+            }
+            return true
+        } catch {
+            NSLog("[Agent] hook script install failed: \(error)")
+            return false
+        }
+    }
+
+    static func scriptsInstalled() -> Bool {
+        for (name, source) in [(notifyScriptName, notifyScript), (decideScriptName, decideScript)] {
+            let url = hooksDirectory.appendingPathComponent(name)
+            guard let current = try? String(contentsOf: url, encoding: .utf8), current == source else {
+                return false
+            }
+        }
+        return true
+    }
+
+    // MARK: settings.json merge
+
+    /// Event names that just forward payloads.
+    private static let notifyEvents = ["SessionStart", "UserPromptSubmit", "Stop", "Notification", "SessionEnd"]
+    /// PreToolUse matcher: tools the user may need to decide on.
+    private static let decideMatcher = "Write|Edit|MultiEdit|NotebookEdit|Bash|AskUserQuestion"
+
+    @discardableResult
+    static func installSettingsHooks() -> Bool {
+        guard var root = readSettings() else { return false }
+
+        var hooks = root["hooks"] as? [String: Any] ?? [:]
+
+        for event in notifyEvents {
+            var groups = hooks[event] as? [[String: Any]] ?? []
+            if groups.contains(where: { isOurGroup($0, script: notifyScriptName) }) { continue }
+            groups.append([
+                "matcher": "",
+                "hooks": [["type": "command", "command": notifyScriptPath]],
+            ])
+            hooks[event] = groups
+        }
+
+        var preToolUse = hooks["PreToolUse"] as? [[String: Any]] ?? []
+        if !preToolUse.contains(where: { isOurGroup($0, script: decideScriptName) }) {
+            preToolUse.append([
+                "matcher": decideMatcher,
+                "hooks": [["type": "command", "command": decideScriptPath]],
+            ])
+            hooks["PreToolUse"] = preToolUse
+        }
+
+        root["hooks"] = hooks
+        return writeSettings(root)
+    }
+
+    static func removeSettingsHooks() {
+        guard var root = readSettings(),
+              var hooks = root["hooks"] as? [String: Any] else { return }
+
+        for event in notifyEvents {
+            guard var groups = hooks[event] as? [[String: Any]] else { continue }
+            groups.removeAll { isOurGroup($0, script: notifyScriptName) }
+            if groups.isEmpty {
+                hooks.removeValue(forKey: event)
+            } else {
+                hooks[event] = groups
+            }
+        }
+
+        if var preToolUse = hooks["PreToolUse"] as? [[String: Any]] {
+            preToolUse.removeAll { isOurGroup($0, script: decideScriptName) }
+            if preToolUse.isEmpty {
+                hooks.removeValue(forKey: "PreToolUse")
+            } else {
+                hooks["PreToolUse"] = preToolUse
+            }
+        }
+
+        if hooks.isEmpty {
+            root.removeValue(forKey: "hooks")
+        } else {
+            root["hooks"] = hooks
+        }
+        _ = writeSettings(root)
+    }
+
+    static func settingsConfigured() -> Bool {
+        guard let root = readSettings(),
+              let hooks = root["hooks"] as? [String: Any] else { return false }
+        for event in notifyEvents {
+            let groups = hooks[event] as? [[String: Any]] ?? []
+            guard groups.contains(where: { isOurGroup($0, script: notifyScriptName) }) else { return false }
+        }
+        let preToolUse = hooks["PreToolUse"] as? [[String: Any]] ?? []
+        return preToolUse.contains(where: { isOurGroup($0, script: decideScriptName) })
+    }
+
+    private static var notifyScriptPath: String { hooksDirectory.appendingPathComponent(notifyScriptName).path }
+    private static var decideScriptPath: String { hooksDirectory.appendingPathComponent(decideScriptName).path }
+
+    private static func isOurGroup(_ group: [String: Any], script: String) -> Bool {
+        let hooks = group["hooks"] as? [[String: Any]] ?? []
+        return hooks.contains { hook in
+            (hook["command"] as? String)?.contains(script) == true
+        }
+    }
+
+    private static func readSettings() -> [String: Any]? {
+        guard let data = FileManager.default.contents(atPath: settingsFileURL.path) else {
+            return [:] // no settings yet — start fresh
+        }
+        if data.isEmpty { return [:] }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    @discardableResult
+    private static func writeSettings(_ root: [String: Any]) -> Bool {
+        do {
+            let data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted])
+            try data.write(to: settingsFileURL, options: .atomic)
+            return true
+        } catch {
+            NSLog("[Agent] settings write failed: \(error)")
+            return false
+        }
+    }
+
+    // MARK: Kill switch
+
+    /// When the DISABLED marker exists, every hook script exits immediately
+    /// and Claude Code behaves exactly as if the notch integration were gone.
+    static var killSwitchEnabled: Bool {
+        get { FileManager.default.fileExists(atPath: disabledFileURL.path) }
+        set {
+            if newValue {
+                try? FileManager.default.createDirectory(at: hooksDirectory, withIntermediateDirectories: true)
+                FileManager.default.createFile(atPath: disabledFileURL.path, contents: Data())
+            } else {
+                try? FileManager.default.removeItem(at: disabledFileURL)
+            }
+        }
+    }
+}

--- a/boringNotch/private/AIAgent/AgentNotificationCard.swift
+++ b/boringNotch/private/AIAgent/AgentNotificationCard.swift
@@ -1,0 +1,537 @@
+//
+//  AgentNotificationCard.swift
+//  boringNotch
+//
+//  The in-notch action surface: when Claude needs a decision the notch
+//  expands (see ContentView) and this view renders the top-priority card —
+//  permission approvals with green/red actions, agent questions with
+//  tappable options (single or multi select), and "done" replies with a
+//  quick-reply box. No floating windows involved.
+//
+
+import SwiftUI
+import Defaults
+
+// MARK: - Root surface (picks the top-priority card)
+
+struct AgentApprovalView: View {
+    @ObservedObject private var vm = AIAgentViewModel.shared
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let question = vm.activeQuestion {
+                AgentQuestionCard(question: question)
+            } else if let permission = vm.activePermission {
+                AgentPermissionCard(permission: permission)
+            } else if let done = vm.activeDoneCard {
+                AgentDoneCardView(card: done)
+            } else {
+                AgentAllClearView()
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.top, 8)
+        .padding(.bottom, 10)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Shared card chrome
+
+private struct AgentCardChrome<Content: View>: View {
+    let tint: Color
+    let icon: String
+    let title: String
+    let subtitle: String
+    var onDismiss: (() -> Void)?
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(spacing: 10) {
+            HStack(alignment: .center, spacing: 12) {
+                ZStack {
+                    Circle()
+                        .fill(tint.opacity(0.16))
+                        .frame(width: 34, height: 34)
+                    Image(systemName: icon)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(tint)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(AgentPalette.paper)
+                        .lineLimit(1)
+
+                    Text(subtitle)
+                        .font(.system(size: 10.5, design: .monospaced))
+                        .foregroundStyle(AgentPalette.paperSecondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                if let onDismiss {
+                    Button(action: onDismiss) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(AgentPalette.paperFaint)
+                            .frame(width: 24, height: 24)
+                            .background(Circle().fill(Color.white.opacity(0.07)))
+                    }
+                    .buttonStyle(.plain)
+                    .help("Dismiss (falls back to the terminal prompt)")
+                }
+            }
+
+            content
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white.opacity(0.035))
+                .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.06), lineWidth: 1))
+        )
+    }
+}
+
+// MARK: - Permission card
+
+struct AgentPermissionCard: View {
+    @ObservedObject private var vm = AIAgentViewModel.shared
+    let permission: AgentPendingPermission
+
+    var body: some View {
+        AgentCardChrome(
+            tint: AgentPalette.waiting,
+            icon: "hand.raised.fill",
+            title: "Claude needs permission",
+            subtitle: subtitleText,
+            onDismiss: { vm.dismissCard(permission.id) }
+        ) {
+            VStack(alignment: .leading, spacing: 10) {
+                if !permission.detail.isEmpty {
+                    Text(permission.detail)
+                        .font(.system(size: 11.5, design: .monospaced))
+                        .foregroundStyle(AgentPalette.paper.opacity(0.88))
+                        .lineLimit(nil)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .fill(Color.black.opacity(0.35))
+                                .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                    .strokeBorder(Color.white.opacity(0.07), lineWidth: 1))
+                        )
+                }
+
+                HStack(spacing: 10) {
+                    Button {
+                        vm.deny(permission: permission)
+                    } label: {
+                        Label("Deny", systemImage: "xmark")
+                    }
+                    .buttonStyle(AgentPrimaryButtonStyle(tint: AgentPalette.waitingApproval))
+                    .keyboardShortcut(.cancelAction)
+
+                    Button("Always allow") {
+                        vm.approve(permission: permission, always: true)
+                    }
+                    .buttonStyle(AgentSecondaryButtonStyle())
+
+                    Spacer()
+
+                    Button {
+                        vm.approve(permission: permission)
+                    } label: {
+                        Label("Approve", systemImage: "checkmark")
+                    }
+                    .buttonStyle(AgentPrimaryButtonStyle(tint: AgentPalette.completed))
+                    .keyboardShortcut(.defaultAction)
+                }
+            }
+        }
+    }
+
+    private var subtitleText: String {
+        var parts = [permission.title]
+        if let dir = permission.directory, !dir.isEmpty {
+            parts.append((dir as NSString).lastPathComponent)
+        }
+        return parts.joined(separator: " · ")
+    }
+}
+
+// MARK: - Question card
+
+struct AgentQuestionCard: View {
+    @ObservedObject private var vm = AIAgentViewModel.shared
+    let question: AgentPendingQuestion
+
+    // Selection mode (multi-select options or several questions)
+    @State private var selections: [String: Set<String>] = [:]
+    @State private var customText = ""
+    @State private var submitting = false
+
+    /// Selection mode: several questions, or the question allows multiple picks.
+    private var needsSelection: Bool {
+        question.questions.count > 1 || question.questions.contains { $0.multiple }
+    }
+
+    var body: some View {
+        AgentCardChrome(
+            tint: AgentPalette.waitingAnswer,
+            icon: "questionmark.bubble.fill",
+            title: titleText,
+            subtitle: subtitleText,
+            onDismiss: { vm.dismissCard(question.id) }
+        ) {
+            if needsSelection {
+                selectionBody
+            } else if let q = question.questions.first {
+                instantBody(q)
+            }
+        }
+    }
+
+    // MARK: Instant answer — one question, one pick, tap to send
+
+    @ViewBuilder
+    private func instantBody(_ q: AgentQuestionItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(q.options) { option in
+                        optionRow(option, questionID: q.id, instant: true)
+                    }
+                }
+                .padding(.vertical, 1)
+            }
+            if q.options.count <= 5 {
+                customField
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    // MARK: Selection mode — pick (possibly several), then confirm
+
+    private var selectionBody: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if question.questions.count > 1 {
+                ScrollView(.vertical, showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(question.questions) { q in
+                            VStack(alignment: .leading, spacing: 5) {
+                                Text(q.question)
+                                    .font(.system(size: 11.5, weight: .medium))
+                                    .foregroundStyle(AgentPalette.paper.opacity(0.85))
+                                    .fixedSize(horizontal: false, vertical: true)
+                                ForEach(q.options) { option in
+                                    optionRow(option, questionID: q.id, instant: false)
+                                }
+                            }
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            } else if let q = question.questions.first {
+                ScrollView(.vertical, showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(q.options) { option in
+                            optionRow(option, questionID: q.id, instant: false)
+                        }
+                    }
+                    .padding(.vertical, 1)
+                }
+                customField
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    vm.dismissCard(question.id)
+                } label: {
+                    Label("Cancel", systemImage: "xmark")
+                }
+                .buttonStyle(AgentSecondaryButtonStyle(tint: AgentPalette.waitingApproval))
+
+                Spacer()
+
+                Button {
+                    confirmSelection()
+                } label: {
+                    Label("Confirm", systemImage: "checkmark")
+                }
+                .buttonStyle(AgentPrimaryButtonStyle(tint: AgentPalette.completed))
+                .disabled(!hasRequiredSelections)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    // MARK: Option row (shared by both modes)
+
+    private func optionRow(_ option: AgentQuestionOption, questionID: String, instant: Bool) -> some View {
+        let isSelected = selections[questionID]?.contains(option.label) ?? false
+
+        return Button {
+            if instant {
+                submit(answers: [[option.label]])
+            } else {
+                toggle(option.label, questionID: questionID)
+            }
+        } label: {
+            HStack(spacing: 8) {
+                if !instant {
+                    ZStack {
+                        Circle()
+                            .strokeBorder(isSelected ? AgentPalette.completed : Color.white.opacity(0.22),
+                                          lineWidth: 1.5)
+                            .frame(width: 16, height: 16)
+                        if isSelected {
+                            Circle()
+                                .fill(AgentPalette.completed)
+                                .frame(width: 16, height: 16)
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 8, weight: .black))
+                                .foregroundStyle(AgentPalette.ink)
+                        }
+                    }
+                } else {
+                    AgentStateDot(color: AgentPalette.paperFaint, pulsing: false, size: 5)
+                }
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(option.label)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(AgentPalette.paper)
+                        .lineLimit(1)
+                    if !option.detail.isEmpty {
+                        Text(option.detail)
+                            .font(.system(size: 10))
+                            .foregroundStyle(AgentPalette.paperSecondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(isSelected ? AgentPalette.completed.opacity(0.14) : Color.white.opacity(0.05))
+                    .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(isSelected ? AgentPalette.completed.opacity(0.45) : Color.white.opacity(0.07),
+                                      lineWidth: 1))
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(submitting)
+    }
+
+    private var customField: some View {
+        HStack(spacing: 6) {
+            TextField("Other — type your own answer…", text: $customText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 11.5))
+                .foregroundStyle(AgentPalette.paper)
+                .onSubmit { submitCustom() }
+            Button {
+                submitCustom()
+            } label: {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 15))
+                    .foregroundStyle(customText.isEmpty ? AgentPalette.paperFaint : AgentPalette.completed)
+            }
+            .buttonStyle(.plain)
+            .disabled(customText.isEmpty)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.white.opacity(0.04))
+                .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.06), lineWidth: 1))
+        )
+    }
+
+    // MARK: Actions
+
+    private func toggle(_ label: String, questionID: String) {
+        let allowsMultiple = question.questions.first { $0.id == questionID }?.multiple ?? false
+        var set = selections[questionID] ?? []
+        if set.contains(label) {
+            set.remove(label)
+        } else {
+            if !allowsMultiple { set = [] }
+            set.insert(label)
+        }
+        selections[questionID] = set
+    }
+
+    private var hasRequiredSelections: Bool {
+        question.questions.allSatisfy { q in
+            !(selections[q.id] ?? []).isEmpty
+        }
+    }
+
+    private func confirmSelection() {
+        let answers = question.questions.map { q in
+            Array((selections[q.id] ?? []).intersection(Set(q.options.map(\.label))))
+        }
+        submit(answers: answers)
+    }
+
+    private func submitCustom() {
+        let text = customText.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty else { return }
+        submit(answers: [[text]])
+    }
+
+    private func submit(answers: [[String]]) {
+        guard !submitting else { return }
+        submitting = true
+        vm.answer(question: question, answers: answers)
+    }
+
+    private var titleText: String {
+        question.questions.first?.header.isEmpty == false
+            ? question.questions.first!.header
+            : (question.questions.first?.question ?? "Claude asks")
+    }
+
+    private var subtitleText: String {
+        let q = question.questions.first
+        if question.questions.count > 1 {
+            return "\(question.questions.count) questions · \(dirName)"
+        }
+        if let q, q.header.isEmpty == false {
+            return q.question
+        }
+        return dirName
+    }
+
+    private var dirName: String {
+        question.directory.map { ($0 as NSString).lastPathComponent } ?? "claude"
+    }
+}
+
+// MARK: - Done card
+
+struct AgentDoneCardView: View {
+    @ObservedObject private var vm = AIAgentViewModel.shared
+    let card: AgentDoneCard
+    @State private var replyText = ""
+    @FocusState private var replyFocused: Bool
+
+    var body: some View {
+        AgentCardChrome(
+            tint: AgentPalette.completed,
+            icon: "checkmark.circle.fill",
+            title: card.title,
+            subtitle: "finished · tap to open",
+            onDismiss: { vm.dismissOldestDoneCard() }
+        ) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(card.reply)
+                    .font(.system(size: 12))
+                    .foregroundStyle(AgentPalette.paper.opacity(0.9))
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(Color.black.opacity(0.3))
+                    )
+
+                HStack(spacing: 10) {
+                    Button {
+                        openInAgentTab()
+                    } label: {
+                        Label("Open agent tab", systemImage: "brain")
+                    }
+                    .buttonStyle(AgentSecondaryButtonStyle())
+
+                    Spacer()
+
+                    quickReply
+                }
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { openInAgentTab() }
+    }
+
+    private var quickReply: some View {
+        HStack(spacing: 6) {
+            TextField("Quick reply…", text: $replyText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 11.5))
+                .foregroundStyle(AgentPalette.paper)
+                .focused($replyFocused)
+                .onSubmit { sendReply() }
+            Button {
+                sendReply()
+            } label: {
+                Image(systemName: "paperplane.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(replyText.isEmpty ? AgentPalette.paperFaint : AgentPalette.completed)
+            }
+            .buttonStyle(.plain)
+            .disabled(replyText.isEmpty)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .frame(maxWidth: 220)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.white.opacity(0.05))
+                .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(replyFocused ? Color.white.opacity(0.18) : Color.white.opacity(0.06), lineWidth: 1))
+        )
+    }
+
+    private func sendReply() {
+        let text = replyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        replyText = ""
+        vm.dismissOldestDoneCard()
+        Task {
+            vm.openChat(sessionID: card.sessionID)
+            await vm.sendPrompt(text)
+        }
+    }
+
+    private func openInAgentTab() {
+        BoringViewCoordinator.shared.currentView = .agent
+        vm.openChat(sessionID: card.sessionID)
+        vm.dismissOldestDoneCard()
+    }
+}
+
+// MARK: - All clear
+
+/// Shown when the notch is open on the approval surface but nothing is
+/// pending anymore (the notch closes itself in this state).
+struct AgentAllClearView: View {
+    var body: some View {
+        VStack(spacing: 6) {
+            AgentStateDot(color: AgentPalette.completed, pulsing: false, size: 8)
+            Text("You're all caught up")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(AgentPalette.paperSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/boringNotch/private/AIAgent/AgentPalette.swift
+++ b/boringNotch/private/AIAgent/AgentPalette.swift
@@ -1,0 +1,158 @@
+//
+//  AgentPalette.swift
+//  boringNotch
+//
+//  Vibe Island-inspired design tokens and small shared components for the
+//  agent surfaces: warm paper text on near-black ink, mono labels, and the
+//  signature state dots with a soft pulse for waiting/running.
+//
+
+import SwiftUI
+
+enum AgentPalette {
+    /// Near-black pill background (matches the physical notch).
+    static let ink = Color(red: 0x0A / 255.0, green: 0x0A / 255.0, blue: 0x0E / 255.0)
+    /// Warm paper white — primary text.
+    static let paper = Color(red: 0xF1 / 255.0, green: 0xEA / 255.0, blue: 0xD9 / 255.0)
+
+    // Status colors (from the v7/v8 vibe-island palette)
+    static let waiting = Color(red: 0xE7 / 255.0, green: 0xA7 / 255.0, blue: 0x62 / 255.0)      // amber
+    static let waitingApproval = Color(red: 0xF4 / 255.0, green: 0xA4 / 255.0, blue: 0xA4 / 255.0) // soft red
+    static let waitingAnswer = Color(red: 0xFF / 255.0, green: 0xD5 / 255.0, blue: 0x8A / 255.0)    // light amber
+    static let running = Color(red: 0x6E / 255.0, green: 0xA7 / 255.0, blue: 0xFF / 255.0)       // blue
+    static let completed = Color(red: 0x6F / 255.0, green: 0xB9 / 255.0, blue: 0x82 / 255.0)     // green
+
+    static let paperSecondary = paper.opacity(0.62)
+    static let paperFaint = paper.opacity(0.4)
+
+    static func tint(for phase: AgentSession.Phase) -> Color {
+        switch phase {
+        case .waitingApproval: return waitingApproval
+        case .waitingAnswer: return waitingAnswer
+        case .busy: return running
+        case .errored: return waitingApproval
+        case .idle: return completed
+        }
+    }
+}
+
+// MARK: - State dot
+
+struct AgentStateDot: View {
+    let color: Color
+    var pulsing: Bool = false
+    var size: CGFloat = 8
+
+    @State private var animate = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(color)
+                .frame(width: size, height: size)
+            if pulsing {
+                Circle()
+                    .stroke(color.opacity(0.5), lineWidth: 1.5)
+                    .frame(width: size, height: size)
+                    .scaleEffect(animate ? 1.9 : 0.9)
+                    .opacity(animate ? 0 : 0.8)
+                    .animation(
+                        .easeOut(duration: 1.4).repeatForever(autoreverses: false),
+                        value: animate)
+            }
+        }
+        .onAppear { animate = true }
+    }
+}
+
+// MARK: - Mono label
+
+struct AgentMonoLabel: View {
+    let text: String
+    var color: Color = AgentPalette.paperFaint
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
+            .tracking(1.4)
+            .foregroundStyle(color)
+            .lineLimit(1)
+    }
+}
+
+// MARK: - Chip
+
+struct AgentChip: View {
+    let text: String
+    var tint: Color = AgentPalette.paperSecondary
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 10, weight: .medium, design: .monospaced))
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .foregroundStyle(tint)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2.5)
+            .background(
+                Capsule().fill(Color.white.opacity(0.06))
+                    .overlay(Capsule().strokeBorder(Color.white.opacity(0.07), lineWidth: 1))
+            )
+    }
+}
+
+// MARK: - Buttons
+
+struct AgentPrimaryButtonStyle: ButtonStyle {
+    var tint: Color = AgentPalette.paper
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 11.5, weight: .semibold))
+            .foregroundStyle(AgentPalette.ink)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 7)
+            .frame(minWidth: 72)
+            .background(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(tint)
+            )
+            .opacity(configuration.isPressed ? 0.8 : 1)
+            .scaleEffect(configuration.isPressed ? 0.97 : 1)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+
+struct AgentSecondaryButtonStyle: ButtonStyle {
+    var tint: Color = AgentPalette.paper
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 11.5, weight: .medium))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 7)
+            .frame(minWidth: 72)
+            .background(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(Color.white.opacity(0.07))
+                    .overlay(RoundedRectangle(cornerRadius: 9, style: .continuous)
+                        .strokeBorder(Color.white.opacity(0.08), lineWidth: 1))
+            )
+            .opacity(configuration.isPressed ? 0.7 : 1)
+            .scaleEffect(configuration.isPressed ? 0.97 : 1)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Age formatting
+
+enum AgentAge {
+    static func string(from date: Date) -> String {
+        let s = Date().timeIntervalSince(date)
+        if s < 60 { return "now" }
+        if s < 3600 { return "\(Int(s / 60))m" }
+        if s < 86_400 { return "\(Int(s / 3600))h" }
+        return "\(Int(s / 86_400))d"
+    }
+}

--- a/boringNotch/private/AIAgent/AgentWire.swift
+++ b/boringNotch/private/AIAgent/AgentWire.swift
@@ -1,0 +1,169 @@
+//
+//  AgentWire.swift
+//  boringNotch
+//
+//  Wire models shared with the Claude Code hook integration
+//  (~/.claude/hooks/boring-notch/boring-notify.sh + boring-decide.sh).
+//
+//  Hook scripts → App (HTTP POST /v1/hook, JSON body):
+//    the raw Claude Code hook payload:
+//      { hook_event_name, session_id, cwd, transcript_path,
+//        tool_name?, tool_input?, prompt?, message?, stop_hook_active? }
+//
+//  App → Hook script (HTTP response body, PreToolUse only):
+//    a Claude Code hookSpecificOutput JSON (permissionDecision allow/deny),
+//    or an empty body meaning "no decision — fall through to the normal
+//    permission flow".
+//
+
+import Foundation
+
+// MARK: - Type-erased JSON value
+
+indirect enum AgentJSON: Codable, Equatable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case object([String: AgentJSON])
+    case array([AgentJSON])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() { self = .null; return }
+        if let v = try? container.decode(Bool.self) { self = .bool(v); return }
+        if let v = try? container.decode(Double.self) { self = .number(v); return }
+        if let v = try? container.decode(String.self) { self = .string(v); return }
+        if let v = try? container.decode([String: AgentJSON].self) { self = .object(v); return }
+        if let v = try? container.decode([AgentJSON].self) { self = .array(v); return }
+        self = .null
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .string(let v): try c.encode(v)
+        case .number(let v): try c.encode(v)
+        case .bool(let v): try c.encode(v)
+        case .object(let v): try c.encode(v)
+        case .array(let v): try c.encode(v)
+        case .null: try c.encodeNil()
+        }
+    }
+
+    var string: String? { if case .string(let v) = self { v } else { nil } }
+    var number: Double? { if case .number(let v) = self { v } else { nil } }
+    var bool: Bool? { if case .bool(let v) = self { v } else { nil } }
+    var object: [String: AgentJSON]? { if case .object(let v) = self { v } else { nil } }
+    var array: [AgentJSON]? { if case .array(let v) = self { v } else { nil } }
+
+    subscript(key: String) -> AgentJSON? { object?[key] }
+    subscript(index: Int) -> AgentJSON? {
+        guard let a = array, a.indices.contains(index) else { return nil }
+        return a[index]
+    }
+
+    static func decode<T: Decodable>(_ type: T.Type, from value: AgentJSON?) -> T? {
+        guard let value else { return nil }
+        guard let data = try? JSONEncoder().encode(value) else { return nil }
+        return try? JSONDecoder().decode(type.self, from: data)
+    }
+}
+
+// MARK: - Live instance (a Claude Code process that fired hooks)
+
+struct AgentInstanceInfo: Identifiable, Equatable {
+    let id: String          // session id reported by the hook
+    var directory: String
+    var pid: Int?
+    var managed: Bool
+    var lastSeen: Date
+
+    var shortDirectory: String {
+        (directory as NSString).lastPathComponent
+    }
+}
+
+// MARK: - Events (normalized from hook payloads)
+
+enum AgentEvent: Equatable {
+    case sessionStarted(sessionID: String, directory: String?)
+    case sessionEnded(sessionID: String)
+    case promptSubmitted(sessionID: String, text: String)
+    case toolUsed(sessionID: String, tool: String, detail: String?)
+    case stopped(sessionID: String, reply: String?)
+    case attention(sessionID: String, message: String)
+    case errored(sessionID: String, message: String)
+}
+
+// MARK: - Pending user action: permission
+
+struct AgentPendingPermission: Identifiable, Equatable {
+    let id: String            // bridge-generated request id
+    let sessionID: String
+    let tool: String
+    var title: String         // human label, e.g. "Bash command"
+    var detail: String        // command line or file path
+    var input: AgentJSON?
+    var directory: String?
+    var arrivedAt: Date
+}
+
+// MARK: - Questions (AskUserQuestion interception)
+
+struct AgentQuestionOption: Identifiable, Equatable {
+    let label: String
+    let detail: String
+    var id: String { label }
+}
+
+struct AgentQuestionItem: Identifiable, Equatable {
+    let question: String
+    let header: String
+    let options: [AgentQuestionOption]
+    var multiple: Bool
+    var id: String { header.isEmpty ? question : header }
+
+    /// Builds from the AskUserQuestion tool_input shape:
+    /// { questions: [ { question, header, options: [ { label, description } ], multiSelect } ] }
+    static func parse(_ json: AgentJSON) -> AgentQuestionItem? {
+        guard let question = json["question"]?.string else { return nil }
+        let options = (json["options"]?.array ?? []).compactMap { opt -> AgentQuestionOption? in
+            guard let label = opt["label"]?.string else { return nil }
+            return AgentQuestionOption(label: label, detail: opt["description"]?.string ?? "")
+        }
+        guard !options.isEmpty else { return nil }
+        return AgentQuestionItem(
+            question: question,
+            header: json["header"]?.string ?? "",
+            options: options,
+            multiple: json["multiSelect"]?.bool ?? false)
+    }
+}
+
+struct AgentPendingQuestion: Identifiable, Equatable {
+    let id: String
+    let sessionID: String
+    var questions: [AgentQuestionItem]
+    var directory: String?
+    var arrivedAt: Date
+}
+
+// MARK: - Decisions (App → held PreToolUse request)
+
+enum AgentDecision: Equatable {
+    case allow
+    case deny(reason: String?)
+    /// AskUserQuestion answered from the notch. Carries one answer list per
+    /// question, in the same order the questions were asked.
+    case answers([[String]])
+}
+
+// MARK: - A parsed chat message ready for display.
+
+struct AgentChatMessage: Identifiable, Equatable {
+    enum Role { case user, assistant, error, system }
+    let id: String
+    let role: Role
+    let text: String
+}

--- a/boringNotch/private/AIAgent/ClaudeCodeAuthOpener.swift
+++ b/boringNotch/private/AIAgent/ClaudeCodeAuthOpener.swift
@@ -1,0 +1,38 @@
+//
+//  ClaudeCodeAuthOpener.swift
+//  boringNotch
+//
+//  Opens Terminal running the claude CLI so the user can sign in once.
+//  Authentication itself always happens in the user's own terminal.
+//
+
+import Foundation
+import AppKit
+
+enum ClaudeCodeAuthOpener {
+    @discardableResult
+    static func openTerminalLogin() -> Bool {
+        let binary = ClaudeCodeRunner.resolveBinary()
+        let command = binary.isEmpty ? "claude" : "'\(binary.replacingOccurrences(of: "'", with: ""))'"
+        let source = """
+        tell application "Terminal"
+            activate
+            do script "\(command)"
+        end tell
+        """
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", source]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            NSLog("[Agent] opened Terminal for Claude Code login")
+            return true
+        } catch {
+            NSLog("[Agent] failed to open Terminal: \(error)")
+            return false
+        }
+    }
+}

--- a/boringNotch/private/AIAgent/ClaudeCodeRunner.swift
+++ b/boringNotch/private/AIAgent/ClaudeCodeRunner.swift
@@ -1,0 +1,317 @@
+//
+//  ClaudeCodeRunner.swift
+//  boringNotch
+//
+//  Drives Claude Code in headless print mode for sessions the notch manages:
+//  spawns `claude -p --output-format stream-json`, streams assistant text
+//  and tool activity back to the view model, and can interrupt a run.
+//  The session's transcript on disk remains the source of truth.
+//
+
+import Foundation
+import Defaults
+
+enum ClaudeAuthState: Equatable {
+    case authenticated
+    case needsAuth
+}
+
+final class ClaudeCodeRunner: @unchecked Sendable {
+    enum Event {
+        case assistantText(String)
+        case toolUsed(name: String, detail: String?)
+        case finished(reply: String?, isError: Bool, message: String?)
+    }
+
+    private var process: Process?
+    private let lock = NSLock()
+    private var interrupted = false
+
+    // MARK: Binary + auth
+
+    private static let lookupLock = NSLock()
+    private static var binaryCache: (path: String, checkedAt: Date)?
+    private static var authCache: (state: ClaudeAuthState, checkedAt: Date)?
+
+    /// Locates the claude CLI: settings override, then PATH via `which`,
+    /// then the usual install locations. The lookup result is cached for a
+    /// minute — `which` forks a process and this runs on a refresh timer.
+    static func resolveBinary() -> String {
+        let configured = Defaults[.aiAgentClaudeBinary]
+        if !configured.isEmpty, FileManager.default.isExecutableFile(atPath: configured) {
+            return configured
+        }
+
+        lookupLock.lock()
+        if let binaryCache,
+           Date().timeIntervalSince(binaryCache.checkedAt) < 60,
+           binaryCache.path.isEmpty || FileManager.default.isExecutableFile(atPath: binaryCache.path) {
+            lookupLock.unlock()
+            return binaryCache.path
+        }
+        lookupLock.unlock()
+
+        var resolved = ""
+        if let p = which("claude"), !p.isEmpty, FileManager.default.isExecutableFile(atPath: p) {
+            resolved = p
+        } else {
+            let home = NSHomeDirectory()
+            let candidates = [
+                (home as NSString).appendingPathComponent(".local/bin/claude"),
+                "/opt/homebrew/bin/claude",
+                "/usr/local/bin/claude",
+            ]
+            resolved = candidates.first { FileManager.default.isExecutableFile(atPath: $0) } ?? ""
+        }
+
+        lookupLock.lock()
+        binaryCache = (resolved, Date())
+        lookupLock.unlock()
+        return resolved
+    }
+
+    private static func which(_ name: String) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        var env = ProcessInfo.processInfo.environment
+        let home = NSHomeDirectory()
+        env["PATH"] = [
+            (home as NSString).appendingPathComponent(".local/bin"),
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            env["PATH"],
+            "/usr/bin:/bin:/usr/sbin:/sbin",
+        ].compactMap { $0 }.joined(separator: ":")
+        process.environment = env
+        process.arguments = [name]
+        let out = Pipe()
+        process.standardOutput = out
+        process.standardError = Pipe()
+        try? process.run()
+        process.waitUntilExit()
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        guard let s = String(data: data, encoding: .utf8) else { return nil }
+        let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        return t.isEmpty ? nil : t
+    }
+
+    /// Best-effort auth check: OAuth account, stored credentials, or an API
+    /// key in the environment. Cached for a minute.
+    static func authState() -> ClaudeAuthState {
+        lookupLock.lock()
+        if let authCache, Date().timeIntervalSince(authCache.checkedAt) < 60 {
+            lookupLock.unlock()
+            return authCache.state
+        }
+        lookupLock.unlock()
+
+        let home = NSHomeDirectory()
+        let fm = FileManager.default
+
+        var state = ClaudeAuthState.needsAuth
+        // ~/.claude.json carries the OAuth account info; scan the raw bytes
+        // instead of parsing what can be a large file.
+        let claudeJSON = (home as NSString).appendingPathComponent(".claude.json")
+        if let data = fm.contents(atPath: claudeJSON),
+           data.range(of: Data("\"oauthAccount\"".utf8)) != nil {
+            state = .authenticated
+        }
+
+        if state == .needsAuth,
+           fm.fileExists(atPath: (home as NSString).appendingPathComponent(".claude/.credentials.json")) {
+            state = .authenticated
+        }
+
+        if state == .needsAuth,
+           ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"]?.isEmpty == false {
+            state = .authenticated
+        }
+
+        lookupLock.lock()
+        authCache = (state, Date())
+        lookupLock.unlock()
+        return state
+    }
+
+    // MARK: Running
+
+    /// Runs one prompt in the given session. Returns once the run finishes.
+    /// Events are delivered on the main actor via `onEvent`.
+    func run(
+        prompt: String,
+        sessionID: String,
+        isNewSession: Bool,
+        directory: String,
+        model: String?,
+        onEvent: @escaping @MainActor (Event) -> Void
+    ) async {
+        let binary = Self.resolveBinary()
+        guard !binary.isEmpty else {
+            await MainActor.run { onEvent(.finished(reply: nil, isError: true, message: "Claude Code CLI not found")) }
+            return
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binary)
+
+        var arguments = ["-p", "--output-format", "stream-json", "--verbose"]
+        if isNewSession {
+            arguments += ["--session-id", sessionID]
+        } else {
+            arguments += ["--resume", sessionID]
+        }
+        if let model, !model.isEmpty {
+            arguments += ["--model", model]
+        }
+        process.arguments = arguments
+
+        let ws = directory.isEmpty ? NSHomeDirectory() : directory
+        process.currentDirectoryURL = URL(fileURLWithPath: ws)
+
+        var env = ProcessInfo.processInfo.environment
+        let home = NSHomeDirectory()
+        env["HOME"] = home
+        env["USER"] = NSUserName()
+        env["LOGNAME"] = NSUserName()
+        env["SHELL"] = "/bin/zsh"
+        env["PATH"] = [
+            (home as NSString).appendingPathComponent(".local/bin"),
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            env["PATH"],
+            "/usr/bin:/bin:/usr/sbin:/sbin",
+        ].compactMap { $0 }.joined(separator: ":")
+        env["BORING_NOTCH_MANAGED"] = "1"
+        process.environment = env
+
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        var stderrText = ""
+        let stderrGroup = DispatchGroup()
+        stderrGroup.enter()
+        stderr.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                stderrGroup.leave()
+            } else if let s = String(data: data, encoding: .utf8) {
+                // readabilityHandler calls are serialized per handle, so a
+                // plain append is race-free here.
+                stderrText += s
+            }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            await MainActor.run { onEvent(.finished(reply: nil, isError: true, message: "Failed to launch claude: \(error.localizedDescription)")) }
+            return
+        }
+
+        lock.lock()
+        self.process = process
+        interrupted = false
+        lock.unlock()
+
+        // Write the prompt to stdin, then close it so the run starts.
+        let promptData = Data(prompt.utf8)
+        try? stdin.fileHandleForWriting.write(contentsOf: promptData)
+        try? stdin.fileHandleForWriting.close()
+
+        // Stream-parse stdout line by line on a background thread.
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            Thread.detachNewThread { [weak self] in
+                let handle = stdout.fileHandleForReading
+                var buffer = Data()
+                var finalReply: String?
+                var finalError: String?
+
+                while true {
+                    let chunk = handle.availableData
+                    if chunk.isEmpty { break }
+                    buffer.append(chunk)
+                    while let idx = buffer.firstIndex(of: 0x0A) {
+                        let lineData = buffer[buffer.startIndex..<idx]
+                        buffer.removeSubrange(buffer.startIndex...idx)
+                        guard !lineData.isEmpty,
+                              let line = String(data: Data(lineData), encoding: .utf8),
+                              let data = line.data(using: .utf8),
+                              let obj = try? JSONDecoder().decode(AgentJSON.self, from: data) else { continue }
+
+                        switch obj["type"]?.string {
+                        case "assistant":
+                            let blocks = obj["message"]?["content"]?.array ?? []
+                            let text = blocks.filter { $0["type"]?.string == "text" }
+                                .compactMap { $0["text"]?.string }
+                                .joined(separator: "\n\n")
+                            if !text.isEmpty {
+                                let reply = text
+                                Task { @MainActor in onEvent(.assistantText(reply)) }
+                            }
+                            for tool in blocks where tool["type"]?.string == "tool_use" {
+                                let name = tool["name"]?.string ?? "tool"
+                                let detail = AgentBridgeServer.describe(tool: name, input: tool["input"])
+                                Task { @MainActor in onEvent(.toolUsed(name: name, detail: detail)) }
+                            }
+                        case "result":
+                            if let result = obj["result"]?.string { finalReply = result }
+                            if obj["is_error"]?.bool == true {
+                                let message = obj["result"]?.string ?? "Claude Code returned an error"
+                                finalError = message
+                            }
+                        default:
+                            break
+                        }
+                    }
+                }
+
+                process.waitUntilExit()
+                stderrGroup.wait()
+                let status = process.terminationStatus
+                let wasInterrupted = self?.isInterrupted() ?? false
+
+                Task { @MainActor in
+                    if wasInterrupted {
+                        onEvent(.finished(reply: finalReply, isError: false, message: "Interrupted"))
+                    } else if status != 0 || finalError != nil {
+                        let message = finalError ?? Self.trimmedTail(stderrText) ?? "claude exited with status \(status)"
+                        onEvent(.finished(reply: nil, isError: true, message: message))
+                    } else {
+                        onEvent(.finished(reply: finalReply, isError: false, message: nil))
+                    }
+                    continuation.resume()
+                }
+            }
+        }
+
+        lock.lock()
+        self.process = nil
+        lock.unlock()
+    }
+
+    func interrupt() {
+        lock.lock()
+        defer { lock.unlock() }
+        interrupted = true
+        if let process, process.isRunning {
+            kill(process.processIdentifier, SIGINT)
+        }
+    }
+
+    private func isInterrupted() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return interrupted
+    }
+
+    private static func trimmedTail(_ s: String) -> String? {
+        let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !t.isEmpty else { return nil }
+        return String(t.suffix(400))
+    }
+}

--- a/boringNotch/private/AIAgent/TranscriptStore.swift
+++ b/boringNotch/private/AIAgent/TranscriptStore.swift
@@ -1,0 +1,345 @@
+//
+//  TranscriptStore.swift
+//  boringNotch
+//
+//  Reads Claude Code session transcripts from ~/.claude/projects/. Each
+//  session is a JSONL file; user/assistant messages, the AI-generated
+//  title, and the model are extracted from it. This is the source of truth
+//  for the sessions list and the chat view.
+//
+//  Performance: transcripts can grow to hundreds of megabytes, and the
+//  sessions list refreshes every few seconds. Files are only re-read when
+//  their size/mtime changed, and each read is bounded to head/tail chunks
+//  (metadata lives at the start, the latest prompt/reply at the end) —
+//  never the whole file. Chat messages are parsed incrementally from the
+//  byte offset of the previous read.
+//
+
+import Foundation
+
+enum TranscriptStore {
+    struct Summary {
+        let id: String
+        var directory: String
+        var title: String?
+        var model: String?
+        var lastPrompt: String?
+        var lastReply: String?
+        var updatedAt: Date
+    }
+
+    /// Per-file read caps for the scan pass.
+    private static let headBytes = 65_536
+    private static let tailBytes = 262_144
+
+    private static let cacheLock = NSLock()
+    /// path → (mtime, size, summary); a nil summary marks a session with no
+    /// conversation so empty files aren't re-read on every scan.
+    private static var summaryCache: [String: (mtime: Date, size: Int64, summary: Summary?)] = [:]
+    /// path → (mtime, size, bytes already parsed, messages) for the chat view.
+    private static var messageCache: [String: (mtime: Date, size: Int64, consumed: Int64, messages: [AgentChatMessage])] = [:]
+
+    static var projectsRoot: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/projects", isDirectory: true)
+    }
+
+    /// Encodes a working directory the way Claude Code names project folders
+    /// ("/Users/gio/dev" → "-Users-gio-dev").
+    static func projectFolderName(for directory: String) -> String {
+        directory.hasPrefix("/")
+            ? directory.replacingOccurrences(of: "/", with: "-")
+            : "-" + directory.replacingOccurrences(of: "/", with: "-")
+    }
+
+    // MARK: Scanning
+
+    /// Scans all project transcripts, most recently updated first. Cached
+    /// summaries are reused for files that haven't changed.
+    static func scan(limit: Int = 40) -> [Summary] {
+        let files = listTranscriptFiles()
+
+        var summaries: [Summary] = []
+        for (url, modified) in files.prefix(limit) {
+            if let summary = summarizeIfChanged(file: url, modified: modified) {
+                summaries.append(summary)
+            }
+        }
+
+        // Keep the cache bounded to the scanned set.
+        cacheLock.lock()
+        let keep = Set(files.prefix(limit).map { $0.url.path })
+        summaryCache = summaryCache.filter { keep.contains($0.key) }
+        cacheLock.unlock()
+
+        return summaries
+    }
+
+    private static func listTranscriptFiles() -> [(url: URL, modified: Date)] {
+        let fm = FileManager.default
+        let dirKeys: [URLResourceKey] = [.contentModificationDateKey]
+        guard let projectDirs = try? fm.contentsOfDirectory(
+            at: projectsRoot, includingPropertiesForKeys: dirKeys,
+            options: [.skipsHiddenFiles]) else { return [] }
+
+        var files: [(url: URL, modified: Date)] = []
+        for dir in projectDirs where dir.hasDirectoryPath {
+            guard let sessionFiles = try? fm.contentsOfDirectory(
+                at: dir, includingPropertiesForKeys: dirKeys,
+                options: [.skipsHiddenFiles]) else { continue }
+            for file in sessionFiles where file.pathExtension == "jsonl" {
+                let modKeys: Set<URLResourceKey> = [.contentModificationDateKey]
+                let modified = (try? file.resourceValues(forKeys: modKeys))?
+                    .contentModificationDate ?? Date.distantPast
+                files.append((file, modified))
+            }
+        }
+
+        files.sort { $0.modified > $1.modified }
+        return files
+    }
+
+    static func fileStat(_ url: URL) -> (mtime: Date, size: Int64) {
+        let keys: Set<URLResourceKey> = [.contentModificationDateKey, .fileSizeKey]
+        let values = try? url.resourceValues(forKeys: keys)
+        return (values?.contentModificationDate ?? .distantPast,
+                Int64(values?.fileSize ?? 0))
+    }
+
+    private static func summarizeIfChanged(file url: URL, modified: Date) -> Summary? {
+        let stat = fileStat(url)
+        cacheLock.lock()
+        let cached = summaryCache[url.path]
+        cacheLock.unlock()
+        if let cached, cached.mtime == stat.mtime, cached.size == stat.size {
+            return cached.summary
+        }
+        let summary = summarize(file: url, modified: modified, size: stat.size)
+        cacheLock.lock()
+        summaryCache[url.path] = (stat.mtime, stat.size, summary)
+        cacheLock.unlock()
+        return summary
+    }
+
+    /// Extracts session metadata from the head and tail of a transcript with
+    /// a light-weight pass: only lines mentioning interesting keys are
+    /// JSON-decoded.
+    private static func summarize(file url: URL, modified: Date, size: Int64) -> Summary? {
+        let id = url.deletingPathExtension().lastPathComponent
+        guard let (head, tail) = readHeadAndTail(url: url, size: size) else { return nil }
+        let text = head == tail ? head : head + "\n" + tail
+
+        var directory = ""
+        var title: String?
+        var model: String?
+        var lastPrompt: String?
+        var lastReply: String?
+
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            let l = line[...]
+            if title == nil, l.contains("\"ai-title\""), let obj = decode(l) {
+                title = obj["aiTitle"]?.string
+                continue
+            }
+            if l.contains("\"cwd\""), directory.isEmpty, let obj = decode(l) {
+                directory = obj["cwd"]?.string ?? ""
+            }
+            if l.contains("\"type\":\"user\""), let obj = decode(l) {
+                if let prompt = userText(from: obj), !prompt.isEmpty {
+                    lastPrompt = prompt
+                }
+                continue
+            }
+            if l.contains("\"type\":\"assistant\""), let obj = decode(l) {
+                if let m = obj["message"]?["model"]?.string { model = m }
+                if let reply = assistantText(from: obj), !reply.isEmpty {
+                    lastReply = reply
+                }
+            }
+        }
+
+        // Skip sessions that contain no conversation at all.
+        guard lastPrompt != nil || lastReply != nil else { return nil }
+
+        return Summary(
+            id: id,
+            directory: directory,
+            title: title,
+            model: model,
+            lastPrompt: lastPrompt,
+            lastReply: lastReply,
+            updatedAt: modified)
+    }
+
+    /// Reads at most the first `headBytes` and last `tailBytes` of a file so
+    /// huge transcripts never hit memory whole. Small files come back with
+    /// both halves equal to the full content.
+    static func readHeadAndTail(url: URL, size: Int64) -> (head: String, tail: String)? {
+        guard size > 0 else { return nil }
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        if size <= Int64(headBytes + tailBytes) {
+            guard let data = try? handle.readToEnd(), !data.isEmpty else { return nil }
+            let text = String(decoding: data, as: UTF8.self)
+            return (text, text)
+        }
+        guard let headData = try? handle.read(upToCount: headBytes) else { return nil }
+        try? handle.seek(toOffset: UInt64(size) - UInt64(tailBytes))
+        guard let tailData = try? handle.readToEnd() else { return nil }
+        return (String(decoding: headData, as: UTF8.self),
+                String(decoding: tailData, as: UTF8.self))
+    }
+
+    // MARK: Messages
+
+    /// Transcript parse for the chat view, oldest first. Incremental: only
+    /// the bytes added since the previous read are parsed; the result is
+    /// cached per file. JSONL transcripts are append-only, so an offset just
+    /// past the last complete line is where the next read resumes.
+    static func messages(sessionID: String, directory: String?) -> [AgentChatMessage] {
+        guard let url = transcriptURL(for: sessionID, directory: directory) else { return [] }
+        let stat = fileStat(url)
+
+        cacheLock.lock()
+        let cached = messageCache[url.path]
+        cacheLock.unlock()
+
+        var messages: [AgentChatMessage]
+        let consumed: Int64
+        if let c = cached, c.consumed > 0, c.consumed <= stat.size {
+            messages = c.messages
+            consumed = parseTranscript(url: url, from: c.consumed, appendingTo: &messages)
+        } else {
+            messages = []
+            consumed = parseTranscript(url: url, from: 0, appendingTo: &messages)
+        }
+
+        cacheLock.lock()
+        messageCache[url.path] = (stat.mtime, stat.size, consumed, messages)
+        if messageCache.count > 8 {
+            let oldest = messageCache
+                .filter { $0.key != url.path }
+                .min { $0.value.mtime < $1.value.mtime }
+            if let oldest { messageCache.removeValue(forKey: oldest.key) }
+        }
+        cacheLock.unlock()
+
+        return messages
+    }
+
+    /// Parses complete JSONL lines starting at `offset`, appending chat
+    /// messages. Returns the offset just past the last complete line so a
+    /// partially written trailing line is picked up on the next read.
+    private static func parseTranscript(
+        url: URL, from offset: Int64, appendingTo messages: inout [AgentChatMessage]
+    ) -> Int64 {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return offset }
+        defer { try? handle.close() }
+        if offset > 0 {
+            try? handle.seek(toOffset: UInt64(offset))
+        }
+        guard let data = try? handle.readToEnd(), !data.isEmpty else { return offset }
+        let text = String(decoding: data, as: UTF8.self)
+        guard let lastNewline = text.lastIndex(of: "\n") else { return offset }
+        let complete = text[text.startIndex...lastNewline]
+
+        for line in complete.split(separator: "\n", omittingEmptySubsequences: true) {
+            let l = line[...]
+            if l.contains("\"type\":\"user\""), let obj = decode(l) {
+                if let prompt = userText(from: obj), !prompt.isEmpty {
+                    messages.append(AgentChatMessage(id: obj["uuid"]?.string ?? UUID().uuidString,
+                                                     role: .user, text: prompt))
+                }
+            } else if l.contains("\"type\":\"assistant\""), let obj = decode(l) {
+                if let reply = assistantText(from: obj), !reply.isEmpty {
+                    messages.append(AgentChatMessage(id: obj["uuid"]?.string ?? UUID().uuidString,
+                                                     role: .assistant, text: reply))
+                }
+            }
+        }
+        return offset + Int64(complete.utf8.count)
+    }
+
+    /// Current session model, from the most recent assistant entry (tail
+    /// chunk only).
+    static func currentModel(sessionID: String, directory: String?) -> String? {
+        guard let url = transcriptURL(for: sessionID, directory: directory) else { return nil }
+        let stat = fileStat(url)
+        guard let (_, tail) = readHeadAndTail(url: url, size: stat.size) else { return nil }
+        for line in tail.split(separator: "\n", omittingEmptySubsequences: true).reversed() {
+            guard line.contains("\"type\":\"assistant\""), let obj = decode(line[...]),
+                  let model = obj["message"]?["model"]?.string else { continue }
+            return model
+        }
+        return nil
+    }
+
+    static func transcriptURL(for sessionID: String, directory: String?) -> URL? {
+        let fm = FileManager.default
+        if let directory, !directory.isEmpty {
+            let candidate = projectsRoot
+                .appendingPathComponent(projectFolderName(for: directory))
+                .appendingPathComponent("\(sessionID).jsonl")
+            if fm.fileExists(atPath: candidate.path) { return candidate }
+        }
+        // Search all project folders for the session file.
+        guard let projectDirs = try? fm.contentsOfDirectory(
+            at: projectsRoot, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]) else {
+            return nil
+        }
+        for dir in projectDirs {
+            let candidate = dir.appendingPathComponent("\(sessionID).jsonl")
+            if fm.fileExists(atPath: candidate.path) { return candidate }
+        }
+        return nil
+    }
+
+    // MARK: Line parsing
+
+    private static func decode<S: StringProtocol>(_ line: S) -> AgentJSON? {
+        guard let data = String(line).data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(AgentJSON.self, from: data)
+    }
+
+    /// Extracts the displayable text of a user entry. Tool results and
+    /// command metadata are not shown as chat bubbles.
+    private static func userText(from entry: AgentJSON) -> String? {
+        guard entry["isSidechain"]?.bool != true,
+              entry["isMeta"]?.bool != true else { return nil }
+        guard let content = entry["message"]?["content"] else { return nil }
+        if let text = content.string {
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { return nil }
+            // Skip local command echoes like <command-name>/model</command-name>
+            if trimmed.hasPrefix("<command-name>") || trimmed.hasPrefix("<local-command") {
+                return nil
+            }
+            return stripSystemReminder(trimmed)
+        }
+        guard let blocks = content.array else { return nil }
+        let texts = blocks
+            .filter { $0["type"]?.string == "text" }
+            .compactMap { $0["text"]?.string }
+            .joined(separator: "\n\n")
+        let trimmed = texts.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : stripSystemReminder(trimmed)
+    }
+
+    /// Extracts the assistant's visible text (ignoring thinking and tool
+    /// use blocks).
+    private static func assistantText(from entry: AgentJSON) -> String? {
+        guard let blocks = entry["message"]?["content"]?.array else { return nil }
+        let texts = blocks
+            .filter { $0["type"]?.string == "text" }
+            .compactMap { $0["text"]?.string }
+            .joined(separator: "\n\n")
+        let trimmed = texts.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func stripSystemReminder(_ text: String) -> String {
+        guard let range = text.range(of: "<system-reminder>") else { return text }
+        return String(text[..<range.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
## What

Adds a native Claude Code integration to boring.notch: an **Agent tab** in the notch that lists your live Claude Code sessions, **in-notch approval cards** when Claude needs a decision or asks a question, and a **chat surface** that drives sessions through headless `claude -p` runs — so you can supervise and steer sessions without leaving the notch.

## How it works

- **Sessions**: discovered from `~/.claude/projects` transcripts, kept live by a tiny localhost hook bridge (`127.0.0.1:8742`). Rows show phase dots (busy / waiting approval / question / errored), last tool and model.
- **Approvals & questions**: the notch expands vertically with a card — green Approve / red Deny, `AskUserQuestion` options with single and multi-select, custom text answers, "done" cards with quick reply. Decisions return the expected `permissionDecision` JSON to Claude Code; timeouts fail open after 30s.
- **Chat**: one chat per session, streaming assistant text and tool activity from the session transcript. Model picker (Anthropic aliases + custom router models). Sends to a terminal-busy session queue automatically and flush the moment the session idles; the queue survives app relaunches.
- **Hooks**: an installer writes the Claude Code hook config into `~/.claude` with a kill switch; holding *external* sessions' tool calls for notch approval is opt-in.
- **Keyboard focus**: the notch panel only becomes key-capable while an agent surface with a text field is visible, so it never steals typing from the active app elsewhere.

## Integration points

- New `boringNotch/private/AIAgent/` group (view model, bridge server, hook installer, transcript store, headless runner, panel + card views)
- `NotchViews.agent` / `.agentApproval` cases, agent tab in `TabSelectionView`, height-only expansion in `ContentView`, key-focus flag in `BoringNotchSkyLightWindow`
- Settings pane + Sounds section, new `Defaults` keys

## Testing

- Built and run locally via GitHub Actions (unsigned ad-hoc)
- Approval flow verified end-to-end against live Claude Code sessions: allow/deny return the expected `permissionDecision` JSON, questions (including `multiSelect`) carry answers back
- Chat sends verified against real sessions: `--resume` keeps the same session id and appends to the same transcript; queued sends flush when the session idles
- Scroll/hover gestures are gated on agent surfaces so scrolling the chat doesn't close the notch

🤖 Generated with [Claude Code](https://claude.com/claude-code)