### PR TITLE
Notification live activity on the notch [1/4]

### DIFF
--- a/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
@@ -106,7 +106,7 @@ class BoringNotchXPCHelper: NSObject, BoringNotchXPCHelperProtocol {
         DispatchQueue.main.async {
             let watcher = Self.watcher
             watcher.onBanner = { notification in
-                NSLog("[boringNotch] captured banner: app=\(notification.appName ?? "-") bundle=\(notification.bundleID ?? "-") title=\(notification.title ?? "-")")
+                NSLog("[boringNotch] captured banner: app=\(notification.appName ?? "-") bundle=\(notification.bundleID ?? "-") title=\(notification.title ?? "-") delegate=\(delegate == nil ? "nil" : "ok")")
                 delegate?.notificationDidAppear([
                     "token": notification.token,
                     "appName": notification.appName ?? "",

--- a/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
@@ -132,6 +132,15 @@ class BoringNotchXPCHelper: NSObject, BoringNotchXPCHelperProtocol {
         DispatchQueue.main.async { reply(Self.watcher.reply(token: token, text: text)) }
     }
 
+    /// Sends an iMessage directly through the Messages scripting
+    /// dictionary, bypassing the notification entirely. The app falls back
+    /// to this when the AX reply above fails because the banner has faded —
+    /// for Messages that recovers a real send instead of a clipboard
+    /// hand-off. No other supported app offers an equivalent.
+    @objc func sendIMessage(_ text: String, toChatNamed name: String, with reply: @escaping (Bool) -> Void) {
+        DispatchQueue.main.async { reply(MessagesSender.send(text, toChatNamed: name)) }
+    }
+
     @objc func performNotificationAction(_ token: String, name: String, with reply: @escaping (Bool) -> Void) {
         DispatchQueue.main.async { reply(Self.watcher.performAction(token: token, name: name)) }
     }

--- a/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
@@ -87,12 +87,26 @@ class BoringNotchXPCHelper: NSObject, BoringNotchXPCHelperProtocol {
     @objc func startNotificationWatching(with reply: @escaping (Bool) -> Void) {
         // Capture the delegate for this connection before hopping queues —
         // NSXPCConnection.current() is only valid inside the incoming call.
-        let delegate = NSXPCConnection.current()?.remoteObjectProxy as? BoringNotchXPCHelperDelegate
+        //
+        // Cast to BoringNotchXPCAppDelegate, not its parent protocol: the
+        // proxy's conformance is built from the exact interface the
+        // connection was configured with, so casting to the parent can
+        // return nil and silently swallow every callback.
+        let connection = NSXPCConnection.current()
+        let proxy = connection?.remoteObjectProxyWithErrorHandler { error in
+            NSLog("[boringNotch] notification callback failed: \(error.localizedDescription)")
+        }
+        let delegate = proxy as? BoringNotchXPCAppDelegate
+
+        if delegate == nil {
+            NSLog("[boringNotch] could not obtain notification delegate proxy — banners will not reach the app")
+        }
 
         // The AX observer needs a live run loop; the helper's is on main.
         DispatchQueue.main.async {
             let watcher = Self.watcher
             watcher.onBanner = { notification in
+                NSLog("[boringNotch] captured banner: app=\(notification.appName ?? "-") bundle=\(notification.bundleID ?? "-") title=\(notification.title ?? "-")")
                 delegate?.notificationDidAppear([
                     "token": notification.token,
                     "appName": notification.appName ?? "",
@@ -104,7 +118,9 @@ class BoringNotchXPCHelper: NSObject, BoringNotchXPCHelperProtocol {
                 ])
             }
             watcher.onBannerGone = { delegate?.notificationDidDisappear($0) }
-            reply(watcher.start())
+            let started = watcher.start()
+            NSLog("[boringNotch] notification watcher start -> \(started), AX trusted: \(AXIsProcessTrusted())")
+            reply(started)
         }
     }
 

--- a/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
@@ -157,6 +157,14 @@ class BoringNotchXPCHelper: NSObject, BoringNotchXPCHelperProtocol {
         DispatchQueue.main.async { reply(Self.watcher.dismiss(token: token)) }
     }
 
+    @objc func holdNotification(_ token: String, offScreen: Bool) {
+        DispatchQueue.main.async { Self.watcher.hold(token: token, offScreen: offScreen) }
+    }
+
+    @objc func releaseNotification(_ token: String) {
+        DispatchQueue.main.async { Self.watcher.release(token: token) }
+    }
+
     private class KeyboardBrightnessClient {
         private static let keyboardID: UInt64 = 1
         private var clientInstance: NSObject?

--- a/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
@@ -78,6 +78,60 @@ class BoringNotchXPCHelper: NSObject, BoringNotchXPCHelperProtocol {
         }
     }
     
+    // MARK: - Notification Center banners
+
+    /// One watcher for the whole helper: `BoringNotchXPCHelper` is created per
+    /// connection, the AX observer must not be.
+    private static let watcher = NotificationWatcher()
+
+    @objc func startNotificationWatching(with reply: @escaping (Bool) -> Void) {
+        // Capture the delegate for this connection before hopping queues —
+        // NSXPCConnection.current() is only valid inside the incoming call.
+        let delegate = NSXPCConnection.current()?.remoteObjectProxy as? BoringNotchXPCHelperDelegate
+
+        // The AX observer needs a live run loop; the helper's is on main.
+        DispatchQueue.main.async {
+            let watcher = Self.watcher
+            watcher.onBanner = { notification in
+                delegate?.notificationDidAppear([
+                    "token": notification.token,
+                    "appName": notification.appName ?? "",
+                    "bundleID": notification.bundleID ?? "",
+                    "title": notification.title ?? "",
+                    "subtitle": notification.subtitle ?? "",
+                    "body": notification.body ?? "",
+                    "actions": notification.actions.joined(separator: "\n")
+                ])
+            }
+            watcher.onBannerGone = { delegate?.notificationDidDisappear($0) }
+            reply(watcher.start())
+        }
+    }
+
+    @objc func stopNotificationWatching() {
+        DispatchQueue.main.async { Self.watcher.stop() }
+    }
+
+    @objc func replyToNotification(_ token: String, text: String, with reply: @escaping (Bool) -> Void) {
+        DispatchQueue.main.async { reply(Self.watcher.reply(token: token, text: text)) }
+    }
+
+    @objc func performNotificationAction(_ token: String, name: String, with reply: @escaping (Bool) -> Void) {
+        DispatchQueue.main.async { reply(Self.watcher.performAction(token: token, name: name)) }
+    }
+
+    @objc func openNotification(_ token: String, with reply: @escaping (Bool) -> Void) {
+        DispatchQueue.main.async { reply(Self.watcher.open(token: token)) }
+    }
+
+    @objc func notificationDebugDump(with reply: @escaping (String) -> Void) {
+        DispatchQueue.main.async { reply(Self.watcher.debugDump()) }
+    }
+
+    @objc func dismissNotification(_ token: String, with reply: @escaping (Bool) -> Void) {
+        DispatchQueue.main.async { reply(Self.watcher.dismiss(token: token)) }
+    }
+
     private class KeyboardBrightnessClient {
         private static let keyboardID: UInt64 = 1
         private var clientInstance: NSObject?

--- a/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelper.swift
@@ -157,8 +157,8 @@ class BoringNotchXPCHelper: NSObject, BoringNotchXPCHelperProtocol {
         DispatchQueue.main.async { reply(Self.watcher.dismiss(token: token)) }
     }
 
-    @objc func holdNotification(_ token: String, offScreen: Bool) {
-        DispatchQueue.main.async { Self.watcher.hold(token: token, offScreen: offScreen) }
+    @objc func holdNotification(_ token: String) {
+        DispatchQueue.main.async { Self.watcher.hold(token: token) }
     }
 
     @objc func releaseNotification(_ token: String) {

--- a/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
@@ -63,6 +63,7 @@ final class BNLunarBrightnessEvent: NSObject, NSSecureCoding {
     func startNotificationWatching(with reply: @escaping (Bool) -> Void)
     func stopNotificationWatching()
     func replyToNotification(_ token: String, text: String, with reply: @escaping (Bool) -> Void)
+    func sendIMessage(_ text: String, toChatNamed name: String, with reply: @escaping (Bool) -> Void)
     func performNotificationAction(_ token: String, name: String, with reply: @escaping (Bool) -> Void)
     func openNotification(_ token: String, with reply: @escaping (Bool) -> Void)
     func dismissNotification(_ token: String, with reply: @escaping (Bool) -> Void)

--- a/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
@@ -59,7 +59,30 @@ final class BNLunarBrightnessEvent: NSObject, NSSecureCoding {
     func stopLunarEventStream()
     /// Write Lunar's hideOSD preference (disable/enable Lunar's OSD when we replace it).
     func setLunarOSDHidden(_ hide: Bool, with reply: @escaping (Bool) -> Void)
+    // Notification Center banner observation (performed by the helper)
+    func startNotificationWatching(with reply: @escaping (Bool) -> Void)
+    func stopNotificationWatching()
+    func replyToNotification(_ token: String, text: String, with reply: @escaping (Bool) -> Void)
+    func performNotificationAction(_ token: String, name: String, with reply: @escaping (Bool) -> Void)
+    func openNotification(_ token: String, with reply: @escaping (Bool) -> Void)
+    func dismissNotification(_ token: String, with reply: @escaping (Bool) -> Void)
+    func notificationDebugDump(with reply: @escaping (String) -> Void)
 }
+
+/// Pushed from the helper back to the app. The app sets an object conforming to
+/// this as its connection's `exportedObject`.
+@objc protocol BoringNotchXPCHelperDelegate {
+    /// Keys: token, appName, bundleID, title, subtitle, body, actions
+    /// (`actions` is newline-joined). A plain string dictionary keeps the XPC
+    /// interface free of custom coded types.
+    func notificationDidAppear(_ payload: [String: String])
+    func notificationDidDisappear(_ token: String)
+}
+
+/// A connection has exactly one exported object, and the helper calls back for
+/// both Lunar events and notification banners — so the app vends a single
+/// object conforming to both.
+@objc protocol BoringNotchXPCAppDelegate: BoringNotchXPCHelperLunarListener, BoringNotchXPCHelperDelegate {}
 
 /*
  To use the service from an application or other process, use NSXPCConnection to establish a connection to the service by doing something like this:

--- a/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
@@ -67,6 +67,8 @@ final class BNLunarBrightnessEvent: NSObject, NSSecureCoding {
     func performNotificationAction(_ token: String, name: String, with reply: @escaping (Bool) -> Void)
     func openNotification(_ token: String, with reply: @escaping (Bool) -> Void)
     func dismissNotification(_ token: String, with reply: @escaping (Bool) -> Void)
+    func holdNotification(_ token: String, offScreen: Bool)
+    func releaseNotification(_ token: String)
     func notificationDebugDump(with reply: @escaping (String) -> Void)
 }
 

--- a/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
+++ b/BoringNotchXPCHelper/BoringNotchXPCHelperProtocol.swift
@@ -67,7 +67,7 @@ final class BNLunarBrightnessEvent: NSObject, NSSecureCoding {
     func performNotificationAction(_ token: String, name: String, with reply: @escaping (Bool) -> Void)
     func openNotification(_ token: String, with reply: @escaping (Bool) -> Void)
     func dismissNotification(_ token: String, with reply: @escaping (Bool) -> Void)
-    func holdNotification(_ token: String, offScreen: Bool)
+    func holdNotification(_ token: String)
     func releaseNotification(_ token: String)
     func notificationDebugDump(with reply: @escaping (String) -> Void)
 }

--- a/BoringNotchXPCHelper/Info.plist
+++ b/BoringNotchXPCHelper/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- Shown in the Automation permission prompt when replying to an
+	     iMessage notification. Required here, on the helper, because the
+	     helper is the process that sends the Apple event — without it macOS
+	     kills the process instead of prompting. -->
+	<key>NSAppleEventsUsageDescription</key>
+	<string>boring.notch sends your replies to iMessage conversations from the notch.</string>
 	<key>XPCService</key>
 	<dict>
 		<key>ServiceType</key>

--- a/BoringNotchXPCHelper/MessagesSender.swift
+++ b/BoringNotchXPCHelper/MessagesSender.swift
@@ -1,0 +1,85 @@
+//
+//  MessagesSender.swift
+//  BoringNotchXPCHelper
+//
+//  Sends iMessage replies through the Messages scripting dictionary.
+//
+//  Why this exists: replying to a notification normally means typing into
+//  the system banner's own AX reply field, which stops working the moment
+//  that banner fades (~5s) — the element is destroyed, measured, not
+//  assumed. Messages is the one supported app with a real scripting
+//  dictionary (`send <text> to <chat|participant>`), so an iMessage reply
+//  can be delivered properly at any time, with no dependency on the
+//  notification still existing.
+//
+//  There is no equivalent for WhatsApp/Telegram/Discord — none ship a
+//  scripting dictionary, and driving their UI with simulated clicks is far
+//  too brittle to put behind a send button. Those keep the clipboard
+//  hand-off.
+//
+//  Lives in the helper because the app is sandboxed; sending Apple events
+//  to another app needs the unsandboxed context the helper already has.
+//
+
+import Foundation
+import AppKit
+
+enum MessagesSender {
+    /// Matches the notification's sender against a Messages chat (then a
+    /// participant) and sends. Returns false if the chat can't be resolved
+    /// or automation permission was denied, so the caller can fall back to
+    /// the clipboard hand-off.
+    static func send(_ text: String, toChatNamed name: String) -> Bool {
+        // Participants only — deliberately not chats. Verified against a
+        // real Messages library: `name of chat` returns `missing value` for
+        // every chat, so matching on it can never succeed. Participants do
+        // carry the display name the notification shows ("Harsh Vardhan
+        // Goswami"), which is the only thing a notification gives us.
+        //
+        // The first match wins. Duplicate participant entries for the same
+        // person are normal (one per handle/service — e:me@…, +9198…), and
+        // they all reach the same human, so picking the first is fine.
+        let script = """
+        tell application "Messages"
+            repeat with p in participants
+                try
+                    if (name of p as string) is equal to "\(escape(name))" then
+                        send "\(escape(text))" to p
+                        return "ok"
+                    end if
+                end try
+            end repeat
+        end tell
+        return "notfound"
+        """
+
+        guard let scriptObject = NSAppleScript(source: script) else { return false }
+
+        var error: NSDictionary?
+        let output = scriptObject.executeAndReturnError(&error)
+
+        if let error {
+            // -1743 is "not authorized to send Apple events" — the user
+            // declined the Automation prompt, which is a legitimate choice,
+            // not a bug. Everything else is worth seeing in the log.
+            NSLog("[boringNotch] Messages send failed: \(error)")
+            return false
+        }
+
+        let ok = output.stringValue == "ok"
+        if !ok {
+            NSLog("[boringNotch] Messages: no chat or participant named \(name.debugDescription)")
+        }
+        return ok
+    }
+
+    /// Message text is arbitrary user input going into an AppleScript
+    /// string literal, so backslashes and quotes have to be neutralised —
+    /// otherwise a quote in a reply breaks the script (or worse, changes
+    /// what it does). Backslash first, or it would re-escape the escapes.
+    private static func escape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/BoringNotchXPCHelper/NotificationWatcher.swift
+++ b/BoringNotchXPCHelper/NotificationWatcher.swift
@@ -150,19 +150,25 @@ final class NotificationWatcher {
         }
     }
 
-    /// Holds a banner open so its reply field stays usable, optionally
-    /// moving it off-screen first so the user never sees it.
+    /// Holds a banner open so its reply field stays usable, moving it
+    /// off-screen first.
     ///
-    /// The off-screen move is safe to leave behind: when no banners are
-    /// showing, notificationcenterui has zero windows — the banner window is
-    /// created per session and destroyed after — so a moved window can't
-    /// permanently hide notifications. A fresh one spawns at its normal
-    /// position.
-    func hold(token: String, offScreen: Bool) {
+    /// The move is not optional. Holding a banner works by re-performing
+    /// its details toggle, which leaves it expanded — showing its own reply
+    /// field, on top of everything, taking focus. Two live text fields
+    /// competing for the same keystrokes is worse than no keep-alive at
+    /// all, so the banner is parked off-screen for the whole hold and the
+    /// notch is the only visible surface.
+    ///
+    /// Safe to leave behind: with no banners showing, notificationcenterui
+    /// has zero windows — the window is created per session and destroyed
+    /// after — so a moved window can't permanently hide notifications. A
+    /// fresh one always spawns at its normal position.
+    func hold(token: String) {
         guard let banner = live[token] else { return }
         held.insert(token)
 
-        guard offScreen, !heldOffScreen.contains(token) else { return }
+        guard !heldOffScreen.contains(token) else { return }
         heldOffScreen.insert(token)
         guard let windowValue = banner[kAXWindowAttribute] else { return }
         let window = windowValue as! AXUIElement

--- a/BoringNotchXPCHelper/NotificationWatcher.swift
+++ b/BoringNotchXPCHelper/NotificationWatcher.swift
@@ -39,10 +39,13 @@ final class NotificationWatcher {
     var onBanner: ((CapturedNotification) -> Void)?
     var onBannerGone: ((String) -> Void)?
 
-    private var observer: AXObserver?
     private var appElement: AXUIElement?
-    private var pollTimer: Timer?
+    private var pollTimer: DispatchSourceTimer?
     private var live: [String: AXUIElement] = [:]
+
+    /// Banners live ~5s, so this catches every one with room to spare while
+    /// staying cheap — each tick is a shallow AX tree walk.
+    private let pollInterval: TimeInterval = 0.35
 
     var isRunning: Bool { appElement != nil }
 
@@ -59,26 +62,23 @@ final class NotificationWatcher {
         let app = AXUIElementCreateApplication(notificationCenter.processIdentifier)
         appElement = app
 
-        var created: AXObserver?
-        let callback: AXObserverCallback = { _, _, _, context in
-            guard let context else { return }
-            Unmanaged<NotificationWatcher>.fromOpaque(context).takeUnretainedValue().scan()
-        }
-        if AXObserverCreate(notificationCenter.processIdentifier, callback, &created) == .success,
-           let created {
-            let context = Unmanaged.passUnretained(self).toOpaque()
-            for name in [kAXWindowCreatedNotification, kAXCreatedNotification, kAXUIElementDestroyedNotification] {
-                AXObserverAddNotification(created, app, name as CFString, context)
-            }
-            CFRunLoopAddSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(created), .defaultMode)
-            observer = created
-        }
-
-        // ponytail: the AX notifications above fire inconsistently for the
-        // banner window, so a light poll backstops them. Remove the timer if a
-        // single notification name ever proves reliable across releases.
-        let timer = Timer(timeInterval: 0.35, repeats: true) { [weak self] _ in self?.scan() }
-        RunLoop.current.add(timer, forMode: .common)
+        // Polling only, deliberately — no AXObserver and no Timer.
+        //
+        // This runs inside an XPC service, whose main thread is driven by
+        // dispatch_main(). That services DispatchQueue.main blocks but does
+        // NOT run a CFRunLoop, so anything depending on one is dead code
+        // here: Timer/RunLoop.add never fires, and an AXObserver's
+        // CFRunLoopSource never delivers. An earlier version used both and
+        // silently captured nothing after the single scan() below — the
+        // watcher reported "started" and then went quiet forever.
+        //
+        // A DispatchSourceTimer needs no run loop, so it works. All watcher
+        // state stays on the main queue, which is also where the helper
+        // dispatches reply/action calls, so there's no locking to get wrong.
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + pollInterval, repeating: pollInterval)
+        timer.setEventHandler { [weak self] in self?.scan() }
+        timer.resume()
         pollTimer = timer
 
         scan()
@@ -86,12 +86,8 @@ final class NotificationWatcher {
     }
 
     func stop() {
-        pollTimer?.invalidate()
+        pollTimer?.cancel()
         pollTimer = nil
-        if let observer {
-            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(observer), .defaultMode)
-        }
-        observer = nil
         appElement = nil
         live.removeAll()
     }
@@ -278,7 +274,10 @@ final class NotificationWatcher {
             }) {
                 AXUIElementPerformAction(button, kAXPressAction as CFString)
             }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+            // Thread.sleep, not RunLoop.run: there's no CFRunLoop to advance
+            // in an XPC service, so RunLoop.run(until:) returns immediately
+            // and the reply field wouldn't have appeared yet.
+            Thread.sleep(forTimeInterval: 0.4)
         }
 
         guard let field = replyField(in: banner) else { return false }

--- a/BoringNotchXPCHelper/NotificationWatcher.swift
+++ b/BoringNotchXPCHelper/NotificationWatcher.swift
@@ -218,11 +218,37 @@ final class NotificationWatcher {
         return found
     }
 
+    /// Matches on a normalized name because both sides can carry invisible
+    /// bidi marks: WhatsApp's `localizedName` is literally "\u{200E}WhatsApp"
+    /// (LEFT-TO-RIGHT MARK), and the banner's own description is wrapped in
+    /// isolates. Comparing raw strings silently failed to resolve WhatsApp's
+    /// bundle ID, which dropped every one of its notifications at the
+    /// allow-list check.
     private func bundleID(forAppNamed name: String) -> String? {
-        NSWorkspace.shared.runningApplications.first {
-            $0.localizedName == name
+        let target = Self.normalizedAppName(name)
+        guard !target.isEmpty else { return nil }
+        return NSWorkspace.shared.runningApplications.first {
+            guard let localizedName = $0.localizedName else { return false }
+            return Self.normalizedAppName(localizedName) == target
         }?.bundleIdentifier
     }
+
+    private static func normalizedAppName(_ name: String) -> String {
+        name.filter { !$0.unicodeScalars.allSatisfy(bidiControlCharacters.contains) }
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
+    /// Directional formatting characters Notification Center and app names
+    /// both sprinkle in: LRM/RLM, the isolate family, and the embedding /
+    /// override set.
+    private static let bidiControlCharacters: CharacterSet = {
+        var set = CharacterSet()
+        set.insert(charactersIn: "\u{200E}\u{200F}")           // LRM, RLM
+        set.insert(charactersIn: "\u{2066}"..."\u{2069}")      // isolates + PDI
+        set.insert(charactersIn: "\u{202A}"..."\u{202E}")      // embeddings/overrides
+        return set
+    }()
 
     // MARK: - Acting on a banner
 

--- a/BoringNotchXPCHelper/NotificationWatcher.swift
+++ b/BoringNotchXPCHelper/NotificationWatcher.swift
@@ -1,0 +1,333 @@
+//
+//  NotificationWatcher.swift
+//  BoringNotchXPCHelper
+//
+//  Observes Notification Center banners through the Accessibility API and
+//  streams them to the app. This lives in the helper because the app itself is
+//  sandboxed, and a sandboxed process cannot drive AX on another application.
+//
+//  Verified hierarchy (macOS 26):
+//    AXWindow "Notification Center" (subrole AXSystemDialog)
+//      └ … groups … > AXScrollArea (identifier AXNotificationListItems)
+//          └ banner (subrole AXNotificationCenterBanner)
+//              · AXIdentifier            = per-notification UUID
+//              · AXAttributedDescription = "App, Title, Subtitle, Body"
+//              └ AXStaticText identifier "title" / "subtitle" / "body" (AXValue)
+//
+//  The window only exists while banners are on screen, so a banner is only
+//  actionable while visible.
+//
+
+import Foundation
+import ApplicationServices
+import AppKit
+
+private let notificationCenterBundleID = "com.apple.notificationcenterui"
+private let bannerSubroles: Set<String> = ["AXNotificationCenterBanner", "AXNotificationCenterAlert"]
+
+struct CapturedNotification {
+    let token: String       // banner AXIdentifier (UUID), stable while on screen
+    let appName: String?
+    let bundleID: String?
+    let title: String?
+    let subtitle: String?
+    let body: String?
+    let actions: [String]   // AX action names, e.g. AXPress / AXReply / button titles
+}
+
+final class NotificationWatcher {
+    var onBanner: ((CapturedNotification) -> Void)?
+    var onBannerGone: ((String) -> Void)?
+
+    private var observer: AXObserver?
+    private var appElement: AXUIElement?
+    private var pollTimer: Timer?
+    private var live: [String: AXUIElement] = [:]
+
+    var isRunning: Bool { appElement != nil }
+
+    // MARK: - Lifecycle
+
+    @discardableResult
+    func start() -> Bool {
+        guard AXIsProcessTrusted() else { return false }
+        guard !isRunning else { return true }
+        guard let notificationCenter = NSRunningApplication.runningApplications(
+            withBundleIdentifier: notificationCenterBundleID
+        ).first else { return false }
+
+        let app = AXUIElementCreateApplication(notificationCenter.processIdentifier)
+        appElement = app
+
+        var created: AXObserver?
+        let callback: AXObserverCallback = { _, _, _, context in
+            guard let context else { return }
+            Unmanaged<NotificationWatcher>.fromOpaque(context).takeUnretainedValue().scan()
+        }
+        if AXObserverCreate(notificationCenter.processIdentifier, callback, &created) == .success,
+           let created {
+            let context = Unmanaged.passUnretained(self).toOpaque()
+            for name in [kAXWindowCreatedNotification, kAXCreatedNotification, kAXUIElementDestroyedNotification] {
+                AXObserverAddNotification(created, app, name as CFString, context)
+            }
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(created), .defaultMode)
+            observer = created
+        }
+
+        // ponytail: the AX notifications above fire inconsistently for the
+        // banner window, so a light poll backstops them. Remove the timer if a
+        // single notification name ever proves reliable across releases.
+        let timer = Timer(timeInterval: 0.35, repeats: true) { [weak self] _ in self?.scan() }
+        RunLoop.current.add(timer, forMode: .common)
+        pollTimer = timer
+
+        scan()
+        return true
+    }
+
+    func stop() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+        if let observer {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(observer), .defaultMode)
+        }
+        observer = nil
+        appElement = nil
+        live.removeAll()
+    }
+
+    // MARK: - Scanning
+
+    private func scan() {
+        guard let appElement else { return }
+        var seen: Set<String> = []
+
+        for window in (appElement[kAXWindowsAttribute] as? [AXUIElement]) ?? [] {
+            guard window[kAXSubroleAttribute] as? String == "AXSystemDialog" else { continue }
+            for banner in banners(in: window) {
+                guard let token = banner[kAXIdentifierAttribute] as? String else { continue }
+                seen.insert(token)
+                guard live[token] == nil else { continue }
+                live[token] = banner
+                onBanner?(capture(banner, token: token))
+            }
+        }
+
+        for token in live.keys where !seen.contains(token) {
+            live[token] = nil
+            onBannerGone?(token)
+        }
+    }
+
+    /// Match on subrole rather than a fixed containment path — the wrapping
+    /// groups change between macOS releases, the subrole has not.
+    private func banners(in element: AXUIElement, depth: Int = 0) -> [AXUIElement] {
+        guard depth < 14 else { return [] }
+        if let subrole = element[kAXSubroleAttribute] as? String, bannerSubroles.contains(subrole) {
+            return [element]
+        }
+        return ((element[kAXChildrenAttribute] as? [AXUIElement]) ?? [])
+            .flatMap { banners(in: $0, depth: depth + 1) }
+    }
+
+    // MARK: - Reading a banner
+
+    private func capture(_ banner: AXUIElement, token: String) -> CapturedNotification {
+        var parts: [String: String] = [:]
+        collectLabelledText(in: banner, into: &parts)
+
+        // AXAttributedDescription reads "App, Title, Subtitle, Body"; only its
+        // first field (the app name) isn't available as a labelled child.
+        let appName = (banner["AXAttributedDescription"] as? NSAttributedString)?.string
+            .components(separatedBy: ",").first?
+            .trimmingCharacters(in: .whitespaces)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\u{200E}\u{2068}\u{2069}"))
+
+        return CapturedNotification(
+            token: token,
+            appName: appName,
+            bundleID: appName.flatMap(bundleID(forAppNamed:)),
+            title: parts["title"],
+            subtitle: parts["subtitle"],
+            body: parts["body"],
+            actions: availableActions(on: banner)
+        )
+    }
+
+    private func collectLabelledText(in element: AXUIElement, into parts: inout [String: String], depth: Int = 0) {
+        guard depth < 10 else { return }
+        if let identifier = element[kAXIdentifierAttribute] as? String,
+           ["title", "subtitle", "body"].contains(identifier),
+           let value = element[kAXValueAttribute] as? String {
+            parts[identifier] = value.trimmingCharacters(
+                in: CharacterSet(charactersIn: "\u{2068}\u{2069}\u{200E}").union(.whitespacesAndNewlines)
+            )
+        }
+        for child in (element[kAXChildrenAttribute] as? [AXUIElement]) ?? [] {
+            collectLabelledText(in: child, into: &parts, depth: depth + 1)
+        }
+    }
+
+    /// Reply/Accept/Decline are exposed either as AX actions on the banner or
+    /// as descendant buttons, and which one varies by app and notification
+    /// type — so report both rather than guessing.
+    private func availableActions(on banner: AXUIElement) -> [String] {
+        // AXPress is the "open the notification" default, not a user-facing
+        // choice — the notch exposes that as tapping the notification itself.
+        var labels = actionNames(of: banner)
+            .map(actionLabel)
+            .filter { $0 != kAXPressAction }
+        for button in descendants(of: banner, matching: [kAXButtonRole, kAXMenuButtonRole]) {
+            if let title = button[kAXTitleAttribute] as? String, !title.isEmpty {
+                labels.append(title)
+            }
+        }
+        return labels
+    }
+
+    /// Maps a user-facing label back to the raw action string AX expects.
+    private func rawAction(on element: AXUIElement, matching predicate: (String) -> Bool) -> String? {
+        actionNames(of: element).first { predicate(actionLabel($0)) }
+    }
+
+    /// Raw action names as AX reports them. Notification Center returns records
+    /// rather than plain names for its custom actions:
+    ///     "Name:Reply\nTarget:0x0\nSelector:(null)"
+    /// The raw string is what `AXUIElementPerformAction` needs, so keep it and
+    /// use `actionLabel` for anything user-facing.
+    private func actionNames(of element: AXUIElement) -> [String] {
+        var names: CFArray?
+        guard AXUIElementCopyActionNames(element, &names) == .success else { return [] }
+        return (names as? [String]) ?? []
+    }
+
+    private func actionLabel(_ raw: String) -> String {
+        guard raw.hasPrefix("Name:") else { return raw }
+        return String(raw.dropFirst("Name:".count).prefix { !$0.isNewline })
+    }
+
+    private func descendants(of element: AXUIElement, matching roles: [String], depth: Int = 0) -> [AXUIElement] {
+        guard depth < 10 else { return [] }
+        var found: [AXUIElement] = []
+        if depth > 0, let role = element[kAXRoleAttribute] as? String, roles.contains(role) {
+            found.append(element)
+        }
+        for child in (element[kAXChildrenAttribute] as? [AXUIElement]) ?? [] {
+            found += descendants(of: child, matching: roles, depth: depth + 1)
+        }
+        return found
+    }
+
+    private func bundleID(forAppNamed name: String) -> String? {
+        NSWorkspace.shared.runningApplications.first {
+            $0.localizedName == name
+        }?.bundleIdentifier
+    }
+
+    // MARK: - Acting on a banner
+
+    /// Types into the banner's reply field and submits it. Only works while
+    /// the banner is on screen and the source app offers a reply field; the
+    /// caller falls back to opening the app otherwise.
+    ///
+    /// Verified against a live WhatsApp banner (2026-08-12): Notification
+    /// Center does not expose a "Reply" action. The field is revealed by
+    /// "Show Details" (collapsed) / "Hide Details" (already expanded), and
+    /// submitted with a "Send" action on the banner itself — not
+    /// kAXConfirmAction on the field, which is untested and unreliable across
+    /// text-area implementations.
+    func reply(token: String, text: String) -> Bool {
+        guard let banner = live[token] else { return false }
+
+        if replyField(in: banner) == nil {
+            if let action = rawAction(on: banner, matching: { $0.localizedCaseInsensitiveContains("details") }) {
+                AXUIElementPerformAction(banner, action as CFString)
+            } else if let button = descendants(of: banner, matching: [kAXButtonRole]).first(where: {
+                ($0[kAXTitleAttribute] as? String)?.lowercased().contains("reply") == true
+            }) {
+                AXUIElementPerformAction(button, kAXPressAction as CFString)
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+        }
+
+        guard let field = replyField(in: banner) else { return false }
+        AXUIElementSetAttributeValue(field, kAXFocusedAttribute as CFString, kCFBooleanTrue)
+        guard AXUIElementSetAttributeValue(field, kAXValueAttribute as CFString, text as CFString) == .success
+        else { return false }
+
+        if let send = rawAction(on: banner, matching: { $0.localizedCaseInsensitiveContains("send") }) {
+            return AXUIElementPerformAction(banner, send as CFString) == .success
+        }
+        return AXUIElementPerformAction(field, kAXConfirmAction as CFString) == .success
+    }
+
+    private func replyField(in element: AXUIElement, depth: Int = 0) -> AXUIElement? {
+        descendants(of: element, matching: [kAXTextFieldRole, kAXTextAreaRole]).first
+    }
+
+    /// Performs a named AX action on the banner, or presses the button with
+    /// that title (Accept / Decline on call notifications).
+    func performAction(token: String, name: String) -> Bool {
+        guard let banner = live[token] else { return false }
+        if let raw = rawAction(on: banner, matching: { $0 == name }) {
+            return AXUIElementPerformAction(banner, raw as CFString) == .success
+        }
+        guard let button = descendants(of: banner, matching: [kAXButtonRole, kAXMenuButtonRole]).first(where: {
+            $0[kAXTitleAttribute] as? String == name
+        }) else { return false }
+        return AXUIElementPerformAction(button, kAXPressAction as CFString) == .success
+    }
+
+    /// Opens the notification in its source app (the banner's default action).
+    func open(token: String) -> Bool {
+        guard let banner = live[token] else { return false }
+        return AXUIElementPerformAction(banner, kAXPressAction as CFString) == .success
+    }
+
+    /// Clears the banner from screen. Notification Center exposes this as a
+    /// "Close" action rather than the AXRemove one might expect.
+    func dismiss(token: String) -> Bool {
+        guard let banner = live[token],
+              let raw = rawAction(on: banner, matching: { $0.localizedCaseInsensitiveContains("close") })
+        else { return false }
+        return AXUIElementPerformAction(banner, raw as CFString) == .success
+    }
+
+    // MARK: - Debug
+
+    /// Full attribute dump of the banner window, for the debug window.
+    func debugDump() -> String {
+        guard let appElement else { return "watcher not running" }
+        var out = ""
+        for window in (appElement[kAXWindowsAttribute] as? [AXUIElement]) ?? [] {
+            guard window[kAXSubroleAttribute] as? String == "AXSystemDialog" else { continue }
+            describe(window, depth: 0, into: &out)
+        }
+        return out.isEmpty ? "no banners on screen" : out
+    }
+
+    private func describe(_ element: AXUIElement, depth: Int, into out: inout String) {
+        guard depth < 14 else { return }
+        let pad = String(repeating: "  ", count: depth)
+        out += "\(pad)\(element[kAXRoleAttribute] as? String ?? "?") \(element[kAXSubroleAttribute] as? String ?? "")"
+        out += " actions=\(actionNames(of: element))\n"
+        var names: CFArray?
+        if AXUIElementCopyAttributeNames(element, &names) == .success, let names = names as? [String] {
+            for name in names where name != kAXChildrenAttribute && name != kAXParentAttribute {
+                guard let value = element[name] else { continue }
+                out += "\(pad)  · \(name) = \(String(describing: value).prefix(200))\n"
+            }
+        }
+        for child in (element[kAXChildrenAttribute] as? [AXUIElement]) ?? [] {
+            describe(child, depth: depth + 1, into: &out)
+        }
+    }
+}
+
+private extension AXUIElement {
+    subscript(attribute: String) -> Any? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(self, attribute as CFString, &value) == .success else { return nil }
+        return value
+    }
+}

--- a/BoringNotchXPCHelper/NotificationWatcher.swift
+++ b/BoringNotchXPCHelper/NotificationWatcher.swift
@@ -115,6 +115,16 @@ final class NotificationWatcher {
         }
     }
 
+    /// Measured, not assumed: once a banner leaves the screen its
+    /// AXUIElement is destroyed outright — reading AXRole from a retained
+    /// reference returns nil and AXUIElementCopyActionNames returns empty.
+    /// Holding onto elements past their banner therefore buys nothing, so
+    /// this is just `live`. Replying is only possible while the banner is
+    /// on screen; there is no API to send on an app's behalf afterwards.
+    private func element(for token: String) -> AXUIElement? {
+        live[token]
+    }
+
     /// Match on subrole rather than a fixed containment path — the wrapping
     /// groups change between macOS releases, the subrole has not.
     private func banners(in element: AXUIElement, depth: Int = 0) -> [AXUIElement] {
@@ -263,7 +273,7 @@ final class NotificationWatcher {
     /// field, which is untested and unreliable across text-area
     /// implementations.
     func reply(token: String, text: String) -> Bool {
-        guard let banner = live[token] else { return false }
+        guard let banner = element(for: token) else { return false }
 
         if replyField(in: banner) == nil {
             if let action = rawAction(on: banner, matching: { $0.localizedCaseInsensitiveContains("reply") })
@@ -298,7 +308,7 @@ final class NotificationWatcher {
     /// Performs a named AX action on the banner, or presses the button with
     /// that title (Accept / Decline on call notifications).
     func performAction(token: String, name: String) -> Bool {
-        guard let banner = live[token] else { return false }
+        guard let banner = element(for: token) else { return false }
         if let raw = rawAction(on: banner, matching: { $0 == name }) {
             return AXUIElementPerformAction(banner, raw as CFString) == .success
         }
@@ -310,14 +320,14 @@ final class NotificationWatcher {
 
     /// Opens the notification in its source app (the banner's default action).
     func open(token: String) -> Bool {
-        guard let banner = live[token] else { return false }
+        guard let banner = element(for: token) else { return false }
         return AXUIElementPerformAction(banner, kAXPressAction as CFString) == .success
     }
 
     /// Clears the banner from screen. Notification Center exposes this as a
     /// "Close" action rather than the AXRemove one might expect.
     func dismiss(token: String) -> Bool {
-        guard let banner = live[token],
+        guard let banner = element(for: token),
               let raw = rawAction(on: banner, matching: { $0.localizedCaseInsensitiveContains("close") })
         else { return false }
         return AXUIElementPerformAction(banner, raw as CFString) == .success

--- a/BoringNotchXPCHelper/NotificationWatcher.swift
+++ b/BoringNotchXPCHelper/NotificationWatcher.swift
@@ -230,17 +230,22 @@ final class NotificationWatcher {
     /// the banner is on screen and the source app offers a reply field; the
     /// caller falls back to opening the app otherwise.
     ///
-    /// Verified against a live WhatsApp banner (2026-08-12): Notification
-    /// Center does not expose a "Reply" action. The field is revealed by
-    /// "Show Details" (collapsed) / "Hide Details" (already expanded), and
-    /// submitted with a "Send" action on the banner itself — not
-    /// kAXConfirmAction on the field, which is untested and unreliable across
-    /// text-area implementations.
+    /// Verified against a live WhatsApp banner (2026-08-12): a collapsed
+    /// banner's actions are ["AXPress", "Show Details", "Reply", "Close"] —
+    /// a real "Reply" action does exist (an earlier check only ever caught
+    /// the banner post-expansion, where it's already gone, which led to a
+    /// wrong assumption here). "Reply" is preferred since it's the more
+    /// direct, purpose-built action; "Show Details" is the fallback for
+    /// banners/apps that don't expose it. Either way the field is submitted
+    /// via the "Send" action on the banner — not kAXConfirmAction on the
+    /// field, which is untested and unreliable across text-area
+    /// implementations.
     func reply(token: String, text: String) -> Bool {
         guard let banner = live[token] else { return false }
 
         if replyField(in: banner) == nil {
-            if let action = rawAction(on: banner, matching: { $0.localizedCaseInsensitiveContains("details") }) {
+            if let action = rawAction(on: banner, matching: { $0.localizedCaseInsensitiveContains("reply") })
+                ?? rawAction(on: banner, matching: { $0.localizedCaseInsensitiveContains("details") }) {
                 AXUIElementPerformAction(banner, action as CFString)
             } else if let button = descendants(of: banner, matching: [kAXButtonRole]).first(where: {
                 ($0[kAXTitleAttribute] as? String)?.lowercased().contains("reply") == true

--- a/BoringNotchXPCHelper/NotificationWatcher.swift
+++ b/BoringNotchXPCHelper/NotificationWatcher.swift
@@ -43,6 +43,16 @@ final class NotificationWatcher {
     private var pollTimer: DispatchSourceTimer?
     private var live: [String: AXUIElement] = [:]
 
+    /// Banners being deliberately kept alive so their reply field stays
+    /// usable, and of those, the ones moved off-screen.
+    private var held: Set<String> = []
+    private var heldOffScreen: Set<String> = []
+    private var lastRefresh = Date.distantPast
+
+    /// Comfortably inside the ~5s dismissal window the toggle resets, so a
+    /// missed tick can't let a held banner slip away.
+    private let refreshInterval: TimeInterval = 2.5
+
     /// Banners live ~5s, so this catches every one with room to spare while
     /// staying cheap — each tick is a shallow AX tree walk.
     private let pollInterval: TimeInterval = 0.35
@@ -111,7 +121,64 @@ final class NotificationWatcher {
 
         for token in live.keys where !seen.contains(token) {
             live[token] = nil
+            heldOffScreen.remove(token)
             onBannerGone?(token)
+        }
+
+        refreshHeldBanners()
+    }
+
+    /// Keeps held banners from timing out.
+    ///
+    /// Measured: an untouched banner dies in ~1.25s and its AX element is
+    /// destroyed with it, which is what made replying impossible after the
+    /// fact. Performing the details toggle resets that dismissal timer —
+    /// re-performing it on an interval held a banner alive for a full 30s
+    /// test with its reply field intact. That's what lets the notch offer a
+    /// working reply box for as long as the notification is showing.
+    private func refreshHeldBanners() {
+        guard !held.isEmpty else { return }
+        let now = Date()
+        guard now.timeIntervalSince(lastRefresh) >= refreshInterval else { return }
+        lastRefresh = now
+
+        for token in held {
+            guard let banner = live[token] else { continue }
+            if let toggle = rawAction(on: banner, matching: { $0.localizedCaseInsensitiveContains("details") }) {
+                AXUIElementPerformAction(banner, toggle as CFString)
+            }
+        }
+    }
+
+    /// Holds a banner open so its reply field stays usable, optionally
+    /// moving it off-screen first so the user never sees it.
+    ///
+    /// The off-screen move is safe to leave behind: when no banners are
+    /// showing, notificationcenterui has zero windows — the banner window is
+    /// created per session and destroyed after — so a moved window can't
+    /// permanently hide notifications. A fresh one spawns at its normal
+    /// position.
+    func hold(token: String, offScreen: Bool) {
+        guard let banner = live[token] else { return }
+        held.insert(token)
+
+        guard offScreen, !heldOffScreen.contains(token) else { return }
+        heldOffScreen.insert(token)
+        guard let windowValue = banner[kAXWindowAttribute] else { return }
+        let window = windowValue as! AXUIElement
+        var target = CGPoint(x: -5000, y: -5000)
+        if let position = AXValueCreate(.cgPoint, &target) {
+            AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, position)
+        }
+    }
+
+    /// Stops holding a banner and lets it dismiss naturally.
+    func release(token: String) {
+        held.remove(token)
+        heldOffScreen.remove(token)
+        guard let banner = live[token] else { return }
+        if let close = rawAction(on: banner, matching: { $0.localizedCaseInsensitiveContains("close") }) {
+            AXUIElementPerformAction(banner, close as CFString)
         }
     }
 

--- a/BoringNotchXPCHelper/main.swift
+++ b/BoringNotchXPCHelper/main.swift
@@ -17,7 +17,7 @@ class ServiceDelegate: NSObject, NSXPCListenerDelegate {
         newConnection.exportedInterface = NSXPCInterface(with: (any BoringNotchXPCHelperProtocol).self)
 
         // Configure the interface for callbacks from the helper to the app.
-        let listenerInterface = NSXPCInterface(with: (any BoringNotchXPCHelperLunarListener).self)
+        let listenerInterface = NSXPCInterface(with: (any BoringNotchXPCAppDelegate).self)
         listenerInterface.setClasses(
             NSSet(array: [BNLunarBrightnessEvent.self]) as! Set<AnyHashable>,
             for: #selector(BoringNotchXPCHelperLunarListener.lunarEventDidUpdate(_:)),

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -99,10 +99,6 @@
 		14288E0C2C6F8EC000B9F80C /* AppIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14288E0B2C6F8EC000B9F80C /* AppIcons.swift */; };
 		1443E7F32C609DCE0027C1FC /* matters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1443E7F22C609DCE0027C1FC /* matters.swift */; };
 		147163982C5D35B70068B555 /* MusicVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147163972C5D35B70068B555 /* MusicVisualizer.swift */; };
-		AA01SNM12E7A0001 /* SystemNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA01SNM22E7A0001 /* SystemNotificationManager.swift */; };
-		AA01NDW12E7A0001 /* NotificationDebugWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA01NDW22E7A0001 /* NotificationDebugWindow.swift */; };
-		AA01NLA12E7A0001 /* NotificationLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA01NLA22E7A0001 /* NotificationLiveActivity.swift */; };
-		AA03OTP12E7A0001 /* OTPDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA03OTP22E7A0001 /* OTPDetector.swift */; };
 		1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147163992C5D35FF0068B555 /* MusicManager.swift */; };
 		1471A8592C6281BD0058408D /* BoringNotchWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1471A8582C6281BD0058408D /* BoringNotchWindow.swift */; };
 		149E0B972C737D00006418B1 /* WebcamManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149E0B962C737D00006418B1 /* WebcamManager.swift */; };
@@ -142,6 +138,12 @@
 		9A987A0D2C73CA66005CA465 /* ShelfView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A987A032C73CA66005CA465 /* ShelfView.swift */; };
 		9A987A102C73CA8D005CA465 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 9A987A0F2C73CA8D005CA465 /* Collections */; };
 		9AB0C6BD2C73C9CB00F7CD30 /* NotchHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */; };
