### PR TITLE
Add lock screen widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ brew install --cask TheBoredTeam/boring-notch/boring-notch
 - Hover over the notch to see it expand and reveal all its secrets.
 - Use the controls to manage your music like a rockstar.
 - Click the star in your menu bar to customize your notch to your heart's content.
+- For lock-screen widgets, open **Settings → Lock Screen**. Enable **Show notch on lock screen**, then turn on the widgets you want: media, timer, weather/status, reminders, and Focus status.
+- The weather/status widget uses Open-Meteo after you allow location access. It can also display your Mac battery and charging state, Bluetooth audio output, next calendar event, and Focus status. Calendar and reminder entries appear after their normal Boring Notch permissions have been granted.
 
 ## 📋 Roadmap
 - [x] Playback live activity 🎧
@@ -113,9 +115,9 @@ brew install --cask TheBoredTeam/boring-notch/boring-notch
 - [x] Notch sizing customization, finetuning on different display sizes 🖥️
 - [x] System OSD replacements (volume, brightness, backlight) 🎚️💡⌨️
 - [ ] Bluetooth Live Activity (connect/disconnect for bluetooth devices) 
-- [ ] Weather integration ⛅️
+- [ ] Weather integration in the expanded notch ⛅️
 - [ ] Customizable Layout options 🛠️
-- [ ] Lock Screen Widgets 🔒
+- [x] Lock Screen widgets: media, timer, weather/status, reminders, battery, Bluetooth, calendar, and Focus 🔒
 - [ ] Extension system 🧩
 - [ ] Notifications (under consideration) 🔔
 <!-- - [ ] Clipboard history manager 📌 `Extension` -->
@@ -187,5 +189,3 @@ For a full list of licenses and attributions, please see the [Third-Party Licens
 
 - **SwiftUI**: For making us look like coding wizards.
 - **You**: For being awesome and checking out **boring.notch**!
-
-

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -119,6 +119,13 @@
 		14D570C62C5F38210011E668 /* BoringHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570C52C5F38210011E668 /* BoringHeader.swift */; };
 		14D570C92C5F38890011E668 /* BoringViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570C82C5F38890011E668 /* BoringViewModel.swift */; };
 		C0D300012F60000100000001 /* DropInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300022F60000100000001 /* DropInteractionState.swift */; };
+		C0D300042F60000100000001 /* LockScreenMediaWidgetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300032F60000100000001 /* LockScreenMediaWidgetManager.swift */; };
+		C0D300062F60000100000001 /* LockScreenMediaWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300052F60000100000001 /* LockScreenMediaWidgetView.swift */; };
+		C0D300082F60000100000001 /* LockScreenWidgetSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300072F60000100000001 /* LockScreenWidgetSupport.swift */; };
+		C0D3000A2F60000100000001 /* LockScreenTimerWidgetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D300092F60000100000001 /* LockScreenTimerWidgetManager.swift */; };
+		C0D3000C2F60000100000001 /* LockScreenAgendaWidgetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3000B2F60000100000001 /* LockScreenAgendaWidgetManager.swift */; };
+		C0D3000E2F60000100000001 /* LockScreenWeatherWidgetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3000D2F60000100000001 /* LockScreenWeatherWidgetManager.swift */; };
+		C0D300102F60000100000001 /* LockScreenSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3000F2F60000100000001 /* LockScreenSettingsView.swift */; };
 		14D570CB2C5F4B2C0011E668 /* BatteryStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570CA2C5F4B2C0011E668 /* BatteryStatusViewModel.swift */; };
 		14D570CD2C5F4BB70011E668 /* BoringBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570CC2C5F4BB70011E668 /* BoringBattery.swift */; };
 		14D570D22C5F6C6A0011E668 /* BoringExtrasMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570D12C5F6C6A0011E668 /* BoringExtrasMenu.swift */; };
@@ -314,6 +321,13 @@
 		14D570C52C5F38210011E668 /* BoringHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringHeader.swift; sourceTree = "<group>"; };
 		14D570C82C5F38890011E668 /* BoringViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringViewModel.swift; sourceTree = "<group>"; };
 		C0D300022F60000100000001 /* DropInteractionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropInteractionState.swift; sourceTree = "<group>"; };
+		C0D300032F60000100000001 /* LockScreenMediaWidgetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenMediaWidgetManager.swift; sourceTree = "<group>"; };
+		C0D300052F60000100000001 /* LockScreenMediaWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenMediaWidgetView.swift; sourceTree = "<group>"; };
+		C0D300072F60000100000001 /* LockScreenWidgetSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenWidgetSupport.swift; sourceTree = "<group>"; };
+		C0D300092F60000100000001 /* LockScreenTimerWidgetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenTimerWidgetManager.swift; sourceTree = "<group>"; };
+		C0D3000B2F60000100000001 /* LockScreenAgendaWidgetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenAgendaWidgetManager.swift; sourceTree = "<group>"; };
+		C0D3000D2F60000100000001 /* LockScreenWeatherWidgetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenWeatherWidgetManager.swift; sourceTree = "<group>"; };
+		C0D3000F2F60000100000001 /* LockScreenSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenSettingsView.swift; sourceTree = "<group>"; };
 		14D570CA2C5F4B2C0011E668 /* BatteryStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryStatusViewModel.swift; sourceTree = "<group>"; };
 		14D570CC2C5F4BB70011E668 /* BoringBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringBattery.swift; sourceTree = "<group>"; };
 		14D570D12C5F6C6A0011E668 /* BoringExtrasMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringExtrasMenu.swift; sourceTree = "<group>"; };
@@ -559,6 +573,7 @@
 				11DB266C2EDD0CDF001EA0CF /* GeneralSettingsView.swift */,
 				11DB266D2EDD0CDF001EA0CF /* OSDSettingsView.swift */,
 				11DB266E2EDD0CDF001EA0CF /* MediaSettingsView.swift */,
+				C0D3000F2F60000100000001 /* LockScreenSettingsView.swift */,
 				11DB266F2EDD0CDF001EA0CF /* SettingsHelpers.swift */,
 				11DB26702EDD0CDF001EA0CF /* ShelfSettingsView.swift */,
 				11DB26712EDD0CDF001EA0CF /* ShortcutsSettingsView.swift */,
@@ -637,6 +652,11 @@
 				F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */,
 				112FB7342CCF16F70015238C /* NotchSpaceManager.swift */,
 				147163992C5D35FF0068B555 /* MusicManager.swift */,
+				C0D300032F60000100000001 /* LockScreenMediaWidgetManager.swift */,
+				C0D300072F60000100000001 /* LockScreenWidgetSupport.swift */,
+				C0D300092F60000100000001 /* LockScreenTimerWidgetManager.swift */,
+				C0D3000B2F60000100000001 /* LockScreenAgendaWidgetManager.swift */,
+				C0D3000D2F60000100000001 /* LockScreenWeatherWidgetManager.swift */,
 				F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */,
 				149E0B962C737D00006418B1 /* WebcamManager.swift */,
 				14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */,
@@ -830,6 +850,7 @@
 			isa = PBXGroup;
 			children = (
 				1194E8862EA6DDA7009C82D6 /* BoringNotchSkyLightWindow.swift */,
+				C0D300052F60000100000001 /* LockScreenMediaWidgetView.swift */,
 				1160F8D72DD98230006FBB94 /* NotchShape.swift */,
 				9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */,
 				14D570C52C5F38210011E668 /* BoringHeader.swift */,
@@ -1071,6 +1092,13 @@
 				1194E87C2EA19E09009C82D6 /* ImageProcessingService.swift in Sources */,
 				1194E8872EA6DDA7009C82D6 /* BoringNotchSkyLightWindow.swift in Sources */,
 				14D570CB2C5F4B2C0011E668 /* BatteryStatusViewModel.swift in Sources */,
+				C0D300042F60000100000001 /* LockScreenMediaWidgetManager.swift in Sources */,
+				C0D300062F60000100000001 /* LockScreenMediaWidgetView.swift in Sources */,
+				C0D300082F60000100000001 /* LockScreenWidgetSupport.swift in Sources */,
+				C0D3000A2F60000100000001 /* LockScreenTimerWidgetManager.swift in Sources */,
+				C0D3000C2F60000100000001 /* LockScreenAgendaWidgetManager.swift in Sources */,
+				C0D3000E2F60000100000001 /* LockScreenWeatherWidgetManager.swift in Sources */,
+				C0D300102F60000100000001 /* LockScreenSettingsView.swift in Sources */,
 				9A0887322C7A693000C160EA /* TabButton.swift in Sources */,
 				1153BD9C2D98853B00979FB0 /* NowPlayingController.swift in Sources */,
 				11985BEF2F37E48900F81585 /* OSDIconView.swift in Sources */,
@@ -1411,7 +1439,7 @@
 				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
 				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
 				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
-				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = YES;
 				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1427,6 +1455,8 @@
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "This app uses AppleEvents to control music";
 				INFOPLIST_KEY_NSCalendarsUsageDescription = "This app uses the calendar to display your calendar events";
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app uses the camera to display a live camera view";
+				INFOPLIST_KEY_NSLocationUsageDescription = "This app uses your location to show local weather on the lock screen";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "This app uses your location to show local weather on the lock screen";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "This app uses Reminders to display your scheduled reminder in the calendar";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1478,7 +1508,7 @@
 				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
 				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
 				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
-				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = YES;
 				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1493,6 +1523,8 @@
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "This app uses AppleEvents to control music";
 				INFOPLIST_KEY_NSCalendarsUsageDescription = "This app uses the calendar to display your calendar events";
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app uses the camera to display a live camera view";
+				INFOPLIST_KEY_NSLocationUsageDescription = "This app uses your location to show local weather on the lock screen";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "This app uses your location to show local weather on the lock screen";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "This app uses Reminders to display your scheduled reminder in the calendar";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -145,8 +145,15 @@
         }
       }
     },
-    "%@x" : {
-      "comment" : "Animation speed multiplier."
+    "%.2g %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$.2g %2$@"
+          }
+        }
+      }
     },
     "%@" : {
       "localizations" : {
@@ -164,6 +171,19 @@
         }
       }
     },
+    "%@：%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@：%2$@"
+          }
+        }
+      }
+    },
+    "%@x" : {
+      "comment" : "Animation speed multiplier."
+    },
     "%lld" : {
       "localizations" : {
         "en" : {
@@ -176,6 +196,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld"
+          }
+        }
+      }
+    },
+    "%lld %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld %2$@"
           }
         }
       }
@@ -21690,6 +21720,9 @@
         }
       }
     },
+    "Show charging wattage" : {
+
+    },
     "Show cool face animation while inactive" : {
       "localizations" : {
         "de" : {
@@ -22133,6 +22166,7 @@
       }
     },
     "Show notch on lock screen" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -24634,7 +24668,7 @@
       }
     },
     "System Setting" : {
-      "comment" : "Week starts on: follow the macOS system setting (shown with the resolved day in parentheses)",
+      "comment" : "Week starts on: follow the macOS system setting",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -122,6 +122,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             enableSkyLightOnAllWindows()
         }
+        LockScreenMediaWidgetManager.shared.screenDidLock()
+        LockScreenTimerWidgetManager.shared.screenDidLock()
+        LockScreenAgendaWidgetManager.shared.screenDidLock()
+        LockScreenWeatherWidgetManager.shared.screenDidLock()
     }
 
     @MainActor
@@ -132,6 +136,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             disableSkyLightOnAllWindows()
         }
+        LockScreenMediaWidgetManager.shared.screenDidUnlock()
+        LockScreenTimerWidgetManager.shared.screenDidUnlock()
+        LockScreenAgendaWidgetManager.shared.screenDidUnlock()
+        LockScreenWeatherWidgetManager.shared.screenDidUnlock()
     }
     
     @MainActor