+		AA01NDW12E7A0001 /* NotificationDebugWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA01NDW22E7A0001 /* NotificationDebugWindow.swift */; };
+		AA01NLA12E7A0001 /* NotificationLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA01NLA22E7A0001 /* NotificationLiveActivity.swift */; };
+		AA01SNM12E7A0001 /* SystemNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA01SNM22E7A0001 /* SystemNotificationManager.swift */; };
+		AA02CAM12E7A0001 /* ContactAvatarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA02CAM22E7A0001 /* ContactAvatarManager.swift */; };
+		AA02NSV12E7A0001 /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA02NSV22E7A0001 /* NotificationSettingsView.swift */; };
+		AA03OTP12E7A0001 /* OTPDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA03OTP22E7A0001 /* OTPDetector.swift */; };
 		B10348D92C74E56000475897 /* ConditionalModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10348D82C74E56000475897 /* ConditionalModifier.swift */; };
 		B10F84A32C6C9596009F3026 /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10F84A22C6C9596009F3026 /* TestView.swift */; };
 		B141C2412CA5F53F00AC8CC8 /* SparkleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B141C2402CA5F53E00AC8CC8 /* SparkleView.swift */; };
@@ -278,8 +280,6 @@
 		11DB26692EDD0CDF001EA0CF /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
 		11DB266A2EDD0CDF001EA0CF /* BatterySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatterySettingsView.swift; sourceTree = "<group>"; };
 		11DB266B2EDD0CDF001EA0CF /* CalendarSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSettingsView.swift; sourceTree = "<group>"; };
-		AA02NSV22E7A0001 /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
-		AA02NSV12E7A0001 /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA02NSV22E7A0001 /* NotificationSettingsView.swift */; };
 		11DB266C2EDD0CDF001EA0CF /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		11DB266D2EDD0CDF001EA0CF /* OSDSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDSettingsView.swift; sourceTree = "<group>"; };
 		11DB266E2EDD0CDF001EA0CF /* MediaSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaSettingsView.swift; sourceTree = "<group>"; };
@@ -299,12 +299,6 @@
 		1443E7F22C609DCE0027C1FC /* matters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = matters.swift; sourceTree = "<group>"; };
 		1443E7F42C609E650027C1FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		147163972C5D35B70068B555 /* MusicVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicVisualizer.swift; sourceTree = "<group>"; };
-		AA01SNM22E7A0001 /* SystemNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemNotificationManager.swift; sourceTree = "<group>"; };
-		AA01NDW22E7A0001 /* NotificationDebugWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDebugWindow.swift; sourceTree = "<group>"; };
-		AA01NLA22E7A0001 /* NotificationLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLiveActivity.swift; sourceTree = "<group>"; };
-		AA02CAM22E7A0001 /* ContactAvatarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactAvatarManager.swift; sourceTree = "<group>"; };
-		AA02CAM12E7A0001 /* ContactAvatarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA02CAM22E7A0001 /* ContactAvatarManager.swift */; };
-		AA03OTP22E7A0001 /* OTPDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPDetector.swift; sourceTree = "<group>"; };
 		147163992C5D35FF0068B555 /* MusicManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicManager.swift; sourceTree = "<group>"; };
 		1471A8582C6281BD0058408D /* BoringNotchWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringNotchWindow.swift; sourceTree = "<group>"; };
 		149E0B962C737D00006418B1 /* WebcamManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcamManager.swift; sourceTree = "<group>"; };
@@ -345,6 +339,12 @@
 		9A987A032C73CA66005CA465 /* ShelfView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShelfView.swift; sourceTree = "<group>"; };
 		9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotchHomeView.swift; sourceTree = "<group>"; };
 		A5167212301F85B40018095A /* boringNotchTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = boringNotchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA01NDW22E7A0001 /* NotificationDebugWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDebugWindow.swift; sourceTree = "<group>"; };
+		AA01NLA22E7A0001 /* NotificationLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLiveActivity.swift; sourceTree = "<group>"; };
+		AA01SNM22E7A0001 /* SystemNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemNotificationManager.swift; sourceTree = "<group>"; };
+		AA02CAM22E7A0001 /* ContactAvatarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactAvatarManager.swift; sourceTree = "<group>"; };
+		AA02NSV22E7A0001 /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
+		AA03OTP22E7A0001 /* OTPDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPDetector.swift; sourceTree = "<group>"; };
 		AFAD1670A870402D88BFFE47 /* AudioOutputRouteResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioOutputRouteResolver.swift; sourceTree = "<group>"; };
 		B10348D82C74E56000475897 /* ConditionalModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalModifier.swift; sourceTree = "<group>"; };
 		B10F84A22C6C9596009F3026 /* TestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView.swift; sourceTree = "<group>"; };
@@ -1251,6 +1251,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 272;
 				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BoringNotchXPCHelper/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BoringNotchXPCHelper;
@@ -1276,6 +1277,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 272;
 				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BoringNotchXPCHelper/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BoringNotchXPCHelper;
@@ -1350,6 +1352,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -1409,6 +1412,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -100,7 +100,6 @@
 		1443E7F32C609DCE0027C1FC /* matters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1443E7F22C609DCE0027C1FC /* matters.swift */; };
 		147163982C5D35B70068B555 /* MusicVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147163972C5D35B70068B555 /* MusicVisualizer.swift */; };
 		1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147163992C5D35FF0068B555 /* MusicManager.swift */; };
-		AA05SRM12E7A0001 /* SmartReplyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05SRM22E7A0001 /* SmartReplyManager.swift */; };
 		1471A8592C6281BD0058408D /* BoringNotchWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1471A8582C6281BD0058408D /* BoringNotchWindow.swift */; };
 		149E0B972C737D00006418B1 /* WebcamManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149E0B962C737D00006418B1 /* WebcamManager.swift */; };
 		149E0B9A2C737D40006418B1 /* WebcamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149E0B992C737D40006418B1 /* WebcamView.swift */; };
@@ -145,6 +144,8 @@
 		AA02CAM12E7A0001 /* ContactAvatarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA02CAM22E7A0001 /* ContactAvatarManager.swift */; };
 		AA02NSV12E7A0001 /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA02NSV22E7A0001 /* NotificationSettingsView.swift */; };
 		AA03OTP12E7A0001 /* OTPDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA03OTP22E7A0001 /* OTPDetector.swift */; };
+		AA04LAS12E7A0001 /* LiveActivityStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA04LAS22E7A0001 /* LiveActivityStack.swift */; };
+		AA05SRM12E7A0001 /* SmartReplyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05SRM22E7A0001 /* SmartReplyManager.swift */; };
 		B10348D92C74E56000475897 /* ConditionalModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10348D82C74E56000475897 /* ConditionalModifier.swift */; };
 		B10F84A32C6C9596009F3026 /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10F84A22C6C9596009F3026 /* TestView.swift */; };
 		B141C2412CA5F53F00AC8CC8 /* SparkleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B141C2402CA5F53E00AC8CC8 /* SparkleView.swift */; };
@@ -301,7 +302,6 @@
 		1443E7F42C609E650027C1FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		147163972C5D35B70068B555 /* MusicVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicVisualizer.swift; sourceTree = "<group>"; };
 		147163992C5D35FF0068B555 /* MusicManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicManager.swift; sourceTree = "<group>"; };
-		AA05SRM22E7A0001 /* SmartReplyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartReplyManager.swift; sourceTree = "<group>"; };
 		1471A8582C6281BD0058408D /* BoringNotchWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringNotchWindow.swift; sourceTree = "<group>"; };
 		149E0B962C737D00006418B1 /* WebcamManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcamManager.swift; sourceTree = "<group>"; };
 		149E0B992C737D40006418B1 /* WebcamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcamView.swift; sourceTree = "<group>"; };
@@ -343,12 +343,12 @@
 		A5167212301F85B40018095A /* boringNotchTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = boringNotchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA01NDW22E7A0001 /* NotificationDebugWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDebugWindow.swift; sourceTree = "<group>"; };
 		AA01NLA22E7A0001 /* NotificationLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLiveActivity.swift; sourceTree = "<group>"; };
-		AA04LAS22E7A0001 /* LiveActivityStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityStack.swift; sourceTree = "<group>"; };
-		AA04LAS12E7A0001 /* LiveActivityStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA04LAS22E7A0001 /* LiveActivityStack.swift */; };
 		AA01SNM22E7A0001 /* SystemNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemNotificationManager.swift; sourceTree = "<group>"; };
 		AA02CAM22E7A0001 /* ContactAvatarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactAvatarManager.swift; sourceTree = "<group>"; };
 		AA02NSV22E7A0001 /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
 		AA03OTP22E7A0001 /* OTPDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPDetector.swift; sourceTree = "<group>"; };
+		AA04LAS22E7A0001 /* LiveActivityStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityStack.swift; sourceTree = "<group>"; };
+		AA05SRM22E7A0001 /* SmartReplyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartReplyManager.swift; sourceTree = "<group>"; };
 		AFAD1670A870402D88BFFE47 /* AudioOutputRouteResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioOutputRouteResolver.swift; sourceTree = "<group>"; };
 		B10348D82C74E56000475897 /* ConditionalModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalModifier.swift; sourceTree = "<group>"; };
 		B10F84A22C6C9596009F3026 /* TestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView.swift; sourceTree = "<group>"; };

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -99,6 +99,10 @@
 		14288E0C2C6F8EC000B9F80C /* AppIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14288E0B2C6F8EC000B9F80C /* AppIcons.swift */; };
 		1443E7F32C609DCE0027C1FC /* matters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1443E7F22C609DCE0027C1FC /* matters.swift */; };
 		147163982C5D35B70068B555 /* MusicVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147163972C5D35B70068B555 /* MusicVisualizer.swift */; };