@@ -312,6 +320,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+
+        // Keep the lock-screen widget synchronized with media and preference changes
+        // even when the first lock event happens after launch.
+        _ = LockScreenMediaWidgetManager.shared
+        _ = LockScreenTimerWidgetManager.shared
+        _ = LockScreenAgendaWidgetManager.shared
+        _ = LockScreenWeatherWidgetManager.shared
 
         NotificationCenter.default.addObserver(
             self,

--- a/boringNotch/components/Notch/LockScreenMediaWidgetView.swift
+++ b/boringNotch/components/Notch/LockScreenMediaWidgetView.swift
@@ -28,7 +28,7 @@ struct LockScreenMediaWidgetView: View {
 
     private var title: String {
         musicManager.songTitle.isEmpty
-            ? LockScreenText.value("Not Playing", "未在播放")
+            ? LockScreenText.value("Not Playing")
             : musicManager.songTitle
     }
 
@@ -60,20 +60,20 @@ struct LockScreenMediaWidgetView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 HStack(spacing: 7) {
-                    mediaButton(systemName: "backward.fill", label: LockScreenText.value("Previous track", "上一首")) {
+                    mediaButton(systemName: "backward.fill", label: LockScreenText.value("Previous track")) {
                         musicManager.previousTrack()
                     }
 
                     mediaButton(
                         systemName: musicManager.isPlaying ? "pause.fill" : "play.fill",
                         label: musicManager.isPlaying
-                            ? LockScreenText.value("Pause", "暂停")
-                            : LockScreenText.value("Play", "播放")
+                            ? LockScreenText.value("Pause")
+                            : LockScreenText.value("Play")
                     ) {
                         musicManager.togglePlay()
                     }
 
-                    mediaButton(systemName: "forward.fill", label: LockScreenText.value("Next track", "下一首")) {
+                    mediaButton(systemName: "forward.fill", label: LockScreenText.value("Next track")) {
                         musicManager.nextTrack()
                     }
                 }

--- a/boringNotch/components/Notch/LockScreenMediaWidgetView.swift
+++ b/boringNotch/components/Notch/LockScreenMediaWidgetView.swift
@@ -1,0 +1,112 @@
+//
+//  LockScreenMediaWidgetView.swift
+//  boringNotch
+//
+
+import SwiftUI
+
+struct LockScreenMediaWidgetView: View {
+    @ObservedObject private var musicManager = MusicManager.shared
+    @State private var progressValue: Double = 0
+    @State private var isAdjustingProgress = false
+
+    private var duration: Double {
+        max(musicManager.songDuration, 1)
+    }
+
+    private var progress: Binding<Double> {
+        Binding(
+            get: {
+                if isAdjustingProgress {
+                    return min(max(progressValue, 0), duration)
+                }
+                return min(max(musicManager.estimatedPlaybackPosition(), 0), duration)
+            },
+            set: { progressValue = min(max($0, 0), duration) }
+        )
+    }
+
+    private var title: String {
+        musicManager.songTitle.isEmpty
+            ? LockScreenText.value("Not Playing", "未在播放")
+            : musicManager.songTitle
+    }
+
+    var body: some View {
+        LockScreenWidgetCard(cornerRadius: 26) {
+            HStack(spacing: 12) {
+                Image(nsImage: musicManager.albumArt)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 64, height: 64)
+                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.system(size: 14, weight: .semibold))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+
+                    Text(musicManager.artistName)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+
+                    Slider(value: progress, in: 0...duration, onEditingChanged: progressEditingChanged)
+                        .controlSize(.small)
+                        .tint(.white)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                HStack(spacing: 7) {
+                    mediaButton(systemName: "backward.fill", label: LockScreenText.value("Previous track", "上一首")) {
+                        musicManager.previousTrack()
+                    }
+
+                    mediaButton(
+                        systemName: musicManager.isPlaying ? "pause.fill" : "play.fill",
+                        label: musicManager.isPlaying
+                            ? LockScreenText.value("Pause", "暂停")
+                            : LockScreenText.value("Play", "播放")
+                    ) {
+                        musicManager.togglePlay()
+                    }
+
+                    mediaButton(systemName: "forward.fill", label: LockScreenText.value("Next track", "下一首")) {
+                        musicManager.nextTrack()
+                    }
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .frame(width: 360, height: 108)
+        }
+    }
+
+    private func progressEditingChanged(_ isEditing: Bool) {
+        if isEditing {
+            progressValue = min(max(musicManager.estimatedPlaybackPosition(), 0), duration)
+            isAdjustingProgress = true
+        } else {
+            isAdjustingProgress = false
+            musicManager.seek(to: progressValue)
+        }
+    }
+
+    private func mediaButton(
+        systemName: String,
+        label: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 12, weight: .semibold))
+                .frame(width: 28, height: 28)
+                .background(.primary.opacity(0.12), in: Circle())
+        }
+        .buttonStyle(.plain)
+        .contentShape(Circle())
+        .accessibilityLabel(label)
+    }
+}

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -19,6 +19,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
     case shelf
     case mirror
     case shortcuts
+    case lockScreen
     case advanced
     case about
 
@@ -35,6 +36,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .shelf: "Shelf"
         case .mirror: "Mirror"
         case .shortcuts: "Shortcuts"
+        case .lockScreen: LockScreenText.value("Lock Screen", "锁定屏幕")
         case .advanced: "Advanced"
         case .about: "About"
         }
@@ -51,6 +53,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .shelf: "books.vertical"
         case .mirror: "camera"
         case .shortcuts: "keyboard"
+        case .lockScreen: "lock.rectangle"
         case .advanced: "gearshape.2"
         case .about: "info.circle"
         }
@@ -100,6 +103,8 @@ struct SettingsView: View {
                     MirrorSettings()
                 case .shortcuts:
                     Shortcuts()
+                case .lockScreen:
+                    LockScreenSettings()
                 case .advanced:
                     Advanced()
                 case .about:

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -36,7 +36,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .shelf: "Shelf"
         case .mirror: "Mirror"
         case .shortcuts: "Shortcuts"
-        case .lockScreen: LockScreenText.value("Lock Screen", "锁定屏幕")
+        case .lockScreen: LockScreenText.value("Lock Screen")
         case .advanced: "Advanced"
         case .about: "About"
         }

--- a/boringNotch/components/Settings/Views/AdvancedSettingsView.swift
+++ b/boringNotch/components/Settings/Views/AdvancedSettingsView.swift
@@ -175,8 +175,12 @@ struct Advanced: View {
                     Text("Hide title bar")
                 }
                 Defaults.Toggle(key: .showOnLockScreen) {
-                    Text("Show notch on lock screen")
+                    Text(LockScreenText.value("Show notch on lock screen", "在锁定屏幕显示刘海"))
                 }
+                Defaults.Toggle(key: .enableLockScreenMediaWidget) {
+                    Text(LockScreenText.value("Show media widget on lock screen", "在锁定屏幕显示媒体小组件"))
+                }
+                .disabled(!showOnLockScreen)
                 Defaults.Toggle(key: .hideFromScreenRecording) {
                     Text("Hide from screen recording")
                 }