+		AA01SNM12E7A0001 /* SystemNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA01SNM22E7A0001 /* SystemNotificationManager.swift */; };
+		AA01NDW12E7A0001 /* NotificationDebugWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA01NDW22E7A0001 /* NotificationDebugWindow.swift */; };
+		AA01NLA12E7A0001 /* NotificationLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA01NLA22E7A0001 /* NotificationLiveActivity.swift */; };
+		AA03OTP12E7A0001 /* OTPDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA03OTP22E7A0001 /* OTPDetector.swift */; };
 		1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147163992C5D35FF0068B555 /* MusicManager.swift */; };
 		1471A8592C6281BD0058408D /* BoringNotchWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1471A8582C6281BD0058408D /* BoringNotchWindow.swift */; };
 		149E0B972C737D00006418B1 /* WebcamManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149E0B962C737D00006418B1 /* WebcamManager.swift */; };
@@ -274,6 +278,8 @@
 		11DB26692EDD0CDF001EA0CF /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
 		11DB266A2EDD0CDF001EA0CF /* BatterySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatterySettingsView.swift; sourceTree = "<group>"; };
 		11DB266B2EDD0CDF001EA0CF /* CalendarSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSettingsView.swift; sourceTree = "<group>"; };
+		AA02NSV22E7A0001 /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
+		AA02NSV12E7A0001 /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA02NSV22E7A0001 /* NotificationSettingsView.swift */; };
 		11DB266C2EDD0CDF001EA0CF /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		11DB266D2EDD0CDF001EA0CF /* OSDSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDSettingsView.swift; sourceTree = "<group>"; };
 		11DB266E2EDD0CDF001EA0CF /* MediaSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaSettingsView.swift; sourceTree = "<group>"; };
@@ -293,6 +299,12 @@
 		1443E7F22C609DCE0027C1FC /* matters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = matters.swift; sourceTree = "<group>"; };
 		1443E7F42C609E650027C1FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		147163972C5D35B70068B555 /* MusicVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicVisualizer.swift; sourceTree = "<group>"; };
+		AA01SNM22E7A0001 /* SystemNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemNotificationManager.swift; sourceTree = "<group>"; };
+		AA01NDW22E7A0001 /* NotificationDebugWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDebugWindow.swift; sourceTree = "<group>"; };
+		AA01NLA22E7A0001 /* NotificationLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLiveActivity.swift; sourceTree = "<group>"; };
+		AA02CAM22E7A0001 /* ContactAvatarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactAvatarManager.swift; sourceTree = "<group>"; };
+		AA02CAM12E7A0001 /* ContactAvatarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA02CAM22E7A0001 /* ContactAvatarManager.swift */; };
+		AA03OTP22E7A0001 /* OTPDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPDetector.swift; sourceTree = "<group>"; };
 		147163992C5D35FF0068B555 /* MusicManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicManager.swift; sourceTree = "<group>"; };
 		1471A8582C6281BD0058408D /* BoringNotchWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringNotchWindow.swift; sourceTree = "<group>"; };
 		149E0B962C737D00006418B1 /* WebcamManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcamManager.swift; sourceTree = "<group>"; };
@@ -559,6 +571,7 @@
 				11DB26692EDD0CDF001EA0CF /* AppearanceSettingsView.swift */,
 				11DB266A2EDD0CDF001EA0CF /* BatterySettingsView.swift */,
 				11DB266B2EDD0CDF001EA0CF /* CalendarSettingsView.swift */,
+				AA02NSV22E7A0001 /* NotificationSettingsView.swift */,
 				11DB266C2EDD0CDF001EA0CF /* GeneralSettingsView.swift */,
 				11DB266D2EDD0CDF001EA0CF /* OSDSettingsView.swift */,
 				11DB266E2EDD0CDF001EA0CF /* MediaSettingsView.swift */,
@@ -587,6 +600,7 @@
 				1153BD972D9881F900979FB0 /* AppleScriptHelper.swift */,
 				14288DD62C6E015000B9F80C /* AudioPlayer.swift */,
 				5955950C2E900ED800C66711 /* ApplicationRelauncher.swift */,
+				AA03OTP22E7A0001 /* OTPDetector.swift */,
 				14288E0B2C6F8EC000B9F80C /* AppIcons.swift */,
 				AFAD1670A870402D88BFFE47 /* AudioOutputRouteResolver.swift */,
 			);
@@ -615,6 +629,7 @@
 			isa = PBXGroup;
 			children = (
 				11985BDF2F37A3C800F81585 /* OSD */,
+				AA01NDW22E7A0001 /* NotificationDebugWindow.swift */,
 				B141C23B2CA5F50900AC8CC8 /* Onboarding */,
 				14C08BB72C8DE49E000F8AA0 /* Calendar */,
 				9A987A042C73CA66005CA465 /* Shelf */,
@@ -639,6 +654,8 @@
 				11D58EA12E760AE100FA8377 /* ImageService.swift */,
 				F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */,
 				112FB7342CCF16F70015238C /* NotchSpaceManager.swift */,
+				AA01SNM22E7A0001 /* SystemNotificationManager.swift */,
+				AA02CAM22E7A0001 /* ContactAvatarManager.swift */,
 				147163992C5D35FF0068B555 /* MusicManager.swift */,
 				F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */,
 				149E0B962C737D00006418B1 /* WebcamManager.swift */,
@@ -832,6 +849,7 @@
 		B186542F2C6F455E000B926A /* Notch */ = {
 			isa = PBXGroup;
 			children = (
+				AA01NLA22E7A0001 /* NotificationLiveActivity.swift */,
 				1194E8862EA6DDA7009C82D6 /* BoringNotchSkyLightWindow.swift */,
 				1160F8D72DD98230006FBB94 /* NotchShape.swift */,
 				9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */,
@@ -1105,6 +1123,11 @@
 				5917FD112E57891600E87F1C /* MediaKeyInterceptor.swift in Sources */,
 				14C08BC12C8E03AD000F8AA0 /* NSImage+Extensions.swift in Sources */,
 				149E0B9A2C737D40006418B1 /* WebcamView.swift in Sources */,
+				AA01SNM12E7A0001 /* SystemNotificationManager.swift in Sources */,
+				AA01NDW12E7A0001 /* NotificationDebugWindow.swift in Sources */,
+				AA01NLA12E7A0001 /* NotificationLiveActivity.swift in Sources */,
+				AA02CAM12E7A0001 /* ContactAvatarManager.swift in Sources */,
+				AA03OTP12E7A0001 /* OTPDetector.swift in Sources */,
 				1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */,
 				F1F2A0A100000000000000F1 /* AudioCaptureManager.swift in Sources */,
 				B1B112932C6A577E00093D8F /* MouseTracker.swift in Sources */,
@@ -1128,6 +1151,7 @@
 				118EBE272E92DE8400D54B5A /* NSMenu+AssociatedObject.swift in Sources */,
 				B1CE8CFE2C6F659400DD9871 /* KeyboardShortcutsHelper.swift in Sources */,
 				11DB26732EDD0CDF001EA0CF /* ShortcutsSettingsView.swift in Sources */,
+				AA02NSV12E7A0001 /* NotificationSettingsView.swift in Sources */,
 				11DB26742EDD0CDF001EA0CF /* GeneralSettingsView.swift in Sources */,
 				11DB26752EDD0CDF001EA0CF /* ShelfSettingsView.swift in Sources */,
 				11DB26762EDD0CDF001EA0CF /* AppearanceSettingsView.swift in Sources */,
@@ -1431,6 +1455,7 @@
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "This app uses AppleEvents to control music";
 				INFOPLIST_KEY_NSCalendarsUsageDescription = "This app uses the calendar to display your calendar events";
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app uses the camera to display a live camera view";
+				INFOPLIST_KEY_NSContactsUsageDescription = "This app matches notification senders to your contacts to show their photo";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "This app uses Reminders to display your scheduled reminder in the calendar";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1497,6 +1522,7 @@
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "This app uses AppleEvents to control music";
 				INFOPLIST_KEY_NSCalendarsUsageDescription = "This app uses the calendar to display your calendar events";
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app uses the camera to display a live camera view";
+				INFOPLIST_KEY_NSContactsUsageDescription = "This app matches notification senders to your contacts to show their photo";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "This app uses Reminders to display your scheduled reminder in the calendar";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		1443E7F32C609DCE0027C1FC /* matters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1443E7F22C609DCE0027C1FC /* matters.swift */; };
 		147163982C5D35B70068B555 /* MusicVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147163972C5D35B70068B555 /* MusicVisualizer.swift */; };
 		1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147163992C5D35FF0068B555 /* MusicManager.swift */; };
+		AA05SRM12E7A0001 /* SmartReplyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05SRM22E7A0001 /* SmartReplyManager.swift */; };
 		1471A8592C6281BD0058408D /* BoringNotchWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1471A8582C6281BD0058408D /* BoringNotchWindow.swift */; };
 		149E0B972C737D00006418B1 /* WebcamManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149E0B962C737D00006418B1 /* WebcamManager.swift */; };
 		149E0B9A2C737D40006418B1 /* WebcamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149E0B992C737D40006418B1 /* WebcamView.swift */; };
@@ -300,6 +301,7 @@
 		1443E7F42C609E650027C1FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		147163972C5D35B70068B555 /* MusicVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicVisualizer.swift; sourceTree = "<group>"; };
 		147163992C5D35FF0068B555 /* MusicManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicManager.swift; sourceTree = "<group>"; };
+		AA05SRM22E7A0001 /* SmartReplyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartReplyManager.swift; sourceTree = "<group>"; };
 		1471A8582C6281BD0058408D /* BoringNotchWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringNotchWindow.swift; sourceTree = "<group>"; };
 		149E0B962C737D00006418B1 /* WebcamManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcamManager.swift; sourceTree = "<group>"; };
 		149E0B992C737D40006418B1 /* WebcamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcamView.swift; sourceTree = "<group>"; };
@@ -659,6 +661,7 @@
 				AA01SNM22E7A0001 /* SystemNotificationManager.swift */,
 				AA02CAM22E7A0001 /* ContactAvatarManager.swift */,
 				147163992C5D35FF0068B555 /* MusicManager.swift */,
+				AA05SRM22E7A0001 /* SmartReplyManager.swift */,
 				F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */,
 				149E0B962C737D00006418B1 /* WebcamManager.swift */,
 				14C08BB52C8DE42D000F8AA0 /* CalendarManager.swift */,
@@ -1133,6 +1136,7 @@
 				AA02CAM12E7A0001 /* ContactAvatarManager.swift in Sources */,
 				AA03OTP12E7A0001 /* OTPDetector.swift in Sources */,
 				1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */,
+				AA05SRM12E7A0001 /* SmartReplyManager.swift in Sources */,
 				F1F2A0A100000000000000F1 /* AudioCaptureManager.swift in Sources */,
 				B1B112932C6A577E00093D8F /* MouseTracker.swift in Sources */,
 				B1C448962C9712C4001F0858 /* ActionBar.swift in Sources */,

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -341,6 +341,8 @@
 		A5167212301F85B40018095A /* boringNotchTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = boringNotchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA01NDW22E7A0001 /* NotificationDebugWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDebugWindow.swift; sourceTree = "<group>"; };
 		AA01NLA22E7A0001 /* NotificationLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLiveActivity.swift; sourceTree = "<group>"; };
+		AA04LAS22E7A0001 /* LiveActivityStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityStack.swift; sourceTree = "<group>"; };
+		AA04LAS12E7A0001 /* LiveActivityStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA04LAS22E7A0001 /* LiveActivityStack.swift */; };
 		AA01SNM22E7A0001 /* SystemNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemNotificationManager.swift; sourceTree = "<group>"; };
 		AA02CAM22E7A0001 /* ContactAvatarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactAvatarManager.swift; sourceTree = "<group>"; };
 		AA02NSV22E7A0001 /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
@@ -850,6 +852,7 @@
 			isa = PBXGroup;
 			children = (
 				AA01NLA22E7A0001 /* NotificationLiveActivity.swift */,
+				AA04LAS22E7A0001 /* LiveActivityStack.swift */,
 				1194E8862EA6DDA7009C82D6 /* BoringNotchSkyLightWindow.swift */,
 				1160F8D72DD98230006FBB94 /* NotchShape.swift */,
 				9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */,
@@ -1126,6 +1129,7 @@
 				AA01SNM12E7A0001 /* SystemNotificationManager.swift in Sources */,
 				AA01NDW12E7A0001 /* NotificationDebugWindow.swift in Sources */,
 				AA01NLA12E7A0001 /* NotificationLiveActivity.swift in Sources */,
+				AA04LAS12E7A0001 /* LiveActivityStack.swift in Sources */,
 				AA02CAM12E7A0001 /* ContactAvatarManager.swift in Sources */,
 				AA03OTP12E7A0001 /* OTPDetector.swift in Sources */,
 				1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */,

--- a/boringNotch/BoringViewCoordinator.swift
+++ b/boringNotch/BoringViewCoordinator.swift
@@ -101,6 +101,7 @@ class BoringViewCoordinator: ObservableObject {
     private var osdReplacementCancellable: AnyCancellable?
     private var boringShelfCancellable: AnyCancellable?
     private var osdSourceCancellables: [AnyCancellable] = []
+    private var notificationLiveActivityCancellable: AnyCancellable?
 
     private init() {
         // Perform migration from name-based to UUID-based storage
@@ -173,11 +174,30 @@ class BoringViewCoordinator: ObservableObject {
                 }
             }
 
+        // Observe changes to the notification live activity
+        notificationLiveActivityCancellable = Defaults.publisher(.notificationLiveActivity)
+            .sink { change in
+                Task { @MainActor in
+                    if change.newValue {
+                        await SystemNotificationManager.shared.start()
+                        if !SystemNotificationManager.shared.isWatching {
+                            Defaults[.notificationLiveActivity] = false
+                        }
+                    } else {
+                        SystemNotificationManager.shared.stop()
+                    }
+                }
+            }
+
         Task { @MainActor in
             helloAnimationRunning = firstLaunch
 
             if Defaults[.osdReplacement] {
                 await MediaKeyInterceptor.shared.start(promptIfNeeded: false)
+            }
+
+            if Defaults[.notificationLiveActivity] {
+                await SystemNotificationManager.shared.start()
             }
             self.applyOSDSources()
         }

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -433,7 +433,12 @@ struct ContentView: View {
                           }
                       } else if !coordinator.expandingView.show && vm.notchState == .closed && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {
                           BoringFaceAnimation()
-                       } else if vm.notchState == .open {
+                       } else if vm.notchState == .open && notificationManager.activeNotification == nil {
+                           // No tab bar over a notification: it's a glance,
+                           // not a place to switch between home and shelf —
+                           // and the header spans the full notch width,
+                           // which is what was stretching the whole panel
+                           // out around a short message.
                            BoringHeader()
                                .frame(height: max(24, displayClosedNotchHeight))
                                .opacity(gestureProgress != 0 ? 1.0 - min(abs(gestureProgress) * 0.1, 0.3) : 1.0)

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -24,6 +24,8 @@ struct ContentView: View {
     @ObservedObject var brightnessManager = BrightnessManager.shared
     @ObservedObject var volumeManager = VolumeManager.shared
     @ObservedObject var notificationManager = SystemNotificationManager.shared
+    /// Which entry of the closed-notch activity stack is on top.
+    @State private var activityIndex: Int = 0
     @State private var hoverTask: Task<Void, Never>?
     @State private var isHovering: Bool = false
     @State private var anyDropDebounceTask: Task<Void, Never>?
@@ -87,6 +89,35 @@ struct ContentView: View {
         )
     }
 
+    /// Closed-notch activities, newest first. A notification sits in front of
+    /// music, so an incoming message takes over the display; when it expires
+    /// it drops out of this list on its own and music comes back — no
+    /// explicit "restore previous activity" bookkeeping needed.
+    private var liveActivities: [LiveActivityItem] {
+        var items: [LiveActivityItem] = []
+
+        if let notification = notificationManager.activeNotification {
+            items.append(.notification(notification))
+        }
+
+        let musicIsShowing = (!coordinator.expandingView.show || coordinator.expandingView.type == .music)
+            && (musicManager.isPlaying || !musicManager.isPlayerIdle)
+            && coordinator.musicLiveActivityEnabled
+        if musicIsShowing {
+            items.append(.music)
+        }
+
+        return items
+    }
+
+    /// The activity currently on top of the stack — what the chin has to be
+    /// sized for.
+    private var selectedActivity: LiveActivityItem? {
+        let items = liveActivities
+        guard !items.isEmpty else { return nil }
+        return items[min(max(activityIndex, 0), items.count - 1)]
+    }
+
     private var computedChinWidth: CGFloat {
         var chinWidth: CGFloat = vm.closedNotchSize.width
 
@@ -96,21 +127,21 @@ struct ContentView: View {
             && vm.notchState == .closed && Defaults[.showPowerStatusNotifications]
         {
             chinWidth = 640
-        } else if notificationManager.activeNotification?.detectedCode != nil && vm.notchState == .closed
-            && !vm.hideOnClosed
-        {
-            // Wide enough for the code itself plus a copy affordance, without
-            // going as far as the battery pill's 640.
-            chinWidth = 420
-        } else if notificationManager.activeNotification != nil && vm.notchState == .closed
-            && !vm.hideOnClosed
-        {
-            chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
-        } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music)
-            && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle)
-            && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed
-        {
-            chinWidth += (2 * max(0, displayClosedNotchHeight - 12) + 20 + 2 * liveActivityEdgeMargin + 2)
+        } else if vm.notchState == .closed, !vm.hideOnClosed, let activity = selectedActivity {
+            // Sized for whichever activity is actually on top, not for
+            // whichever happens to exist — otherwise swiping to music while a
+            // notification is still in the stack leaves the chin at the
+            // notification's width.
+            switch activity {
+            case .notification(let notification) where notification.detectedCode != nil:
+                // Wide enough for the code itself plus a copy affordance,
+                // without going as far as the battery pill's 640.
+                chinWidth = 420
+            case .notification:
+                chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
+            case .music:
+                chinWidth += (2 * max(0, displayClosedNotchHeight - 12) + 20 + 2 * liveActivityEdgeMargin + 2)
+            }
         } else if !coordinator.expandingView.show && vm.notchState == .closed
             && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace]
             && !vm.hideOnClosed
@@ -234,6 +265,18 @@ struct ContentView: View {
                                 isHovering = false
                             }
                         }
+                    }
+                    // A new notification always takes the front of the stack,
+                    // even if the user had swiped away to music.
+                    .onChange(of: notificationManager.activeNotification?.id) { _, newID in
+                        if newID != nil { activityIndex = 0 }
+                    }
+                    // Activities disappear on their own (a notification
+                    // expires, music stops). Keep the selection in range so
+                    // the stack falls back to whatever is left instead of
+                    // pointing past the end.
+                    .onChange(of: liveActivities.count) { _, count in
+                        if activityIndex >= count { activityIndex = max(count - 1, 0) }
                     }
                     .onChange(of: vm.isBatteryPopoverActive) {
                         if !vm.isBatteryPopoverActive && !isHovering && vm.notchState == .open && !SharingStateManager.shared.preventNotchClose {
@@ -361,9 +404,6 @@ struct ContentView: View {
                             .frame(width: 76, alignment: .trailing)
                         }
                         .frame(height: displayClosedNotchHeight, alignment: .center)
-                      } else if let notification = notificationManager.activeNotification, vm.notchState == .closed, !vm.hideOnClosed {
-                          NotificationLiveActivity(notification: notification)
-                              .transition(.opacity)
                       } else if coordinator.shouldShowSneakPeek(on: vm.screenUUID) && Defaults[.inlineOSD] && (coordinator.sneakPeekState(for: vm.screenUUID).type != .music) && (coordinator.sneakPeekState(for: vm.screenUUID).type != .battery) && vm.notchState == .closed {
                           InlineOSD(
                               type: coordinator.binding(for: vm.screenUUID).type,
@@ -374,9 +414,16 @@ struct ContentView: View {
                               gestureProgress: $gestureProgress
                           )
                               .transition(.opacity)
-                      } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music) && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed {
-                          MusicLiveActivity()
-                              .frame(alignment: .center)
+                      } else if !liveActivities.isEmpty && vm.notchState == .closed && !vm.hideOnClosed {
+                          LiveActivityStackView(items: liveActivities, index: $activityIndex) { item in
+                              switch item {
+                              case .notification(let notification):
+                                  NotificationLiveActivity(notification: notification)
+                              case .music:
+                                  MusicLiveActivity()
+                                      .frame(alignment: .center)
+                              }
+                          }
                       } else if !coordinator.expandingView.show && vm.notchState == .closed && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {
                           BoringFaceAnimation()
                        } else if vm.notchState == .open {

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -719,7 +719,16 @@ struct ContentView: View {
             withAnimation(animationSpring) {
                 isHovering = true
             }
-            
+
+            // Freeze the dismiss countdown the moment the pointer arrives,
+            // not when the notch finishes opening. Opening waits out
+            // minimumHoverDuration plus an animation, and a notification
+            // near the end of its life would expire during that — so it
+            // vanished exactly as the notch opened around it.
+            if notificationManager.activeNotification != nil {
+                notificationManager.holdActive()
+            }
+
             if vm.notchState == .closed && Defaults[.enableHaptics] {
                 haptics.toggle()
             }
@@ -751,7 +760,10 @@ struct ContentView: View {
                     withAnimation(animationSpring) {
                         self.isHovering = false
                     }
-                    
+
+                    // Pointer left — let the notification age out again.
+                    self.notificationManager.resumeDismiss()
+
                     if self.vm.notchState == .open && !self.vm.isBatteryPopoverActive && !SharingStateManager.shared.preventNotchClose {
                         self.vm.close()
                     }

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentView: View {
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var brightnessManager = BrightnessManager.shared
     @ObservedObject var volumeManager = VolumeManager.shared
+    @ObservedObject var notificationManager = SystemNotificationManager.shared
     @State private var hoverTask: Task<Void, Never>?
     @State private var isHovering: Bool = false
     @State private var anyDropDebounceTask: Task<Void, Never>?
@@ -95,6 +96,16 @@ struct ContentView: View {
             && vm.notchState == .closed && Defaults[.showPowerStatusNotifications]
         {
             chinWidth = 640
+        } else if notificationManager.activeNotification?.detectedCode != nil && vm.notchState == .closed
+            && !vm.hideOnClosed
+        {
+            // Wide enough for the code itself plus a copy affordance, without
+            // going as far as the battery pill's 640.
+            chinWidth = 420
+        } else if notificationManager.activeNotification != nil && vm.notchState == .closed
+            && !vm.hideOnClosed
+        {
+            chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
         } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music)
             && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle)
             && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed
@@ -350,6 +361,9 @@ struct ContentView: View {
                             .frame(width: 76, alignment: .trailing)
                         }
                         .frame(height: displayClosedNotchHeight, alignment: .center)
+                      } else if let notification = notificationManager.activeNotification, vm.notchState == .closed, !vm.hideOnClosed {
+                          NotificationLiveActivity(notification: notification)
+                              .transition(.opacity)
                       } else if coordinator.shouldShowSneakPeek(on: vm.screenUUID) && Defaults[.inlineOSD] && (coordinator.sneakPeekState(for: vm.screenUUID).type != .music) && (coordinator.sneakPeekState(for: vm.screenUUID).type != .battery) && vm.notchState == .closed {
                           InlineOSD(
                               type: coordinator.binding(for: vm.screenUUID).type,
@@ -422,18 +436,24 @@ struct ContentView: View {
               .zIndex(1)
             if vm.notchState == .open {
                 VStack {
-                    switch coordinator.currentView {
-                    case .home:
-                        NotchHomeView(
-                            albumArtNamespace: albumArtNamespace,
-                            horizontalMediaGestureFeedback: horizontalMediaGestureFeedback,
-                            isHoveringMusicArea: $isHoveringMusicArea
-                        )
-                    case .shelf:
-                        ShelfView(
-                            dropInteraction: vm.dropInteraction,
-                            animation: vm.animation
-                        )
+                    // An open notch with a live notification is showing the
+                    // reply UI — the usual tabs can wait until it's dismissed.
+                    if let notification = notificationManager.activeNotification {
+                        NotificationExpandedView(notification: notification)
+                    } else {
+                        switch coordinator.currentView {
+                        case .home:
+                            NotchHomeView(
+                                albumArtNamespace: albumArtNamespace,
+                                horizontalMediaGestureFeedback: horizontalMediaGestureFeedback,
+                                isHoveringMusicArea: $isHoveringMusicArea
+                            )
+                        case .shelf:
+                            ShelfView(
+                                dropInteraction: vm.dropInteraction,
+                                animation: vm.animation
+                            )
+                        }
                     }
                 }
                 .transition(

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -216,7 +216,14 @@ struct ContentView: View {
                     .opacity((isNotchHeightZero && vm.notchState == .closed) ? 0.01 : 1)
                 
                 mainLayout
-                    .frame(height: vm.notchState == .open ? openNotchHeight : nil)
+                    // alignment: .top matters here — without it this frame
+                    // defaults to centering, and shrinking the height for a
+                    // notification (openNotchHeight < vm.notchSize.height)
+                    // then pulls the visible top edge down by half the
+                    // difference instead of staying flush with the window's
+                    // top-anchored origin. That's what read as "the notch
+                    // sits a bit off the top of the screen."
+                    .frame(height: vm.notchState == .open ? openNotchHeight : nil, alignment: .top)
                     .conditionalModifier(true) { view in
                         return view
                             .animation(vm.notchState == .open ? StandardAnimations.open : StandardAnimations.close, value: vm.notchState)

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -110,6 +110,13 @@ struct ContentView: View {
         return items
     }
 
+    /// A notification is a glance, not a workspace — it doesn't need the full
+    /// height the home/shelf tabs are sized for, and stretching to fill it
+    /// just surrounds two lines of text with empty black.
+    private var openNotchHeight: CGFloat {
+        notificationManager.activeNotification != nil ? 132 : vm.notchSize.height
+    }
+
     /// The activity currently on top of the stack — what the chin has to be
     /// sized for.
     private var selectedActivity: LiveActivityItem? {
@@ -209,7 +216,7 @@ struct ContentView: View {
                     .opacity((isNotchHeightZero && vm.notchState == .closed) ? 0.01 : 1)
                 
                 mainLayout
-                    .frame(height: vm.notchState == .open ? vm.notchSize.height : nil)
+                    .frame(height: vm.notchState == .open ? openNotchHeight : nil)
                     .conditionalModifier(true) { view in
                         return view
                             .animation(vm.notchState == .open ? StandardAnimations.open : StandardAnimations.close, value: vm.notchState)

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -24600,6 +24600,9 @@
         }
       }
     },
+    "Suggest replies with Apple Intelligence" : {
+
+    },
     "System" : {
       "localizations" : {
         "de" : {

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -604,6 +604,9 @@
         }
       }
     },
+    "actions: %@" : {
+
+    },
     "Add" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1861,6 +1864,9 @@
         }
       },
       "shouldTranslate" : false
+    },
+    "Apps" : {
+
     },
     "Auto-scroll to next event" : {
       "localizations" : {
@@ -5133,6 +5139,9 @@
         }
       }
     },
+    "Clear" : {
+
+    },
     "Clear slot" : {
       "localizations" : {
         "de" : {
@@ -6133,6 +6142,12 @@
           }
         }
       }
+    },
+    "Copied" : {
+
+    },
+    "Copy" : {
+
     },
     "Copy Meeting Link" : {
 
@@ -7919,6 +7934,9 @@
         }
       }
     },
+    "Dump AX tree" : {
+
+    },
     "Edit layout" : {
       "localizations" : {
         "cs" : {
@@ -9134,6 +9152,9 @@
         }
       }
     },
+    "expired" : {
+
+    },
     "Extend hover area" : {
       "localizations" : {
         "de" : {
@@ -9594,6 +9615,8 @@
     },
     "Frame shape" : {
       "comment" : "A label for the shape of the mirror frame."
+    },
+    "From all apps" : {
     },
     "Full charge" : {
       "localizations" : {
@@ -11125,6 +11148,9 @@
           }
         }
       }
+    },
+    "Hide system banner, show in notch only" : {
+
     },
     "Hide title bar" : {
       "localizations" : {
@@ -15654,6 +15680,9 @@
         }
       }
     },
+    "Not watching" : {
+
+    },
     "Notch animation" : {
       "localizations" : {
         "cs" : {
@@ -16184,6 +16213,12 @@
         }
       }
     },
+    "Notification Debug" : {
+
+    },
+    "Notifications" : {
+
+    },
     "Now Playing" : {
       "localizations" : {
         "cs" : {
@@ -16281,6 +16316,12 @@
           }
         }
       }
+    },
+    "Only these apps show a live activity in the notch. Turn on \"From all apps\" to mirror everything instead." : {
+
+    },
+    "Open" : {
+
     },
     "Open Calendar Settings" : {
       "localizations" : {
@@ -16399,6 +16440,9 @@
           }
         }
       }
+    },
+    "Open in %@" : {
+
     },
     "Open Notch" : {
       "extractionState" : "stale",
@@ -19124,6 +19168,12 @@
         }
       }
     },