--- a/boringNotch/components/Settings/Views/AdvancedSettingsView.swift
+++ b/boringNotch/components/Settings/Views/AdvancedSettingsView.swift
@@ -175,10 +175,10 @@ struct Advanced: View {
                     Text("Hide title bar")
                 }
                 Defaults.Toggle(key: .showOnLockScreen) {
-                    Text(LockScreenText.value("Show notch on lock screen", "在锁定屏幕显示刘海"))
+                    Text(LockScreenText.value("Show notch on lock screen"))
                 }
                 Defaults.Toggle(key: .enableLockScreenMediaWidget) {
-                    Text(LockScreenText.value("Show media widget on lock screen", "在锁定屏幕显示媒体小组件"))
+                    Text(LockScreenText.value("Show media widget on lock screen"))
                 }
                 .disabled(!showOnLockScreen)
                 Defaults.Toggle(key: .hideFromScreenRecording) {

--- a/boringNotch/components/Settings/Views/LockScreenSettingsView.swift
+++ b/boringNotch/components/Settings/Views/LockScreenSettingsView.swift
@@ -40,192 +40,180 @@ struct LockScreenSettings: View {
         Form {
             Section {
                 Defaults.Toggle(key: .showOnLockScreen) {
-                    Text(LockScreenText.value("Show notch on lock screen", "在锁定屏幕显示刘海"))
+                    Text(LockScreenText.value("Show notch on lock screen"))
                 }
-                Text(LockScreenText.value(
-                    "Widgets are only visible while the Mac is locked. Enable the widgets you want below.",
-                    "小组件只会在 Mac 锁定时显示。请在下方启用需要的组件。"
-                ))
+                Text(LockScreenText.value("Widgets are only visible while the Mac is locked. Enable the widgets you want below."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } header: {
-                Text(LockScreenText.value("Lock Screen", "锁定屏幕"))
+                Text(LockScreenText.value("Lock Screen"))
             }
 
             Section {
                 Defaults.Toggle(key: .enableLockScreenMediaWidget) {
-                    Text(LockScreenText.value("Show media widget", "显示媒体小组件"))
+                    Text(LockScreenText.value("Show media widget"))
                 }
                 Defaults.Toggle(key: .enableLockScreenWeatherWidget) {
-                    Text(LockScreenText.value("Show weather and status widget", "显示天气与状态小组件"))
+                    Text(LockScreenText.value("Show weather and status widget"))
                 }
                 Defaults.Toggle(key: .enableLockScreenTimerWidget) {
-                    Text(LockScreenText.value("Show timer widget", "显示计时器小组件"))
+                    Text(LockScreenText.value("Show timer widget"))
                 }
                 Defaults.Toggle(key: .enableLockScreenReminderWidget) {
-                    Text(LockScreenText.value("Show reminder widget", "显示提醒事项小组件"))
+                    Text(LockScreenText.value("Show reminder widget"))
                 }
                 Defaults.Toggle(key: .enableLockScreenFocusWidget) {
-                    Text(LockScreenText.value("Show Focus status", "显示专注模式状态"))
+                    Text(LockScreenText.value("Show Focus status"))
                 }
             } header: {
-                Text(LockScreenText.value("Widgets", "小组件"))
+                Text(LockScreenText.value("Widgets"))
             }
             .disabled(!showOnLockScreen)
 
             Section {
-                Picker(LockScreenText.value("Appearance", "外观"), selection: $appearance) {
+                Picker(LockScreenText.value("Appearance"), selection: $appearance) {
                     ForEach(LockScreenWidgetAppearance.allCases) { appearance in
                         Text(appearance.title).tag(appearance)
                     }
                 }
                 .pickerStyle(.segmented)
             } header: {
-                Text(LockScreenText.value("Appearance", "外观"))
+                Text(LockScreenText.value("Appearance"))
             }
             .disabled(!showOnLockScreen)
 
             Section {
-                Picker(LockScreenText.value("Style", "样式"), selection: $weatherStyle) {
+                Picker(LockScreenText.value("Style"), selection: $weatherStyle) {
                     ForEach(LockScreenWeatherWidgetStyle.allCases) { style in
                         Text(style.title).tag(style)
                     }
                 }
                 .pickerStyle(.segmented)
 
-                Picker(LockScreenText.value("Temperature", "温度单位"), selection: $temperatureUnit) {
+                Picker(LockScreenText.value("Temperature"), selection: $temperatureUnit) {
                     ForEach(LockScreenWeatherTemperatureUnit.allCases) { unit in
                         Text(unit.title).tag(unit)
                     }
                 }
 
-                Toggle(LockScreenText.value("Show location", "显示位置"), isOn: $showLocation)
-                Toggle(LockScreenText.value("Show sunrise", "显示日出时间"), isOn: $showSunrise)
-                Toggle(LockScreenText.value("Show air quality", "显示空气质量"), isOn: $showAQI)
+                Toggle(LockScreenText.value("Show location"), isOn: $showLocation)
+                Toggle(LockScreenText.value("Show sunrise"), isOn: $showSunrise)
+                Toggle(LockScreenText.value("Show air quality"), isOn: $showAQI)
 
                 HStack {
-                    Text(LockScreenText.value("Vertical offset", "垂直偏移"))
+                    Text(LockScreenText.value("Vertical offset"))
                     Slider(value: $weatherOffset, in: -160...160, step: 2)
-                    Text("\(Int(weatherOffset)) \(LockScreenText.value("px", "像素"))")
+                    Text("\(Int(weatherOffset)) \(LockScreenText.value("px"))")
                         .foregroundStyle(.secondary)
                         .frame(width: 54, alignment: .trailing)
                 }
 
-                Button(LockScreenText.value("Allow location access", "允许访问位置")) {
+                Button(LockScreenText.value("Allow location access")) {
                     LockScreenWeatherWidgetManager.shared.prepareLocationAccess()
                 }
             } header: {
-                Text(LockScreenText.value("Weather", "天气"))
+                Text(LockScreenText.value("Weather"))
             } footer: {
-                Text(LockScreenText.value(
-                    "Weather is provided by Open-Meteo. Boring Notch asks for your location only after you allow it.",
-                    "天气数据由 Open-Meteo 提供。只有在你允许后，Boring Notch 才会请求位置。"
-                ))
+                Text(LockScreenText.value("Weather is provided by Open-Meteo. Boring Notch asks for your location only after you allow it."))
             }
             .disabled(!showOnLockScreen || !enableWeather)
 
             Section {
-                Toggle(LockScreenText.value("Show Mac battery", "显示 Mac 电池"), isOn: $showBattery)
-                Toggle(LockScreenText.value("Show charging state", "显示充电状态"), isOn: $showCharging)
+                Toggle(LockScreenText.value("Show Mac battery"), isOn: $showBattery)
+                Toggle(LockScreenText.value("Show charging state"), isOn: $showCharging)
                     .disabled(!showBattery)
-                Toggle(LockScreenText.value("Show charging percentage", "显示充电百分比"), isOn: $showChargingPercentage)
+                Toggle(LockScreenText.value("Show charging percentage"), isOn: $showChargingPercentage)
                     .disabled(!showBattery || !showCharging)
-                Toggle(LockScreenText.value("Show Bluetooth audio output", "显示蓝牙音频输出"), isOn: $showBluetooth)
-                Toggle(LockScreenText.value("Show next calendar event", "显示下一个日历事件"), isOn: $showCalendarEvent)
+                Toggle(LockScreenText.value("Show Bluetooth audio output"), isOn: $showBluetooth)
+                Toggle(LockScreenText.value("Show next calendar event"), isOn: $showCalendarEvent)
 
                 HStack {
-                    Text(LockScreenText.value("Calendar look-ahead", "日历预览范围"))
+                    Text(LockScreenText.value("Calendar look-ahead"))
                     Slider(value: $calendarLookaheadHours, in: 0.25...24, step: 0.25)
-                    Text("\(calendarLookaheadHours, specifier: "%.2g") \(LockScreenText.value("h", "小时"))")
+                    Text("\(calendarLookaheadHours, specifier: "%.2g") \(LockScreenText.value("h"))")
                         .foregroundStyle(.secondary)
                         .frame(width: 44, alignment: .trailing)
                 }
             } header: {
-                Text(LockScreenText.value("Status rows", "状态信息"))
+                Text(LockScreenText.value("Status rows"))
             }
             .disabled(!showOnLockScreen || !enableWeather)
 
             Section {
                 HStack {
-                    Text(LockScreenText.value("Duration", "时长"))
+                    Text(LockScreenText.value("Duration"))
                     Spacer()
-                    TextField(LockScreenText.value("Minutes", "分钟"), value: $timerMinutes, format: .number)
+                    TextField(LockScreenText.value("Minutes"), value: $timerMinutes, format: .number)
                         .frame(width: 72)
-                    Text(LockScreenText.value("minutes", "分钟"))
+                    Text(LockScreenText.value("minutes"))
                         .foregroundStyle(.secondary)
                 }
                 Button(timer.isTimerActive
-                    ? LockScreenText.value("Restart timer", "重新开始计时")
-                    : LockScreenText.value("Start timer", "开始计时")) {
+                    ? LockScreenText.value("Restart timer")
+                    : LockScreenText.value("Start timer")) {
                     timer.start(minutes: timerMinutes)
                 }
                 .disabled(timerMinutes <= 0)
 
                 if timer.isTimerActive {
                     HStack {
-                        Text("\(LockScreenText.value("Remaining", "剩余时间"))：\(timer.formattedRemainingTime)")
+                        Text("\(LockScreenText.value("Remaining")): \(timer.formattedRemainingTime)")
                         Spacer()
-                        Button(LockScreenText.value("Cancel", "取消"), role: .destructive) { timer.cancel() }
+                        Button(LockScreenText.value("Cancel"), role: .destructive) { timer.cancel() }
                     }
                 }
 
                 HStack {
-                    Text(LockScreenText.value("Vertical offset", "垂直偏移"))
+                    Text(LockScreenText.value("Vertical offset"))
                     Slider(value: $timerOffset, in: -160...160, step: 2)
-                    Text("\(Int(timerOffset)) \(LockScreenText.value("px", "像素"))")
+                    Text("\(Int(timerOffset)) \(LockScreenText.value("px"))")
                         .foregroundStyle(.secondary)
                         .frame(width: 54, alignment: .trailing)
                 }
                 HStack {
-                    Text(LockScreenText.value("Width", "宽度"))
+                    Text(LockScreenText.value("Width"))
                     Slider(value: $timerWidth, in: 260...520, step: 10)
-                    Text("\(Int(timerWidth)) \(LockScreenText.value("px", "像素"))")
+                    Text("\(Int(timerWidth)) \(LockScreenText.value("px"))")
                         .foregroundStyle(.secondary)
                         .frame(width: 54, alignment: .trailing)
                 }
             } header: {
-                Text(LockScreenText.value("Timer", "计时器"))
+                Text(LockScreenText.value("Timer"))
             }
             .disabled(!showOnLockScreen || !enableTimer)
 
             Section {
-                Picker(LockScreenText.value("Alignment", "对齐方式"), selection: $reminderAlignment) {
+                Picker(LockScreenText.value("Alignment"), selection: $reminderAlignment) {
                     ForEach(LockScreenReminderAlignment.allCases) { alignment in
                         Text(alignment.title).tag(alignment)
                     }
                 }
                 .pickerStyle(.segmented)
                 HStack {
-                    Text(LockScreenText.value("Vertical offset", "垂直偏移"))
+                    Text(LockScreenText.value("Vertical offset"))
                     Slider(value: $reminderOffset, in: -160...160, step: 2)
-                    Text("\(Int(reminderOffset)) \(LockScreenText.value("px", "像素"))")
+                    Text("\(Int(reminderOffset)) \(LockScreenText.value("px"))")
                         .foregroundStyle(.secondary)
                         .frame(width: 54, alignment: .trailing)
                 }
             } header: {
-                Text(LockScreenText.value("Reminders", "提醒事项"))
+                Text(LockScreenText.value("Reminders"))
             } footer: {
-                Text(LockScreenText.value(
-                    "Displays the next incomplete reminder that is due within the calendar look-ahead window.",
-                    "显示日历预览范围内下一条未完成且到期的提醒事项。"
-                ))
+                Text(LockScreenText.value("Displays the next incomplete reminder that is due within the calendar look-ahead window."))
             }
             .disabled(!showOnLockScreen || !enableReminder)
 
             Section {
-                Toggle(LockScreenText.value("Focus is active", "专注模式已开启"), isOn: $focusActive)
-                TextField(LockScreenText.value("Focus name", "专注模式名称"), text: $focusName)
+                Toggle(LockScreenText.value("Focus is active"), isOn: $focusActive)
+                TextField(LockScreenText.value("Focus name"), text: $focusName)
             } header: {
-                Text(LockScreenText.value("Focus", "专注模式"))
+                Text(LockScreenText.value("Focus"))
             } footer: {
-                Text(LockScreenText.value(
-                    "Boring Notch also listens for macOS Focus notifications. These controls are a manual fallback when macOS does not expose a mode name.",
-                    "Boring Notch 也会监听 macOS 的专注模式通知。当系统未提供模式名称时，可在这里手动设置。"
-                ))
+                Text(LockScreenText.value("Boring Notch also listens for macOS Focus notifications. These controls are a manual fallback when macOS does not expose a mode name."))
             }
             .disabled(!showOnLockScreen || !enableFocus)
         }
         .formStyle(.grouped)
-        .navigationTitle(LockScreenText.value("Lock Screen", "锁定屏幕"))
+        .navigationTitle(LockScreenText.value("Lock Screen"))
     }
 }

--- a/boringNotch/components/Settings/Views/LockScreenSettingsView.swift
+++ b/boringNotch/components/Settings/Views/LockScreenSettingsView.swift
@@ -1,0 +1,231 @@
+//
+//  LockScreenSettingsView.swift
+//  boringNotch
+//
+
+import Defaults
+import SwiftUI
+
+struct LockScreenSettings: View {
+    @Default(.showOnLockScreen) private var showOnLockScreen
+    @Default(.enableLockScreenMediaWidget) private var enableMedia
+    @Default(.enableLockScreenWeatherWidget) private var enableWeather
+    @Default(.enableLockScreenTimerWidget) private var enableTimer
+    @Default(.enableLockScreenReminderWidget) private var enableReminder
+    @Default(.enableLockScreenFocusWidget) private var enableFocus
+    @Default(.lockScreenWidgetAppearance) private var appearance
+    @Default(.lockScreenWeatherWidgetStyle) private var weatherStyle
+    @Default(.lockScreenWeatherTemperatureUnit) private var temperatureUnit
+    @Default(.lockScreenWeatherShowsLocation) private var showLocation
+    @Default(.lockScreenWeatherShowsSunrise) private var showSunrise
+    @Default(.lockScreenWeatherShowsAQI) private var showAQI
+    @Default(.lockScreenWeatherVerticalOffset) private var weatherOffset
+    @Default(.lockScreenBatteryShowsBatteryGauge) private var showBattery
+    @Default(.lockScreenBatteryShowsCharging) private var showCharging
+    @Default(.lockScreenBatteryShowsChargingPercentage) private var showChargingPercentage
+    @Default(.lockScreenBatteryShowsBluetooth) private var showBluetooth
+    @Default(.lockScreenShowCalendarEvent) private var showCalendarEvent
+    @Default(.lockScreenCalendarEventLookaheadHours) private var calendarLookaheadHours
+    @Default(.lockScreenReminderWidgetHorizontalAlignment) private var reminderAlignment
+    @Default(.lockScreenReminderWidgetVerticalOffset) private var reminderOffset
+    @Default(.lockScreenTimerVerticalOffset) private var timerOffset
+    @Default(.lockScreenTimerWidgetWidth) private var timerWidth
+    @Default(.lockScreenFocusActive) private var focusActive
+    @Default(.lockScreenFocusName) private var focusName
+
+    @ObservedObject private var timer = LockScreenTimerWidgetManager.shared
+    @State private var timerMinutes = 10.0
+
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Toggle(key: .showOnLockScreen) {
+                    Text(LockScreenText.value("Show notch on lock screen", "在锁定屏幕显示刘海"))
+                }
+                Text(LockScreenText.value(
+                    "Widgets are only visible while the Mac is locked. Enable the widgets you want below.",
+                    "小组件只会在 Mac 锁定时显示。请在下方启用需要的组件。"
+                ))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } header: {
+                Text(LockScreenText.value("Lock Screen", "锁定屏幕"))
+            }
+
+            Section {
+                Defaults.Toggle(key: .enableLockScreenMediaWidget) {
+                    Text(LockScreenText.value("Show media widget", "显示媒体小组件"))
+                }
+                Defaults.Toggle(key: .enableLockScreenWeatherWidget) {
+                    Text(LockScreenText.value("Show weather and status widget", "显示天气与状态小组件"))
+                }
+                Defaults.Toggle(key: .enableLockScreenTimerWidget) {
+                    Text(LockScreenText.value("Show timer widget", "显示计时器小组件"))
+                }
+                Defaults.Toggle(key: .enableLockScreenReminderWidget) {
+                    Text(LockScreenText.value("Show reminder widget", "显示提醒事项小组件"))
+                }
+                Defaults.Toggle(key: .enableLockScreenFocusWidget) {
+                    Text(LockScreenText.value("Show Focus status", "显示专注模式状态"))
+                }
+            } header: {
+                Text(LockScreenText.value("Widgets", "小组件"))
+            }
+            .disabled(!showOnLockScreen)
+
+            Section {
+                Picker(LockScreenText.value("Appearance", "外观"), selection: $appearance) {
+                    ForEach(LockScreenWidgetAppearance.allCases) { appearance in
+                        Text(appearance.title).tag(appearance)
+                    }
+                }
+                .pickerStyle(.segmented)
+            } header: {
+                Text(LockScreenText.value("Appearance", "外观"))
+            }
+            .disabled(!showOnLockScreen)
+
+            Section {
+                Picker(LockScreenText.value("Style", "样式"), selection: $weatherStyle) {
+                    ForEach(LockScreenWeatherWidgetStyle.allCases) { style in
+                        Text(style.title).tag(style)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Picker(LockScreenText.value("Temperature", "温度单位"), selection: $temperatureUnit) {
+                    ForEach(LockScreenWeatherTemperatureUnit.allCases) { unit in
+                        Text(unit.title).tag(unit)
+                    }
+                }
+
+                Toggle(LockScreenText.value("Show location", "显示位置"), isOn: $showLocation)
+                Toggle(LockScreenText.value("Show sunrise", "显示日出时间"), isOn: $showSunrise)
+                Toggle(LockScreenText.value("Show air quality", "显示空气质量"), isOn: $showAQI)
+
+                HStack {
+                    Text(LockScreenText.value("Vertical offset", "垂直偏移"))
+                    Slider(value: $weatherOffset, in: -160...160, step: 2)
+                    Text("\(Int(weatherOffset)) \(LockScreenText.value("px", "像素"))")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 54, alignment: .trailing)
+                }
+
+                Button(LockScreenText.value("Allow location access", "允许访问位置")) {
+                    LockScreenWeatherWidgetManager.shared.prepareLocationAccess()
+                }
+            } header: {
+                Text(LockScreenText.value("Weather", "天气"))
+            } footer: {
+                Text(LockScreenText.value(
+                    "Weather is provided by Open-Meteo. Boring Notch asks for your location only after you allow it.",
+                    "天气数据由 Open-Meteo 提供。只有在你允许后，Boring Notch 才会请求位置。"
+                ))
+            }
+            .disabled(!showOnLockScreen || !enableWeather)
+
+            Section {
+                Toggle(LockScreenText.value("Show Mac battery", "显示 Mac 电池"), isOn: $showBattery)
+                Toggle(LockScreenText.value("Show charging state", "显示充电状态"), isOn: $showCharging)
+                    .disabled(!showBattery)
+                Toggle(LockScreenText.value("Show charging percentage", "显示充电百分比"), isOn: $showChargingPercentage)
+                    .disabled(!showBattery || !showCharging)
+                Toggle(LockScreenText.value("Show Bluetooth audio output", "显示蓝牙音频输出"), isOn: $showBluetooth)
+                Toggle(LockScreenText.value("Show next calendar event", "显示下一个日历事件"), isOn: $showCalendarEvent)
+
+                HStack {
+                    Text(LockScreenText.value("Calendar look-ahead", "日历预览范围"))
+                    Slider(value: $calendarLookaheadHours, in: 0.25...24, step: 0.25)
+                    Text("\(calendarLookaheadHours, specifier: "%.2g") \(LockScreenText.value("h", "小时"))")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 44, alignment: .trailing)
+                }
+            } header: {
+                Text(LockScreenText.value("Status rows", "状态信息"))
+            }
+            .disabled(!showOnLockScreen || !enableWeather)
+
+            Section {
+                HStack {
+                    Text(LockScreenText.value("Duration", "时长"))
+                    Spacer()
+                    TextField(LockScreenText.value("Minutes", "分钟"), value: $timerMinutes, format: .number)
+                        .frame(width: 72)
+                    Text(LockScreenText.value("minutes", "分钟"))
+                        .foregroundStyle(.secondary)
+                }
+                Button(timer.isTimerActive
+                    ? LockScreenText.value("Restart timer", "重新开始计时")
+                    : LockScreenText.value("Start timer", "开始计时")) {
+                    timer.start(minutes: timerMinutes)
+                }
+                .disabled(timerMinutes <= 0)
+
+                if timer.isTimerActive {
+                    HStack {
+                        Text("\(LockScreenText.value("Remaining", "剩余时间"))：\(timer.formattedRemainingTime)")
+                        Spacer()
+                        Button(LockScreenText.value("Cancel", "取消"), role: .destructive) { timer.cancel() }
+                    }
+                }
+
+                HStack {
+                    Text(LockScreenText.value("Vertical offset", "垂直偏移"))
+                    Slider(value: $timerOffset, in: -160...160, step: 2)
+                    Text("\(Int(timerOffset)) \(LockScreenText.value("px", "像素"))")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 54, alignment: .trailing)
+                }
+                HStack {
+                    Text(LockScreenText.value("Width", "宽度"))
+                    Slider(value: $timerWidth, in: 260...520, step: 10)
+                    Text("\(Int(timerWidth)) \(LockScreenText.value("px", "像素"))")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 54, alignment: .trailing)
+                }
+            } header: {
+                Text(LockScreenText.value("Timer", "计时器"))
+            }
+            .disabled(!showOnLockScreen || !enableTimer)
+
+            Section {
+                Picker(LockScreenText.value("Alignment", "对齐方式"), selection: $reminderAlignment) {
+                    ForEach(LockScreenReminderAlignment.allCases) { alignment in
+                        Text(alignment.title).tag(alignment)
+                    }
+                }
+                .pickerStyle(.segmented)
+                HStack {
+                    Text(LockScreenText.value("Vertical offset", "垂直偏移"))
+                    Slider(value: $reminderOffset, in: -160...160, step: 2)
+                    Text("\(Int(reminderOffset)) \(LockScreenText.value("px", "像素"))")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 54, alignment: .trailing)
+                }
+            } header: {
+                Text(LockScreenText.value("Reminders", "提醒事项"))
+            } footer: {
+                Text(LockScreenText.value(
+                    "Displays the next incomplete reminder that is due within the calendar look-ahead window.",
+                    "显示日历预览范围内下一条未完成且到期的提醒事项。"
+                ))
+            }
+            .disabled(!showOnLockScreen || !enableReminder)
+
+            Section {
+                Toggle(LockScreenText.value("Focus is active", "专注模式已开启"), isOn: $focusActive)
+                TextField(LockScreenText.value("Focus name", "专注模式名称"), text: $focusName)
+            } header: {
+                Text(LockScreenText.value("Focus", "专注模式"))
+            } footer: {
+                Text(LockScreenText.value(
+                    "Boring Notch also listens for macOS Focus notifications. These controls are a manual fallback when macOS does not expose a mode name.",
+                    "Boring Notch 也会监听 macOS 的专注模式通知。当系统未提供模式名称时，可在这里手动设置。"
+                ))
+            }
+            .disabled(!showOnLockScreen || !enableFocus)
+        }
+        .formStyle(.grouped)
+        .navigationTitle(LockScreenText.value("Lock Screen", "锁定屏幕"))
+    }
+}

--- a/boringNotch/helpers/AudioOutputRouteResolver.swift
+++ b/boringNotch/helpers/AudioOutputRouteResolver.swift
@@ -44,6 +44,24 @@ final class AudioOutputRouteResolver {
         }
     }
 
+    var isBluetoothOutput: Bool {
+        stateQueue.sync {
+            switch cachedRouteKind {
+            case .airPods, .airPodsPro, .airPodsMax, .bluetoothHeadphones:
+                true
+            default:
+                false
+            }
+        }
+    }
+
+    var currentOutputName: String {
+        let deviceID = systemOutputDeviceID()
+        guard deviceID != kAudioObjectUnknown else { return "Bluetooth" }
+        let name = readStringProperty(deviceID: deviceID, selector: kAudioObjectPropertyName)
+        return name.isEmpty ? "Bluetooth" : name
+    }
+
     private init() {
         refreshCachedRouteKind()
         setupAudioRouteListener()

--- a/boringNotch/managers/LockScreenAgendaWidgetManager.swift
+++ b/boringNotch/managers/LockScreenAgendaWidgetManager.swift
@@ -1,0 +1,158 @@
+//
+//  LockScreenAgendaWidgetManager.swift
+//  boringNotch
+//
+
+import AppKit
+import Combine
+import Defaults
+import Foundation
+import SwiftUI
+
+@MainActor
+final class LockScreenAgendaWidgetManager: ObservableObject {
+    static let shared = LockScreenAgendaWidgetManager()
+
+    @Published private(set) var nextCalendarEvent: EventModel?
+    @Published private(set) var nextReminder: EventModel?
+
+    private let panel = LockScreenWidgetPanel(allowsInteraction: false)
+    private let calendarService = CalendarService()
+    private var refreshTimer: Timer?
+    private var isLocked = false
+    private var cancellables = Set<AnyCancellable>()
+
+    private init() {
+        Defaults.publisher(.showOnLockScreen)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+        Defaults.publisher(.enableLockScreenReminderWidget)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+        Defaults.publisher(.enableLockScreenWeatherWidget)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+        Defaults.publisher(.lockScreenShowCalendarEvent)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+        Defaults.publisher(.lockScreenCalendarEventLookaheadHours)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+        Defaults.publisher(.lockScreenReminderWidgetHorizontalAlignment)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+        Defaults.publisher(.lockScreenReminderWidgetVerticalOffset)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+    }
+
+    func screenDidLock() {
+        isLocked = true
+        startRefreshTimer()
+        refresh()
+    }
+
+    func screenDidUnlock() {
+        isLocked = false
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+        panel.hide()
+    }
+
+    func refresh() {
+        guard isLocked, Defaults[.showOnLockScreen] else {
+            panel.hide()
+            return
+        }
+
+        Task { [weak self] in
+            guard let self else { return }
+            let now = Date()
+            let end = now.addingTimeInterval(max(1, Defaults[.lockScreenCalendarEventLookaheadHours]) * 3600)
+            let events = await calendarService.events(from: now, to: end, calendars: [])
+            guard !Task.isCancelled else { return }
+            update(with: events, now: now)
+        }
+    }
+
+    private func update(with events: [EventModel], now: Date) {
+        let upcoming = events.filter { event in
+            event.end >= now && !event.type.isReminder
+        }
+        nextCalendarEvent = upcoming.first
+
+        nextReminder = events.first { event in
+            if case .reminder(let completed) = event.type {
+                return !completed
+            }
+            return false
+        }
+
+        updateReminderPanel()
+    }
+
+    private func updateReminderPanel() {
+        guard Defaults[.enableLockScreenReminderWidget],
+              let reminder = nextReminder,
+              let context = LockScreenDisplayContextProvider.shared.snapshot()
+        else {
+            panel.hide()
+            return
+        }
+
+        let size = CGSize(width: 360, height: 48)
+        let frame = LockScreenWidgetLayout.reminder(
+            in: context.frame,
+            size: size,
+            alignment: Defaults[.lockScreenReminderWidgetHorizontalAlignment],
+            offset: CGFloat(Defaults[.lockScreenReminderWidgetVerticalOffset])
+        )
+        panel.show(LockScreenReminderWidgetView(reminder: reminder), frame: frame, cornerRadius: 22)
+    }
+
+    private func startRefreshTimer() {
+        refreshTimer?.invalidate()
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.refresh() }
+        }
+        if let refreshTimer {
+            RunLoop.main.add(refreshTimer, forMode: .common)
+        }
+    }
+}
+
+private struct LockScreenReminderWidgetView: View {
+    let reminder: EventModel
+
+    var body: some View {
+        LockScreenWidgetCard(cornerRadius: 22) {
+            HStack(spacing: 10) {
+                Image(systemName: "checklist")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(Color(nsColor: reminder.calendar.color))
+
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color(nsColor: reminder.calendar.color))
+                    .frame(width: 5, height: 19)
+
+                Text(reminder.title.isEmpty
+                    ? LockScreenText.value("Reminder", "提醒事项")
+                    : reminder.title)
+                    .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    .lineLimit(1)
+
+                Spacer(minLength: 4)
+
+                Text(reminder.start, style: .time)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 14)
+            .frame(width: 360, height: 48)
+        }
+    }
+}