+    "Reply" : {
+
+    },
+    "reply…" : {
+
+    },
     "Request Accessibility" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -19247,6 +19297,9 @@
           }
         }
       }
+    },
+    "Requires Accessibility access. Only banners are mirrored — notifications delivered silently to Notification Center aren't visible to the app." : {
+
     },
     "Requires macOS 14.2 or later. Update macOS to enable real-time audio waveform." : {
       "localizations" : {
@@ -20266,6 +20319,9 @@
           }
         }
       }
+    },
+    "Send" : {
+
     },
     "Settings" : {
       "localizations" : {
@@ -22417,6 +22473,9 @@
         }
       }
     },
+    "Show notifications in the notch" : {
+
+    },
     "Show on all displays" : {
       "localizations" : {
         "cs" : {
@@ -24415,6 +24474,12 @@
           }
         }
       }
+    },
+    "Start" : {
+
+    },
+    "Stop" : {
+
     },
     "Stopped" : {
       "extractionState" : "stale",
@@ -27033,6 +27098,9 @@
           }
         }
       }
+    },
+    "Watching" : {
+
     },
     "Week starts on" : {
       "comment" : "Calendar setting: which weekday the week strip starts on",

--- a/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
+++ b/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
@@ -63,6 +63,7 @@ final class BNLunarBrightnessEvent: NSObject, NSSecureCoding {
     func startNotificationWatching(with reply: @escaping (Bool) -> Void)
     func stopNotificationWatching()
     func replyToNotification(_ token: String, text: String, with reply: @escaping (Bool) -> Void)
+    func sendIMessage(_ text: String, toChatNamed name: String, with reply: @escaping (Bool) -> Void)
     func performNotificationAction(_ token: String, name: String, with reply: @escaping (Bool) -> Void)
     func openNotification(_ token: String, with reply: @escaping (Bool) -> Void)
     func dismissNotification(_ token: String, with reply: @escaping (Bool) -> Void)

--- a/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
+++ b/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
@@ -67,6 +67,8 @@ final class BNLunarBrightnessEvent: NSObject, NSSecureCoding {
     func performNotificationAction(_ token: String, name: String, with reply: @escaping (Bool) -> Void)
     func openNotification(_ token: String, with reply: @escaping (Bool) -> Void)
     func dismissNotification(_ token: String, with reply: @escaping (Bool) -> Void)
+    func holdNotification(_ token: String, offScreen: Bool)
+    func releaseNotification(_ token: String)
     func notificationDebugDump(with reply: @escaping (String) -> Void)
 }
 

--- a/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
+++ b/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
@@ -67,7 +67,7 @@ final class BNLunarBrightnessEvent: NSObject, NSSecureCoding {
     func performNotificationAction(_ token: String, name: String, with reply: @escaping (Bool) -> Void)
     func openNotification(_ token: String, with reply: @escaping (Bool) -> Void)
     func dismissNotification(_ token: String, with reply: @escaping (Bool) -> Void)
-    func holdNotification(_ token: String, offScreen: Bool)
+    func holdNotification(_ token: String)
     func releaseNotification(_ token: String)
     func notificationDebugDump(with reply: @escaping (String) -> Void)
 }

--- a/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
+++ b/boringNotch/XPCHelperClient/BoringNotchXPCHelperProtocol.swift
@@ -59,4 +59,26 @@ final class BNLunarBrightnessEvent: NSObject, NSSecureCoding {
     func stopLunarEventStream()
     /// Write Lunar's hideOSD preference (disable/enable Lunar's OSD when we replace it).
     func setLunarOSDHidden(_ hide: Bool, with reply: @escaping (Bool) -> Void)
+    // Notification Center banner observation (performed by the helper)
+    func startNotificationWatching(with reply: @escaping (Bool) -> Void)
+    func stopNotificationWatching()
+    func replyToNotification(_ token: String, text: String, with reply: @escaping (Bool) -> Void)
+    func performNotificationAction(_ token: String, name: String, with reply: @escaping (Bool) -> Void)
+    func openNotification(_ token: String, with reply: @escaping (Bool) -> Void)
+    func dismissNotification(_ token: String, with reply: @escaping (Bool) -> Void)
+    func notificationDebugDump(with reply: @escaping (String) -> Void)
 }
+
+/// Pushed from the helper back to the app. The app sets an object conforming to
+/// this as its connection's `exportedObject`.
+@objc protocol BoringNotchXPCHelperDelegate {
+    /// Keys: token, appName, bundleID, title, subtitle, body, actions
+    /// (`actions` is newline-joined).
+    func notificationDidAppear(_ payload: [String: String])
+    func notificationDidDisappear(_ token: String)
+}
+
+/// A connection has exactly one exported object, and the helper calls back for
+/// both Lunar events and notification banners — so the app vends a single
+/// object conforming to both.
+@objc protocol BoringNotchXPCAppDelegate: BoringNotchXPCHelperLunarListener, BoringNotchXPCHelperDelegate {}

--- a/boringNotch/XPCHelperClient/XPCHelperClient.swift
+++ b/boringNotch/XPCHelperClient/XPCHelperClient.swift
@@ -430,10 +430,10 @@ extension XPCHelperClient {
 
     /// Keeps a banner alive so its reply field stays usable, optionally
     /// moving it off-screen so the user never sees it.
-    nonisolated func holdNotification(token: String, offScreen: Bool) {
+    nonisolated func holdNotification(token: String) {
         Task {
             let service = await MainActor.run { ensureRemoteService() }
-            try? await service.withService { $0.holdNotification(token, offScreen: offScreen) }
+            try? await service.withService { $0.holdNotification(token) }
         }
     }
 

--- a/boringNotch/XPCHelperClient/XPCHelperClient.swift
+++ b/boringNotch/XPCHelperClient/XPCHelperClient.swift
@@ -428,6 +428,22 @@ extension XPCHelperClient {
         }
     }
 
+    /// Keeps a banner alive so its reply field stays usable, optionally
+    /// moving it off-screen so the user never sees it.
+    nonisolated func holdNotification(token: String, offScreen: Bool) {
+        Task {
+            let service = await MainActor.run { ensureRemoteService() }
+            try? await service.withService { $0.holdNotification(token, offScreen: offScreen) }
+        }
+    }
+
+    nonisolated func releaseNotification(token: String) {
+        Task {
+            let service = await MainActor.run { ensureRemoteService() }
+            try? await service.withService { $0.releaseNotification(token) }
+        }
+    }
+
     nonisolated func sendIMessage(_ text: String, toChatNamed name: String) async -> Bool {
         do {
             let service = await MainActor.run { ensureRemoteService() }

--- a/boringNotch/XPCHelperClient/XPCHelperClient.swift
+++ b/boringNotch/XPCHelperClient/XPCHelperClient.swift
@@ -15,6 +15,7 @@ final class XPCHelperClient: NSObject {
     private var remoteService: RemoteXPCService<BoringNotchXPCHelperProtocol>?
     private var connection: NSXPCConnection?
     private var lastKnownAuthorization: Bool?
+    private let notificationDelegate = NotificationXPCDelegate()
     private var monitoringTask: Task<Void, Never>?
     private var lunarListener: BoringNotchXPCHelperLunarListener?
     private var hasLunarListener: Bool = false
@@ -34,14 +35,11 @@ final class XPCHelperClient: NSObject {
         
         let conn = NSXPCConnection(serviceName: serviceName)
 
-        if needsListener, let lunarListener {
-            let listenerInterface = makeLunarListenerInterface()
-            conn.exportedInterface = listenerInterface
-            conn.exportedObject = lunarListener
-            hasLunarListener = true
-        } else {
-            hasLunarListener = false
-        }
+        // One exported object serves both callback protocols.
+        notificationDelegate.lunarListener = lunarListener
+        conn.exportedInterface = makeAppDelegateInterface()
+        conn.exportedObject = notificationDelegate
+        hasLunarListener = needsListener && lunarListener != nil
         
         conn.interruptionHandler = { [weak self] in
             Task { @MainActor in
@@ -60,7 +58,7 @@ final class XPCHelperClient: NSObject {
         }
         
         conn.resume()
-        
+
         let service = RemoteXPCService<BoringNotchXPCHelperProtocol>(
             connection: conn,
             remoteInterface: BoringNotchXPCHelperProtocol.self
@@ -75,8 +73,8 @@ final class XPCHelperClient: NSObject {
         remoteService
     }
 
-    private func makeLunarListenerInterface() -> NSXPCInterface {
-        let interface = NSXPCInterface(with: (any BoringNotchXPCHelperLunarListener).self)
+    private func makeAppDelegateInterface() -> NSXPCInterface {
+        let interface = NSXPCInterface(with: (any BoringNotchXPCAppDelegate).self)
         interface.setClasses(
             NSSet(array: [BNLunarBrightnessEvent.self]) as! Set<AnyHashable>,
             for: #selector(BoringNotchXPCHelperLunarListener.lunarEventDidUpdate(_:)),
@@ -329,4 +327,126 @@ final class XPCHelperClient: NSObject {
         }
     }
 }
+
+// MARK: - Notification Center banners
+
+/// The app's single exported XPC object. Banner pushes are republished as local
+/// notifications; Lunar events are forwarded to whichever listener the OSD code
+/// registered, since both callbacks share one connection.
+final class NotificationXPCDelegate: NSObject, BoringNotchXPCAppDelegate {
+    var lunarListener: BoringNotchXPCHelperLunarListener?
+
+    func lunarEventDidUpdate(_ event: BNLunarBrightnessEvent) {
+        lunarListener?.lunarEventDidUpdate(event)
+    }
+
+    func lunarStreamDidStop(_ reason: String?) {
+        lunarListener?.lunarStreamDidStop(reason)
+    }
+
+    func notificationDidAppear(_ payload: [String: String]) {
+        NotificationCenter.default.post(
+            name: .systemNotificationDidAppear, object: nil, userInfo: payload
+        )
+    }
+
+    func notificationDidDisappear(_ token: String) {
+        NotificationCenter.default.post(
+            name: .systemNotificationDidDisappear, object: nil, userInfo: ["token": token]
+        )
+    }
+}
+
+extension XPCHelperClient {
+    nonisolated func startNotificationWatching() async -> Bool {
+        do {
+            let service = await MainActor.run { ensureRemoteService() }
+            return try await service.withContinuation { service, continuation in
+                service.startNotificationWatching { started in
+                    continuation.resume(returning: started)
+                }
+            }
+        } catch {
+            return false
+        }
+    }
+
+    nonisolated func stopNotificationWatching() {
+        Task {
+            let service = await MainActor.run { ensureRemoteService() }
+            try? await service.withService { $0.stopNotificationWatching() }
+        }
+    }
+
+    nonisolated func replyToNotification(token: String, text: String) async -> Bool {
+        do {
+            let service = await MainActor.run { ensureRemoteService() }
+            return try await service.withContinuation { service, continuation in
+                service.replyToNotification(token, text: text) { sent in
+                    continuation.resume(returning: sent)
+                }
+            }
+        } catch {
+            return false
+        }
+    }
+
+    nonisolated func performNotificationAction(token: String, name: String) async -> Bool {
+        do {
+            let service = await MainActor.run { ensureRemoteService() }
+            return try await service.withContinuation { service, continuation in
+                service.performNotificationAction(token, name: name) { done in
+                    continuation.resume(returning: done)
+                }
+            }
+        } catch {
+            return false
+        }
+    }
+
+    nonisolated func openNotification(token: String) async -> Bool {
+        do {
+            let service = await MainActor.run { ensureRemoteService() }
+            return try await service.withContinuation { service, continuation in
+                service.openNotification(token) { opened in
+                    continuation.resume(returning: opened)
+                }
+            }
+        } catch {
+            return false
+        }
+    }
+
+    nonisolated func dismissNotification(token: String) async -> Bool {
+        do {
+            let service = await MainActor.run { ensureRemoteService() }
+            return try await service.withContinuation { service, continuation in
+                service.dismissNotification(token) { dismissed in
+                    continuation.resume(returning: dismissed)
+                }
+            }
+        } catch {
+            return false
+        }
+    }
+
+    nonisolated func notificationDebugDump() async -> String {
+        do {
+            let service = await MainActor.run { ensureRemoteService() }
+            return try await service.withContinuation { service, continuation in
+                service.notificationDebugDump { dump in
+                    continuation.resume(returning: dump)
+                }
+            }
+        } catch {
+            return "xpc error: \(error)"
+        }
+    }
+}
+
+extension Notification.Name {
+    static let systemNotificationDidAppear = Notification.Name("systemNotificationDidAppear")
+    static let systemNotificationDidDisappear = Notification.Name("systemNotificationDidDisappear")
+}
+
 

--- a/boringNotch/XPCHelperClient/XPCHelperClient.swift
+++ b/boringNotch/XPCHelperClient/XPCHelperClient.swift
@@ -23,16 +23,22 @@ final class XPCHelperClient: NSObject {
     // MARK: - Connection Management (Main Actor Isolated)
     
     private func ensureRemoteService(needsListener: Bool = false) -> RemoteXPCService<BoringNotchXPCHelperProtocol> {
-        if let existing = remoteService, (!needsListener || hasLunarListener) {
+        // Always reuse a live connection — never tear one down to attach a
+        // listener. The exported object below serves *both* callback
+        // protocols from the moment the connection is created, so there's
+        // nothing to re-negotiate.
+        //
+        // This previously invalidated and rebuilt the connection whenever
+        // Lunar/OSD asked for a listener. The helper captures its callback
+        // proxy once, when notification watching starts; invalidating that
+        // connection left it holding a dead proxy, so banners kept being
+        // captured in the helper and silently never arrived in the app.
+        if let existing = remoteService {
+            notificationDelegate.lunarListener = lunarListener
+            hasLunarListener = hasLunarListener || (needsListener && lunarListener != nil)
             return existing
         }
 
-        if let connection {
-            connection.invalidate()
-            self.connection = nil
-            self.remoteService = nil
-        }
-        
         let conn = NSXPCConnection(serviceName: serviceName)
 
         // One exported object serves both callback protocols.
@@ -40,7 +46,7 @@ final class XPCHelperClient: NSObject {
         conn.exportedInterface = makeAppDelegateInterface()
         conn.exportedObject = notificationDelegate
         hasLunarListener = needsListener && lunarListener != nil
-        
+
         conn.interruptionHandler = { [weak self] in
             Task { @MainActor in
                 self?.connection = nil
@@ -291,6 +297,10 @@ final class XPCHelperClient: NSObject {
 
     func startLunarEventStream(listener: BoringNotchXPCHelperLunarListener) async -> Bool {
         lunarListener = listener
+        // Register on the shared exported object too: the connection may
+        // already exist (it isn't rebuilt for listeners any more), in
+        // which case this is the only path that hooks Lunar events up.
+        notificationDelegate.lunarListener = listener
         do {
             let service = ensureRemoteService(needsListener: true)
             return try await service.withContinuation { service, continuation in

--- a/boringNotch/XPCHelperClient/XPCHelperClient.swift
+++ b/boringNotch/XPCHelperClient/XPCHelperClient.swift
@@ -428,6 +428,19 @@ extension XPCHelperClient {
         }
     }
 
+    nonisolated func sendIMessage(_ text: String, toChatNamed name: String) async -> Bool {
+        do {
+            let service = await MainActor.run { ensureRemoteService() }
+            return try await service.withContinuation { service, continuation in
+                service.sendIMessage(text, toChatNamed: name) { sent in
+                    continuation.resume(returning: sent)
+                }
+            }
+        } catch {
+            return false
+        }
+    }
+
     nonisolated func dismissNotification(token: String) async -> Bool {
         do {
             let service = await MainActor.run { ensureRemoteService() }

--- a/boringNotch/XPCHelperClient/XPCHelperClient.swift
+++ b/boringNotch/XPCHelperClient/XPCHelperClient.swift
@@ -345,6 +345,7 @@ final class NotificationXPCDelegate: NSObject, BoringNotchXPCAppDelegate {
     }
 
     func notificationDidAppear(_ payload: [String: String]) {
+        NSLog("[boringNotch] app received banner: \(payload["appName"] ?? "-") / \(payload["title"] ?? "-")")
         NotificationCenter.default.post(
             name: .systemNotificationDidAppear, object: nil, userInfo: payload
         )

--- a/boringNotch/boringNotch.entitlements
+++ b/boringNotch/boringNotch.entitlements
@@ -22,6 +22,8 @@
 	<true/>
 	<key>com.apple.security.personal-information.calendars</key>
 	<true/>
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
 	<key>com.apple.security.temporary-exception.apple-events</key>
 	<array>
 		<string>com.spotify.client</string>

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -21,6 +21,9 @@ struct DynamicNotchApp: App {
     let updaterController: SPUStandardUpdaterController
 
     init() {
+        #if DEBUG
+        OTPDetector.runSelfCheck()
+        #endif
         let sparkleUpdaterDelegate = BoringSparkleUpdaterDelegate()
         self.sparkleUpdaterDelegate = sparkleUpdaterDelegate
         updaterController = SPUStandardUpdaterController(
@@ -40,6 +43,10 @@ struct DynamicNotchApp: App {
             }
             .keyboardShortcut(KeyEquivalent(","), modifiers: .command)
             CheckForUpdatesView(updater: updaterController.updater)
+            Button("Notification Debug") {
+                openWindow(id: "notification-debug")
+                NSApp.activate(ignoringOtherApps: true)
+            }
             Divider()
             Button("Restart Boring Notch") {
                 ApplicationRelauncher.restart()
@@ -48,6 +55,10 @@ struct DynamicNotchApp: App {
                 NSApplication.shared.terminate(self)
             }
             .keyboardShortcut(KeyEquivalent("Q"), modifiers: .command)
+        }
+
+        Window("Notification Debug", id: "notification-debug") {
+            NotificationDebugView()
         }
     }
 }

--- a/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
@@ -146,6 +146,25 @@ class BoringNotchSkyLightWindow: NSPanel {
         }
     }
     
-    override var canBecomeKey: Bool { false }
+    /// False by default so a click on the notch never activates the app or
+    /// steals focus from whatever is frontmost — load-bearing for every
+    /// normal interaction (hover-to-open, music controls, OSD). A text field
+    /// needs this flipped on for the moment it's actually being typed into,
+    /// and back off the instant it isn't — never left permanently true.
+    ///
+    /// This is the window class actually instantiated for the notch
+    /// (createBoringNotchWindow uses BoringNotchSkyLightWindow, not the
+    /// separate, unused BoringNotchWindow class) — an earlier fix targeted
+    /// that unused class and silently did nothing.
+    var wantsKeyForTextInput = false {
+        didSet {
+            guard wantsKeyForTextInput != oldValue else { return }
+            if wantsKeyForTextInput {
+                makeKey()
+            }
+        }
+    }
+
+    override var canBecomeKey: Bool { wantsKeyForTextInput }
     override var canBecomeMain: Bool { false }
 }

--- a/boringNotch/components/Notch/BoringNotchWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchWindow.swift
@@ -40,10 +40,29 @@ class BoringNotchWindow: NSPanel {
         hasShadow = false
     }
     
-    override var canBecomeKey: Bool {
-        false
+    /// False by default so a click on the notch never steals focus from
+    /// whatever app is frontmost — that's load-bearing for every other
+    /// interaction (hover-to-open, music controls, OSD). But it also means
+    /// NO text field in this window can ever receive a keystroke: SwiftUI's
+    /// @FocusState/.focused() only sets the responder *within* the view
+    /// hierarchy, and macOS never routes real keyDown events to a window
+    /// that can't become key. A reply field needs this flipped on for the
+    /// moment it's actually being typed into, and back off immediately
+    /// after — never left permanently true, or every other interaction
+    /// regresses.
+    var wantsKeyForTextInput = false {
+        didSet {
+            guard wantsKeyForTextInput != oldValue else { return }
+            if wantsKeyForTextInput {
+                makeKey()
+            }
+        }
     }
-    
+
+    override var canBecomeKey: Bool {
+        wantsKeyForTextInput
+    }
+
     override var canBecomeMain: Bool {
         false
     }

--- a/boringNotch/components/Notch/LiveActivityStack.swift
+++ b/boringNotch/components/Notch/LiveActivityStack.swift
@@ -1,0 +1,115 @@
+//
+//  LiveActivityStack.swift
+//  boringNotch
+//
+//  A browsable stack of closed-notch live activities, in the spirit of the
+//  Dynamic Island / Lock Screen activity stack: the newest activity takes
+//  the front, older ones sit behind it, and the user can swipe between them.
+//
+//  Transient activities (a notification) auto-expire and reveal whatever was
+//  underneath (music), so an incoming message interrupts the now-playing
+//  display for a beat and then hands it back on its own.
+//
+
+import Defaults
+import SwiftUI
+
+/// One entry in the closed-notch stack.
+///
+/// Deliberately excludes the momentary HUDs — volume/brightness OSD and the
+/// battery pill. Those are interrupts, not activities: they take over for
+/// ~1.5s and aren't something you'd want to swipe back to, which is also how
+/// iOS separates them from live activities.
+enum LiveActivityItem: Identifiable, Equatable {
+    case notification(SystemNotification)
+    case music
+
+    var id: String {
+        switch self {
+        case .notification(let notification): "notification-\(notification.id)"
+        case .music: "music"
+        }
+    }
+}
+
+/// Renders the selected activity with the others hinted behind it, and
+/// handles swiping between them.
+///
+/// Takes its content via a closure so callers keep ownership of how each
+/// activity draws — `MusicLiveActivity` depends on ContentView's namespace
+/// and gesture state, and dragging it out here would be a much larger,
+/// riskier change than this feature needs.
+struct LiveActivityStackView<Content: View>: View {
+    let items: [LiveActivityItem]
+    @Binding var index: Int
+    @ViewBuilder let content: (LiveActivityItem) -> Content
+
+    @State private var dragOffset: CGFloat = 0
+    @State private var haptics: Bool = false
+
+    private var clampedIndex: Int { min(max(index, 0), max(items.count - 1, 0)) }
+
+    var body: some View {
+        ZStack {
+            // The card behind the front one, nudged down and dimmed. Purely a
+            // depth cue that there's more here — the closed notch has no room
+            // for a page-dot row.
+            if items.count > 1 {
+                Capsule()
+                    .fill(.white.opacity(0.12))
+                    .frame(height: 3)
+                    .padding(.horizontal, 40)
+                    .offset(y: 9)
+                    .transition(.opacity)
+            }
+
+            if let item = items[safe: clampedIndex] {
+                content(item)
+                    .id(item.id)
+                    .offset(x: dragOffset)
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .top).combined(with: .opacity),
+                        removal: .opacity
+                    ))
+            }
+        }
+        .animation(.smooth(duration: 0.3), value: clampedIndex)
+        .animation(.smooth(duration: 0.3), value: items.count)
+        .contentShape(Rectangle())
+        // minimumDistance keeps taps (open the notch) and the notch's own
+        // vertical pan gestures working — this only claims deliberate
+        // horizontal drags.
+        .gesture(
+            DragGesture(minimumDistance: 14)
+                .onChanged { value in
+                    guard items.count > 1, abs(value.translation.width) > abs(value.translation.height) else { return }
+                    dragOffset = value.translation.width * 0.3
+                }
+                .onEnded { value in
+                    dragOffset = 0
+                    guard items.count > 1,
+                          abs(value.translation.width) > abs(value.translation.height),
+                          abs(value.translation.width) > 24
+                    else { return }
+                    move(by: value.translation.width < 0 ? 1 : -1)
+                }
+        )
+        .sensoryFeedback(.alignment, trigger: haptics)
+    }
+
+    private func move(by delta: Int) {
+        let next = clampedIndex + delta
+        guard items.indices.contains(next) else { return }
+        withAnimation(.smooth(duration: 0.3)) { index = next }
+        if Defaults[.enableHaptics] { haptics.toggle() }
+    }
+}
+
+private extension Array {
+    /// The stack's contents change out from under the selection (a
+    /// notification expires, music stops), so every read is bounds-checked
+    /// rather than trusting an index that was valid a frame ago.
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/boringNotch/components/Notch/LiveActivityStack.swift
+++ b/boringNotch/components/Notch/LiveActivityStack.swift
@@ -51,18 +51,12 @@ struct LiveActivityStackView<Content: View>: View {
 
     var body: some View {
         ZStack {
-            // The card behind the front one, nudged down and dimmed. Purely a
-            // depth cue that there's more here — the closed notch has no room
-            // for a page-dot row.
-            if items.count > 1 {
-                Capsule()
-                    .fill(.white.opacity(0.12))
-                    .frame(height: 3)
-                    .padding(.horizontal, 40)
-                    .offset(y: 9)
-                    .transition(.opacity)
-            }
-
+            // No "card behind the card" depth cue here. A full-width shape
+            // drawn behind the content is bisected by the black rectangle
+            // that masks the physical notch cutout, so it renders as two
+            // disembodied lines flanking the notch rather than as a stack.
+            // The closed pill has no room for a page-dot row either, so the
+            // stack stays discoverable by swiping rather than by ornament.
             if let item = items[safe: clampedIndex] {
                 content(item)
                     .id(item.id)

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -114,6 +114,7 @@ struct NotificationExpandedView: View {
     @State private var didHandOff = false
     @FocusState private var replyFocused: Bool
     @State private var hostWindow: BoringNotchWindow?
+    @State private var suggestions: [String] = []
 
     private var kind: NotificationKind { .init(notification) }
 
@@ -314,6 +315,44 @@ struct NotificationExpandedView: View {
     // MARK: - Reply
 
     private var replyRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if !suggestions.isEmpty {
+                suggestionChips
+            }
+            replyField
+        }
+        .task(id: notification.id) {
+            guard Defaults[.smartRepliesEnabled], let body = notification.body else { return }
+            suggestions = await SmartReplyManager.suggestReplies(sender: notification.sender, body: body)
+        }
+    }
+
+    /// Tapping a chip fills the field rather than sending immediately — an
+    /// AI-drafted reply should get a glance before it goes out under your
+    /// name, not fire on a single tap.
+    private var suggestionChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(suggestions, id: \.self) { suggestion in
+                    Button {
+                        replyText = suggestion
+                        replyFocused = true
+                    } label: {
+                        Text(suggestion)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(.white.opacity(0.1), in: Capsule())
+                    }
+                    .buttonStyle(ScaleDownButtonStyle())
+                }
+            }
+        }
+    }
+
+    private var replyField: some View {
         HStack(spacing: 8) {
             HStack(spacing: 6) {
                 TextField("Reply", text: $replyText, axis: .horizontal)

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -1,0 +1,482 @@
+//
+//  NotificationLiveActivity.swift
+//  boringNotch
+//
+//  Closed-state and expanded presentations for an incoming system
+//  notification mirrored from Notification Center.
+//
+//  Design intent: mirror the restraint of a native macOS/iOS notification
+//  banner — clear hierarchy (who → what → action), one obvious primary
+//  action, generous but not wasteful spacing, and motion that settles
+//  rather than bounces. Reuses the app's existing visual language (accent
+//  color, AppIcon, MarqueeText, HoverButton) rather than inventing new
+//  primitives.
+//
+
+import Defaults
+import SwiftUI
+
+/// Closed notch: app icon on the left, a status dot on the right that
+/// briefly pulses on arrival — the same "something just happened" language
+/// as an unread badge, without needing to read anything at a glance.
+struct NotificationLiveActivity: View {
+    @EnvironmentObject var vm: BoringViewModel
+    let notification: SystemNotification
+
+    // The ring is always in the tree; its scale/opacity are what animate.
+    // Gating the view itself with `if` would give SwiftUI no starting frame
+    // to interpolate from, so the "pulse" would just appear already faded.
+    @State private var ringScale: CGFloat = 1
+    @State private var ringOpacity: Double = 0
+
+    private var itemSize: CGFloat { max(0, vm.effectiveClosedNotchHeight - 12) }
+
+    var body: some View {
+        Group {
+            if let code = notification.detectedCode {
+                codePill(code)
+            } else {
+                statusPill
+            }
+        }
+        .frame(height: vm.effectiveClosedNotchHeight, alignment: .center)
+        .onAppear { pulse() }
+        .onChange(of: notification.id) { _, _ in pulse() }
+    }
+
+    /// The default closed treatment: icon left, status dot right.
+    private var statusPill: some View {
+        HStack {
+            NotificationAppIcon(bundleID: notification.bundleID, size: itemSize)
+
+            Rectangle()
+                .fill(.black)
+                .frame(width: vm.closedNotchSize.width - cornerRadiusInsets.closed.top)
+
+            ZStack {
+                Circle()
+                    .stroke(Color.effectiveAccent, lineWidth: 1.5)
+                    .scaleEffect(ringScale)
+                    .opacity(ringOpacity)
+                Circle()
+                    .fill(notification.isLive ? Color.effectiveAccent : Color.secondary)
+                    .frame(width: 7, height: 7)
+            }
+            .frame(width: itemSize, height: itemSize)
+        }
+    }
+
+    /// A verification code doesn't need opening the notch to be useful — the
+    /// closed pill widens just enough to show the code and a one-tap copy,
+    /// same instinct as iOS surfacing OTPs directly on the lock screen.
+    private func codePill(_ code: String) -> some View {
+        HStack {
+            NotificationAppIcon(bundleID: notification.bundleID, size: itemSize)
+
+            Rectangle()
+                .fill(.black)
+                .frame(width: vm.closedNotchSize.width - cornerRadiusInsets.closed.top)
+
+            HStack(spacing: 8) {
+                Text(code)
+                    .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                    .kerning(1.5)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+
+                CodeCopyButton(code: code, diameter: itemSize)
+            }
+        }
+    }
+
+    private func pulse() {
+        ringScale = 1
+        ringOpacity = 0.8
+        withAnimation(.easeOut(duration: 0.6)) {
+            ringScale = 1.8
+            ringOpacity = 0
+        }
+    }
+}
+
+/// Open notch: sender, message, and one clear primary action — a reply
+/// composer, call controls, or a hand-off to the source app, depending on
+/// what the notification actually supports.
+struct NotificationExpandedView: View {
+    @EnvironmentObject var vm: BoringViewModel
+    @ObservedObject private var manager = SystemNotificationManager.shared
+
+    let notification: SystemNotification
+
+    @State private var replyText = ""
+    @State private var isSending = false
+    @State private var didSend = false
+    @FocusState private var replyFocused: Bool
+
+    private var kind: NotificationKind { .init(notification) }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            headerAvatar
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 6) {
+                header
+                textBlock
+                actionArea
+            }
+        }
+        .padding(.horizontal, 4)
+        .onAppear {
+            manager.holdActive()
+            if kind == .reply { replyFocused = true }
+        }
+        .onDisappear { manager.resumeDismiss() }
+    }
+
+    // MARK: - Avatar
+
+    /// A contact photo (or monogram fallback) when the notification has a
+    /// human sender, badged with the source app's icon bottom-trailing —
+    /// mirrors iMessage's own Communication Notifications treatment, but
+    /// works for any app since it's a plain name lookup rather than an
+    /// intent donation.
+    @ViewBuilder
+    private var headerAvatar: some View {
+        if let sender = notification.sender {
+            ZStack(alignment: .bottomTrailing) {
+                PersonAvatarView(name: sender, size: 44)
+                if let bundleID = notification.bundleID {
+                    AppIcon(for: bundleID)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 18, height: 18)
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                        .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(.black, lineWidth: 1.5))
+                        .offset(x: 3, y: 3)
+                }
+            }
+        } else {
+            NotificationAppIcon(bundleID: notification.bundleID, size: 44)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(notification.sender ?? notification.appName ?? "Notification")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+
+            Text(notification.receivedAt, style: .relative)
+                .font(.system(size: 11))
+                .foregroundStyle(.tertiary)
+                .fixedSize()
+
+            Spacer(minLength: 8)
+
+            HoverButton(icon: "xmark", iconColor: .secondary, scale: .medium) {
+                manager.dismissActive(token: notification.id)
+            }
+        }
+    }
+
+    // MARK: - Body text
+
+    @ViewBuilder
+    private var textBlock: some View {
+        if let subtitle = notification.subtitle, subtitle != notification.sender {
+            Text(subtitle)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+
+        if let body = notification.body {
+            Text(body)
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary.opacity(0.9))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .lineSpacing(1)
+        }
+    }
+
+    // MARK: - Primary action, chosen by what the notification supports
+
+    @ViewBuilder
+    private var actionArea: some View {
+        switch kind {
+        case .code(let value):
+            codeRow(value)
+        case .call:
+            callActionRow
+        case .reply:
+            replyRow
+        case .openOnly:
+            openRow
+        }
+    }
+
+    // MARK: - Verification code
+
+    private func codeRow(_ code: String) -> some View {
+        HStack(spacing: 10) {
+            Text(code)
+                .font(.system(size: 20, weight: .semibold, design: .monospaced))
+                .kerning(2)
+                .foregroundStyle(.white)
+                .lineLimit(1)
+
+            Spacer(minLength: 8)
+
+            CodeCopyButton(code: code, diameter: 26, showsLabel: true)
+        }
+        .padding(.top, 4)
+    }
+
+    // MARK: - Reply
+
+    private var replyRow: some View {
+        HStack(spacing: 8) {
+            HStack(spacing: 6) {
+                TextField("Reply", text: $replyText, axis: .horizontal)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 13))
+                    .focused($replyFocused)
+                    .onSubmit(send)
+                    .disabled(isSending || didSend)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(.white.opacity(0.08), in: Capsule())
+            .overlay(Capsule().strokeBorder(.white.opacity(replyFocused ? 0.18 : 0)))
+            .animation(.easeOut(duration: 0.15), value: replyFocused)
+
+            sendButton
+        }
+        .padding(.top, 2)
+    }
+
+    @ViewBuilder
+    private var sendButton: some View {
+        ZStack {
+            Circle()
+                .fill(didSend ? Color.green : (canSend ? Color.effectiveAccent : Color.white.opacity(0.1)))
+                .frame(width: 26, height: 26)
+
+            if isSending {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(.white)
+            } else if didSend {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(.white)
+            } else {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(canSend ? .white : .secondary)
+            }
+        }
+        .animation(.smooth(duration: 0.25), value: isSending)
+        .animation(.smooth(duration: 0.25), value: didSend)
+        .contentShape(Circle())
+        .onTapGesture(perform: send)
+        .disabled(!canSend)
+        .sensoryFeedback(.success, trigger: didSend)
+    }
+
+    private var canSend: Bool {
+        !replyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSending && !didSend
+    }
+
+    private func send() {
+        guard canSend else { return }
+        let text = replyText
+        isSending = true
+        Task {
+            let sent = await manager.reply(to: notification, text: text)
+            isSending = false
+            if sent {
+                didSend = true
+                replyText = ""
+                try? await Task.sleep(for: .milliseconds(900))
+                manager.dismissActive(token: notification.id)
+            }
+        }
+    }
+
+    // MARK: - Calls
+
+    /// Real phone/FaceTime affordance — green to accept, red to decline —
+    /// rather than generic rectangular buttons.
+    private var callActionRow: some View {
+        HStack(spacing: 14) {
+            Spacer()
+            if let decline = notification.actions.first(where: {
+                $0.localizedCaseInsensitiveContains("decline")
+            }) {
+                callButton(symbol: "phone.down.fill", tint: .red) {
+                    Task {
+                        await manager.perform(decline, on: notification)
+                        manager.dismissActive(token: notification.id)
+                    }
+                }
+            }
+            if let accept = notification.actions.first(where: { action in
+                ["accept", "answer", "join"].contains { action.localizedCaseInsensitiveContains($0) }
+            }) {
+                callButton(symbol: "phone.fill", tint: .green) {
+                    Task {
+                        await manager.perform(accept, on: notification)
+                        manager.dismissActive(token: notification.id)
+                    }
+                }
+            }
+        }
+        .padding(.top, 2)
+    }
+
+    private func callButton(symbol: String, tint: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Circle()
+                .fill(tint)
+                .frame(width: 30, height: 30)
+                .overlay {
+                    Image(systemName: symbol)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.white)
+                }
+        }
+        .buttonStyle(ScaleDownButtonStyle())
+    }
+
+    // MARK: - Fallback: no reply field available
+
+    private var openRow: some View {
+        Button {
+            Task { await manager.open(notification) }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.up.forward.app.fill")
+                    .font(.system(size: 11))
+                Text("Open in \(notification.appName ?? "app")")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(.white.opacity(0.06), in: Capsule())
+        }
+        .buttonStyle(ScaleDownButtonStyle())
+        .padding(.top, 2)
+    }
+}
+
+/// What a notification's actions actually let the user do — decides which
+/// action row renders. Computed once per render rather than scattering the
+/// same string matching across the view.
+private enum NotificationKind: Equatable {
+    case code(String), call, reply, openOnly
+
+    init(_ notification: SystemNotification) {
+        // A verification code wins over everything else — copying it is
+        // almost certainly what the user opened the notch for.
+        if let code = notification.detectedCode {
+            self = .code(code)
+            return
+        }
+        let hasCallActions = notification.actions.contains { action in
+            ["accept", "decline", "answer", "join"].contains { action.localizedCaseInsensitiveContains($0) }
+        }
+        if hasCallActions {
+            self = .call
+        } else if notification.canReply {
+            self = .reply
+        } else {
+            self = .openOnly
+        }
+    }
+}
+
+private struct NotificationAppIcon: View {
+    let bundleID: String?
+    let size: CGFloat
+
+    var body: some View {
+        Group {
+            if let bundleID {
+                AppIcon(for: bundleID)
+                    .resizable()
+            } else {
+                Image(systemName: "bell.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .padding(size * 0.22)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .aspectRatio(contentMode: .fit)
+        .frame(width: size, height: size)
+        .clipShape(RoundedRectangle(cornerRadius: size * 0.22))
+    }
+}
+
+/// A restrained press state for the plain icon-style buttons above —
+/// matches the subtle scale feedback used on the album art button rather
+/// than a full opacity/highlight change.
+private struct ScaleDownButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.92 : 1)
+            .animation(.smooth(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
+/// Copies a code to the pasteboard and morphs into a checkmark for a beat —
+/// same confirmation language as the reply send button, so the two feel like
+/// one design rather than two different affordances for "did that work?"
+private struct CodeCopyButton: View {
+    let code: String
+    var diameter: CGFloat
+    var showsLabel: Bool = false
+
+    @State private var didCopy = false
+
+    var body: some View {
+        Button(action: copy) {
+            HStack(spacing: 4) {
+                Image(systemName: didCopy ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: diameter * 0.42, weight: .semibold))
+                if showsLabel {
+                    Text(didCopy ? "Copied" : "Copy")
+                        .font(.system(size: 12, weight: .medium))
+                }
+            }
+            .foregroundStyle(.white)
+            .frame(height: diameter)
+            .padding(.horizontal, showsLabel ? 10 : 0)
+            .frame(width: showsLabel ? nil : diameter)
+            .background(
+                (didCopy ? Color.green : Color.effectiveAccent),
+                in: Capsule()
+            )
+        }
+        .buttonStyle(ScaleDownButtonStyle())
+        .animation(.smooth(duration: 0.25), value: didCopy)
+        .sensoryFeedback(.success, trigger: didCopy)
+    }
+
+    private func copy() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(code, forType: .string)
+        didCopy = true
+        Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            didCopy = false
+        }
+    }
+}

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -141,20 +141,31 @@ struct NotificationExpandedView: View {
     /// mirrors iMessage's own Communication Notifications treatment, but
     /// works for any app since it's a plain name lookup rather than an
     /// intent donation.
+    ///
+    /// Only attempted for messaging/calling apps. Other apps' "title" field
+    /// is often not a person at all — Claude's is a session name, for
+    /// instance — and treating it as one would both look wrong and fire a
+    /// pointless Contacts search.
+    private static let personAvatarBundleIDs: Set<String> = [
+        "com.apple.MobileSMS", "com.apple.FaceTime", "com.apple.mail", "com.microsoft.Outlook",
+        "net.whatsapp.WhatsApp", "ru.keepcoder.Telegram", "com.tdesktop.Telegram",
+        "com.hnc.Discord"
+    ]
+
     @ViewBuilder
     private var headerAvatar: some View {
-        if let sender = notification.sender {
+        if let sender = notification.sender,
+           let bundleID = notification.bundleID,
+           Self.personAvatarBundleIDs.contains(bundleID) {
             ZStack(alignment: .bottomTrailing) {
                 PersonAvatarView(name: sender, size: 44)
-                if let bundleID = notification.bundleID {
-                    AppIcon(for: bundleID)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 18, height: 18)
-                        .clipShape(RoundedRectangle(cornerRadius: 5))
-                        .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(.black, lineWidth: 1.5))
-                        .offset(x: 3, y: 3)
-                }
+                AppIcon(for: bundleID)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 18, height: 18)
+                    .clipShape(RoundedRectangle(cornerRadius: 5))
+                    .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(.black, lineWidth: 1.5))
+                    .offset(x: 3, y: 3)
             }
         } else {
             NotificationAppIcon(bundleID: notification.bundleID, size: 44)

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -111,6 +111,7 @@ struct NotificationExpandedView: View {
     @State private var replyText = ""
     @State private var isSending = false
     @State private var didSend = false
+    @State private var didHandOff = false
     @FocusState private var replyFocused: Bool
 
     private var kind: NotificationKind { .init(notification) }
@@ -119,17 +120,20 @@ struct NotificationExpandedView: View {
         HStack(alignment: .center, spacing: 12) {
             headerAvatar
 
+            // maxWidth (not .infinity) lets this shrink to whatever the
+            // message actually needs while still wrapping long ones, so the
+            // notch hugs the content instead of always spanning its full
+            // width.
             VStack(alignment: .leading, spacing: 5) {
                 header
                 textBlock
                 actionArea
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: 300, alignment: .leading)
+
+            dismissButton
+                .padding(.leading, 4)
         }
-        // Sized to its content, not to the notch. The opened notch is built
-        // for the home/shelf tabs; a notification is a glance, so filling
-        // that area just wraps two lines of text in empty black.
-        .frame(maxWidth: 460, alignment: .leading)
         .padding(.horizontal, 4)
         // Rebuild cleanly when one notification replaces another, instead of
         // reusing the previous one's view state.
@@ -193,16 +197,18 @@ struct NotificationExpandedView: View {
                 .foregroundStyle(.primary)
                 .lineLimit(1)
 
+            // No Spacer here — it would expand to fill and drag the notch
+            // out to full width regardless of how short the message is.
             Text(notification.receivedAt, style: .relative)
                 .font(.system(size: 11))
                 .foregroundStyle(.tertiary)
                 .fixedSize()
+        }
+    }
 
-            Spacer(minLength: 8)
-
-            HoverButton(icon: "xmark", iconColor: .secondary, scale: .medium) {
-                manager.dismissActive(token: notification.id)
-            }
+    private var dismissButton: some View {
+        HoverButton(icon: "xmark", iconColor: .secondary, scale: .medium) {
+            manager.dismissActive(token: notification.id)
         }
     }
 
@@ -253,8 +259,6 @@ struct NotificationExpandedView: View {
                 .foregroundStyle(.white)
                 .lineLimit(1)
 
-            Spacer(minLength: 8)
-
             CodeCopyButton(code: code, diameter: 26, showsLabel: true)
         }
         .padding(.top, 4)
@@ -270,7 +274,10 @@ struct NotificationExpandedView: View {
                     .font(.system(size: 13))
                     .focused($replyFocused)
                     .onSubmit(send)
-                    .disabled(isSending || didSend)
+                    .disabled(isSending || didSend || didHandOff)
+                    // A bare TextField takes every point offered, which
+                    // would stretch the notch back out.
+                    .frame(width: 200)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 7)
@@ -287,7 +294,7 @@ struct NotificationExpandedView: View {
     private var sendButton: some View {
         ZStack {
             Circle()
-                .fill(didSend ? Color.green : (canSend ? Color.effectiveAccent : Color.white.opacity(0.1)))
+                .fill(fillStyle)
                 .frame(width: 26, height: 26)
 
             if isSending {
@@ -298,6 +305,12 @@ struct NotificationExpandedView: View {
                 Image(systemName: "checkmark")
                     .font(.system(size: 11, weight: .bold))
                     .foregroundStyle(.white)
+            } else if didHandOff {
+                // Clipboard, not a checkmark: the message wasn't delivered,
+                // it was copied for the user to paste into the app.
+                Image(systemName: "doc.on.clipboard")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(.white)
             } else {
                 Image(systemName: "arrow.up")
                     .font(.system(size: 12, weight: .semibold))
@@ -306,14 +319,22 @@ struct NotificationExpandedView: View {
         }
         .animation(.smooth(duration: 0.25), value: isSending)
         .animation(.smooth(duration: 0.25), value: didSend)
+        .animation(.smooth(duration: 0.25), value: didHandOff)
         .contentShape(Circle())
         .onTapGesture(perform: send)
         .disabled(!canSend)
         .sensoryFeedback(.success, trigger: didSend)
     }
 
+    private var fillStyle: Color {
+        if didSend { return .green }
+        if didHandOff { return .orange }
+        return canSend ? .effectiveAccent : .white.opacity(0.1)
+    }
+
     private var canSend: Bool {
-        !replyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSending && !didSend
+        !replyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !isSending && !didSend && !didHandOff
     }
 
     private func send() {
@@ -321,14 +342,16 @@ struct NotificationExpandedView: View {
         let text = replyText
         isSending = true
         Task {
-            let sent = await manager.reply(to: notification, text: text)
+            let outcome = await manager.reply(to: notification, text: text)
             isSending = false
-            if sent {
-                didSend = true
-                replyText = ""
-                try? await Task.sleep(for: .milliseconds(900))
-                manager.dismissActive(token: notification.id)
-            }
+            replyText = ""
+            // A hand-off is not a delivery — showing the same checkmark for
+            // both would tell the user their message went out when it's
+            // actually sitting on the clipboard.
+            didSend = outcome == .sent
+            didHandOff = outcome == .handedOffToApp
+            try? await Task.sleep(for: .milliseconds(1200))
+            manager.dismissActive(token: notification.id)
         }
     }
 
@@ -338,7 +361,6 @@ struct NotificationExpandedView: View {
     /// rather than generic rectangular buttons.
     private var callActionRow: some View {
         HStack(spacing: 14) {
-            Spacer()
             if let decline = notification.actions.first(where: {
                 $0.localizedCaseInsensitiveContains("decline")
             }) {

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -134,16 +134,14 @@ struct NotificationExpandedView: View {
         // Rebuild cleanly when one notification replaces another, instead of
         // reusing the previous one's view state.
         .id(notification.id)
+        // This view exists only while the notch is open, so appear/disappear
+        // is the open/close signal: pause the countdown while the user is
+        // looking at it, resume when they close. holdActive caps itself at
+        // maxLifetime, so an abandoned open notch still lets the
+        // notification go rather than pinning it forever.
         .onAppear {
+            manager.holdActive()
             if kind == .reply { replyFocused = true }
-        }
-        // Hold the notification open only while the user is actually typing
-        // a reply. Holding it for the whole time the notch is open pinned
-        // stale notifications indefinitely and blocked the normal notch
-        // content — opening the notch minutes later still showed the old
-        // message.
-        .onChange(of: replyFocused) { _, focused in
-            if focused { manager.holdActive() } else { manager.resumeDismiss() }
         }
         .onDisappear { manager.resumeDismiss() }
     }

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -132,12 +132,12 @@ struct NotificationExpandedView: View {
             .frame(maxWidth: 300, alignment: .leading)
         }
         .padding(.horizontal, 4)
-        .padding(.trailing, 20)
         // Pinned to the card's actual top-right corner rather than sitting
         // inline at the avatar's vertical center, matching where a close
         // control belongs on a notification.
         .overlay(alignment: .topTrailing) {
             dismissButton
+                .padding(.top, -2)
         }
         // Rebuild cleanly when one notification replaces another, instead of
         // reusing the previous one's view state.
@@ -208,12 +208,28 @@ struct NotificationExpandedView: View {
                 .foregroundStyle(.tertiary)
                 .fixedSize()
         }
+        // Clears the close button, which overlays the card rather than
+        // taking a layout slot — reserved here, on the one row it can
+        // actually collide with, instead of on the whole card (which pushed
+        // the reply row's right edge in by 20pt of dead space for no
+        // reason, since nothing else in the card runs that wide).
+        .padding(.trailing, 22)
     }
 
+    /// Deliberately not HoverButton's default 30pt sizing — that reads as a
+    /// full toolbar control; a notification's close button wants to be
+    /// closer to iOS's compact circular dismiss.
     private var dismissButton: some View {
-        HoverButton(icon: "xmark", iconColor: .secondary, scale: .medium) {
+        Button {
             manager.dismissActive(token: notification.id)
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 18, height: 18)
+                .background(.white.opacity(0.1), in: Circle())
         }
+        .buttonStyle(ScaleDownButtonStyle())
     }
 
     // MARK: - Body text

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -115,6 +115,7 @@ struct NotificationExpandedView: View {
     @FocusState private var replyFocused: Bool
     @State private var hostWindow: BoringNotchSkyLightWindow?
     @State private var suggestions: [String] = []
+    @State private var isComposing = false
 
     private var kind: NotificationKind { .init(notification) }
 
@@ -162,6 +163,9 @@ struct NotificationExpandedView: View {
             // stuck `true` here would leave the window able to steal focus
             // on some later, unrelated click.
             hostWindow?.wantsKeyForTextInput = false
+            // Same reasoning for the compose hold: a leaked one would pin
+            // the notch open permanently, since every close path checks it.
+            endComposing()
         }
         .onChange(of: replyFocused) { _, focused in
             // The window can only accept keystrokes while it's key, and it
@@ -170,8 +174,16 @@ struct NotificationExpandedView: View {
             hostWindow?.wantsKeyForTextInput = focused
             if focused {
                 manager.holdWhileTyping()
+                // Clicking into the field changes window key status, which
+                // rebuilds tracking areas and fires a spurious hover-exit —
+                // that's what was closing the notch the instant you tapped
+                // the input. Every close path already honours
+                // preventNotchClose, so hold it for the whole compose
+                // session rather than trying to filter the bogus hover.
+                beginComposing()
             } else {
                 manager.holdActive()
+                endComposing()
             }
         }
         .onChange(of: replyText) { _, _ in
@@ -424,6 +436,23 @@ struct NotificationExpandedView: View {
     private var canSend: Bool {
         !replyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !isSending && !didSend && !didHandOff
+    }
+
+    /// SharingStateManager refcounts its sessions, so these must stay
+    /// balanced — a leaked begin pins the notch open for good, since every
+    /// close path honours preventNotchClose. The local flag guarantees at
+    /// most one outstanding session per view regardless of how many times
+    /// focus flips.
+    private func beginComposing() {
+        guard !isComposing else { return }
+        isComposing = true
+        SharingStateManager.shared.beginInteraction()
+    }
+
+    private func endComposing() {
+        guard isComposing else { return }
+        isComposing = false
+        SharingStateManager.shared.endInteraction()
     }
 
     private func send() {

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -362,7 +362,11 @@ struct NotificationExpandedView: View {
     private var suggestionChips: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 6) {
-                ForEach(suggestions, id: \.self) { suggestion in
+                // Keyed by position, not by the string itself: two identical
+                // suggestions would collide as ForEach ids and render
+                // undefined. SmartReplyManager already dedupes, but the
+                // view shouldn't depend on model output being distinct.
+                ForEach(Array(suggestions.enumerated()), id: \.offset) { _, suggestion in
                     Button {
                         replyText = suggestion
                         replyFocused = true

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -116,6 +116,7 @@ struct NotificationExpandedView: View {
     @State private var hostWindow: BoringNotchSkyLightWindow?
     @State private var suggestions: [String] = []
     @State private var isComposing = false
+    @State private var endComposeTask: Task<Void, Never>?
 
     private var kind: NotificationKind { .init(notification) }
 
@@ -157,22 +158,26 @@ struct NotificationExpandedView: View {
         }
         .onDisappear {
             manager.resumeDismiss()
+            // Tear down immediately here, and cancel any deferred teardown:
+            // the view is going away, so there's no in-flight click left to
+            // protect, and letting that task outlive the view would leak a
+            // refcounted hold that pins the notch open for good.
+            endComposeTask?.cancel()
+            endComposeTask = nil
             // Always hand key status back — if this fired without the
-            // focus-lost branch below running first (the whole view can
-            // disappear while still focused, e.g. the notch closing), a
-            // stuck `true` here would leave the window able to steal focus
-            // on some later, unrelated click.
+            // focus-lost branch running first (the view can disappear while
+            // still focused, e.g. the notch closing), a stuck `true` would
+            // leave the window able to steal focus on some later click.
             hostWindow?.wantsKeyForTextInput = false
-            // Same reasoning for the compose hold: a leaked one would pin
-            // the notch open permanently, since every close path checks it.
             endComposing()
         }
         .onChange(of: replyFocused) { _, focused in
-            // The window can only accept keystrokes while it's key, and it
-            // must not stay key a moment longer than the field is actually
-            // focused — see BoringNotchSkyLightWindow.wantsKeyForTextInput.
-            hostWindow?.wantsKeyForTextInput = focused
             if focused {
+                // The window can only accept keystrokes while it's key —
+                // see BoringNotchSkyLightWindow.wantsKeyForTextInput.
+                endComposeTask?.cancel()
+                endComposeTask = nil
+                hostWindow?.wantsKeyForTextInput = true
                 manager.holdWhileTyping()
                 // Clicking into the field changes window key status, which
                 // rebuilds tracking areas and fires a spurious hover-exit —
@@ -182,8 +187,20 @@ struct NotificationExpandedView: View {
                 // session rather than trying to filter the bogus hover.
                 beginComposing()
             } else {
-                manager.holdActive()
-                endComposing()
+                // Deliberately deferred. Clicking Send blurs the field on
+                // mouse-down; releasing the hold and key status right then
+                // can close the notch out from under the click before
+                // mouse-up lands, so the press never completes. Give an
+                // in-flight click time to finish, and cancel if focus comes
+                // straight back.
+                endComposeTask?.cancel()
+                endComposeTask = Task {
+                    try? await Task.sleep(for: .milliseconds(350))
+                    guard !Task.isCancelled else { return }
+                    hostWindow?.wantsKeyForTextInput = false
+                    manager.holdActive()
+                    endComposing()
+                }
             }
         }
         .onChange(of: replyText) { _, _ in
@@ -392,38 +409,47 @@ struct NotificationExpandedView: View {
     }
 
     @ViewBuilder
+    /// A real Button, not a shape with .onTapGesture. In a non-activating
+    /// panel a bare tap gesture needs a clean mouse-down/up pair in a window
+    /// whose key status isn't changing — but clicking here blurs the text
+    /// field, which flips key status mid-click and ate the tap. Enter
+    /// (onSubmit) worked the whole time, and the suggestion chips (already
+    /// Buttons) worked, which is what pointed at the gesture rather than at
+    /// send() itself. Buttons track the press properly across that change.
     private var sendButton: some View {
-        ZStack {
-            Circle()
-                .fill(fillStyle)
-                .frame(width: 26, height: 26)
+        Button(action: send) {
+            ZStack {
+                Circle()
+                    .fill(fillStyle)
+                    .frame(width: 26, height: 26)
 
-            if isSending {
-                ProgressView()
-                    .controlSize(.small)
-                    .tint(.white)
-            } else if didSend {
-                Image(systemName: "checkmark")
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundStyle(.white)
-            } else if didHandOff {
-                // Clipboard, not a checkmark: the message wasn't delivered,
-                // it was copied for the user to paste into the app.
-                Image(systemName: "doc.on.clipboard")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(.white)
-            } else {
-                Image(systemName: "arrow.up")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(canSend ? .white : .secondary)
+                if isSending {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(.white)
+                } else if didSend {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(.white)
+                } else if didHandOff {
+                    // Clipboard, not a checkmark: the message wasn't
+                    // delivered, it was copied for the user to paste.
+                    Image(systemName: "doc.on.clipboard")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.white)
+                } else {
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(canSend ? .white : .secondary)
+                }
             }
+            .contentShape(Circle())
         }
+        .buttonStyle(ScaleDownButtonStyle())
+        .disabled(!canSend)
         .animation(.smooth(duration: 0.25), value: isSending)
         .animation(.smooth(duration: 0.25), value: didSend)
         .animation(.smooth(duration: 0.25), value: didHandOff)
-        .contentShape(Circle())
-        .onTapGesture(perform: send)
-        .disabled(!canSend)
         .sensoryFeedback(.success, trigger: didSend)
     }
 

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -113,7 +113,7 @@ struct NotificationExpandedView: View {
     @State private var didSend = false
     @State private var didHandOff = false
     @FocusState private var replyFocused: Bool
-    @State private var hostWindow: BoringNotchWindow?
+    @State private var hostWindow: BoringNotchSkyLightWindow?
     @State private var suggestions: [String] = []
 
     private var kind: NotificationKind { .init(notification) }
@@ -144,7 +144,7 @@ struct NotificationExpandedView: View {
         // Rebuild cleanly when one notification replaces another, instead of
         // reusing the previous one's view state.
         .id(notification.id)
-        .background(WindowAccessor { self.hostWindow = $0 as? BoringNotchWindow })
+        .background(WindowAccessor { self.hostWindow = $0 as? BoringNotchSkyLightWindow })
         // This view exists only while the notch is open, so appear/disappear
         // is the open/close signal: pause the countdown while the user is
         // looking at it, resume when they close. holdActive caps itself at
@@ -166,7 +166,7 @@ struct NotificationExpandedView: View {
         .onChange(of: replyFocused) { _, focused in
             // The window can only accept keystrokes while it's key, and it
             // must not stay key a moment longer than the field is actually
-            // focused — see BoringNotchWindow.wantsKeyForTextInput.
+            // focused — see BoringNotchSkyLightWindow.wantsKeyForTextInput.
             hostWindow?.wantsKeyForTextInput = focused
             if focused {
                 manager.holdWhileTyping()
@@ -616,7 +616,7 @@ private struct CodeCopyButton: View {
 }
 
 /// Reads the NSWindow hosting this SwiftUI view. Needed because
-/// BoringNotchWindow can't become key by default (a click on the notch must
+/// BoringNotchSkyLightWindow can't become key by default (a click on the notch must
 /// never steal focus from the frontmost app) — the reply field has to reach
 /// through to that window to ask for key status only for the moment it's
 /// actually being typed into.

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -116,21 +116,21 @@ struct NotificationExpandedView: View {
     private var kind: NotificationKind { .init(notification) }
 
     var body: some View {
-        HStack(alignment: .center, spacing: 16) {
+        HStack(alignment: .center, spacing: 12) {
             headerAvatar
 
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 5) {
                 header
                 textBlock
                 actionArea
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        // Fill the opened notch rather than clustering in its top-left
-        // corner — this sits in the same slot NotchHomeView occupies, which
-        // is sized to the full open notch.
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-        .padding(.horizontal, 8)
+        // Sized to its content, not to the notch. The opened notch is built
+        // for the home/shelf tabs; a notification is a glance, so filling
+        // that area just wraps two lines of text in empty black.
+        .frame(maxWidth: 460, alignment: .leading)
+        .padding(.horizontal, 4)
         // Rebuild cleanly when one notification replaces another, instead of
         // reusing the previous one's view state.
         .id(notification.id)
@@ -170,17 +170,17 @@ struct NotificationExpandedView: View {
            let bundleID = notification.bundleID,
            Self.personAvatarBundleIDs.contains(bundleID) {
             ZStack(alignment: .bottomTrailing) {
-                PersonAvatarView(name: sender, size: 64)
+                PersonAvatarView(name: sender, size: 46)
                 AppIcon(for: bundleID)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 24, height: 24)
-                    .clipShape(RoundedRectangle(cornerRadius: 7))
-                    .overlay(RoundedRectangle(cornerRadius: 7).strokeBorder(.black, lineWidth: 2))
-                    .offset(x: 4, y: 4)
+                    .frame(width: 20, height: 20)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(.black, lineWidth: 1.5))
+                    .offset(x: 3, y: 3)
             }
         } else {
-            NotificationAppIcon(bundleID: notification.bundleID, size: 64)
+            NotificationAppIcon(bundleID: notification.bundleID, size: 46)
         }
     }
 
@@ -189,12 +189,12 @@ struct NotificationExpandedView: View {
     private var header: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
             Text(notification.sender ?? notification.appName ?? "Notification")
-                .font(.system(size: 17, weight: .semibold))
+                .font(.system(size: 14, weight: .semibold))
                 .foregroundStyle(.primary)
                 .lineLimit(1)
 
             Text(notification.receivedAt, style: .relative)
-                .font(.system(size: 12))
+                .font(.system(size: 11))
                 .foregroundStyle(.tertiary)
                 .fixedSize()
 
@@ -212,18 +212,18 @@ struct NotificationExpandedView: View {
     private var textBlock: some View {
         if let subtitle = notification.subtitle, subtitle != notification.sender {
             Text(subtitle)
-                .font(.system(size: 13, weight: .medium))
+                .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
         }
 
         if let body = notification.body {
             Text(body)
-                .font(.system(size: 15))
+                .font(.system(size: 13))
                 .foregroundStyle(.secondary.opacity(0.9))
                 .lineLimit(2)
                 .fixedSize(horizontal: false, vertical: true)
-                .lineSpacing(2)
+                .lineSpacing(1)
         }
     }
 

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -116,7 +116,6 @@ struct NotificationExpandedView: View {
     @State private var hostWindow: BoringNotchSkyLightWindow?
     @State private var suggestions: [String] = []
     @State private var isComposing = false
-    @State private var endComposeTask: Task<Void, Never>?
 
     private var kind: NotificationKind { .init(notification) }
 
@@ -156,52 +155,47 @@ struct NotificationExpandedView: View {
             manager.holdActive()
             if kind == .reply { replyFocused = true }
         }
+        // The single teardown point for both the key-window grant and the
+        // compose hold. Focus changes are too noisy to release on (see
+        // onChange above), so everything is unwound here — and it must be
+        // unconditional: a stuck grant would let the notch steal focus on
+        // some later unrelated click, and a leaked compose hold would pin
+        // the notch open permanently, since every close path checks it.
         .onDisappear {
             manager.resumeDismiss()
-            // Tear down immediately here, and cancel any deferred teardown:
-            // the view is going away, so there's no in-flight click left to
-            // protect, and letting that task outlive the view would leak a
-            // refcounted hold that pins the notch open for good.
-            endComposeTask?.cancel()
-            endComposeTask = nil
-            // Always hand key status back — if this fired without the
-            // focus-lost branch running first (the view can disappear while
-            // still focused, e.g. the notch closing), a stuck `true` would
-            // leave the window able to steal focus on some later click.
             hostWindow?.wantsKeyForTextInput = false
             endComposing()
         }
+        // Apply a pending key request once the window resolves —
+        // WindowAccessor reports asynchronously, so onAppear's auto-focus
+        // can run while hostWindow is still nil.
+        .onChange(of: hostWindow) { _, window in
+            if replyFocused { window?.wantsKeyForTextInput = true }
+        }
         .onChange(of: replyFocused) { _, focused in
-            if focused {
-                // The window can only accept keystrokes while it's key —
-                // see BoringNotchSkyLightWindow.wantsKeyForTextInput.
-                endComposeTask?.cancel()
-                endComposeTask = nil
-                hostWindow?.wantsKeyForTextInput = true
-                manager.holdWhileTyping()
-                // Clicking into the field changes window key status, which
-                // rebuilds tracking areas and fires a spurious hover-exit —
-                // that's what was closing the notch the instant you tapped
-                // the input. Every close path already honours
-                // preventNotchClose, so hold it for the whole compose
-                // session rather than trying to filter the bogus hover.
-                beginComposing()
-            } else {
-                // Deliberately deferred. Clicking Send blurs the field on
-                // mouse-down; releasing the hold and key status right then
-                // can close the notch out from under the click before
-                // mouse-up lands, so the press never completes. Give an
-                // in-flight click time to finish, and cancel if focus comes
-                // straight back.
-                endComposeTask?.cancel()
-                endComposeTask = Task {
-                    try? await Task.sleep(for: .milliseconds(350))
-                    guard !Task.isCancelled else { return }
-                    hostWindow?.wantsKeyForTextInput = false
-                    manager.holdActive()
-                    endComposing()
-                }
+            guard focused else {
+                // Deliberately does NOT release key status or the compose
+                // hold. Focus flips constantly for reasons that have
+                // nothing to do with the user being done: the suggestion
+                // chips arriving restructure the view above the field and
+                // drop focus, and clicking Send blurs on mouse-down.
+                // Releasing on each of those resigned key status
+                // mid-typing and closed the notch out from under clicks.
+                // Both are released in onDisappear instead, which is the
+                // only unambiguous "done" signal.
+                manager.holdActive()
+                return
             }
+            // The window can only accept keystrokes while it's key — see
+            // BoringNotchSkyLightWindow.wantsKeyForTextInput.
+            hostWindow?.wantsKeyForTextInput = true
+            manager.holdWhileTyping()
+            // Clicking into the field changes window key status, which
+            // rebuilds tracking areas and fires a spurious hover-exit —
+            // that's what closed the notch the instant you tapped the
+            // input. Every close path already honours preventNotchClose,
+            // so hold it for the whole compose session.
+            beginComposing()
         }
         .onChange(of: replyText) { _, _ in
             // Stop the timer's clock is exactly what typing should do — a

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -130,11 +130,15 @@ struct NotificationExpandedView: View {
                 actionArea
             }
             .frame(maxWidth: 300, alignment: .leading)
-
-            dismissButton
-                .padding(.leading, 4)
         }
         .padding(.horizontal, 4)
+        .padding(.trailing, 20)
+        // Pinned to the card's actual top-right corner rather than sitting
+        // inline at the avatar's vertical center, matching where a close
+        // control belongs on a notification.
+        .overlay(alignment: .topTrailing) {
+            dismissButton
+        }
         // Rebuild cleanly when one notification replaces another, instead of
         // reusing the previous one's view state.
         .id(notification.id)
@@ -275,15 +279,18 @@ struct NotificationExpandedView: View {
                     .focused($replyFocused)
                     .onSubmit(send)
                     .disabled(isSending || didSend || didHandOff)
-                    // A bare TextField takes every point offered, which
-                    // would stretch the notch back out.
-                    .frame(width: 200)
+                    // Safe to let this fill available width now: the
+                    // containing column is already capped at 300pt, so this
+                    // only fills up to that cap rather than stretching the
+                    // notch itself the way an unbounded TextField would.
+                    .frame(maxWidth: .infinity)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 7)
             .background(.white.opacity(0.08), in: Capsule())
             .overlay(Capsule().strokeBorder(.white.opacity(replyFocused ? 0.18 : 0)))
             .animation(.easeOut(duration: 0.15), value: replyFocused)
+            .frame(maxWidth: .infinity)
 
             sendButton
         }

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -113,6 +113,7 @@ struct NotificationExpandedView: View {
     @State private var didSend = false
     @State private var didHandOff = false
     @FocusState private var replyFocused: Bool
+    @State private var hostWindow: BoringNotchWindow?
 
     private var kind: NotificationKind { .init(notification) }
 
@@ -142,6 +143,7 @@ struct NotificationExpandedView: View {
         // Rebuild cleanly when one notification replaces another, instead of
         // reusing the previous one's view state.
         .id(notification.id)
+        .background(WindowAccessor { self.hostWindow = $0 as? BoringNotchWindow })
         // This view exists only while the notch is open, so appear/disappear
         // is the open/close signal: pause the countdown while the user is
         // looking at it, resume when they close. holdActive caps itself at
@@ -151,7 +153,32 @@ struct NotificationExpandedView: View {
             manager.holdActive()
             if kind == .reply { replyFocused = true }
         }
-        .onDisappear { manager.resumeDismiss() }
+        .onDisappear {
+            manager.resumeDismiss()
+            // Always hand key status back — if this fired without the
+            // focus-lost branch below running first (the whole view can
+            // disappear while still focused, e.g. the notch closing), a
+            // stuck `true` here would leave the window able to steal focus
+            // on some later, unrelated click.
+            hostWindow?.wantsKeyForTextInput = false
+        }
+        .onChange(of: replyFocused) { _, focused in
+            // The window can only accept keystrokes while it's key, and it
+            // must not stay key a moment longer than the field is actually
+            // focused — see BoringNotchWindow.wantsKeyForTextInput.
+            hostWindow?.wantsKeyForTextInput = focused
+            if focused {
+                manager.holdWhileTyping()
+            } else {
+                manager.holdActive()
+            }
+        }
+        .onChange(of: replyText) { _, _ in
+            // Stop the timer's clock is exactly what typing should do — a
+            // keystroke is the clearest possible "still here" signal, so it
+            // gets an uncapped hold rather than the notch-open cap.
+            if replyFocused { manager.holdWhileTyping() }
+        }
     }
 
     // MARK: - Avatar
@@ -547,4 +574,21 @@ private struct CodeCopyButton: View {
             didCopy = false
         }
     }
+}
+
+/// Reads the NSWindow hosting this SwiftUI view. Needed because
+/// BoringNotchWindow can't become key by default (a click on the notch must
+/// never steal focus from the frontmost app) — the reply field has to reach
+/// through to that window to ask for key status only for the moment it's
+/// actually being typed into.
+private struct WindowAccessor: NSViewRepresentable {
+    let onResolve: (NSWindow?) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { onResolve(view.window) }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
 }

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -116,20 +116,34 @@ struct NotificationExpandedView: View {
     private var kind: NotificationKind { .init(notification) }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
+        HStack(alignment: .center, spacing: 16) {
             headerAvatar
-                .padding(.top, 2)
 
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 8) {
                 header
                 textBlock
                 actionArea
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal, 4)
+        // Fill the opened notch rather than clustering in its top-left
+        // corner — this sits in the same slot NotchHomeView occupies, which
+        // is sized to the full open notch.
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .padding(.horizontal, 8)
+        // Rebuild cleanly when one notification replaces another, instead of
+        // reusing the previous one's view state.
+        .id(notification.id)
         .onAppear {
-            manager.holdActive()
             if kind == .reply { replyFocused = true }
+        }
+        // Hold the notification open only while the user is actually typing
+        // a reply. Holding it for the whole time the notch is open pinned
+        // stale notifications indefinitely and blocked the normal notch
+        // content — opening the notch minutes later still showed the old
+        // message.
+        .onChange(of: replyFocused) { _, focused in
+            if focused { manager.holdActive() } else { manager.resumeDismiss() }
         }
         .onDisappear { manager.resumeDismiss() }
     }
@@ -158,17 +172,17 @@ struct NotificationExpandedView: View {
            let bundleID = notification.bundleID,
            Self.personAvatarBundleIDs.contains(bundleID) {
             ZStack(alignment: .bottomTrailing) {
-                PersonAvatarView(name: sender, size: 44)
+                PersonAvatarView(name: sender, size: 64)
                 AppIcon(for: bundleID)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 18, height: 18)
-                    .clipShape(RoundedRectangle(cornerRadius: 5))
-                    .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(.black, lineWidth: 1.5))
-                    .offset(x: 3, y: 3)
+                    .frame(width: 24, height: 24)
+                    .clipShape(RoundedRectangle(cornerRadius: 7))
+                    .overlay(RoundedRectangle(cornerRadius: 7).strokeBorder(.black, lineWidth: 2))
+                    .offset(x: 4, y: 4)
             }
         } else {
-            NotificationAppIcon(bundleID: notification.bundleID, size: 44)
+            NotificationAppIcon(bundleID: notification.bundleID, size: 64)
         }
     }
 
@@ -177,12 +191,12 @@ struct NotificationExpandedView: View {
     private var header: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
             Text(notification.sender ?? notification.appName ?? "Notification")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: 17, weight: .semibold))
                 .foregroundStyle(.primary)
                 .lineLimit(1)
 
             Text(notification.receivedAt, style: .relative)
-                .font(.system(size: 11))
+                .font(.system(size: 12))
                 .foregroundStyle(.tertiary)
                 .fixedSize()
 
@@ -200,18 +214,18 @@ struct NotificationExpandedView: View {
     private var textBlock: some View {
         if let subtitle = notification.subtitle, subtitle != notification.sender {
             Text(subtitle)
-                .font(.system(size: 12, weight: .medium))
+                .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
         }
 
         if let body = notification.body {
             Text(body)
-                .font(.system(size: 13))
+                .font(.system(size: 15))
                 .foregroundStyle(.secondary.opacity(0.9))
                 .lineLimit(2)
                 .fixedSize(horizontal: false, vertical: true)
-                .lineSpacing(1)
+                .lineSpacing(2)
         }
     }
 

--- a/boringNotch/components/NotificationDebugWindow.swift
+++ b/boringNotch/components/NotificationDebugWindow.swift
@@ -1,0 +1,91 @@
+//
+//  NotificationDebugWindow.swift
+//  boringNotch
+//
+//  Developer window for inspecting captured Notification Center banners before
+//  they are wired into the notch UI.
+//
+
+import SwiftUI
+
+struct NotificationDebugView: View {
+    @StateObject private var manager = SystemNotificationManager.shared
+    @State private var replyText = ""
+    @State private var axDump = ""
+    @State private var lastResult = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Circle()
+                    .fill(manager.isWatching ? .green : .red)
+                    .frame(width: 8, height: 8)
+                Text(manager.isWatching ? "Watching" : "Not watching")
+                Spacer()
+                Button("Start") { Task { await manager.start() } }
+                Button("Stop") { manager.stop() }
+                Button("Clear") { manager.clear() }
+                Button("Dump AX tree") { Task { axDump = await manager.debugDump() } }
+            }
+
+            if !lastResult.isEmpty {
+                Text(lastResult).font(.caption).foregroundStyle(.secondary)
+            }
+
+            List(manager.notifications) { notification in
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        if let icon = notification.icon {
+                            Image(nsImage: icon).resizable().frame(width: 20, height: 20)
+                        }
+                        Text(notification.appName ?? "unknown app").bold()
+                        Text(notification.bundleID ?? "no bundle id")
+                            .font(.caption).foregroundStyle(.secondary)
+                        Spacer()
+                        if !notification.isLive {
+                            Text("expired").font(.caption).foregroundStyle(.orange)
+                        }
+                    }
+                    Text(notification.title ?? "—")
+                    if let subtitle = notification.subtitle {
+                        Text(subtitle).font(.caption)
+                    }
+                    Text(notification.body ?? "—").font(.caption).foregroundStyle(.secondary)
+                    Text("actions: \(notification.actions.joined(separator: ", "))")
+                        .font(.caption2).foregroundStyle(.tertiary)
+
+                    HStack {
+                        TextField("reply…", text: $replyText)
+                            .onSubmit { send(to: notification) }
+                        Button("Send") { send(to: notification) }
+                            .disabled(replyText.isEmpty)
+                        Button("Open") {
+                            Task { await manager.open(notification) }
+                        }
+                    }
+                    .disabled(!notification.isLive)
+                }
+                .padding(.vertical, 4)
+            }
+
+            if !axDump.isEmpty {
+                ScrollView {
+                    Text(axDump).font(.system(.caption, design: .monospaced)).textSelection(.enabled)
+                }
+                .frame(height: 200)
+            }
+        }
+        .padding()
+        .frame(minWidth: 520, minHeight: 480)
+        .task { await manager.start() }
+    }
+
+    private func send(to notification: SystemNotification) {
+        let text = replyText
+        replyText = ""
+        Task {
+            let sent = await manager.reply(to: notification, text: text)
+            lastResult = sent ? "replied" : "no reply field — opened the app instead"
+        }
+    }
+}

--- a/boringNotch/components/NotificationDebugWindow.swift
+++ b/boringNotch/components/NotificationDebugWindow.swift
@@ -84,8 +84,12 @@ struct NotificationDebugView: View {
         let text = replyText
         replyText = ""
         Task {
-            let sent = await manager.reply(to: notification, text: text)
-            lastResult = sent ? "replied" : "no reply field — opened the app instead"
+            switch await manager.reply(to: notification, text: text) {
+            case .sent:
+                lastResult = "replied via the live banner"
+            case .handedOffToApp:
+                lastResult = "banner gone — copied to clipboard and opened the app"
+            }
         }
     }
 }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -13,6 +13,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
     case general
     case appearance
     case media
+    case notifications
     case calendar
     case osd
     case battery
@@ -29,6 +30,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: "General"
         case .appearance: "Appearance"
         case .media: "Media"
+        case .notifications: "Notifications"
         case .calendar: "Calendar"
         case .osd: "OSD"
         case .battery: "Battery"
@@ -45,6 +47,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .general: "gear"
         case .appearance: "eye"
         case .media: "play.laptopcomputer"
+        case .notifications: "bell.badge"
         case .calendar: "calendar"
         case .osd: "dial.medium.fill"
         case .battery: "battery.100.bolt"
@@ -88,6 +91,8 @@ struct SettingsView: View {
                     Appearance()
                 case .media:
                     Media()
+                case .notifications:
+                    NotificationSettingsView()
                 case .calendar:
                     CalendarSettings()
                 case .osd:

--- a/boringNotch/components/Settings/Views/NotificationSettingsView.swift
+++ b/boringNotch/components/Settings/Views/NotificationSettingsView.swift
@@ -67,9 +67,36 @@ struct NotificationSettingsView: View {
                 }
             }
             .disabled(!notificationLiveActivity)
+
+            Section {
+                Defaults.Toggle(key: .smartRepliesEnabled) {
+                    Text("Suggest replies with Apple Intelligence")
+                }
+                .disabled(!notificationLiveActivity || !smartRepliesAvailable)
+            } footer: {
+                Text(smartReplyFooter)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .formStyle(.grouped)
         .navigationTitle("Notifications")
+    }
+
+    private var smartRepliesAvailable: Bool {
+        if case .available = SmartReplyManager.availability { return true }
+        return false
+    }
+
+    private var smartReplyFooter: String {
+        // Drafts run entirely on-device via Apple's on-device model — no
+        // network calls, nothing leaves the Mac.
+        switch SmartReplyManager.availability {
+        case .available:
+            return "Drafts a few short reply options for messages, entirely on-device. Nothing is sent over the network."
+        case .unavailable(let reason):
+            return reason
+        }
     }
 
     @ViewBuilder

--- a/boringNotch/components/Settings/Views/NotificationSettingsView.swift
+++ b/boringNotch/components/Settings/Views/NotificationSettingsView.swift
@@ -1,0 +1,108 @@
+//
+//  NotificationSettingsView.swift
+//  boringNotch
+//
+//  Per-app controls for the notch's notification live activity: which apps
+//  are mirrored, and which of those should also have their system banner
+//  auto-dismissed once captured.
+//
+
+import Defaults
+import SwiftUI
+
+private struct KnownNotificationApp: Identifiable {
+    let bundleID: String
+    let name: String
+    var id: String { bundleID }
+}
+
+private let knownNotificationApps: [KnownNotificationApp] = [
+    .init(bundleID: "com.apple.MobileSMS", name: "Messages"),
+    .init(bundleID: "com.apple.FaceTime", name: "FaceTime"),
+    .init(bundleID: "com.apple.mail", name: "Mail"),
+    .init(bundleID: "com.microsoft.Outlook", name: "Outlook"),
+    .init(bundleID: "net.whatsapp.WhatsApp", name: "WhatsApp"),
+    .init(bundleID: "ru.keepcoder.Telegram", name: "Telegram"),
+    .init(bundleID: "com.tdesktop.Telegram", name: "Telegram Desktop"),
+    .init(bundleID: "com.hnc.Discord", name: "Discord")
+]
+
+struct NotificationSettingsView: View {
+    @Default(.notificationLiveActivity) var notificationLiveActivity
+    @Default(.notificationsFromAllApps) var notificationsFromAllApps
+    @Default(.notificationAllowedApps) var allowedApps
+    @Default(.notificationSuppressedApps) var suppressedApps
+
+    var body: some View {
+        Form {
+            Section {
+                Defaults.Toggle(key: .notificationLiveActivity) {
+                    Text("Show notifications in the notch")
+                }
+            } footer: {
+                Text("Requires Accessibility access. Only banners are mirrored — notifications delivered silently to Notification Center aren't visible to the app.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                Defaults.Toggle(key: .notificationsFromAllApps) {
+                    Text("From all apps")
+                }
+                .disabled(!notificationLiveActivity)
+
+                if !notificationsFromAllApps {
+                    ForEach(knownNotificationApps) { app in
+                        appRow(app)
+                    }
+                }
+            } header: {
+                Text("Apps")
+            } footer: {
+                if !notificationsFromAllApps {
+                    Text("Only these apps show a live activity in the notch. Turn on \"From all apps\" to mirror everything instead.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .disabled(!notificationLiveActivity)
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Notifications")
+    }
+
+    @ViewBuilder
+    private func appRow(_ app: KnownNotificationApp) -> some View {
+        let isAllowed = allowedApps.contains(app.bundleID)
+
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                AppIcon(for: app.bundleID)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 20, height: 20)
+                    .clipShape(RoundedRectangle(cornerRadius: 5))
+
+                Toggle(app.name, isOn: Binding(
+                    get: { allowedApps.contains(app.bundleID) },
+                    set: { on in
+                        if on { allowedApps.insert(app.bundleID) } else { allowedApps.remove(app.bundleID) }
+                    }
+                ))
+            }
+
+            if isAllowed {
+                Toggle("Hide system banner, show in notch only", isOn: Binding(
+                    get: { suppressedApps.contains(app.bundleID) },
+                    set: { on in
+                        if on { suppressedApps.insert(app.bundleID) } else { suppressedApps.remove(app.bundleID) }
+                    }
+                ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.leading, 28)
+            }
+        }
+        .disabled(!notificationLiveActivity)
+    }
+}

--- a/boringNotch/components/Settings/Views/NotificationSettingsView.swift
+++ b/boringNotch/components/Settings/Views/NotificationSettingsView.swift
@@ -32,7 +32,6 @@ struct NotificationSettingsView: View {
     @Default(.notificationLiveActivity) var notificationLiveActivity
     @Default(.notificationsFromAllApps) var notificationsFromAllApps
     @Default(.notificationAllowedApps) var allowedApps
-    @Default(.notificationSuppressedApps) var suppressedApps
 
     var body: some View {
         Form {
@@ -101,35 +100,19 @@ struct NotificationSettingsView: View {
 
     @ViewBuilder
     private func appRow(_ app: KnownNotificationApp) -> some View {
-        let isAllowed = allowedApps.contains(app.bundleID)
+        HStack {
+            AppIcon(for: app.bundleID)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 20, height: 20)
+                .clipShape(RoundedRectangle(cornerRadius: 5))
 
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                AppIcon(for: app.bundleID)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 20, height: 20)
-                    .clipShape(RoundedRectangle(cornerRadius: 5))
-
-                Toggle(app.name, isOn: Binding(
-                    get: { allowedApps.contains(app.bundleID) },
-                    set: { on in
-                        if on { allowedApps.insert(app.bundleID) } else { allowedApps.remove(app.bundleID) }
-                    }
-                ))
-            }
-
-            if isAllowed {
-                Toggle("Hide system banner, show in notch only", isOn: Binding(
-                    get: { suppressedApps.contains(app.bundleID) },
-                    set: { on in
-                        if on { suppressedApps.insert(app.bundleID) } else { suppressedApps.remove(app.bundleID) }
-                    }
-                ))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .padding(.leading, 28)
-            }
+            Toggle(app.name, isOn: Binding(
+                get: { allowedApps.contains(app.bundleID) },
+                set: { on in
+                    if on { allowedApps.insert(app.bundleID) } else { allowedApps.remove(app.bundleID) }
+                }
+            ))
         }
         .disabled(!notificationLiveActivity)
     }

--- a/boringNotch/components/Settings/Views/NotificationSettingsView.swift
+++ b/boringNotch/components/Settings/Views/NotificationSettingsView.swift
@@ -24,7 +24,8 @@ private let knownNotificationApps: [KnownNotificationApp] = [
     .init(bundleID: "net.whatsapp.WhatsApp", name: "WhatsApp"),
     .init(bundleID: "ru.keepcoder.Telegram", name: "Telegram"),
     .init(bundleID: "com.tdesktop.Telegram", name: "Telegram Desktop"),
-    .init(bundleID: "com.hnc.Discord", name: "Discord")
+    .init(bundleID: "com.hnc.Discord", name: "Discord"),
+    .init(bundleID: "com.anthropic.claudefordesktop", name: "Claude")
 ]
 
 struct NotificationSettingsView: View {

--- a/boringNotch/helpers/OTPDetector.swift
+++ b/boringNotch/helpers/OTPDetector.swift
@@ -1,0 +1,167 @@
+//
+//  OTPDetector.swift
+//  boringNotch
+//
+//  Finds a one-time verification code in notification text. Precision over
+//  recall: a phone number or price shown as a fake "code to copy" is worse
+//  than occasionally missing a real one — same trade-off iOS's own OTP
+//  autofill makes (it also requires contextual signal, not bare digits).
+//
+//  Rules, in order:
+//   1. A digit run of 4–8 digits (or two 3-digit groups joined by a dash/
+//      space, e.g. "123-456") is a *candidate*.
+//   2. A candidate is only accepted if a verification-related keyword
+//      ("code", "otp", "verification", "passcode", "pin", …) appears within
+//      `keywordWindow` characters of it — this is what keeps "call me at
+//      9876543210" and "invoice #48293021" from matching, since neither has
+//      a keyword nearby, without needing hand-written phone/invoice rules.
+//   3. Currency, percentage, and time-adjacent digits are rejected outright
+//      even if a keyword happens to be nearby (e.g. "OTP fee is $500").
+//   4. If no digit-only candidate is accepted, a secondary pass looks for a
+//      short uppercase alphanumeric token (Steam Guard-style: "R7K9P2") next
+//      to the same keyword set.
+//
+
+import Foundation
+
+enum OTPDetector {
+    /// Longest a real OTP/2FA code gets in practice; wider misses ambiguity
+    /// with tracking numbers and account IDs.
+    private static let digitCountRange = 4...8
+
+    /// How close a keyword has to be to a candidate to count as context,
+    /// measured in UTF-16 code units. Covers "Your code is 482910" and
+    /// "482910 is your verification code" without also matching a keyword
+    /// three sentences away.
+    private static let keywordWindow = 40
+
+    private static let keywords = [
+        "verification", "one-time", "one time", "passcode", "otp",
+        "security code", "confirmation code", "confirmation", "access code",
+        "auth code", "authentication code", "two-factor", "2fa", "pin", "code"
+    ]
+
+    /// Used for the alphanumeric fallback only. Excludes bare "code"/"pin" —
+    /// those two are common in non-OTP contexts too ("promo code SAVE20",
+    /// "pin your location"), which is fine for the digit-only pass (a random
+    /// 6-digit number near "code" is almost always a real OTP) but would
+    /// wrongly accept a dictionary-word promo code like "SAVE20" here.
+    private static let strongKeywords = [
+        "verification", "one-time", "one time", "passcode", "otp",
+        "security code", "confirmation code", "access code", "auth code",
+        "authentication code", "two-factor", "2fa"
+    ]
+
+    private static let digitRunRegex = try! NSRegularExpression(
+        pattern: #"\d{3}[-\s]\d{3}\b|\b\d{4,8}\b"#
+    )
+    private static let alphanumericRegex = try! NSRegularExpression(
+        pattern: #"\b(?=[A-Z0-9]*\d)(?=[A-Z0-9]*[A-Z])[A-Z0-9]{5,8}\b"#
+    )
+
+    /// Returns the code with any separators stripped, ready to paste into an
+    /// OTP field — or nil if nothing in `text` clears the bar above.
+    static func detect(in text: String) -> String? {
+        guard !text.isEmpty else { return nil }
+        let ns = text as NSString
+
+        if let match = bestDigitCandidate(in: text, ns: ns) {
+            return match.replacingOccurrences(of: "-", with: "")
+                .replacingOccurrences(of: " ", with: "")
+        }
+
+        return bestAlphanumericCandidate(in: text, ns: ns)
+    }
+
+    private static func bestDigitCandidate(in text: String, ns: NSString) -> String? {
+        let matches = digitRunRegex.matches(in: text, range: NSRange(location: 0, length: ns.length))
+        for match in matches {
+            guard !isExcluded(match.range, in: ns), hasNearbyKeyword(match.range, in: ns) else { continue }
+            return ns.substring(with: match.range)
+        }
+        return nil
+    }
+
+    private static func bestAlphanumericCandidate(in text: String, ns: NSString) -> String? {
+        let matches = alphanumericRegex.matches(in: text, range: NSRange(location: 0, length: ns.length))
+        for match in matches where hasNearbyKeyword(match.range, in: ns, from: strongKeywords) {
+            return ns.substring(with: match.range)
+        }
+        return nil
+    }
+
+    /// Currency amounts, percentages, and clock times shouldn't match even
+    /// with a keyword nearby ("OTP delivery fee is $500", "meeting at 4:30").
+    private static func isExcluded(_ range: NSRange, in ns: NSString) -> Bool {
+        let before = charBefore(range, in: ns)
+        let after = charAfter(range, in: ns)
+
+        if let before, "$€£¥₹".contains(before) { return true }
+        if let after, after == "%" { return true }
+        if let after, after == ":" { return true }
+        if let before, before == ":" { return true }
+        if let after, after == "." {
+            // "500.00" — a decimal amount, not a code with a trailing period.
+            let next = ns.substring(with: NSRange(location: range.location + range.length, length: min(3, ns.length - range.location - range.length)))
+            if next.dropFirst().allSatisfy(\.isNumber) { return true }
+        }
+        return false
+    }
+
+    private static func charBefore(_ range: NSRange, in ns: NSString) -> Character? {
+        guard range.location > 0 else { return nil }
+        return Character(UnicodeScalar(ns.character(at: range.location - 1))!)
+    }
+
+    private static func charAfter(_ range: NSRange, in ns: NSString) -> Character? {
+        let end = range.location + range.length
+        guard end < ns.length else { return nil }
+        return Character(UnicodeScalar(ns.character(at: end))!)
+    }
+
+    private static func hasNearbyKeyword(_ range: NSRange, in ns: NSString, from list: [String] = keywords) -> Bool {
+        let windowStart = max(0, range.location - keywordWindow)
+        let windowEnd = min(ns.length, range.location + range.length + keywordWindow)
+        let window = ns.substring(with: NSRange(location: windowStart, length: windowEnd - windowStart)).lowercased()
+        return list.contains { window.contains($0) }
+    }
+}
+
+#if DEBUG
+/// Non-exhaustive but covers the shapes that matter: separators, prefix vs.
+/// suffix keyword position, currency/time/percentage traps, and an
+/// alphanumeric fallback. Run via `OTPDetector.runSelfCheck()`.
+extension OTPDetector {
+    static func runSelfCheck() {
+        let shouldDetect: [(String, String)] = [
+            ("Your WhatsApp code: 123-456. Don't share this with anyone.", "123456"),
+            ("G-593821 is your Google verification code.", "593821"),
+            ("Your Instagram code is 482910. Learn more.", "482910"),
+            ("Use 7482 as your verification code. Expires in 10 minutes.", "7482"),
+            ("123456 is your Facebook confirmation code", "123456"),
+            ("<#> Your ABC App code is 384950 #hash", "384950"),
+            ("Your OTP for a transaction of INR 500.00 is 837201. Valid for 5 mins.", "837201"),
+            ("Your Amazon OTP is: 4821", "4821"),
+            ("Your Steam Guard verification code: R7K9P2", "R7K9P2")
+        ]
+
+        let shouldMiss: [String] = [
+            "Hey, call me at 9876543210 when you're free",
+            "Meeting at 3:30 today, don't forget code review at 4",
+            "Your invoice #48293021 total is due",
+            "Ref: 293847, please quote when calling about your 2023 order",
+            "Get 20% off with code SAVE20 at checkout",
+            "The OTP delivery fee is $5000 this month"
+        ]
+
+        for (text, expected) in shouldDetect {
+            let got = detect(in: text)
+            assert(got == expected, "OTPDetector missed \"\(text)\" — expected \(expected), got \(got ?? "nil")")
+        }
+        for text in shouldMiss {
+            let got = detect(in: text)
+            assert(got == nil, "OTPDetector false-positived on \"\(text)\" — got \(got ?? "nil")")
+        }
+    }
+}
+#endif

--- a/boringNotch/managers/ContactAvatarManager.swift
+++ b/boringNotch/managers/ContactAvatarManager.swift
@@ -1,0 +1,123 @@
+//
+//  ContactAvatarManager.swift
+//  boringNotch
+//
+//  Resolves a notification sender's name to a Contacts photo, for the
+//  "person, not app" avatar treatment iMessage's Communication Notifications
+//  use. Notification Center banners don't expose a photo over Accessibility
+//  at all (verified against live WhatsApp/Discord banners — title/subtitle/
+//  body text and buttons only, no image element), so this is the only way
+//  to get one for third-party apps too.
+//
+//  Many senders won't resolve — a WhatsApp/Telegram display name rarely
+//  matches a Contacts card exactly, and some notifications aren't from a
+//  person at all. Callers fall back to a monogram avatar in that case.
+//
+
+import AppKit
+import Contacts
+import SwiftUI
+
+@MainActor
+final class ContactAvatarManager: ObservableObject {
+    static let shared = ContactAvatarManager()
+
+    private let store = CNContactStore()
+    private var isAuthorized = false
+    /// Exact-name lookups are cheap to repeat but the store fetch isn't;
+    /// cache misses too so a name that doesn't resolve isn't retried forever.
+    private var cache: [String: NSImage?] = [:]
+
+    private init() {
+        isAuthorized = CNContactStore.authorizationStatus(for: .contacts) == .authorized
+    }
+
+    private func ensureAuthorized() async -> Bool {
+        switch CNContactStore.authorizationStatus(for: .contacts) {
+        case .authorized:
+            isAuthorized = true
+            return true
+        case .notDetermined:
+            let granted = (try? await store.requestAccess(for: .contacts)) ?? false
+            isAuthorized = granted
+            return granted
+        default:
+            return false
+        }
+    }
+
+    /// Looks up a contact photo by exact display-name match. Returns nil
+    /// immediately (no permission prompt) unless the caller has already
+    /// established access via `requestAccessIfNeeded`.
+    func photo(forSenderNamed name: String) -> NSImage? {
+        if let cached = cache[name] { return cached }
+        guard isAuthorized else { return nil }
+
+        let keys = [CNContactImageDataKey, CNContactThumbnailImageDataKey] as [CNKeyDescriptor]
+        let predicate = CNContact.predicateForContacts(matchingName: name)
+
+        guard let contacts = try? store.unifiedContacts(matching: predicate, keysToFetch: keys),
+              // Ambiguous matches (multiple people share a first name) are
+              // worse than no photo — a wrong face is worse than a monogram.
+              contacts.count == 1,
+              let data = contacts[0].thumbnailImageData ?? contacts[0].imageData,
+              let image = NSImage(data: data)
+        else {
+            cache[name] = .some(nil)
+            return nil
+        }
+
+        cache[name] = image
+        return image
+    }
+
+    /// Call once, e.g. when notification live activity starts, so the first
+    /// banner isn't blocked on a permission prompt mid-render.
+    func requestAccessIfNeeded() async {
+        _ = await ensureAuthorized()
+    }
+}
+
+/// Stable "person" avatar: a real contact photo when one resolves, otherwise
+/// a colored monogram — the same fallback Contacts/Messages/Mail use for
+/// people without a saved photo, so it never looks broken.
+struct PersonAvatarView: View {
+    let name: String
+    let size: CGFloat
+
+    @ObservedObject private var contacts = ContactAvatarManager.shared
+
+    var body: some View {
+        Group {
+            if let photo = contacts.photo(forSenderNamed: name) {
+                Image(nsImage: photo)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                ZStack {
+                    monogramColor
+                    Text(initials)
+                        .font(.system(size: size * 0.4, weight: .semibold))
+                        .foregroundStyle(.white)
+                }
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+    }
+
+    private var initials: String {
+        let parts = name.split(separator: " ").prefix(2)
+        let letters = parts.compactMap { $0.first }.map(String.init)
+        return letters.isEmpty ? "?" : letters.joined().uppercased()
+    }
+
+    /// Hashes the name to a hue so the same person gets the same color across
+    /// notifications, without needing to persist anything.
+    private var monogramColor: Color {
+        var hasher = Hasher()
+        hasher.combine(name)
+        let hue = Double(abs(hasher.finalize()) % 360) / 360
+        return Color(hue: hue, saturation: 0.55, brightness: 0.75)
+    }
+}

--- a/boringNotch/managers/ContactAvatarManager.swift
+++ b/boringNotch/managers/ContactAvatarManager.swift
@@ -63,10 +63,12 @@ final class ContactAvatarManager: ObservableObject {
               let data = contacts[0].thumbnailImageData ?? contacts[0].imageData,
               let image = NSImage(data: data)
         else {
+            NSLog("[boringNotch] avatar for \(name.debugDescription): no contact photo, using monogram")
             cache[name] = .some(nil)
             return nil
         }
 
+        NSLog("[boringNotch] avatar for \(name.debugDescription): using contact photo")
         cache[name] = image
         return image
     }

--- a/boringNotch/managers/SmartReplyManager.swift
+++ b/boringNotch/managers/SmartReplyManager.swift
@@ -80,7 +80,16 @@ enum SmartReplyManager {
                 """)
             let prompt = "From: \(sender ?? "someone")\nMessage: \(body)\n\nSuggest 3 short possible replies."
             let result = try await session.respond(to: prompt, generating: ReplySuggestionSet.self)
-            return Array(result.content.replies.prefix(3))
+
+            // The model repeats itself sometimes ("Got it!" twice), which is
+            // both useless as a second chip and a duplicate SwiftUI ForEach
+            // id. Dedupe case-insensitively, keeping first-seen order.
+            var seen = Set<String>()
+            return result.content.replies
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty && seen.insert($0.lowercased()).inserted }
+                .prefix(3)
+                .map { $0 }
         } catch {
             return []
         }

--- a/boringNotch/managers/SmartReplyManager.swift
+++ b/boringNotch/managers/SmartReplyManager.swift
@@ -1,0 +1,100 @@
+//
+//  SmartReplyManager.swift
+//  boringNotch
+//
+//  Draft reply suggestions using Apple's on-device Foundation Models —
+//  entirely local, no network calls, same model that powers Apple
+//  Intelligence system-wide.
+//
+//  Every touchpoint here is macOS 26+ and Apple-Intelligence-enabled only.
+//  This project's deployment target is macOS 14, so nothing outside an
+//  `@available`/`#available` guard may reference FoundationModels — Swift's
+//  autolinking weak-links the framework based on those annotations, which is
+//  what lets the app still launch on older macOS versions at all. Skipping a
+//  guard wouldn't just lose this feature, it would risk the whole app
+//  failing to launch below macOS 26.
+//
+
+import Foundation
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+enum SmartReplyAvailability: Equatable {
+    case available
+    case unavailable(reason: String)
+}
+
+enum SmartReplyManager {
+    static var availability: SmartReplyAvailability {
+        #if canImport(FoundationModels)
+        guard #available(macOS 26.0, *) else {
+            return .unavailable(reason: "Requires macOS 26 or later.")
+        }
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            return .available
+        case .unavailable(let reason):
+            return .unavailable(reason: describeUnavailable(reason))
+        }
+        #else
+        return .unavailable(reason: "Requires macOS 26 or later.")
+        #endif
+    }
+
+    #if canImport(FoundationModels)
+    @available(macOS 26.0, *)
+    private static func describeUnavailable(_ reason: SystemLanguageModel.Availability.UnavailableReason) -> String {
+        switch reason {
+        case .deviceNotEligible:
+            return "This Mac doesn't support Apple Intelligence."
+        case .appleIntelligenceNotEnabled:
+            return "Turn on Apple Intelligence in System Settings → Apple Intelligence & Siri."
+        case .modelNotReady:
+            return "The on-device model is still downloading."
+        @unknown default:
+            return "Apple Intelligence isn't available right now."
+        }
+    }
+    #endif
+
+    /// Up to three short reply drafts for the given message, or an empty
+    /// array on any unavailability/failure — callers show nothing rather
+    /// than an error state for what's an optional nicety, not a feature the
+    /// UI depends on.
+    static func suggestReplies(sender: String?, body: String) async -> [String] {
+        #if canImport(FoundationModels)
+        guard #available(macOS 26.0, *),
+              case .available = SystemLanguageModel.default.availability,
+              !body.isEmpty
+        else { return [] }
+
+        do {
+            let session = LanguageModelSession(instructions: """
+                You draft extremely short, casual reply suggestions to an \
+                incoming message, in the voice of the person replying, not \
+                the sender. Match the tone and language of the message. \
+                Never invent facts, plans, times, or commitments the message \
+                doesn't mention. Each reply must be under 8 words.
+                """)
+            let prompt = "From: \(sender ?? "someone")\nMessage: \(body)\n\nSuggest 3 short possible replies."
+            let result = try await session.respond(to: prompt, generating: ReplySuggestionSet.self)
+            return Array(result.content.replies.prefix(3))
+        } catch {
+            return []
+        }
+        #else
+        return []
+        #endif
+    }
+}
+
+#if canImport(FoundationModels)
+@available(macOS 26.0, *)
+@Generable
+struct ReplySuggestionSet: Equatable {
+    @Guide(description: "2 to 3 short, casual reply suggestions, each under 8 words")
+    let replies: [String]
+}
+#endif

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -33,8 +33,13 @@ struct SystemNotification: Identifiable, Equatable {
     /// Any of the three is a decent hint; `SystemNotificationManager.reply`
     /// is the actual source of truth and falls back to opening the app if no
     /// field materializes.
+    /// Whether to offer a reply box at all — based on the app supporting
+    /// replies, not on whether the banner is still alive. The compose box
+    /// stays for as long as the notification is in the notch; if the banner
+    /// has since died, `reply` degrades instead of the UI disappearing out
+    /// from under a half-typed message.
     var canReply: Bool {
-        isLive && actions.contains {
+        actions.contains {
             $0.localizedCaseInsensitiveContains("reply")
                 || $0.localizedCaseInsensitiveContains("send")
                 || $0.localizedCaseInsensitiveContains("details")
@@ -270,14 +275,33 @@ final class SystemNotificationManager: ObservableObject {
 
     // MARK: - Acting
 
-    /// Sends an inline reply. Returns false when the banner is gone or the app
-    /// has no reply action — callers should fall back to `open`.
+    enum ReplyOutcome {
+        /// Delivered through the live banner's reply field.
+        case sent
+        /// The banner was gone, so the draft went to the clipboard and the
+        /// app was opened for the user to paste.
+        case handedOffToApp
+    }
+
+    /// Sends an inline reply.
+    ///
+    /// Replying works by typing into the system banner's own reply field, so
+    /// it's only possible while that banner is on screen — roughly five
+    /// seconds. There is no API to send on an app's behalf after that.
+    /// Rather than dropping a typed message on the floor, hand it off: put
+    /// the draft on the clipboard and open the app so it's one paste away.
     @discardableResult
-    func reply(to notification: SystemNotification, text: String) async -> Bool {
-        let sent = await XPCHelperClient.shared.replyToNotification(token: notification.id, text: text)
-        if !sent { await open(notification) }
+    func reply(to notification: SystemNotification, text: String) async -> ReplyOutcome {
+        if await XPCHelperClient.shared.replyToNotification(token: notification.id, text: text) {
+            dismissActive(token: notification.id)
+            return .sent
+        }
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        await open(notification)
         dismissActive(token: notification.id)
-        return sent
+        return .handedOffToApp
     }
 
     func perform(_ action: String, on notification: SystemNotification) async -> Bool {

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -167,8 +167,21 @@ final class SystemNotificationManager: ObservableObject {
     /// apps people actually reply to.
     private func isAllowed(_ notification: SystemNotification) -> Bool {
         if Defaults[.notificationsFromAllApps] { return true }
-        guard let bundleID = notification.bundleID else { return false }
-        return Defaults[.notificationAllowedApps].contains(bundleID)
+
+        if let bundleID = notification.bundleID {
+            return Defaults[.notificationAllowedApps].contains(bundleID)
+        }
+
+        // Bundle ID resolution goes through the app's *running* name, which
+        // can miss (renamed app, helper process owning the notification, an
+        // app that quit between posting and capture). Rather than silently
+        // dropping the notification, fall back to matching the app name
+        // against the tail of an allowed bundle ID — "WhatsApp" against
+        // net.whatsapp.WhatsApp.
+        guard let appName = notification.appName?.lowercased(), !appName.isEmpty else { return false }
+        return Defaults[.notificationAllowedApps].contains { bundleID in
+            bundleID.split(separator: ".").last.map { appName == $0.lowercased() } ?? false
+        }
     }
 
     private func show(_ notification: SystemNotification) {

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -298,6 +298,20 @@ final class SystemNotificationManager: ObservableObject {
             return .sent
         }
 
+        // The banner is gone, so AX can't deliver. Messages is the one
+        // supported app that can still be sent to properly — it has a real
+        // scripting dictionary, so the reply goes out for real instead of
+        // becoming a clipboard hand-off. Nothing equivalent exists for
+        // WhatsApp/Telegram/Discord.
+        if notification.bundleID == "com.apple.MobileSMS",
+           let chatName = notification.sender,
+           await XPCHelperClient.shared.sendIMessage(text, toChatNamed: chatName) {
+            NSLog("[boringNotch] reply sent via Messages scripting for \(chatName)")
+            playSentSound()
+            dismissActive(token: notification.id)
+            return .sent
+        }
+
         NSLog("[boringNotch] reply could not be delivered (banner gone) — handing off to \(notification.appName ?? "app")")
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -145,7 +145,11 @@ final class SystemNotificationManager: ObservableObject {
             notifications.removeLast(notifications.count - historyLimit)
         }
 
-        guard isAllowed(notification) else { return }
+        guard isAllowed(notification) else {
+            NSLog("[boringNotch] filtered out: \(notification.appName ?? "-") bundle=\(notification.bundleID ?? "nil")")
+            return
+        }
+        NSLog("[boringNotch] showing in notch: \(notification.appName ?? "-")")
         show(notification)
         suppressSystemBannerIfNeeded(notification)
     }

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -217,6 +217,19 @@ final class SystemNotificationManager: ObservableObject {
         withAnimation(.smooth) { activeNotification = nil }
     }
 
+    /// Keeps the notification up for as long as the reply field is actually
+    /// being typed into — no cap. A keystroke is the clearest possible
+    /// signal that this isn't an abandoned notch, so `maxLifetime` (which
+    /// exists to protect against exactly that) doesn't apply here. Reverting
+    /// to the capped `holdActive` happens the moment the field loses focus,
+    /// and the notch closing at all (hover-out) tears the view down
+    /// regardless, so this can't strand a notification the way an
+    /// unconditional hold on notch-open did.
+    func holdWhileTyping() {
+        dismissTask?.cancel()
+        dismissTask = nil
+    }
+
     /// Keeps the notification up while the user is engaging with it — the
     /// notch is open, or they're typing a reply. Without this the countdown
     /// keeps running and the notification vanishes mid-read.

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -75,13 +75,11 @@ final class SystemNotificationManager: ObservableObject {
     /// The notification the notch is currently showing, if any.
     @Published var activeNotification: SystemNotification?
 
-    /// How long the notch keeps showing a notification after it arrives.
+    /// How long the closed notch shows a notification before handing the
+    /// pill back to whatever was there before (usually music). Only applies
+    /// while the notch is closed and unhovered — hovering or opening it
+    /// holds the notification indefinitely.
     private let activeDuration: TimeInterval = 8
-
-    /// Ceiling on how long a notification can occupy the notch even while
-    /// held open. Past this it's stale — the source banner is long gone, so
-    /// replying is impossible anyway.
-    private let maxLifetime: TimeInterval = 30
     private var dismissTask: Task<Void, Never>?
 
     /// Expired banners are kept around briefly so the notch can still show the
@@ -217,51 +215,37 @@ final class SystemNotificationManager: ObservableObject {
         withAnimation(.smooth) { activeNotification = nil }
     }
 
-    /// Keeps the notification up for as long as the reply field is actually
-    /// being typed into — no cap. A keystroke is the clearest possible
-    /// signal that this isn't an abandoned notch, so `maxLifetime` (which
-    /// exists to protect against exactly that) doesn't apply here. Reverting
-    /// to the capped `holdActive` happens the moment the field loses focus,
-    /// and the notch closing at all (hover-out) tears the view down
-    /// regardless, so this can't strand a notification the way an
-    /// unconditional hold on notch-open did.
+    /// Keeps the notification up for as long as the reply field is being
+    /// typed into. Same behaviour as `holdActive` now — kept as a separate
+    /// name because the call sites mean different things.
     func holdWhileTyping() {
-        dismissTask?.cancel()
-        dismissTask = nil
+        holdActive()
     }
 
-    /// Keeps the notification up while the user is engaging with it — the
-    /// notch is open, or they're typing a reply. Without this the countdown
-    /// keeps running and the notification vanishes mid-read.
+    /// Holds the notification indefinitely while the notch is open. No time
+    /// cap: it stays until the notch closes or a newer notification
+    /// replaces it.
     ///
-    /// Bounded by `maxLifetime` rather than cancelled outright: an
-    /// indefinite hold meant an opened notch pinned its notification
-    /// forever, so hovering the notch much later still showed a long-dead
-    /// message instead of the normal content.
+    /// This previously capped at `maxLifetime` to stop an abandoned open
+    /// notch pinning a stale message. That cap is unnecessary now that
+    /// closing the notch clears the notification outright (see
+    /// `resumeDismiss`) — the notch closing is what bounds it, so a stale
+    /// one can't survive to be seen later regardless of how long it was
+    /// held.
     func holdActive() {
         dismissTask?.cancel()
         dismissTask = nil
-
-        guard let active = activeNotification else { return }
-        let remaining = maxLifetime - Date().timeIntervalSince(active.receivedAt)
-        guard remaining > 0 else {
-            dismissActive(token: active.id)
-            return
-        }
-        dismissTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(remaining))
-            guard !Task.isCancelled else { return }
-            await MainActor.run { self?.dismissActive(token: active.id) }
-        }
     }
 
     /// Restarts the dismiss countdown once the user stops interacting —
-    /// without this a held notification would stay in the notch forever.
+    /// Clears the notification shortly after the notch closes. This is what
+    /// bounds the otherwise-indefinite `holdActive`, so it must always
+    /// schedule — a bail-if-busy check here would let an indefinite hold
+    /// survive the notch closing and strand the notification.
     ///
-    /// Replaces whatever task is pending rather than bailing when one
-    /// exists: holdActive always leaves its maxLifetime cap scheduled, so a
-    /// bail-if-busy check here would leave the notification sitting for the
-    /// full cap after the notch closed instead of the short countdown.
+    /// The short delay exists so briefly clipping the notch edge on the way
+    /// past doesn't destroy a notification the user was mid-way through
+    /// reading.
     func resumeDismiss(after delay: TimeInterval = 3) {
         guard let active = activeNotification else { return }
         dismissTask?.cancel()

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -159,19 +159,22 @@ final class SystemNotificationManager: ObservableObject {
         }
         NSLog("[boringNotch] showing in notch: \(notification.appName ?? "-")")
         show(notification)
-        suppressSystemBannerIfNeeded(notification)
+        holdSystemBanner(notification)
     }
 
-    /// Closes the OS banner right after capture for apps the user has opted
-    /// to mute at the system level — the notch's own live activity is meant
-    /// to be the only thing they see for these. This can only run after the
-    /// banner has already rendered and been read; nothing can stop it from
-    /// appearing at all.
-    private func suppressSystemBannerIfNeeded(_ notification: SystemNotification) {
-        guard let bundleID = notification.bundleID,
-              Defaults[.notificationSuppressedApps].contains(bundleID)
-        else { return }
-        Task { await XPCHelperClient.shared.dismissNotification(token: notification.id) }
+    /// Holds the system banner open for as long as the notch is showing the
+    /// notification, so its reply field stays usable — an untouched banner
+    /// dies in seconds, taking the only means of replying with it.
+    ///
+    /// For apps set to "hide system banner", the banner is also moved
+    /// off-screen, which is what makes hiding and replying possible at the
+    /// same time. The previous implementation closed the banner outright,
+    /// which hid it but destroyed the reply field along with it.
+    private func holdSystemBanner(_ notification: SystemNotification) {
+        let hidden = notification.bundleID.map {
+            Defaults[.notificationSuppressedApps].contains($0)
+        } ?? false
+        XPCHelperClient.shared.holdNotification(token: notification.id, offScreen: hidden)
     }
 
     /// The notch mirrors banners rather than replacing them, so an unfiltered
@@ -212,6 +215,12 @@ final class SystemNotificationManager: ObservableObject {
         if let token, activeNotification?.id != token { return }
         dismissTask?.cancel()
         dismissTask = nil
+        // Stop holding the system banner open — otherwise the keep-alive
+        // would pin it (visibly, for non-hidden apps) long after the notch
+        // has moved on.
+        if let id = activeNotification?.id {
+            XPCHelperClient.shared.releaseNotification(token: id)
+        }
         withAnimation(.smooth) { activeNotification = nil }
     }
 

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -164,17 +164,16 @@ final class SystemNotificationManager: ObservableObject {
 
     /// Holds the system banner open for as long as the notch is showing the
     /// notification, so its reply field stays usable — an untouched banner
-    /// dies in seconds, taking the only means of replying with it.
+    /// dies in seconds, taking the only means of replying with it — and
+    /// parks it off-screen for the duration.
     ///
-    /// For apps set to "hide system banner", the banner is also moved
-    /// off-screen, which is what makes hiding and replying possible at the
-    /// same time. The previous implementation closed the banner outright,
-    /// which hid it but destroyed the reply field along with it.
+    /// Hiding isn't optional here: holding works by re-triggering the
+    /// banner's details toggle, which leaves it expanded with its own reply
+    /// field visible and focused. Two text fields fighting over the same
+    /// keystrokes is worse than no keep-alive, so the notch is the only
+    /// surface on screen while it's held.
     private func holdSystemBanner(_ notification: SystemNotification) {
-        let hidden = notification.bundleID.map {
-            Defaults[.notificationSuppressedApps].contains($0)
-        } ?? false
-        XPCHelperClient.shared.holdNotification(token: notification.id, offScreen: hidden)
+        XPCHelperClient.shared.holdNotification(token: notification.id)
     }
 
     /// The notch mirrors banners rather than replacing them, so an unfiltered

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -282,23 +282,43 @@ final class SystemNotificationManager: ObservableObject {
 
     /// Sends an inline reply.
     ///
-    /// Replying works by typing into the system banner's own reply field, so
-    /// it's only possible while that banner is on screen — roughly five
-    /// seconds. There is no API to send on an app's behalf after that.
-    /// Rather than dropping a typed message on the floor, hand it off: put
-    /// the draft on the clipboard and open the app so it's one paste away.
+    /// Replying types into the notification's own reply field via
+    /// Accessibility, so it depends on that element still being reachable.
+    /// The helper retains elements after their banner fades (the
+    /// notification lives on in Notification Center), which is what makes
+    /// replying work beyond the ~5s banner. If it genuinely can't be
+    /// reached, hand off rather than dropping a typed message: the draft
+    /// goes to the clipboard and the app opens so it's one paste away.
     @discardableResult
     func reply(to notification: SystemNotification, text: String) async -> ReplyOutcome {
         if await XPCHelperClient.shared.replyToNotification(token: notification.id, text: text) {
+            NSLog("[boringNotch] reply sent via AX for \(notification.appName ?? "-")")
+            playSentSound()
             dismissActive(token: notification.id)
             return .sent
         }
 
+        NSLog("[boringNotch] reply could not be delivered (banner gone) — handing off to \(notification.appName ?? "app")")
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
+        playHandOffSound()
         await open(notification)
         dismissActive(token: notification.id)
         return .handedOffToApp
+    }
+
+    /// Only on a real send. A "sent" sound when nothing was sent is a lie
+    /// the user can't see through — they'd find out when the reply never
+    /// arrived.
+    private func playSentSound() {
+        NSSound(named: "Tink")?.play()
+    }
+
+    /// Distinct from the sent sound on purpose: there's still feedback that
+    /// the click registered, but it must not read as a delivery. The orange
+    /// clipboard glyph on the button carries the actual meaning.
+    private func playHandOffSound() {
+        NSSound(named: "Pop")?.play()
     }
 
     func perform(_ action: String, on notification: SystemNotification) async -> Bool {

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -72,6 +72,11 @@ final class SystemNotificationManager: ObservableObject {
 
     /// How long the notch keeps showing a notification after it arrives.
     private let activeDuration: TimeInterval = 8
+
+    /// Ceiling on how long a notification can occupy the notch even while
+    /// held open. Past this it's stale — the source banner is long gone, so
+    /// replying is impossible anyway.
+    private let maxLifetime: TimeInterval = 30
     private var dismissTask: Task<Void, Never>?
 
     /// Expired banners are kept around briefly so the notch can still show the
@@ -207,16 +212,41 @@ final class SystemNotificationManager: ObservableObject {
         withAnimation(.smooth) { activeNotification = nil }
     }
 
-    /// Keeps the notification up while the user is interacting with it.
+    /// Keeps the notification up while the user is engaging with it — the
+    /// notch is open, or they're typing a reply. Without this the countdown
+    /// keeps running and the notification vanishes mid-read.
+    ///
+    /// Bounded by `maxLifetime` rather than cancelled outright: an
+    /// indefinite hold meant an opened notch pinned its notification
+    /// forever, so hovering the notch much later still showed a long-dead
+    /// message instead of the normal content.
     func holdActive() {
         dismissTask?.cancel()
         dismissTask = nil
+
+        guard let active = activeNotification else { return }
+        let remaining = maxLifetime - Date().timeIntervalSince(active.receivedAt)
+        guard remaining > 0 else {
+            dismissActive(token: active.id)
+            return
+        }
+        dismissTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(remaining))
+            guard !Task.isCancelled else { return }
+            await MainActor.run { self?.dismissActive(token: active.id) }
+        }
     }
 
     /// Restarts the dismiss countdown once the user stops interacting —
     /// without this a held notification would stay in the notch forever.
+    ///
+    /// Replaces whatever task is pending rather than bailing when one
+    /// exists: holdActive always leaves its maxLifetime cap scheduled, so a
+    /// bail-if-busy check here would leave the notification sitting for the
+    /// full cap after the notch closed instead of the short countdown.
     func resumeDismiss(after delay: TimeInterval = 3) {
-        guard let active = activeNotification, dismissTask == nil else { return }
+        guard let active = activeNotification else { return }
+        dismissTask?.cancel()
         dismissTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled else { return }

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -27,15 +27,17 @@ struct SystemNotification: Identifiable, Equatable {
     /// True while the banner still exists, i.e. while replying can work.
     var isLive: Bool = true
 
-    /// Best-effort signal for showing the reply row. Notification Center
-    /// doesn't label reply-capable banners consistently — WhatsApp exposes
-    /// "Show Details" (reveals the field) and "Send" (submits), never the
-    /// word "reply" (verified against a live banner). Either is a decent
-    /// hint; `SystemNotificationManager.reply` is the actual source of truth
-    /// and falls back to opening the app if no field materializes.
+    /// Best-effort signal for showing the reply row. A collapsed WhatsApp
+    /// banner exposes "Reply" directly; once expanded that's replaced by
+    /// "Show Details"/"Send" (verified against live banners in both states).
+    /// Any of the three is a decent hint; `SystemNotificationManager.reply`
+    /// is the actual source of truth and falls back to opening the app if no
+    /// field materializes.
     var canReply: Bool {
         isLive && actions.contains {
-            $0.localizedCaseInsensitiveContains("send") || $0.localizedCaseInsensitiveContains("details")
+            $0.localizedCaseInsensitiveContains("reply")
+                || $0.localizedCaseInsensitiveContains("send")
+                || $0.localizedCaseInsensitiveContains("details")
         }
     }
 

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -1,0 +1,252 @@
+//
+//  SystemNotificationManager.swift
+//  boringNotch
+//
+//  Collects Notification Center banners captured by the XPC helper and exposes
+//  them to the UI. The helper does the Accessibility work; this side only
+//  models what is currently on screen.
+//
+
+import AppKit
+import Combine
+import Defaults
+import SwiftUI
+
+struct SystemNotification: Identifiable, Equatable {
+    /// Notification Center's own identifier for the banner, valid while it is
+    /// on screen. Also the token the helper needs to act on it.
+    let id: String
+    let appName: String?
+    let bundleID: String?
+    let title: String?
+    let subtitle: String?
+    let body: String?
+    let actions: [String]
+    let receivedAt: Date
+
+    /// True while the banner still exists, i.e. while replying can work.
+    var isLive: Bool = true
+
+    /// Best-effort signal for showing the reply row. Notification Center
+    /// doesn't label reply-capable banners consistently — WhatsApp exposes
+    /// "Show Details" (reveals the field) and "Send" (submits), never the
+    /// word "reply" (verified against a live banner). Either is a decent
+    /// hint; `SystemNotificationManager.reply` is the actual source of truth
+    /// and falls back to opening the app if no field materializes.
+    var canReply: Bool {
+        isLive && actions.contains {
+            $0.localizedCaseInsensitiveContains("send") || $0.localizedCaseInsensitiveContains("details")
+        }
+    }
+
+    /// A verification code found in the notification text, if any. Computed
+    /// rather than stored — it's cheap regex work and only ever read a
+    /// handful of times per notification.
+    var detectedCode: String? {
+        OTPDetector.detect(in: [title, subtitle, body].compactMap { $0 }.joined(separator: " "))
+    }
+
+    var icon: NSImage? {
+        guard let bundleID,
+              let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID)
+        else { return nil }
+        return NSWorkspace.shared.icon(forFile: url.path)
+    }
+
+    /// Whoever the message is from — banners put the sender in the title.
+    var sender: String? { title }
+}
+
+@MainActor
+final class SystemNotificationManager: ObservableObject {
+    static let shared = SystemNotificationManager()
+
+    /// Most recent first, live banners before expired ones.
+    @Published private(set) var notifications: [SystemNotification] = []
+    @Published private(set) var isWatching = false
+
+    /// The notification the notch is currently showing, if any.
+    @Published var activeNotification: SystemNotification?
+
+    /// How long the notch keeps showing a notification after it arrives.
+    private let activeDuration: TimeInterval = 8
+    private var dismissTask: Task<Void, Never>?
+
+    /// Expired banners are kept around briefly so the notch can still show the
+    /// last message after the banner itself has faded.
+    private let historyLimit = 20
+
+    private var observers: [NSObjectProtocol] = []
+
+    private init() {
+        observers.append(NotificationCenter.default.addObserver(
+            forName: .systemNotificationDidAppear, object: nil, queue: .main
+        ) { [weak self] note in
+            guard let payload = note.userInfo as? [String: String] else { return }
+            MainActor.assumeIsolated { self?.add(payload) }
+        })
+
+        observers.append(NotificationCenter.default.addObserver(
+            forName: .systemNotificationDidDisappear, object: nil, queue: .main
+        ) { [weak self] note in
+            guard let token = note.userInfo?["token"] as? String else { return }
+            MainActor.assumeIsolated { self?.markExpired(token) }
+        })
+    }
+
+    deinit {
+        observers.forEach(NotificationCenter.default.removeObserver)
+    }
+
+    // MARK: - Lifecycle
+
+    func start() async {
+        guard await XPCHelperClient.shared.ensureAccessibilityAuthorization(promptIfNeeded: true) else {
+            isWatching = false
+            return
+        }
+        isWatching = await XPCHelperClient.shared.startNotificationWatching()
+        // Ask up front so the first banner isn't blocked on a permission
+        // prompt mid-render. Contacts access is optional — a denial just
+        // means every avatar falls back to a monogram.
+        await ContactAvatarManager.shared.requestAccessIfNeeded()
+    }
+
+    func stop() {
+        XPCHelperClient.shared.stopNotificationWatching()
+        isWatching = false
+    }
+
+    // MARK: - Incoming banners
+
+    private func add(_ payload: [String: String]) {
+        guard let token = payload["token"], !token.isEmpty else { return }
+        func value(_ key: String) -> String? {
+            let string = payload[key] ?? ""
+            return string.isEmpty ? nil : string
+        }
+
+        let notification = SystemNotification(
+            id: token,
+            appName: value("appName"),
+            bundleID: value("bundleID"),
+            title: value("title"),
+            subtitle: value("subtitle"),
+            body: value("body"),
+            actions: (value("actions") ?? "").components(separatedBy: "\n").filter { !$0.isEmpty },
+            receivedAt: Date()
+        )
+
+        notifications.removeAll { $0.id == token }
+        notifications.insert(notification, at: 0)
+        if notifications.count > historyLimit {
+            notifications.removeLast(notifications.count - historyLimit)
+        }
+
+        guard isAllowed(notification) else { return }
+        show(notification)
+        suppressSystemBannerIfNeeded(notification)
+    }
+
+    /// Closes the OS banner right after capture for apps the user has opted
+    /// to mute at the system level — the notch's own live activity is meant
+    /// to be the only thing they see for these. This can only run after the
+    /// banner has already rendered and been read; nothing can stop it from
+    /// appearing at all.
+    private func suppressSystemBannerIfNeeded(_ notification: SystemNotification) {
+        guard let bundleID = notification.bundleID,
+              Defaults[.notificationSuppressedApps].contains(bundleID)
+        else { return }
+        Task { await XPCHelperClient.shared.dismissNotification(token: notification.id) }
+    }
+
+    /// The notch mirrors banners rather than replacing them, so an unfiltered
+    /// feed would duplicate every system notification. Default to the messaging
+    /// apps people actually reply to.
+    private func isAllowed(_ notification: SystemNotification) -> Bool {
+        if Defaults[.notificationsFromAllApps] { return true }
+        guard let bundleID = notification.bundleID else { return false }
+        return Defaults[.notificationAllowedApps].contains(bundleID)
+    }
+
+    private func show(_ notification: SystemNotification) {
+        withAnimation(.smooth) { activeNotification = notification }
+        dismissTask?.cancel()
+        dismissTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(self?.activeDuration ?? 8))
+            guard !Task.isCancelled else { return }
+            await MainActor.run { self?.dismissActive(token: notification.id) }
+        }
+    }
+
+    /// Passing a token only dismisses if it is still the one on screen, so a
+    /// newer notification isn't cleared by an older one's timer.
+    func dismissActive(token: String? = nil) {
+        if let token, activeNotification?.id != token { return }
+        dismissTask?.cancel()
+        dismissTask = nil
+        withAnimation(.smooth) { activeNotification = nil }
+    }
+
+    /// Keeps the notification up while the user is interacting with it.
+    func holdActive() {
+        dismissTask?.cancel()
+        dismissTask = nil
+    }
+
+    /// Restarts the dismiss countdown once the user stops interacting —
+    /// without this a held notification would stay in the notch forever.
+    func resumeDismiss(after delay: TimeInterval = 3) {
+        guard let active = activeNotification, dismissTask == nil else { return }
+        dismissTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled else { return }
+            await MainActor.run { self?.dismissActive(token: active.id) }
+        }
+    }
+
+    private func markExpired(_ token: String) {
+        if let index = notifications.firstIndex(where: { $0.id == token }) {
+            notifications[index].isLive = false
+        }
+        if activeNotification?.id == token {
+            activeNotification?.isLive = false
+        }
+    }
+
+    func clear() {
+        notifications.removeAll()
+        dismissActive()
+    }
+
+    // MARK: - Acting
+
+    /// Sends an inline reply. Returns false when the banner is gone or the app
+    /// has no reply action — callers should fall back to `open`.
+    @discardableResult
+    func reply(to notification: SystemNotification, text: String) async -> Bool {
+        let sent = await XPCHelperClient.shared.replyToNotification(token: notification.id, text: text)
+        if !sent { await open(notification) }
+        dismissActive(token: notification.id)
+        return sent
+    }
+
+    func perform(_ action: String, on notification: SystemNotification) async -> Bool {
+        await XPCHelperClient.shared.performNotificationAction(token: notification.id, name: action)
+    }
+
+    /// Opens the notification in its source app; falls back to launching the
+    /// app once the banner is gone.
+    @discardableResult
+    func open(_ notification: SystemNotification) async -> Bool {
+        if await XPCHelperClient.shared.openNotification(token: notification.id) { return true }
+        guard let bundleID = notification.bundleID,
+              let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID)
+        else { return false }
+        return (try? await NSWorkspace.shared.openApplication(at: url, configuration: .init())) != nil
+    }
+
+    func debugDump() async -> String {
+        await XPCHelperClient.shared.notificationDebugDump()
+    }
+}

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -326,14 +326,6 @@ extension Defaults.Keys {
             "com.anthropic.claudefordesktop"
         ]
     )
-    /// Apps whose system banner gets closed immediately after boring.notch
-    /// captures it, so the notch becomes the only lasting surface. Can't
-    /// prevent the banner from rendering at all — there's no macOS API for
-    /// that — this just makes it live on screen for well under a second.
-    static let notificationSuppressedApps = Key<Set<String>>(
-        "notificationSuppressedApps",
-        default: []
-    )
     /// Off by default: a new capability, even though it runs entirely
     /// on-device with no network calls. Only takes effect on macOS 26+ with
     /// Apple Intelligence enabled — see SmartReplyManager.

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -322,7 +322,8 @@ extension Defaults.Keys {
             "net.whatsapp.WhatsApp",
             "ru.keepcoder.Telegram",     // Telegram Desktop (App Store build)
             "com.tdesktop.Telegram",
-            "com.hnc.Discord"
+            "com.hnc.Discord",
+            "com.anthropic.claudefordesktop"
         ]
     )
     /// Apps whose system banner gets closed immediately after boring.notch

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -307,6 +307,33 @@ extension Defaults.Keys {
     // MARK: OSD
     static let osdReplacement = Key<Bool>("osdReplacement", default: false)
     static let inlineOSD = Key<Bool>("inlineOSD", default: false)
+
+    // MARK: Notifications
+    /// Off by default: mirroring banners needs Accessibility access.
+    static let notificationLiveActivity = Key<Bool>("notificationLiveActivity", default: false)
+    static let notificationsFromAllApps = Key<Bool>("notificationsFromAllApps", default: false)
+    static let notificationAllowedApps = Key<Set<String>>(
+        "notificationAllowedApps",
+        default: [
+            "com.apple.MobileSMS",       // Messages
+            "com.apple.FaceTime",
+            "com.apple.mail",
+            "com.microsoft.Outlook",
+            "net.whatsapp.WhatsApp",
+            "ru.keepcoder.Telegram",     // Telegram Desktop (App Store build)
+            "com.tdesktop.Telegram",
+            "com.hnc.Discord"
+        ]
+    )
+    /// Apps whose system banner gets closed immediately after boring.notch
+    /// captures it, so the notch becomes the only lasting surface. Can't
+    /// prevent the banner from rendering at all — there's no macOS API for
+    /// that — this just makes it live on screen for well under a second.
+    static let notificationSuppressedApps = Key<Set<String>>(
+        "notificationSuppressedApps",
+        default: []
+    )
+
     static let enableGradient = Key<Bool>("enableGradient", default: false)
     static let systemEventIndicatorShadow = Key<Bool>("systemEventIndicatorShadow", default: false)
     static let systemEventIndicatorUseAccent = Key<Bool>("systemEventIndicatorUseAccent", default: false)

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -334,6 +334,10 @@ extension Defaults.Keys {
         "notificationSuppressedApps",
         default: []
     )
+    /// Off by default: a new capability, even though it runs entirely
+    /// on-device with no network calls. Only takes effect on macOS 26+ with
+    /// Apple Intelligence enabled — see SmartReplyManager.
+    static let smartRepliesEnabled = Key<Bool>("smartRepliesEnabled", default: false)
 
     static let enableGradient = Key<Bool>("enableGradient", default: false)
     static let systemEventIndicatorShadow = Key<Bool>("systemEventIndicatorShadow", default: false)

--- a/boringNotch/sizing/matters.swift
+++ b/boringNotch/sizing/matters.swift
@@ -88,6 +88,15 @@ enum MusicPlayerImageSizes {
 @MainActor func syncNotchHeightIfNeeded() {
     var didChangeHeight = false
 
+    // "Match real notch height" isn't a valid choice for a non-notch display
+    // — there's no real notch to match — so it's not offered in that
+    // Picker. A value here can only be leftover from an older build that
+    // allowed it; fall back to the sensible default rather than leaving a
+    // persisted value with no matching Picker tag.
+    if Defaults[.nonNotchHeightMode] == .matchRealNotchSize {
+        Defaults[.nonNotchHeightMode] = .matchMenuBar
+    }
+
     switch Defaults[.notchHeightMode] {
     case .matchRealNotchSize:
         let realHeight = getRealNotchHeight()


### PR DESCRIPTION
**Stack 1 of 4.** Base for #2. Split out of #1496 for reviewability.

## Summary
The notification system foundation: an XPC helper captures system notification banners via Accessibility and the notch mirrors them.

- **Closed notch**: chin pill with sender app icon + live dot; dedicated OTP code pill with tap-to-copy
- **Open notch**: expanded card — reply field (keystroke/focus fixes, dismiss pause while typing, keep-open while composing), Apple Intelligence smart-reply suggestions, iMessage replies via Messages scripting, send/hand-off sounds
- **Queueing**: notifications arriving mid-reply are queued; dismiss/expiry lifecycle managed
- **Reliability**: WhatsApp drop fix, XPC callback/connection liveness, watcher startup scanning, stale-notification hijacking fix, banner hold+off-screen parking so replies keep working

## Test plan
- [x] `xcodebuild -scheme boringNotch build` at this tip — clean
- [ ] Manual: banner → chin pill → open → reply