--- a/boringNotch/managers/LockScreenAgendaWidgetManager.swift
+++ b/boringNotch/managers/LockScreenAgendaWidgetManager.swift
@@ -140,7 +140,7 @@ private struct LockScreenReminderWidgetView: View {
                     .frame(width: 5, height: 19)
 
                 Text(reminder.title.isEmpty
-                    ? LockScreenText.value("Reminder", "提醒事项")
+                    ? LockScreenText.value("Reminder")
                     : reminder.title)
                     .font(.system(size: 15, weight: .semibold, design: .rounded))
                     .lineLimit(1)

--- a/boringNotch/managers/LockScreenMediaWidgetManager.swift
+++ b/boringNotch/managers/LockScreenMediaWidgetManager.swift
@@ -1,0 +1,196 @@
+//
+//  LockScreenMediaWidgetManager.swift
+//  boringNotch
+//
+//  A small, independent SkyLight panel for the macOS lock screen.
+//
+
+import AppKit
+import Combine
+import CoreGraphics
+import Defaults
+import SkyLightWindow
+import SwiftUI
+
+@MainActor
+final class LockScreenMediaWidgetManager {
+    static let shared = LockScreenMediaWidgetManager()
+
+    private let musicManager = MusicManager.shared
+    private var panelWindow: NSPanel?
+    private var isSkyLightEnabled = false
+    private var isLocked = false
+    private var cancellables = Set<AnyCancellable>()
+
+    private let panelSize = CGSize(width: 360, height: 108)
+    private let panelCornerRadius: CGFloat = 26
+
+    private init() {
+        observeChanges()
+    }
+
+    func screenDidLock() {
+        isLocked = true
+        refresh()
+    }
+
+    func screenDidUnlock() {
+        isLocked = false
+        dismiss()
+    }
+
+    private func observeChanges() {
+        musicManager.objectWillChange
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.refresh()
+                }
+            }
+            .store(in: &cancellables)
+
+        Defaults.publisher(.showOnLockScreen)
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.refresh()
+                }
+            }
+            .store(in: &cancellables)
+
+        Defaults.publisher(.enableLockScreenMediaWidget)
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.refresh()
+                }
+            }
+            .store(in: &cancellables)
+
+        Defaults.publisher(.hideFromScreenRecording)
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.updateSharingType()
+                }
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(
+            for: NSApplication.didChangeScreenParametersNotification
+        )
+        .sink { [weak self] _ in
+            Task { @MainActor in
+                self?.reposition()
+            }
+        }
+        .store(in: &cancellables)
+    }
+
+    private var shouldDisplay: Bool {
+        guard isLocked,
+              Defaults[.showOnLockScreen],
+              Defaults[.enableLockScreenMediaWidget]
+        else { return false }
+
+        // Do not show placeholder metadata before a media controller has supplied
+        // a real track. Paused tracks with real metadata remain available.
+        if musicManager.isPlaying {
+            return true
+        }
+
+        let title = musicManager.songTitle.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let artist = musicManager.artistName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let placeholderTitles = ["i'm handsome", "unknown", "not playing"]
+        let placeholderArtists = ["me", "unknown"]
+        return (!title.isEmpty && !placeholderTitles.contains(title))
+            || (!artist.isEmpty && !placeholderArtists.contains(artist))
+    }
+
+    private func refresh() {
+        guard shouldDisplay else {
+            dismiss()
+            return
+        }
+        present()
+    }
+
+    private func present() {
+        guard let screen = targetScreen() else { return }
+
+        let frame = LockScreenWidgetLayout.media(in: screen.frame, size: panelSize)
+        let window: NSPanel
+
+        if let existingWindow = panelWindow {
+            window = existingWindow
+        } else {
+            let newWindow = NSPanel(
+                contentRect: frame,
+                styleMask: [.borderless, .nonactivatingPanel],
+                backing: .buffered,
+                defer: false
+            )
+            newWindow.isReleasedWhenClosed = false
+            newWindow.isOpaque = false
+            newWindow.backgroundColor = .clear
+            newWindow.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+            newWindow.collectionBehavior = [
+                .canJoinAllSpaces,
+                .stationary,
+                .fullScreenAuxiliary,
+                .ignoresCycle,
+            ]
+            newWindow.isMovable = false
+            newWindow.hasShadow = false
+            newWindow.hidesOnDeactivate = false
+            newWindow.acceptsMouseMovedEvents = true
+            let hostingView = NSHostingView(rootView: LockScreenMediaWidgetView())
+            hostingView.frame = NSRect(origin: .zero, size: panelSize)
+            hostingView.autoresizingMask = [.width, .height]
+            newWindow.contentView = hostingView
+
+            if let content = newWindow.contentView {
+                content.wantsLayer = true
+                content.layer?.masksToBounds = true
+                content.layer?.cornerRadius = panelCornerRadius
+            }
+
+            panelWindow = newWindow
+            window = newWindow
+        }
+
+        window.setFrame(frame, display: true)
+        updateSharingType()
+
+        if !isSkyLightEnabled {
+            SkyLightOperator.shared.delegateWindow(window)
+            isSkyLightEnabled = true
+        }
+
+        window.orderFrontRegardless()
+    }
+
+    private func dismiss() {
+        panelWindow?.orderOut(nil)
+    }
+
+    private func updateSharingType() {
+        panelWindow?.sharingType = Defaults[.hideFromScreenRecording] ? .none : .readWrite
+    }
+
+    private func reposition() {
+        guard shouldDisplay, let window = panelWindow, let screen = targetScreen() else { return }
+        window.setFrame(LockScreenWidgetLayout.media(in: screen.frame, size: panelSize), display: true)
+    }
+
+    private func targetScreen() -> NSScreen? {
+        // The lock screen is normally hosted by the built-in display. Falling
+        // back keeps this usable on desktops and Macs without a built-in panel.
+        if let builtIn = NSScreen.screens.first(where: { screen in
+            guard let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
+                return false
+            }
+            return CGDisplayIsBuiltin(CGDirectDisplayID(number.uint32Value)) != 0
+        }) {
+            return builtIn
+        }
+        return NSScreen.main ?? NSScreen.screens.first
+    }
+
+}

--- a/boringNotch/managers/LockScreenTimerWidgetManager.swift
+++ b/boringNotch/managers/LockScreenTimerWidgetManager.swift
@@ -1,0 +1,188 @@
+//
+//  LockScreenTimerWidgetManager.swift
+//  boringNotch
+//
+
+import AppKit
+import Combine
+import Defaults
+import Foundation
+import SwiftUI
+
+@MainActor
+final class LockScreenTimerWidgetManager: ObservableObject {
+    static let shared = LockScreenTimerWidgetManager()
+
+    @Published private(set) var remainingTime: TimeInterval = 0
+    @Published private(set) var isTimerActive = false
+    @Published private(set) var isPaused = false
+
+    private let panel = LockScreenWidgetPanel(allowsInteraction: true)
+    private var deadline: Date?
+    private var pausedRemainingTime: TimeInterval = 0
+    private var ticker: Timer?
+    private var isLocked = false
+    private var cancellables = Set<AnyCancellable>()
+
+    private init() {
+        Defaults.publisher(.enableLockScreenTimerWidget)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+        Defaults.publisher(.showOnLockScreen)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+        Defaults.publisher(.lockScreenTimerVerticalOffset)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+        Defaults.publisher(.lockScreenTimerWidgetWidth)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+        NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+    }
+
+    func screenDidLock() {
+        isLocked = true
+        refresh()
+    }
+
+    func screenDidUnlock() {
+        isLocked = false
+        panel.hide()
+    }
+
+    func start(minutes: Double) {
+        let duration = max(1, minutes * 60)
+        pausedRemainingTime = duration
+        remainingTime = duration
+        deadline = Date().addingTimeInterval(duration)
+        isPaused = false
+        isTimerActive = true
+        startTicker()
+        refresh()
+    }
+
+    func togglePause() {
+        guard isTimerActive else { return }
+
+        if isPaused {
+            deadline = Date().addingTimeInterval(pausedRemainingTime)
+            isPaused = false
+            startTicker()
+        } else {
+            pausedRemainingTime = remainingTime
+            deadline = nil
+            isPaused = true
+            stopTicker()
+        }
+        refresh()
+    }
+
+    func cancel() {
+        stopTicker()
+        deadline = nil
+        pausedRemainingTime = 0
+        remainingTime = 0
+        isPaused = false
+        isTimerActive = false
+        refresh()
+    }
+
+    var formattedRemainingTime: String {
+        let seconds = max(0, Int(remainingTime.rounded(.up)))
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+        let remainder = seconds % 60
+        if hours > 0 {
+            return String(format: "%02d:%02d:%02d", hours, minutes, remainder)
+        }
+        return String(format: "%02d:%02d", minutes, remainder)
+    }
+
+    private func startTicker() {
+        stopTicker()
+        ticker = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick() }
+        }
+        if let ticker {
+            RunLoop.main.add(ticker, forMode: .common)
+        }
+    }
+
+    private func stopTicker() {
+        ticker?.invalidate()
+        ticker = nil
+    }
+
+    private func tick() {
+        guard let deadline else { return }
+        remainingTime = max(0, deadline.timeIntervalSinceNow)
+        if remainingTime == 0 {
+            cancel()
+        }
+    }
+
+    private var shouldDisplay: Bool {
+        isLocked
+            && isTimerActive
+            && Defaults[.showOnLockScreen]
+            && Defaults[.enableLockScreenTimerWidget]
+    }
+
+    private func refresh() {
+        guard shouldDisplay, let context = LockScreenDisplayContextProvider.shared.snapshot() else {
+            panel.hide()
+            return
+        }
+
+        let width = min(max(CGFloat(Defaults[.lockScreenTimerWidgetWidth]), 260), 520)
+        let size = CGSize(width: width, height: 72)
+        let frame = LockScreenWidgetLayout.timer(
+            in: context.frame,
+            size: size,
+            offset: CGFloat(Defaults[.lockScreenTimerVerticalOffset])
+        )
+        panel.show(LockScreenTimerWidgetView(), frame: frame, cornerRadius: 24)
+    }
+}
+
+private struct LockScreenTimerWidgetView: View {
+    @ObservedObject private var timer = LockScreenTimerWidgetManager.shared
+
+    var body: some View {
+        LockScreenWidgetCard {
+            HStack(spacing: 14) {
+                Image(systemName: "timer")
+                    .font(.system(size: 19, weight: .semibold))
+                    .foregroundStyle(.orange)
+                    .frame(width: 30)
+
+                Text(timer.formattedRemainingTime)
+                    .font(.system(size: 32, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Button(action: timer.togglePause) {
+                    Image(systemName: timer.isPaused ? "play.fill" : "pause.fill")
+                        .frame(width: 30, height: 30)
+                        .background(.primary.opacity(0.12), in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(timer.isPaused
+                    ? LockScreenText.value("Resume timer", "继续计时")
+                    : LockScreenText.value("Pause timer", "暂停计时"))
+
+                Button(action: timer.cancel) {
+                    Image(systemName: "xmark")
+                        .frame(width: 30, height: 30)
+                        .background(.primary.opacity(0.12), in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(LockScreenText.value("Cancel timer", "取消计时"))
+            }
+            .padding(.horizontal, 16)
+            .frame(height: 72)
+        }
+    }
+}

--- a/boringNotch/managers/LockScreenTimerWidgetManager.swift
+++ b/boringNotch/managers/LockScreenTimerWidgetManager.swift
@@ -170,8 +170,8 @@ private struct LockScreenTimerWidgetView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(timer.isPaused
-                    ? LockScreenText.value("Resume timer", "继续计时")
-                    : LockScreenText.value("Pause timer", "暂停计时"))
+                    ? LockScreenText.value("Resume timer")
+                    : LockScreenText.value("Pause timer"))
 
                 Button(action: timer.cancel) {
                     Image(systemName: "xmark")
@@ -179,7 +179,7 @@ private struct LockScreenTimerWidgetView: View {
                         .background(.primary.opacity(0.12), in: Circle())
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(LockScreenText.value("Cancel timer", "取消计时"))
+                .accessibilityLabel(LockScreenText.value("Cancel timer"))
             }
             .padding(.horizontal, 16)
             .frame(height: 72)

--- a/boringNotch/managers/LockScreenWeatherWidgetManager.swift
+++ b/boringNotch/managers/LockScreenWeatherWidgetManager.swift
@@ -1,0 +1,522 @@
+//
+//  LockScreenWeatherWidgetManager.swift
+//  boringNotch
+//
+//  A compact Open-Meteo powered lock-screen status widget. It combines weather
+//  with the battery, audio-route, calendar and Focus information already
+//  available to Boring Notch.
+//
+
+import AppKit
+import Combine
+@preconcurrency import CoreLocation
+import Defaults
+import Foundation
+import SwiftUI
+
+@MainActor
+final class LockScreenWeatherWidgetManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+    static let shared = LockScreenWeatherWidgetManager()
+
+    @Published private(set) var snapshot = LockScreenWeatherSnapshot.placeholder
+
+    private let panel = LockScreenWidgetPanel(allowsInteraction: false)
+    private let locationManager = CLLocationManager()
+    private let battery = BatteryStatusViewModel.shared
+    private let agenda = LockScreenAgendaWidgetManager.shared
+    private let focus = LockScreenFocusMonitor.shared
+    private var currentLocation: CLLocation?
+    private var weather: WeatherData?
+    private var lastFetchDate: Date?
+    private var isLocked = false
+    private var isFetching = false
+    private var statusRefreshTimer: Timer?
+    private var cancellables = Set<AnyCancellable>()
+
+    private override init() {
+        super.init()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyKilometer
+
+        observeSettings()
+
+        battery.objectWillChange
+            .sink { [weak self] _ in self?.render() }
+            .store(in: &cancellables)
+        agenda.objectWillChange
+            .sink { [weak self] _ in self?.render() }
+            .store(in: &cancellables)
+        focus.objectWillChange
+            .sink { [weak self] _ in self?.render() }
+            .store(in: &cancellables)
+        NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)
+            .sink { [weak self] _ in self?.render() }
+            .store(in: &cancellables)
+    }
+
+    func screenDidLock() {
+        isLocked = true
+        startStatusRefreshTimer()
+        refresh()
+    }
+
+    private func observeSettings() {
+        Defaults.publisher(.showOnLockScreen).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.enableLockScreenWeatherWidget).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.enableLockScreenFocusWidget).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.lockScreenWeatherRefreshInterval).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.lockScreenWeatherShowsLocation).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.lockScreenWeatherShowsSunrise).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.lockScreenWeatherWidgetStyle).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.lockScreenWeatherTemperatureUnit).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.lockScreenWeatherShowsAQI).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.lockScreenWeatherVerticalOffset).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.lockScreenBatteryShowsBatteryGauge).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.lockScreenBatteryShowsCharging).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.lockScreenBatteryShowsChargingPercentage).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.lockScreenBatteryShowsBluetooth).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+        Defaults.publisher(.lockScreenShowCalendarEvent).sink { [weak self] _ in self?.refresh() }.store(in: &cancellables)
+    }
+
+    private func startStatusRefreshTimer() {
+        statusRefreshTimer?.invalidate()
+        statusRefreshTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.refresh() }
+        }
+        if let statusRefreshTimer {
+            RunLoop.main.add(statusRefreshTimer, forMode: .common)
+        }
+    }
+
+    func screenDidUnlock() {
+        isLocked = false
+        statusRefreshTimer?.invalidate()
+        statusRefreshTimer = nil
+        panel.hide()
+    }
+
+    func prepareLocationAccess() {
+        switch locationManager.authorizationStatus {
+        case .notDetermined:
+            locationManager.requestWhenInUseAuthorization()
+        case .authorizedAlways:
+            locationManager.requestLocation()
+        default:
+            break
+        }
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let isAuthorized = manager.authorizationStatus == .authorizedAlways
+        Task { @MainActor [weak self] in
+            if isAuthorized {
+                self?.locationManager.requestLocation()
+            }
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        let coordinate = location.coordinate
+        Task { @MainActor [weak self] in
+            self?.currentLocation = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+            self?.refresh(force: true)
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        Task { @MainActor [weak self] in
+            self?.render()
+        }
+    }
+
+    func refresh(force: Bool = false) {
+        render()
+        guard shouldDisplay, !isFetching else { return }
+
+        let interval = Defaults[.lockScreenWeatherRefreshInterval]
+        let needsFetch = force || lastFetchDate == nil || Date().timeIntervalSince(lastFetchDate ?? .distantPast) >= interval
+        guard needsFetch else { return }
+
+        prepareLocationAccess()
+        guard let currentLocation else { return }
+
+        isFetching = true
+        let unit = Defaults[.lockScreenWeatherTemperatureUnit]
+        Task { [weak self] in
+            defer { self?.isFetching = false }
+            do {
+                let data = try await Self.fetchWeather(for: currentLocation, unit: unit)
+                let locationName = await Self.locationName(for: currentLocation)
+                guard !Task.isCancelled else { return }
+                self?.weather = data.with(locationName: locationName)
+                self?.lastFetchDate = Date()
+                self?.render()
+            } catch {
+                self?.render()
+            }
+        }
+    }
+
+    private var shouldDisplay: Bool {
+        isLocked && Defaults[.showOnLockScreen] && Defaults[.enableLockScreenWeatherWidget]
+    }
+
+    private func render() {
+        let newSnapshot = makeSnapshot()
+        snapshot = newSnapshot
+
+        guard shouldDisplay, let context = LockScreenDisplayContextProvider.shared.snapshot() else {
+            panel.hide()
+            return
+        }
+
+        let style = Defaults[.lockScreenWeatherWidgetStyle]
+        let size = style == .inline
+            ? CGSize(width: 500, height: 88)
+            : CGSize(width: 160, height: 160)
+        let frame = LockScreenWidgetLayout.weather(
+            in: context.frame,
+            size: size,
+            offset: CGFloat(Defaults[.lockScreenWeatherVerticalOffset])
+        )
+        panel.show(
+            LockScreenWeatherWidgetView(snapshot: newSnapshot),
+            frame: frame,
+            cornerRadius: style == .inline ? 26 : 80
+        )
+    }
+
+    private func makeSnapshot() -> LockScreenWeatherSnapshot {
+        let calendarEvent = agenda.nextCalendarEvent
+        let batteryLevel = max(0, min(100, Int(battery.levelBattery.rounded())))
+        let showsBattery = Defaults[.lockScreenBatteryShowsBatteryGauge]
+        let showBluetooth = Defaults[.lockScreenBatteryShowsBluetooth]
+        let bluetoothName = showBluetooth && AudioOutputRouteResolver.shared.isBluetoothOutput
+            ? AudioOutputRouteResolver.shared.currentOutputName
+            : nil
+        let focusName = Defaults[.enableLockScreenFocusWidget] && focus.isActive ? focus.name : nil
+
+        return LockScreenWeatherSnapshot(
+            temperature: weather?.temperature,
+            unitSymbol: Defaults[.lockScreenWeatherTemperatureUnit].symbol,
+            symbolName: weather.map { Self.symbol(for: $0.weatherCode) } ?? "cloud.fill",
+            description: weather.map { Self.description(for: $0.weatherCode) }
+                ?? LockScreenText.value("Weather unavailable", "天气暂不可用"),
+            locationName: Defaults[.lockScreenWeatherShowsLocation] ? weather?.locationName : nil,
+            sunrise: Defaults[.lockScreenWeatherShowsSunrise] ? weather?.sunrise : nil,
+            aqi: Defaults[.lockScreenWeatherShowsAQI] ? weather?.aqi : nil,
+            batteryLevel: showsBattery ? batteryLevel : nil,
+            isCharging: battery.isCharging,
+            isPluggedIn: battery.isPluggedIn,
+            chargingPercentage: Defaults[.lockScreenBatteryShowsChargingPercentage] ? batteryLevel : nil,
+            bluetoothName: bluetoothName,
+            calendarTitle: Defaults[.lockScreenShowCalendarEvent] ? calendarEvent?.title : nil,
+            calendarStart: Defaults[.lockScreenShowCalendarEvent] ? calendarEvent?.start : nil,
+            focusName: focusName,
+            style: Defaults[.lockScreenWeatherWidgetStyle]
+        )
+    }
+
+    private static func fetchWeather(
+        for location: CLLocation,
+        unit: LockScreenWeatherTemperatureUnit
+    ) async throws -> WeatherData {
+        var components = URLComponents(string: "https://api.open-meteo.com/v1/forecast")!
+        components.queryItems = [
+            URLQueryItem(name: "latitude", value: String(location.coordinate.latitude)),
+            URLQueryItem(name: "longitude", value: String(location.coordinate.longitude)),
+            URLQueryItem(name: "current", value: "temperature_2m,weather_code"),
+            URLQueryItem(name: "daily", value: "sunrise,sunset"),
+            URLQueryItem(name: "timezone", value: "auto"),
+        ]
+        if unit == .fahrenheit {
+            components.queryItems?.append(URLQueryItem(name: "temperature_unit", value: "fahrenheit"))
+        }
+
+        let (data, response) = try await URLSession.shared.data(from: components.url!)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw URLError(.badServerResponse)
+        }
+
+        let decoded = try JSONDecoder().decode(OpenMeteoResponse.self, from: data)
+        let formatter = ISO8601DateFormatter()
+        let sunrise = decoded.daily.sunrise.first.flatMap(formatter.date(from:))
+        let sunset = decoded.daily.sunset.first.flatMap(formatter.date(from:))
+        return WeatherData(
+            temperature: decoded.current.temperature,
+            weatherCode: decoded.current.weatherCode,
+            sunrise: sunrise,
+            sunset: sunset,
+            aqi: nil,
+            locationName: nil
+        )
+    }
+
+    private static func locationName(for location: CLLocation) async -> String? {
+        guard let place = try? await CLGeocoder().reverseGeocodeLocation(location).first else { return nil }
+        return place.locality ?? place.administrativeArea ?? place.country
+    }
+
+    private static func symbol(for weatherCode: Int) -> String {
+        switch weatherCode {
+        case 0: "sun.max.fill"
+        case 1, 2: "cloud.sun.fill"
+        case 3: "cloud.fill"
+        case 45, 48: "cloud.fog.fill"
+        case 51, 53, 55, 56, 57: "cloud.drizzle.fill"
+        case 61, 63, 65, 66, 67, 80, 81, 82: "cloud.rain.fill"
+        case 71, 73, 75, 77, 85, 86: "cloud.snow.fill"
+        case 95, 96, 99: "cloud.bolt.rain.fill"
+        default: "cloud.fill"
+        }
+    }
+
+    private static func description(for weatherCode: Int) -> String {
+        switch weatherCode {
+        case 0: LockScreenText.value("Clear", "晴朗")
+        case 1, 2: LockScreenText.value("Partly cloudy", "晴间多云")
+        case 3: LockScreenText.value("Overcast", "阴天")
+        case 45, 48: LockScreenText.value("Foggy", "有雾")
+        case 51, 53, 55, 56, 57: LockScreenText.value("Drizzle", "毛毛雨")
+        case 61, 63, 65, 66, 67, 80, 81, 82: LockScreenText.value("Rain", "下雨")
+        case 71, 73, 75, 77, 85, 86: LockScreenText.value("Snow", "下雪")
+        case 95, 96, 99: LockScreenText.value("Thunderstorm", "雷暴")
+        default: LockScreenText.value("Weather", "天气")
+        }
+    }
+}
+
+@MainActor
+private final class LockScreenFocusMonitor: NSObject, ObservableObject {
+    static let shared = LockScreenFocusMonitor()
+
+    @Published private(set) var isActive: Bool
+    @Published private(set) var name: String
+    private var observers: [NSObjectProtocol] = []
+    private var cancellables = Set<AnyCancellable>()
+
+    private override init() {
+        isActive = Defaults[.lockScreenFocusActive]
+        name = Defaults[.lockScreenFocusName]
+        super.init()
+
+        let center = DistributedNotificationCenter.default()
+        observers.append(center.addObserver(
+            forName: Notification.Name("_NSDoNotDisturbEnabledNotification"),
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let focusName = notification.userInfo?["FocusModeName"] as? String
+            Task { @MainActor in self?.setFocus(active: true, name: focusName) }
+        })
+        observers.append(center.addObserver(
+            forName: Notification.Name("_NSDoNotDisturbDisabledNotification"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.setFocus(active: false, name: nil) }
+        })
+
+        Defaults.publisher(.lockScreenFocusActive)
+            .sink { [weak self] change in self?.isActive = change.newValue }
+            .store(in: &cancellables)
+        Defaults.publisher(.lockScreenFocusName)
+            .sink { [weak self] change in self?.name = change.newValue }
+            .store(in: &cancellables)
+    }
+
+    private func setFocus(active: Bool, name: String?) {
+        isActive = active
+        if let focusName = name, !focusName.isEmpty {
+            self.name = focusName
+        }
+    }
+}
+
+private struct WeatherData: Equatable {
+    let temperature: Double
+    let weatherCode: Int
+    let sunrise: Date?
+    let sunset: Date?
+    let aqi: Int?
+    let locationName: String?
+
+    func with(locationName: String?) -> Self {
+        Self(
+            temperature: temperature,
+            weatherCode: weatherCode,
+            sunrise: sunrise,
+            sunset: sunset,
+            aqi: aqi,
+            locationName: locationName
+        )
+    }
+}
+
+private struct OpenMeteoResponse: Decodable {
+    struct Current: Decodable {
+        let temperature: Double
+        let weatherCode: Int
+
+        enum CodingKeys: String, CodingKey {
+            case temperature = "temperature_2m"
+            case weatherCode = "weather_code"
+        }
+    }
+
+    struct Daily: Decodable {
+        let sunrise: [String]
+        let sunset: [String]
+    }
+
+    let current: Current
+    let daily: Daily
+}
+
+struct LockScreenWeatherSnapshot: Equatable {
+    let temperature: Double?
+    let unitSymbol: String
+    let symbolName: String
+    let description: String
+    let locationName: String?
+    let sunrise: Date?
+    let aqi: Int?
+    let batteryLevel: Int?
+    let isCharging: Bool
+    let isPluggedIn: Bool
+    let chargingPercentage: Int?
+    let bluetoothName: String?
+    let calendarTitle: String?
+    let calendarStart: Date?
+    let focusName: String?
+    let style: LockScreenWeatherWidgetStyle
+
+    static let placeholder = Self(
+        temperature: nil, unitSymbol: "°", symbolName: "cloud.fill",
+        description: LockScreenText.value("Weather unavailable", "天气暂不可用"),
+        locationName: nil, sunrise: nil, aqi: nil, batteryLevel: nil, isCharging: false,
+        isPluggedIn: false, chargingPercentage: nil, bluetoothName: nil, calendarTitle: nil,
+        calendarStart: nil, focusName: nil, style: .inline
+    )
+}
+
+private struct LockScreenWeatherWidgetView: View {
+    let snapshot: LockScreenWeatherSnapshot
+
+    var body: some View {
+        switch snapshot.style {
+        case .inline: inlineWidget
+        case .circular: circularWidget
+        }
+    }
+
+    private var inlineWidget: some View {
+        LockScreenWidgetCard(cornerRadius: 26) {
+            HStack(spacing: 13) {
+                Image(systemName: snapshot.symbolName)
+                    .font(.system(size: 29, weight: .medium))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(.yellow)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(temperatureText)
+                        .font(.system(size: 25, weight: .bold, design: .rounded))
+                    Text(snapshot.locationName ?? snapshot.description)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .frame(width: 106, alignment: .leading)
+
+                Divider().frame(height: 44)
+                statusColumn
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 17)
+            .frame(width: 500, height: 88)
+        }
+    }
+
+    private var circularWidget: some View {
+        LockScreenWidgetCard(cornerRadius: 80) {
+            VStack(spacing: 4) {
+                Image(systemName: snapshot.symbolName)
+                    .font(.system(size: 34, weight: .medium))
+                    .foregroundStyle(.yellow)
+                Text(temperatureText)
+                    .font(.system(size: 31, weight: .bold, design: .rounded))
+                Text(snapshot.locationName ?? snapshot.description)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .frame(maxWidth: 120)
+            }
+            .frame(width: 160, height: 160)
+        }
+    }
+
+    @ViewBuilder
+    private var statusColumn: some View {
+        LazyVGrid(
+            columns: [GridItem(.flexible()), GridItem(.flexible())],
+            alignment: .leading,
+            spacing: 5
+        ) {
+            if let calendarTitle = snapshot.calendarTitle {
+                statusRow("calendar", text: calendarTitle, detail: snapshot.calendarStart.map { $0.formatted(date: .omitted, time: .shortened) })
+            }
+            if let focusName = snapshot.focusName {
+                statusRow("moon.zzz.fill", text: focusName, detail: nil)
+            }
+            if let batteryLevel = snapshot.batteryLevel {
+                statusRow(
+                    snapshot.isCharging ? "battery.100.bolt" : "battery.100",
+                    text: "\(batteryLevel)%",
+                    detail: batteryDetail
+                )
+            }
+            if let bluetoothName = snapshot.bluetoothName {
+                statusRow("bluetooth", text: bluetoothName, detail: nil)
+            }
+            if let aqi = snapshot.aqi {
+                statusRow("aqi.medium", text: "AQI \(aqi)", detail: nil)
+            }
+            if let sunrise = snapshot.sunrise {
+                statusRow("sunrise.fill", text: sunrise.formatted(date: .omitted, time: .shortened), detail: nil)
+            }
+        }
+        .font(.system(size: 12, weight: .medium))
+        .frame(width: 300, alignment: .leading)
+    }
+
+    private var batteryDetail: String? {
+        guard snapshot.isPluggedIn else { return nil }
+        if snapshot.isCharging, let percentage = snapshot.chargingPercentage {
+            return LockScreenText.value("Charging \(percentage)%", "正在充电 \(percentage)%")
+        }
+        return snapshot.isCharging
+            ? LockScreenText.value("Charging", "正在充电")
+            : LockScreenText.value("Plugged in", "已接通电源")
+    }
+
+    private var temperatureText: String {
+        guard let temperature = snapshot.temperature else { return "--" }
+        return "\(Int(temperature.rounded()))\(snapshot.unitSymbol)"
+    }
+
+    private func statusRow(_ icon: String, text: String, detail: String?) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .frame(width: 14)
+                .foregroundStyle(.secondary)
+            Text(text)
+                .lineLimit(1)
+            if let detail {
+                Text(detail)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+    }
+}

--- a/boringNotch/managers/LockScreenWeatherWidgetManager.swift
+++ b/boringNotch/managers/LockScreenWeatherWidgetManager.swift
@@ -202,7 +202,7 @@ final class LockScreenWeatherWidgetManager: NSObject, ObservableObject, CLLocati
             unitSymbol: Defaults[.lockScreenWeatherTemperatureUnit].symbol,
             symbolName: weather.map { Self.symbol(for: $0.weatherCode) } ?? "cloud.fill",
             description: weather.map { Self.description(for: $0.weatherCode) }
-                ?? LockScreenText.value("Weather unavailable", "天气暂不可用"),
+                ?? LockScreenText.value("Weather unavailable"),
             locationName: Defaults[.lockScreenWeatherShowsLocation] ? weather?.locationName : nil,
             sunrise: Defaults[.lockScreenWeatherShowsSunrise] ? weather?.sunrise : nil,
             aqi: Defaults[.lockScreenWeatherShowsAQI] ? weather?.aqi : nil,
@@ -274,15 +274,15 @@ final class LockScreenWeatherWidgetManager: NSObject, ObservableObject, CLLocati
 
     private static func description(for weatherCode: Int) -> String {
         switch weatherCode {
-        case 0: LockScreenText.value("Clear", "晴朗")
-        case 1, 2: LockScreenText.value("Partly cloudy", "晴间多云")
-        case 3: LockScreenText.value("Overcast", "阴天")
-        case 45, 48: LockScreenText.value("Foggy", "有雾")
-        case 51, 53, 55, 56, 57: LockScreenText.value("Drizzle", "毛毛雨")
-        case 61, 63, 65, 66, 67, 80, 81, 82: LockScreenText.value("Rain", "下雨")
-        case 71, 73, 75, 77, 85, 86: LockScreenText.value("Snow", "下雪")
-        case 95, 96, 99: LockScreenText.value("Thunderstorm", "雷暴")
-        default: LockScreenText.value("Weather", "天气")
+        case 0: LockScreenText.value("Clear")
+        case 1, 2: LockScreenText.value("Partly cloudy")
+        case 3: LockScreenText.value("Overcast")
+        case 45, 48: LockScreenText.value("Foggy")
+        case 51, 53, 55, 56, 57: LockScreenText.value("Drizzle")
+        case 61, 63, 65, 66, 67, 80, 81, 82: LockScreenText.value("Rain")
+        case 71, 73, 75, 77, 85, 86: LockScreenText.value("Snow")
+        case 95, 96, 99: LockScreenText.value("Thunderstorm")
+        default: LockScreenText.value("Weather")
         }
     }
 }
@@ -394,7 +394,7 @@ struct LockScreenWeatherSnapshot: Equatable {
 
     static let placeholder = Self(
         temperature: nil, unitSymbol: "°", symbolName: "cloud.fill",
-        description: LockScreenText.value("Weather unavailable", "天气暂不可用"),
+        description: LockScreenText.value("Weather unavailable"),
         locationName: nil, sunrise: nil, aqi: nil, batteryLevel: nil, isCharging: false,
         isPluggedIn: false, chargingPercentage: nil, bluetoothName: nil, calendarTitle: nil,
         calendarStart: nil, focusName: nil, style: .inline
@@ -493,11 +493,11 @@ private struct LockScreenWeatherWidgetView: View {
     private var batteryDetail: String? {
         guard snapshot.isPluggedIn else { return nil }
         if snapshot.isCharging, let percentage = snapshot.chargingPercentage {
-            return LockScreenText.value("Charging \(percentage)%", "正在充电 \(percentage)%")
+            return String(format: LockScreenText.value("Charging %@"), "\(percentage)%")
         }
         return snapshot.isCharging
-            ? LockScreenText.value("Charging", "正在充电")
-            : LockScreenText.value("Plugged in", "已接通电源")
+            ? LockScreenText.value("Charging")
+            : LockScreenText.value("Plugged in")
     }
 
     private var temperatureText: String {

--- a/boringNotch/managers/LockScreenWidgetSupport.swift
+++ b/boringNotch/managers/LockScreenWidgetSupport.swift
@@ -1,0 +1,244 @@
+//
+//  LockScreenWidgetSupport.swift
+//  boringNotch
+//
+//  Shared SkyLight window and display placement support for lock-screen widgets.
+//
+
+import AppKit
+import CoreGraphics
+import Defaults
+import Foundation
+import SkyLightWindow
+import SwiftUI
+
+enum LockScreenText {
+    static func value(_ english: String, _ simplifiedChinese: String) -> String {
+        let selectedLanguage = Defaults[.appLanguage]
+        let usesChinese = selectedLanguage.rawValue.hasPrefix("zh")
+            || (selectedLanguage == .system && Locale.preferredLanguages.first?.hasPrefix("zh") == true)
+        return usesChinese ? simplifiedChinese : english
+    }
+}
+
+struct LockScreenDisplayContext {
+    let screen: NSScreen
+    let frame: NSRect
+}
+
+@MainActor
+final class LockScreenDisplayContextProvider {
+    static let shared = LockScreenDisplayContextProvider()
+
+    private var context: LockScreenDisplayContext?
+    private var observers: [NSObjectProtocol] = []
+
+    private init() {
+        refresh()
+
+        observers.append(NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                _ = self?.refresh()
+            }
+        })
+
+        observers.append(NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.screensDidWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                _ = self?.refresh()
+            }
+        })
+    }
+
+    func snapshot() -> LockScreenDisplayContext? {
+        context ?? refresh()
+    }
+
+    @discardableResult
+    func refresh() -> LockScreenDisplayContext? {
+        guard let screen = preferredScreen() else {
+            context = nil
+            return nil
+        }
+
+        let newContext = LockScreenDisplayContext(screen: screen, frame: screen.frame)
+        context = newContext
+        return newContext
+    }
+
+    private func preferredScreen() -> NSScreen? {
+        if let builtIn = NSScreen.screens.first(where: { screen in
+            guard let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
+                return false
+            }
+            return CGDisplayIsBuiltin(CGDirectDisplayID(number.uint32Value)) != 0
+        }) {
+            return builtIn
+        }
+
+        return NSScreen.main ?? NSScreen.screens.first
+    }
+}
+
+@MainActor
+final class LockScreenWidgetPanel {
+    private var window: NSPanel?
+    private var delegatedToSkyLight = false
+    private let allowsInteraction: Bool
+
+    init(allowsInteraction: Bool) {
+        self.allowsInteraction = allowsInteraction
+    }
+
+    var isVisible: Bool { window?.isVisible == true }
+    var frame: NSRect? { window?.frame }
+
+    func show<Content: View>(
+        _ content: Content,
+        frame: NSRect,
+        cornerRadius: CGFloat = 24
+    ) {
+        let panel = ensureWindow(frame: frame)
+        let hostingView = NSHostingView(rootView: content)
+        hostingView.frame = NSRect(origin: .zero, size: frame.size)
+        hostingView.autoresizingMask = [.width, .height]
+
+        panel.setFrame(frame, display: true)
+        panel.contentView = hostingView
+        panel.ignoresMouseEvents = !allowsInteraction
+        panel.sharingType = Defaults[.hideFromScreenRecording] ? .none : .readWrite
+
+        if let contentView = panel.contentView {
+            contentView.wantsLayer = true
+            contentView.layer?.masksToBounds = true
+            contentView.layer?.cornerRadius = cornerRadius
+        }
+
+        if !delegatedToSkyLight {
+            SkyLightOperator.shared.delegateWindow(panel)
+            delegatedToSkyLight = true
+        }
+
+        panel.orderFrontRegardless()
+    }
+
+    func move(to frame: NSRect) {
+        window?.setFrame(frame, display: true)
+    }
+
+    func hide() {
+        window?.orderOut(nil)
+    }
+
+    private func ensureWindow(frame: NSRect) -> NSPanel {
+        if let window { return window }
+
+        let newWindow = NSPanel(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        newWindow.isReleasedWhenClosed = false
+        newWindow.isOpaque = false
+        newWindow.backgroundColor = .clear
+        newWindow.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        newWindow.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+        newWindow.isMovable = false
+        newWindow.hasShadow = false
+        newWindow.hidesOnDeactivate = false
+        newWindow.acceptsMouseMovedEvents = allowsInteraction
+        newWindow.ignoresMouseEvents = !allowsInteraction
+        window = newWindow
+        return newWindow
+    }
+}
+
+struct LockScreenWidgetCard<Content: View>: View {
+    let content: Content
+    let cornerRadius: CGFloat
+
+    init(cornerRadius: CGFloat = 24, @ViewBuilder content: () -> Content) {
+        self.cornerRadius = cornerRadius
+        self.content = content()
+    }
+
+    var body: some View {
+        let appearance = Defaults[.lockScreenWidgetAppearance]
+        content
+            .foregroundStyle(appearance == .dark ? .white : .black)
+            .background(background(for: appearance))
+            .overlay {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(
+                        appearance == .dark ? .white.opacity(0.18) : .black.opacity(0.12),
+                        lineWidth: 1
+                    )
+            }
+            .preferredColorScheme(appearance == .dark ? .dark : .light)
+    }
+
+    @ViewBuilder
+    private func background(for appearance: LockScreenWidgetAppearance) -> some View {
+        if #available(macOS 26.0, *) {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .fill(.clear)
+                .glassEffect(
+                    .clear.tint(appearance == .dark ? .white.opacity(0.16) : .white.opacity(0.28)),
+                    in: .rect(cornerRadius: cornerRadius)
+                )
+        } else {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .fill(appearance == .dark ? Color.black.opacity(0.28) : Color.white.opacity(0.48))
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        }
+    }
+}
+
+enum LockScreenWidgetLayout {
+    static func media(in screen: NSRect, size: CGSize) -> NSRect {
+        NSRect(
+            x: screen.midX - size.width / 2,
+            y: screen.midY - size.height - 100,
+            width: size.width,
+            height: size.height
+        )
+    }
+
+    static func timer(in screen: NSRect, size: CGSize, offset: CGFloat) -> NSRect {
+        let y = max(screen.minY + 100, screen.midY - 84 + clamped(offset))
+        return NSRect(x: screen.midX - size.width / 2, y: y, width: size.width, height: size.height)
+    }
+
+    static func weather(in screen: NSRect, size: CGSize, offset: CGFloat) -> NSRect {
+        let y = min(screen.maxY - size.height - 72, screen.midY + 76 + clamped(offset))
+        return NSRect(x: screen.midX - size.width / 2, y: y, width: size.width, height: size.height)
+    }
+
+    static func reminder(
+        in screen: NSRect,
+        size: CGSize,
+        alignment: LockScreenReminderAlignment,
+        offset: CGFloat
+    ) -> NSRect {
+        let x: CGFloat
+        switch alignment {
+        case .leading: x = screen.minX + 24
+        case .center: x = screen.midX - size.width / 2
+        case .trailing: x = screen.maxX - size.width - 24
+        }
+        let y = min(screen.maxY - size.height - 40, screen.midY + 8 + clamped(offset))
+        return NSRect(x: x, y: y, width: size.width, height: size.height)
+    }
+
+    private static func clamped(_ offset: CGFloat) -> CGFloat {
+        min(max(offset, -160), 160)
+    }
+}

--- a/boringNotch/managers/LockScreenWidgetSupport.swift
+++ b/boringNotch/managers/LockScreenWidgetSupport.swift
@@ -13,12 +13,92 @@ import SkyLightWindow
 import SwiftUI
 
 enum LockScreenText {
-    static func value(_ english: String, _ simplifiedChinese: String) -> String {
-        let selectedLanguage = Defaults[.appLanguage]
-        let usesChinese = selectedLanguage.rawValue.hasPrefix("zh")
-            || (selectedLanguage == .system && Locale.preferredLanguages.first?.hasPrefix("zh") == true)
-        return usesChinese ? simplifiedChinese : english
+    static func value(_ key: String) -> String {
+        let localized = NSLocalizedString(key, comment: "")
+        guard localized == key, usesSimplifiedChinese else { return localized }
+        return simplifiedChinese[key] ?? key
     }
+
+    private static var usesSimplifiedChinese: Bool {
+        let selectedLanguage = Defaults[.appLanguage]
+        return selectedLanguage.rawValue.hasPrefix("zh")
+            || (selectedLanguage == .system && Locale.preferredLanguages.first?.hasPrefix("zh") == true)
+    }
+
+    private static let simplifiedChinese: [String: String] = [
+        "Alignment": "对齐方式",
+        "Allow location access": "允许访问位置",
+        "Appearance": "外观",
+        "Calendar look-ahead": "日历预览范围",
+        "Cancel": "取消",
+        "Cancel timer": "取消计时",
+        "Center": "居中",
+        "Charging": "正在充电",
+        "Charging %@": "正在充电 %@",
+        "Circular": "圆形",
+        "Clear": "晴朗",
+        "Celsius": "摄氏度",
+        "Dark": "深色",
+        "Displays the next incomplete reminder that is due within the calendar look-ahead window.": "显示日历预览范围内下一条未完成且到期的提醒事项。",
+        "Drizzle": "毛毛雨",
+        "Duration": "时长",
+        "Fahrenheit": "华氏度",
+        "Focus": "专注模式",
+        "Focus is active": "专注模式已开启",
+        "Focus name": "专注模式名称",
+        "Foggy": "有雾",
+        "Inline": "横向",
+        "Left": "左侧",
+        "Light": "浅色",
+        "Lock Screen": "锁定屏幕",
+        "minutes": "分钟",
+        "Minutes": "分钟",
+        "Next track": "下一首",
+        "Not Playing": "未在播放",
+        "Overcast": "阴天",
+        "Partly cloudy": "晴间多云",
+        "Pause": "暂停",
+        "Pause timer": "暂停计时",
+        "Play": "播放",
+        "Plugged in": "已接通电源",
+        "Previous track": "上一首",
+        "px": "像素",
+        "Rain": "下雨",
+        "Reminder": "提醒事项",
+        "Reminders": "提醒事项",
+        "Remaining": "剩余时间",
+        "Restart timer": "重新开始计时",
+        "Resume timer": "继续计时",
+        "Right": "右侧",
+        "Show air quality": "显示空气质量",
+        "Show Bluetooth audio output": "显示蓝牙音频输出",
+        "Show charging percentage": "显示充电百分比",
+        "Show charging state": "显示充电状态",
+        "Show Focus status": "显示专注模式状态",
+        "Show location": "显示位置",
+        "Show Mac battery": "显示 Mac 电池",
+        "Show media widget": "显示媒体小组件",
+        "Show next calendar event": "显示下一个日历事件",
+        "Show reminder widget": "显示提醒事项小组件",
+        "Show sunrise": "显示日出时间",
+        "Show timer widget": "显示计时器小组件",
+        "Show weather and status widget": "显示天气与状态小组件",
+        "Snow": "下雪",
+        "Start timer": "开始计时",
+        "Status rows": "状态信息",
+        "Style": "样式",
+        "Temperature": "温度单位",
+        "Thunderstorm": "雷暴",
+        "Timer": "计时器",
+        "Vertical offset": "垂直偏移",
+        "Weather": "天气",
+        "Weather is provided by Open-Meteo. Boring Notch asks for your location only after you allow it.": "天气数据由 Open-Meteo 提供。只有在你允许后，Boring Notch 才会请求位置。",
+        "Weather unavailable": "天气暂不可用",
+        "Widgets": "小组件",
+        "Widgets are only visible while the Mac is locked. Enable the widgets you want below.": "小组件只会在 Mac 锁定时显示。请在下方启用需要的组件。",
+        "Width": "宽度",
+        "h": "小时"
+    ]
 }
 
 struct LockScreenDisplayContext {

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -38,8 +38,8 @@ enum LockScreenWidgetAppearance: String, CaseIterable, Identifiable, Defaults.Se
 
     var title: String {
         switch self {
-        case .dark: LockScreenText.value("Dark", "深色")
-        case .light: LockScreenText.value("Light", "浅色")
+        case .dark: LockScreenText.value("Dark")
+        case .light: LockScreenText.value("Light")
         }
     }
 }
@@ -52,8 +52,8 @@ enum LockScreenWeatherWidgetStyle: String, CaseIterable, Identifiable, Defaults.
 
     var title: String {
         switch self {
-        case .inline: LockScreenText.value("Inline", "横向")
-        case .circular: LockScreenText.value("Circular", "圆形")
+        case .inline: LockScreenText.value("Inline")
+        case .circular: LockScreenText.value("Circular")
         }
     }
 }
@@ -66,8 +66,8 @@ enum LockScreenWeatherTemperatureUnit: String, CaseIterable, Identifiable, Defau
 
     var title: String {
         switch self {
-        case .celsius: LockScreenText.value("Celsius", "摄氏度")
-        case .fahrenheit: LockScreenText.value("Fahrenheit", "华氏度")
+        case .celsius: LockScreenText.value("Celsius")
+        case .fahrenheit: LockScreenText.value("Fahrenheit")
         }
     }
 
@@ -92,9 +92,9 @@ enum LockScreenReminderAlignment: String, CaseIterable, Identifiable, Defaults.S
 
     var title: String {
         switch self {
-        case .leading: LockScreenText.value("Left", "左侧")
-        case .center: LockScreenText.value("Center", "居中")
-        case .trailing: LockScreenText.value("Right", "右侧")
+        case .leading: LockScreenText.value("Left")
+        case .center: LockScreenText.value("Center")
+        case .trailing: LockScreenText.value("Right")
         }
     }
 }

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -30,6 +30,75 @@ enum HideNotchOption: String, Defaults.Serializable {
     case never
 }
 
+enum LockScreenWidgetAppearance: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case dark
+    case light
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .dark: LockScreenText.value("Dark", "深色")
+        case .light: LockScreenText.value("Light", "浅色")
+        }
+    }
+}
+
+enum LockScreenWeatherWidgetStyle: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case inline
+    case circular
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .inline: LockScreenText.value("Inline", "横向")
+        case .circular: LockScreenText.value("Circular", "圆形")
+        }
+    }
+}
+
+enum LockScreenWeatherTemperatureUnit: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case celsius
+    case fahrenheit
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .celsius: LockScreenText.value("Celsius", "摄氏度")
+        case .fahrenheit: LockScreenText.value("Fahrenheit", "华氏度")
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .celsius: "°C"
+        case .fahrenheit: "°F"
+        }
+    }
+
+    static var matchingSystemPreference: Self {
+        UnitTemperature(forLocale: .current) == .fahrenheit ? .fahrenheit : .celsius
+    }
+}
+
+enum LockScreenReminderAlignment: String, CaseIterable, Identifiable, Defaults.Serializable {
+    case leading
+    case center
+    case trailing
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .leading: LockScreenText.value("Left", "左侧")
+        case .center: LockScreenText.value("Center", "居中")
+        case .trailing: LockScreenText.value("Right", "右侧")
+        }
+    }
+}
+
 struct AppLanguage: RawRepresentable, Hashable, Identifiable, Defaults.Serializable {
     static let system = AppLanguage(rawValue: "system")
 
@@ -231,6 +300,45 @@ extension Defaults.Keys {
     static let notchHeight = Key<CGFloat>("notchHeight", default: 32)
     //static let openLastTabByDefault = Key<Bool>("openLastTabByDefault", default: false)
     static let showOnLockScreen = Key<Bool>("showOnLockScreen", default: false)
+    static let enableLockScreenMediaWidget = Key<Bool>("enableLockScreenMediaWidget", default: false)
+    static let enableLockScreenWeatherWidget = Key<Bool>("enableLockScreenWeatherWidget", default: false)
+    static let enableLockScreenFocusWidget = Key<Bool>("enableLockScreenFocusWidget", default: false)
+    static let enableLockScreenReminderWidget = Key<Bool>("enableLockScreenReminderWidget", default: false)
+    static let enableLockScreenTimerWidget = Key<Bool>("enableLockScreenTimerWidget", default: false)
+    static let lockScreenWidgetAppearance = Key<LockScreenWidgetAppearance>(
+        "lockScreenWidgetAppearance", default: .dark
+    )
+    static let lockScreenWeatherRefreshInterval = Key<TimeInterval>(
+        "lockScreenWeatherRefreshInterval", default: 30 * 60
+    )
+    static let lockScreenWeatherShowsLocation = Key<Bool>("lockScreenWeatherShowsLocation", default: true)
+    static let lockScreenWeatherShowsSunrise = Key<Bool>("lockScreenWeatherShowsSunrise", default: true)
+    static let lockScreenWeatherWidgetStyle = Key<LockScreenWeatherWidgetStyle>(
+        "lockScreenWeatherWidgetStyle", default: .inline
+    )
+    static let lockScreenWeatherTemperatureUnit = Key<LockScreenWeatherTemperatureUnit>(
+        "lockScreenWeatherTemperatureUnit", default: .matchingSystemPreference
+    )
+    static let lockScreenWeatherShowsAQI = Key<Bool>("lockScreenWeatherShowsAQI", default: true)
+    static let lockScreenWeatherVerticalOffset = Key<Double>("lockScreenWeatherVerticalOffset", default: 0)
+    static let lockScreenTimerVerticalOffset = Key<Double>("lockScreenTimerVerticalOffset", default: 0)
+    static let lockScreenTimerWidgetWidth = Key<Double>("lockScreenTimerWidgetWidth", default: 350)
+    static let lockScreenReminderWidgetHorizontalAlignment = Key<LockScreenReminderAlignment>(
+        "lockScreenReminderWidgetHorizontalAlignment", default: .center
+    )
+    static let lockScreenReminderWidgetVerticalOffset = Key<Double>("lockScreenReminderWidgetVerticalOffset", default: 0)
+    static let lockScreenCalendarEventLookaheadHours = Key<Double>(
+        "lockScreenCalendarEventLookaheadHours", default: 3
+    )
+    static let lockScreenBatteryShowsBatteryGauge = Key<Bool>("lockScreenWeatherShowsBatteryGauge", default: true)
+    static let lockScreenBatteryShowsCharging = Key<Bool>("lockScreenWeatherShowsCharging", default: true)
+    static let lockScreenBatteryShowsChargingPercentage = Key<Bool>(
+        "lockScreenWeatherShowsChargingPercentage", default: true
+    )
+    static let lockScreenBatteryShowsBluetooth = Key<Bool>("lockScreenWeatherShowsBluetooth", default: true)
+    static let lockScreenShowCalendarEvent = Key<Bool>("lockScreenShowCalendarEvent", default: true)
+    static let lockScreenFocusName = Key<String>("lockScreenFocusName", default: "Do Not Disturb")
+    static let lockScreenFocusActive = Key<Bool>("lockScreenFocusActive", default: false)
     static let hideFromScreenRecording = Key<Bool>("hideFromScreenRecording", default: false)
     
     // MARK: Appearance


### PR DESCRIPTION
## Summary
- Add configurable lock-screen widgets for media, weather and status, timers, reminders, and focus status.
- Localize the new controls to match the selected app or system language.
- Use Liquid Glass on supported macOS versions with a material fallback.
- Commit media seeking only after the progress slider drag ends.

## Validation
- `xcodebuild -project boringNotch.xcodeproj -scheme boringNotch -configuration Debug -destination platform=macOS CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
- `plutil -lint boringNotch/Info.plist`
