### PR TITLE
Compact mode + notification queueing hardening [2/4]

### DIFF
--- a/BoringNotchXPCHelper/NotificationWatcher.swift
+++ b/BoringNotchXPCHelper/NotificationWatcher.swift
@@ -100,6 +100,14 @@ final class NotificationWatcher {
         pollTimer = nil
         appElement = nil
         live.removeAll()
+        // Correctness hygiene rather than the fix for a live leak: once
+        // pollTimer stops, refreshHeldBanners never runs again either, so
+        // anything still in `held` stops being artificially kept alive and
+        // dies on its own within a couple of seconds regardless. But
+        // leaving stale tokens around after a stop/restart cycle is still
+        // wrong, so clear them explicitly.
+        held.removeAll()
+        heldOffScreen.removeAll()
     }
 
     // MARK: - Scanning

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -302,6 +302,8 @@
 		1443E7F42C609E650027C1FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		147163972C5D35B70068B555 /* MusicVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicVisualizer.swift; sourceTree = "<group>"; };
 		147163992C5D35FF0068B555 /* MusicManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicManager.swift; sourceTree = "<group>"; };
+		AA07ARM22E7A0001 /* AudioRouteManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRouteManager.swift; sourceTree = "<group>"; };
+		AA07ARM12E7A0001 /* AudioRouteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA07ARM22E7A0001 /* AudioRouteManager.swift */; };
 		1471A8582C6281BD0058408D /* BoringNotchWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringNotchWindow.swift; sourceTree = "<group>"; };
 		149E0B962C737D00006418B1 /* WebcamManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcamManager.swift; sourceTree = "<group>"; };
 		149E0B992C737D40006418B1 /* WebcamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebcamView.swift; sourceTree = "<group>"; };
@@ -663,6 +665,7 @@
 				AA01SNM22E7A0001 /* SystemNotificationManager.swift */,
 				AA02CAM22E7A0001 /* ContactAvatarManager.swift */,
 				147163992C5D35FF0068B555 /* MusicManager.swift */,
+				AA07ARM22E7A0001 /* AudioRouteManager.swift */,
 				AA05SRM22E7A0001 /* SmartReplyManager.swift */,
 				F1F2A0A200000000000000F2 /* AudioCaptureManager.swift */,
 				149E0B962C737D00006418B1 /* WebcamManager.swift */,
@@ -1140,6 +1143,7 @@
 				AA02CAM12E7A0001 /* ContactAvatarManager.swift in Sources */,
 				AA03OTP12E7A0001 /* OTPDetector.swift in Sources */,
 				1471639A2C5D35FF0068B555 /* MusicManager.swift in Sources */,
+				AA07ARM12E7A0001 /* AudioRouteManager.swift in Sources */,
 				AA05SRM12E7A0001 /* SmartReplyManager.swift in Sources */,
 				F1F2A0A100000000000000F1 /* AudioCaptureManager.swift in Sources */,
 				B1B112932C6A577E00093D8F /* MouseTracker.swift in Sources */,

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -343,6 +343,8 @@
 		A5167212301F85B40018095A /* boringNotchTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = boringNotchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA01NDW22E7A0001 /* NotificationDebugWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDebugWindow.swift; sourceTree = "<group>"; };
 		AA01NLA22E7A0001 /* NotificationLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLiveActivity.swift; sourceTree = "<group>"; };
+		AA06CHV22E7A0001 /* CompactHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactHomeView.swift; sourceTree = "<group>"; };
+		AA06CHV12E7A0001 /* CompactHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA06CHV22E7A0001 /* CompactHomeView.swift */; };
 		AA01SNM22E7A0001 /* SystemNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemNotificationManager.swift; sourceTree = "<group>"; };
 		AA02CAM22E7A0001 /* ContactAvatarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactAvatarManager.swift; sourceTree = "<group>"; };
 		AA02NSV22E7A0001 /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
@@ -855,6 +857,7 @@
 			isa = PBXGroup;
 			children = (
 				AA01NLA22E7A0001 /* NotificationLiveActivity.swift */,
+				AA06CHV22E7A0001 /* CompactHomeView.swift */,
 				AA04LAS22E7A0001 /* LiveActivityStack.swift */,
 				1194E8862EA6DDA7009C82D6 /* BoringNotchSkyLightWindow.swift */,
 				1160F8D72DD98230006FBB94 /* NotchShape.swift */,
@@ -1132,6 +1135,7 @@
 				AA01SNM12E7A0001 /* SystemNotificationManager.swift in Sources */,
 				AA01NDW12E7A0001 /* NotificationDebugWindow.swift in Sources */,
 				AA01NLA12E7A0001 /* NotificationLiveActivity.swift in Sources */,
+				AA06CHV12E7A0001 /* CompactHomeView.swift in Sources */,
 				AA04LAS12E7A0001 /* LiveActivityStack.swift in Sources */,
 				AA02CAM12E7A0001 /* ContactAvatarManager.swift in Sources */,
 				AA03OTP12E7A0001 /* OTPDetector.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -115,7 +115,11 @@ struct ContentView: View {
     /// just surrounds two lines of text with empty black.
     private var openNotchHeight: CGFloat {
         if notificationManager.activeNotification != nil { return 132 }
-        return Defaults[.compactMode] ? 180 : vm.notchSize.height
+        // 134pt is Atoll's own content height for this layout (50 header +
+        // 10 progress + 56 controls + 15/3 padding). The 420x180 constant is
+        // its window allowance, not the panel — using it left the content
+        // floating in empty space.
+        return Defaults[.compactMode] ? 134 : vm.notchSize.height
     }
 
     /// Compact mode drops the tab bar along with the tabs it switches

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -173,6 +173,12 @@ struct ContentView: View {
                 chinWidth += (2 * max(0, vm.effectiveClosedNotchHeight - 12) + 20)
             case .music:
                 chinWidth += (2 * max(0, displayClosedNotchHeight - 12) + 20 + 2 * liveActivityEdgeMargin + 2)
+                // The inline song-change peek widens the pill itself, so the
+                // chin has to grow with it — otherwise the hover region is
+                // narrower than what's on screen.
+                if showingInlineMusicPeek {
+                    chinWidth += 2 * inlineMusicPeekLabelWidth
+                }
             }
         } else if !coordinator.expandingView.show && vm.notchState == .closed
             && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace]
@@ -628,6 +634,32 @@ struct ContentView: View {
         )
     }
 
+    /// True while the song-change peek is expanding the closed pill inline.
+    private var showingInlineMusicPeek: Bool {
+        coordinator.expandingView.show
+            && coordinator.expandingView.type == .music
+            && Defaults[.sneakPeekStyles] == .inline
+    }
+
+    /// Width of the black centre section of the closed music pill.
+    ///
+    /// Derived from the real notch width rather than the previous hard-coded
+    /// 380. That constant assumed a particular notch size: the title sits
+    /// left of the cutout and the artist right of it, separated by a spacer
+    /// as wide as the notch itself, so on a wider notch there was no room
+    /// left for the artist and the labels collided. Sizing from
+    /// closedNotchSize keeps a fixed label budget either side whatever the
+    /// hardware is, and keeps liveActivityEdgeMargin in play so content
+    /// clears the bezel — the inline path had dropped it entirely.
+    private var musicActivityCenterWidth: CGFloat {
+        let margin = vm.closedNotchSize.width - 4 + (2 * liveActivityEdgeMargin)
+        guard showingInlineMusicPeek else { return margin }
+        return margin + (2 * inlineMusicPeekLabelWidth)
+    }
+
+    /// Space reserved for the title (left of the cutout) and artist (right).
+    private let inlineMusicPeekLabelWidth: CGFloat = 110
+
     @ViewBuilder
     func MusicLiveActivity() -> some View {
         HStack(spacing: 0) {
@@ -664,7 +696,10 @@ struct ContentView: View {
             Rectangle()
                 .fill(.black)
                 .overlay(
-                    HStack(alignment: .top) {
+                    // .center, not .top: the album art beside this is
+                    // vertically centered, so top-aligned labels sat visibly
+                    // high against it.
+                    HStack(alignment: .center) {
                         if coordinator.expandingView.show
                             && coordinator.expandingView.type == .music
                         {
@@ -673,7 +708,7 @@ struct ContentView: View {
                                 color: Defaults[.coloredSpectrogram]
                                     ? Color(nsColor: musicManager.avgColor) : Color.gray,
                                 delayDuration: 0.4,
-                                frameWidth: 100
+                                frameWidth: inlineMusicPeekLabelWidth
                             )
                             .opacity(
                                 (coordinator.expandingView.show
@@ -685,6 +720,7 @@ struct ContentView: View {
                             Text(musicManager.artistName)
                                 .lineLimit(1)
                                 .truncationMode(.tail)
+                                .frame(width: inlineMusicPeekLabelWidth, alignment: .trailing)
                                 .foregroundStyle(
                                     Defaults[.coloredSpectrogram]
                                         ? Color(nsColor: musicManager.avgColor)
@@ -698,14 +734,9 @@ struct ContentView: View {
                                 )
                         }
                     }
+                    .padding(.horizontal, 8)
                 )
-                .frame(
-                    width: (coordinator.expandingView.show
-                        && coordinator.expandingView.type == .music
-                        && Defaults[.sneakPeekStyles] == .inline)
-                        ? 380
-                        : vm.closedNotchSize.width - 4 + (2 * liveActivityEdgeMargin)
-                )
+                .frame(width: musicActivityCenterWidth)
 
             HStack {
                 AudioSpectrumView(

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -525,10 +525,11 @@ struct ContentView: View {
                         // Player only — no tab switching, so currentView is
                         // ignored here rather than offering a shelf the
                         // compact layout has no room (or tab bar) for.
-                        // 420pt wide matches Atoll's minimalistic base size,
-                        // which these proportions were designed against.
+                        // Fixed 420 rather than maxWidth: the content sizes
+                        // itself to ~350 otherwise, which left the panel
+                        // narrower than Atoll's. This pins it to their width.
                         CompactHomeView(albumArtNamespace: albumArtNamespace)
-                            .frame(maxWidth: 420)
+                            .frame(width: 420)
                     } else {
                         switch coordinator.currentView {
                         case .home:

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -56,10 +56,16 @@ struct ContentView: View {
         return effectiveHeight / 38.0
     }
     
+    /// Compact mode gets a rounder opened shape (35 vs 19) — at its smaller
+    /// size the standard radius reads square rather than pill-like.
+    private var openedInsets: (top: CGFloat, bottom: CGFloat) {
+        Defaults[.compactMode] ? compactCornerRadiusInsets.opened : cornerRadiusInsets.opened
+    }
+
     private var topCornerRadius: CGFloat {
         // If the notch is open, return the opened radius.
         if vm.notchState == .open {
-            return cornerRadiusInsets.opened.top
+            return openedInsets.top
         }
 
         // For the closed notch, scale if enabled
@@ -76,7 +82,7 @@ struct ContentView: View {
         let bottomCorner: CGFloat
 
         if vm.notchState == .open {
-            bottomCorner = cornerRadiusInsets.opened.bottom
+            bottomCorner = openedInsets.bottom
         } else if let scaleFactor = cornerRadiusScaleFactor {
             bottomCorner = max(0, baseClosedBottom * scaleFactor)
         } else {
@@ -113,13 +119,17 @@ struct ContentView: View {
     /// A notification is a glance, not a workspace — it doesn't need the full
     /// height the home/shelf tabs are sized for, and stretching to fill it
     /// just surrounds two lines of text with empty black.
-    private var openNotchHeight: CGFloat {
+    /// nil means "size to content".
+    ///
+    /// Compact mode must use nil: this frame bounds hit-testing as well as
+    /// layout, so any value shorter than the content leaves the transport
+    /// row outside the hover region — moving toward the buttons registered
+    /// as a hover-exit and closed the notch. The compact panel's height is
+    /// controlled by its own internal padding instead, which is the honest
+    /// lever anyway.
+    private var openNotchHeight: CGFloat? {
         if notificationManager.activeNotification != nil { return 132 }
-        // 134pt is Atoll's own content height for this layout (50 header +
-        // 10 progress + 56 controls + 15/3 padding). The 420x180 constant is
-        // its window allowance, not the panel — using it left the content
-        // floating in empty space.
-        return Defaults[.compactMode] ? 134 : vm.notchSize.height
+        return Defaults[.compactMode] ? nil : vm.notchSize.height
     }
 
     /// Compact mode drops the tab bar along with the tabs it switches
@@ -211,7 +221,7 @@ struct ContentView: View {
                     .frame(alignment: .top)
                     .padding(
                         .horizontal,
-                        vm.notchState == .open ? cornerRadiusInsets.opened.top : cornerRadiusInsets.closed.bottom
+                        vm.notchState == .open ? openedInsets.top : cornerRadiusInsets.closed.bottom
                     )
                     .padding([.horizontal, .bottom], vm.notchState == .open ? 12 : 0)
                     .background(.black)

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -115,7 +115,7 @@ struct ContentView: View {
     /// just surrounds two lines of text with empty black.
     private var openNotchHeight: CGFloat {
         if notificationManager.activeNotification != nil { return 132 }
-        return Defaults[.compactMode] ? 150 : vm.notchSize.height
+        return Defaults[.compactMode] ? 180 : vm.notchSize.height
     }
 
     /// Compact mode drops the tab bar along with the tabs it switches
@@ -521,8 +521,10 @@ struct ContentView: View {
                         // Player only — no tab switching, so currentView is
                         // ignored here rather than offering a shelf the
                         // compact layout has no room (or tab bar) for.
+                        // 420pt wide matches Atoll's minimalistic base size,
+                        // which these proportions were designed against.
                         CompactHomeView(albumArtNamespace: albumArtNamespace)
-                            .frame(maxWidth: 380)
+                            .frame(maxWidth: 420)
                     } else {
                         switch coordinator.currentView {
                         case .home:

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -525,11 +525,11 @@ struct ContentView: View {
                         // Player only — no tab switching, so currentView is
                         // ignored here rather than offering a shelf the
                         // compact layout has no room (or tab bar) for.
-                        // Fixed 420 rather than maxWidth: the content sizes
-                        // itself to ~350 otherwise, which left the panel
-                        // narrower than Atoll's. This pins it to their width.
+                        // 336 = Atoll's 420 base less 20%, which also lands
+                        // within a few points of their Dynamic Island width
+                        // (340) — the tighter of their two compact sizes.
                         CompactHomeView(albumArtNamespace: albumArtNamespace)
-                            .frame(width: 420)
+                            .frame(width: 336)
                     } else {
                         switch coordinator.currentView {
                         case .home:

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -114,7 +114,18 @@ struct ContentView: View {
     /// height the home/shelf tabs are sized for, and stretching to fill it
     /// just surrounds two lines of text with empty black.
     private var openNotchHeight: CGFloat {
-        notificationManager.activeNotification != nil ? 132 : vm.notchSize.height
+        if notificationManager.activeNotification != nil { return 132 }
+        return Defaults[.compactMode] ? 150 : vm.notchSize.height
+    }
+
+    /// Compact mode drops the tab bar along with the tabs it switches
+    /// between — there's only the player to show, so a switcher would have
+    /// nothing to switch to. Also what keeps the panel narrow, since the
+    /// header spans the full notch width.
+    private var showsHeader: Bool {
+        vm.notchState == .open
+            && notificationManager.activeNotification == nil
+            && !Defaults[.compactMode]
     }
 
     /// The activity currently on top of the stack — what the chin has to be
@@ -440,7 +451,7 @@ struct ContentView: View {
                           }
                       } else if !coordinator.expandingView.show && vm.notchState == .closed && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {
                           BoringFaceAnimation()
-                       } else if vm.notchState == .open && notificationManager.activeNotification == nil {
+                       } else if showsHeader {
                            // No tab bar over a notification: it's a glance,
                            // not a place to switch between home and shelf —
                            // and the header spans the full notch width,
@@ -506,6 +517,12 @@ struct ContentView: View {
                     // reply UI — the usual tabs can wait until it's dismissed.
                     if let notification = notificationManager.activeNotification {
                         NotificationExpandedView(notification: notification)
+                    } else if Defaults[.compactMode] {
+                        // Player only — no tab switching, so currentView is
+                        // ignored here rather than offering a shelf the
+                        // compact layout has no room (or tab bar) for.
+                        CompactHomeView(albumArtNamespace: albumArtNamespace)
+                            .frame(maxWidth: 380)
                     } else {
                         switch coordinator.currentView {
                         case .home:

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -180,6 +180,28 @@
         }
       }
     },
+    "%lld more waiting" : {
+
+    },
+    "%lld%%" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%%"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%%"
+          }
+        }
+      }
+    },
+    "+%lld" : {
+
+    },
     "About" : {
       "localizations" : {
         "cs" : {

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -16216,9 +16216,6 @@
         }
       }
     },
-    "Nothing Playing" : {
-
-    },
     "Notification Debug" : {
 
     },

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -5967,6 +5967,9 @@
         }
       }
     },
+    "Compact mode" : {
+
+    },
     "Continue" : {
       "localizations" : {
         "cs" : {
@@ -11149,9 +11152,6 @@
         }
       }
     },
-    "Hide system banner, show in notch only" : {
-
-    },
     "Hide title bar" : {
       "localizations" : {
         "de" : {
@@ -16212,6 +16212,9 @@
           }
         }
       }
+    },
+    "Nothing playing" : {
+
     },
     "Notification Debug" : {
 
@@ -23416,6 +23419,9 @@
           }
         }
       }
+    },
+    "Shows a smaller opened notch with just the music player — no tabs, calendar or mirror." : {
+
     },
     "Slider color" : {
       "localizations" : {

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -16213,7 +16213,7 @@
         }
       }
     },
-    "Nothing playing" : {
+    "Nothing Playing" : {
 
     },
     "Notification Debug" : {

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -12558,6 +12558,9 @@
         }
       }
     },
+    "Looking for devices…" : {
+
+    },
     "Low" : {
       "localizations" : {
         "cs" : {
@@ -17517,6 +17520,9 @@
           }
         }
       }
+    },
+    "Output" : {
+
     },
     "Pick a Color" : {
       "localizations" : {

--- a/boringNotch/components/Live activities/BoringBattery.swift
+++ b/boringNotch/components/Live activities/BoringBattery.swift
@@ -39,6 +39,25 @@ struct BatteryView: View {
         }
     }
 
+    /// The outline is an SF Symbol scaled by width, so everything drawn
+    /// inside it has to scale by width too.
+    ///
+    /// These were previously absolute: the fill height was
+    /// `(batteryWidth - 2.75) - 18`, which only lands correctly at the
+    /// default 30pt — at compact mode's 24pt it collapses to ~3pt, a sliver
+    /// floating inside the outline. Expressing them relative to a reference
+    /// width keeps the 30pt case numerically identical to before while
+    /// making every other size correct.
+    private static let referenceWidth: CGFloat = 30
+    private var sizeScale: CGFloat { batteryWidth / Self.referenceWidth }
+
+    /// 9.25pt at the 30pt reference — the interior cavity height of the
+    /// battery symbol.
+    private var fillHeight: CGFloat { 9.25 * sizeScale }
+    /// Combined width of the outline stroke and terminal nub.
+    private var fillInset: CGFloat { 6 * sizeScale }
+    private var fillLeadingInset: CGFloat { 2 * sizeScale }
+
     var body: some View {
         ZStack(alignment: .leading) {
 
@@ -51,13 +70,13 @@ struct BatteryView: View {
                     width: batteryWidth + 1
                 )
 
-            RoundedRectangle(cornerRadius: 2.5)
+            RoundedRectangle(cornerRadius: 2.5 * sizeScale)
                 .fill(batteryColor)
                 .frame(
-                    width: CGFloat(((CGFloat(CFloat(levelBattery)) / 100) * (batteryWidth - 6))),
-                    height: (batteryWidth - 2.75) - 18
+                    width: (CGFloat(levelBattery) / 100) * (batteryWidth - fillInset),
+                    height: fillHeight
                 )
-                .padding(.leading, 2)
+                .padding(.leading, fillLeadingInset)
 
             if iconStatus != "" && (isForNotification || Defaults[.showPowerStatusIcons]) {
                 ZStack {
@@ -66,8 +85,8 @@ struct BatteryView: View {
                         .aspectRatio(contentMode: .fit)
                         .foregroundColor(.white)
                         .frame(
-                            width: 17,
-                            height: 17
+                            width: 17 * sizeScale,
+                            height: 17 * sizeScale
                         )
                 }
                 .frame(width: batteryWidth, height: batteryWidth)

--- a/boringNotch/components/Notch/CompactHomeView.swift
+++ b/boringNotch/components/Notch/CompactHomeView.swift
@@ -45,31 +45,29 @@ struct CompactHomeView: View {
     private let vizBlockWidth: CGFloat = 42
     private let vizBarWidth: CGFloat = 24
 
+    // No idle branch, deliberately. The standard layout has none either —
+    // it renders whatever MusicManager last cached, so a paused or stopped
+    // track keeps its art, title and scrub position. A "Nothing Playing"
+    // placeholder here made compact mode lose state the full layout keeps.
     var body: some View {
-        if !musicManager.isPlaying && musicManager.isPlayerIdle {
-            idleState
-        } else {
-            VStack(spacing: 0) {
-                header
-                    .frame(height: albumArtWidth)
+        VStack(spacing: 0) {
+            header
+                .frame(height: albumArtWidth)
 
-                progressRow
-                    .padding(.top, 4)
+            progressRow
+                .padding(.top, 4)
 
-                transport
-                    .padding(.top, 1)
-            }
-            .padding(.horizontal, 12)
-            // Atoll's formula is 15/3, but that assumes the player is the
-            // whole panel. Here a 38pt notch-clearance spacer sits above it,
-            // so keeping 15/3 pushed the total to 189. Trimmed by 9 to land
-            // the panel on Atoll's 180 overall, which is the number that
-            // actually shows.
-            .padding(.top, 4)
-            .padding(.bottom, 1)
-            .frame(maxWidth: .infinity)
-            .buttonStyle(PlainButtonStyle())
+            transport
+                .padding(.top, 1)
         }
+        .padding(.horizontal, 12)
+        // Atoll's 15/3 formula assumes the player is the whole panel; here
+        // a notch-clearance spacer sits above it, so these are trimmed to
+        // land the panel at the intended overall height.
+        .padding(.top, 4)
+        .padding(.bottom, 1)
+        .frame(maxWidth: .infinity)
+        .buttonStyle(PlainButtonStyle())
     }
 
     // MARK: - Header
@@ -296,17 +294,6 @@ struct CompactHomeView: View {
         musicManager.repeatMode == .off ? .primary : .red
     }
 
-    private var idleState: some View {
-        VStack(spacing: 8) {
-            Image(systemName: "music.note.slash")
-                .font(.system(size: 24, weight: .light))
-                .foregroundStyle(.gray)
-            Text("Nothing Playing")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.gray)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
 }
 
 /// Output device list for the compact player's media-output button.

--- a/boringNotch/components/Notch/CompactHomeView.swift
+++ b/boringNotch/components/Notch/CompactHomeView.swift
@@ -13,10 +13,11 @@
 //  remaining time, and a 10pt-spaced transport row.
 //
 //  Built on this project's own MusicSliderView / HoverButton /
-//  MarqueeText and the musicControlSlots preference rather than porting
-//  Atoll's ~1500-line view wholesale, so seeking and the configured
-//  transport buttons stay identical between the two layouts instead of
-//  drifting apart.
+//  MarqueeText rather than porting Atoll's ~1500-line view wholesale, so
+//  seeking behaves identically in both layouts instead of drifting apart.
+//  The transport row is a fixed five here rather than the musicControlSlots
+//  preference — that preference exists to configure the full layout, and
+//  its default would leave compact mode without shuffle or media output.
 //
 
 import Defaults
@@ -31,8 +32,6 @@ struct CompactHomeView: View {
     @State private var dragging: Bool = false
     @State private var lastDragged: Date = .distantPast
 
-    @Default(.musicControlSlots) private var slotConfig
-    @Default(.musicControlSlotLimit) private var slotLimit
     @Default(.coloredSpectrogram) private var coloredSpectrogram
     @Default(.playerColorTinting) private var playerColorTinting
 
@@ -75,8 +74,7 @@ struct CompactHomeView: View {
             )
 
             HStack(alignment: .center, spacing: headerSpacing) {
-                AlbumArtView(vm: vm, albumArtNamespace: albumArtNamespace)
-                    .frame(width: albumArtWidth, height: albumArtWidth)
+                compactAlbumArt
 
                 VStack(alignment: .leading, spacing: 1) {
                     MarqueeText(
@@ -138,8 +136,6 @@ struct CompactHomeView: View {
 
     // MARK: - Transport
 
-    /// Uses the same slot preference as the full layout, so the buttons
-    /// configured there are the ones that appear here.
     private var transport: some View {
         HStack(spacing: 10) {
             ForEach(Array(displayedSlots.enumerated()), id: \.offset) { _, slot in
@@ -149,15 +145,12 @@ struct CompactHomeView: View {
         .frame(maxWidth: .infinity, alignment: .center)
     }
 
+    /// Fixed five, deliberately not the musicControlSlots preference. That
+    /// preference defaults to [.none, .previous, .playPause, .next, .none],
+    /// which is why this row was rendering only three buttons — compact
+    /// mode is meant to show shuffle and media output too.
     private var displayedSlots: [MusicControlButton] {
-        // Padding is done here rather than via NotchHomeView's `padded`
-        // helper, which is fileprivate to that file.
-        let count = min(max(slotLimit, MusicControlButton.minSlotCount), MusicControlButton.maxSlotCount)
-        var slots = slotConfig
-        if slots.count < count {
-            slots += Array(repeating: .none, count: count - slots.count)
-        }
-        return Array(slots.prefix(count))
+        [.shuffle, .previous, .playPause, .next, .none]
     }
 
     @ViewBuilder
@@ -184,12 +177,53 @@ struct CompactHomeView: View {
                 MusicManager.shared.toggleRepeat()
             }
         case .none:
-            EmptyView()
+            mediaOutputButton
         default:
             // Slots that only make sense in the full layout are skipped
             // rather than rendered half-working in a player-only view.
             EmptyView()
         }
+    }
+
+    /// Shows where audio is currently going and opens Sound settings.
+    ///
+    /// Atoll's equivalent opens a popover that switches device inline, but
+    /// that needs its AudioRouteManager (enumeration + switching), which
+    /// this project doesn't have — AudioOutputRouteResolver only classifies
+    /// the current route. Handing off to Sound settings is honest about
+    /// that rather than faking a picker that can't switch anything.
+    private var mediaOutputButton: some View {
+        HoverButton(icon: routeSymbol, scale: .medium) {
+            if let url = URL(string: "x-apple.systempreferences:com.apple.Sound-Settings.extension") {
+                NSWorkspace.shared.open(url)
+            }
+        }
+    }
+
+    private var compactAlbumArt: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Image(nsImage: musicManager.albumArt)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: albumArtWidth, height: albumArtWidth)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            // Badge scaled to this art. AlbumArtView's is a fixed 30pt with
+            // a +10/+10 offset, sized for the 120pt art in the full layout —
+            // on 50pt art it spills outside the corner.
+            if !musicManager.usingAppIconForArtwork {
+                AppIcon(for: musicManager.bundleIdentifier ?? "com.apple.Music")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 18, height: 18)
+                    .offset(x: 5, y: 5)
+            }
+        }
+        .frame(width: albumArtWidth, height: albumArtWidth)
+    }
+
+    private var routeSymbol: String {
+        AudioOutputRouteResolver.shared.outputRouteSymbol()
     }
 
     private var repeatIcon: String {

--- a/boringNotch/components/Notch/CompactHomeView.swift
+++ b/boringNotch/components/Notch/CompactHomeView.swift
@@ -26,6 +26,7 @@ import SwiftUI
 struct CompactHomeView: View {
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var musicManager = MusicManager.shared
+    @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     let albumArtNamespace: Namespace.ID
 
     @State private var sliderValue: Double = 0
@@ -37,7 +38,7 @@ struct CompactHomeView: View {
     @Default(.coloredSpectrogram) private var coloredSpectrogram
     @Default(.playerColorTinting) private var playerColorTinting
 
-    private let albumArtWidth: CGFloat = 50
+    private let albumArtWidth: CGFloat = 45
     private let headerSpacing: CGFloat = 10
     /// Matches the trailing time label's width in the row below, so the
     /// visualizer's bars sit centred over "-0:00" rather than drifting.
@@ -53,10 +54,10 @@ struct CompactHomeView: View {
                     .frame(height: albumArtWidth)
 
                 progressRow
-                    .padding(.top, 6)
+                    .padding(.top, 4)
 
                 transport
-                    .padding(.top, 2)
+                    .padding(.top, 1)
             }
             .padding(.horizontal, 12)
             // Atoll's formula is 15/3, but that assumes the player is the
@@ -64,7 +65,7 @@ struct CompactHomeView: View {
             // so keeping 15/3 pushed the total to 189. Trimmed by 9 to land
             // the panel on Atoll's 180 overall, which is the number that
             // actually shows.
-            .padding(.top, 8)
+            .padding(.top, 4)
             .padding(.bottom, 1)
             .frame(maxWidth: .infinity)
             .buttonStyle(PlainButtonStyle())
@@ -114,6 +115,26 @@ struct CompactHomeView: View {
                 .frame(width: vizBlockWidth)
             }
         }
+        .overlay(alignment: .topTrailing) {
+            // Compact mode hides BoringHeader (it spans the full notch
+            // width), which took the battery with it. Overlaid rather than
+            // placed in the HStack so it doesn't steal width from the title.
+            if Defaults[.showBatteryIndicator] {
+                BoringBatteryView(
+                    batteryWidth: 24,
+                    isCharging: batteryModel.isCharging,
+                    isInLowPowerMode: batteryModel.isInLowPowerMode,
+                    isPluggedIn: batteryModel.isPluggedIn,
+                    levelBattery: batteryModel.levelBattery,
+                    maxCapacity: batteryModel.maxCapacity,
+                    timeToFullCharge: batteryModel.timeToFullCharge,
+                    timeToDischarge: batteryModel.timeToDischarge,
+                    maxAdapterWatts: batteryModel.maxAdapterWatts,
+                    isForNotification: false
+                )
+                .offset(y: -14)
+            }
+        }
     }
 
     // MARK: - Progress
@@ -156,8 +177,8 @@ struct CompactHomeView: View {
     /// Atoll's control dimensions: 36pt secondary buttons with 18pt glyphs,
     /// a 54pt play/pause with a 26pt glyph. HoverButton's 30/40 is what made
     /// this row read undersized against the rest of the panel.
-    private let controlSize: CGFloat = 36
-    private let playPauseSize: CGFloat = 54
+    private let controlSize: CGFloat = 32
+    private let playPauseSize: CGFloat = 48
 
     private func compactControl(
         icon: String,
@@ -175,12 +196,11 @@ struct CompactHomeView: View {
         )
     }
 
-    /// Fixed five, deliberately not the musicControlSlots preference. That
-    /// preference defaults to [.none, .previous, .playPause, .next, .none],
-    /// which is why this row was rendering only three buttons — compact
-    /// mode is meant to show shuffle and media output too.
+    /// Fixed five rather than the musicControlSlots preference, so compact
+    /// mode always shows the full transport regardless of how the standard
+    /// layout is configured.
     private var displayedSlots: [MusicControlButton] {
-        [.shuffle, .previous, .playPause, .next, .none]
+        [.shuffle, .previous, .playPause, .next, .mediaOutput]
     }
 
     @ViewBuilder
@@ -190,29 +210,31 @@ struct CompactHomeView: View {
             compactControl(
                 icon: "shuffle",
                 size: controlSize,
-                glyph: 18,
+                glyph: 16,
                 tint: musicManager.isShuffled ? .red : .white
             ) { MusicManager.shared.toggleShuffle() }
         case .previous:
-            compactControl(icon: "backward.fill", size: controlSize, glyph: 18) {
+            compactControl(icon: "backward.fill", size: controlSize, glyph: 16) {
                 MusicManager.shared.previousTrack()
             }
         case .playPause:
             compactControl(
                 icon: musicManager.isPlaying ? "pause.fill" : "play.fill",
                 size: playPauseSize,
-                glyph: 26
+                glyph: 23
             ) { MusicManager.shared.togglePlay() }
         case .next:
-            compactControl(icon: "forward.fill", size: controlSize, glyph: 18) {
+            compactControl(icon: "forward.fill", size: controlSize, glyph: 16) {
                 MusicManager.shared.nextTrack()
             }
         case .repeatMode:
-            compactControl(icon: repeatIcon, size: controlSize, glyph: 18, tint: repeatIconColor) {
+            compactControl(icon: repeatIcon, size: controlSize, glyph: 16, tint: repeatIconColor) {
                 MusicManager.shared.toggleRepeat()
             }
-        case .none:
+        case .mediaOutput:
             mediaOutputButton
+        case .none:
+            EmptyView()
         default:
             // Slots that only make sense in the full layout are skipped
             // rather than rendered half-working in a player-only view.
@@ -223,7 +245,7 @@ struct CompactHomeView: View {
     /// Shows where audio is going and switches it, via a popover device
     /// picker.
     private var mediaOutputButton: some View {
-        compactControl(icon: routeSymbol, size: controlSize, glyph: 18) {
+        compactControl(icon: routeSymbol, size: controlSize, glyph: 16) {
             // Enumerate on open rather than polling: devices come and go
             // (AirPods connecting, a display waking) and a list built at
             // launch would be stale by the time anyone opened it.
@@ -372,5 +394,30 @@ private struct CompactControlButton: View {
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.18)) { isHovering = hovering }
         }
+    }
+}
+
+/// Audio-output slot for the standard layout's control row.
+///
+/// Separate from CompactHomeView's inline version only because that one
+/// uses the compact button sizing; the picker and behaviour are shared.
+struct MediaOutputSlotButton: View {
+    @ObservedObject private var routeManager = AudioRouteManager.shared
+    @State private var showingPicker = false
+
+    var body: some View {
+        HoverButton(icon: routeSymbol, scale: .medium) {
+            routeManager.refreshDevices()
+            showingPicker.toggle()
+        }
+        .popover(isPresented: $showingPicker, arrowEdge: .bottom) {
+            AudioOutputPicker(routeManager: routeManager) {
+                showingPicker = false
+            }
+        }
+    }
+
+    private var routeSymbol: String {
+        routeManager.activeDevice?.iconName ?? AudioOutputRouteResolver.shared.outputRouteSymbol()
     }
 }

--- a/boringNotch/components/Notch/CompactHomeView.swift
+++ b/boringNotch/components/Notch/CompactHomeView.swift
@@ -31,6 +31,8 @@ struct CompactHomeView: View {
     @State private var sliderValue: Double = 0
     @State private var dragging: Bool = false
     @State private var lastDragged: Date = .distantPast
+    @State private var showingOutputPicker = false
+    @ObservedObject private var routeManager = AudioRouteManager.shared
 
     @Default(.coloredSpectrogram) private var coloredSpectrogram
     @Default(.playerColorTinting) private var playerColorTinting
@@ -185,18 +187,21 @@ struct CompactHomeView: View {
         }
     }
 
-    /// Shows where audio is currently going and opens Sound settings.
-    ///
-    /// Atoll's equivalent opens a popover that switches device inline, but
-    /// that needs its AudioRouteManager (enumeration + switching), which
-    /// this project doesn't have — AudioOutputRouteResolver only classifies
-    /// the current route. Handing off to Sound settings is honest about
-    /// that rather than faking a picker that can't switch anything.
+    /// Shows where audio is going and switches it, via a popover device
+    /// picker.
     private var mediaOutputButton: some View {
         HoverButton(icon: routeSymbol, scale: .medium) {
-            if let url = URL(string: "x-apple.systempreferences:com.apple.Sound-Settings.extension") {
-                NSWorkspace.shared.open(url)
-            }
+            // Enumerate on open rather than polling: devices come and go
+            // (AirPods connecting, a display waking) and a list built at
+            // launch would be stale by the time anyone opened it.
+            routeManager.refreshDevices()
+            showingOutputPicker.toggle()
+        }
+        .popover(isPresented: $showingOutputPicker, arrowEdge: .bottom) {
+            AudioOutputPicker(
+                routeManager: routeManager,
+                onSelect: { showingOutputPicker = false }
+            )
         }
     }
 
@@ -222,8 +227,10 @@ struct CompactHomeView: View {
         .frame(width: albumArtWidth, height: albumArtWidth)
     }
 
+    /// Prefer the live device's own icon; fall back to the resolver's
+    /// classification before the first enumeration has run.
     private var routeSymbol: String {
-        AudioOutputRouteResolver.shared.outputRouteSymbol()
+        routeManager.activeDevice?.iconName ?? AudioOutputRouteResolver.shared.outputRouteSymbol()
     }
 
     private var repeatIcon: String {
@@ -244,5 +251,58 @@ struct CompactHomeView: View {
                 .foregroundStyle(.gray)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Output device list for the compact player's media-output button.
+struct AudioOutputPicker: View {
+    @ObservedObject var routeManager: AudioRouteManager
+    let onSelect: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Output")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
+                .padding(.bottom, 6)
+
+            if routeManager.devices.isEmpty {
+                // Enumeration is async, so an empty list on first open is
+                // normal rather than an error worth alarming anyone about.
+                Text("Looking for devices…")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 10)
+            } else {
+                ForEach(routeManager.devices) { device in
+                    Button {
+                        routeManager.select(device)
+                        onSelect()
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: device.iconName)
+                                .frame(width: 18)
+                            Text(device.name)
+                                .font(.system(size: 12))
+                                .lineLimit(1)
+                            Spacer(minLength: 12)
+                            if device.id == routeManager.activeDeviceID {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 10, weight: .bold))
+                            }
+                        }
+                        .contentShape(Rectangle())
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.bottom, 6)
+            }
+        }
+        .frame(minWidth: 220)
     }
 }

--- a/boringNotch/components/Notch/CompactHomeView.swift
+++ b/boringNotch/components/Notch/CompactHomeView.swift
@@ -59,8 +59,13 @@ struct CompactHomeView: View {
                     .padding(.top, 2)
             }
             .padding(.horizontal, 12)
-            .padding(.top, 15)
-            .padding(.bottom, 3)
+            // Atoll's formula is 15/3, but that assumes the player is the
+            // whole panel. Here a 38pt notch-clearance spacer sits above it,
+            // so keeping 15/3 pushed the total to 189. Trimmed by 9 to land
+            // the panel on Atoll's 180 overall, which is the number that
+            // actually shows.
+            .padding(.top, 8)
+            .padding(.bottom, 1)
             .frame(maxWidth: .infinity)
             .buttonStyle(PlainButtonStyle())
         }

--- a/boringNotch/components/Notch/CompactHomeView.swift
+++ b/boringNotch/components/Notch/CompactHomeView.swift
@@ -1,0 +1,180 @@
+//
+//  CompactHomeView.swift
+//  boringNotch
+//
+//  A smaller open-notch layout: just the now-playing essentials — art,
+//  title, scrubber, transport — with no tab bar, calendar or mirror.
+//
+//  Deliberately built on the same pieces the full layout uses
+//  (MusicSliderView, HoverButton, MarqueeText, the musicControlSlots
+//  preference) rather than a parallel implementation, so a fix to seeking
+//  or the control slots applies to both layouts instead of drifting.
+//
+
+import Defaults
+import SwiftUI
+
+struct CompactHomeView: View {
+    @EnvironmentObject var vm: BoringViewModel
+    @ObservedObject var musicManager = MusicManager.shared
+    let albumArtNamespace: Namespace.ID
+
+    @State private var sliderValue: Double = 0
+    @State private var dragging: Bool = false
+    @State private var lastDragged: Date = .distantPast
+
+    @Default(.musicControlSlots) private var slotConfig
+    @Default(.musicControlSlotLimit) private var slotLimit
+    @Default(.coloredSpectrogram) private var coloredSpectrogram
+    @Default(.playerColorTinting) private var playerColorTinting
+
+    private let artSize: CGFloat = 56
+
+    var body: some View {
+        if musicManager.isPlayerIdle && !musicManager.isPlaying {
+            idleState
+        } else {
+            VStack(spacing: 8) {
+                header
+                MusicSliderView(
+                    sliderValue: $sliderValue,
+                    duration: $musicManager.songDuration,
+                    lastDragged: $lastDragged,
+                    color: musicManager.avgColor,
+                    dragging: $dragging,
+                    currentDate: Date(),
+                    timestampDate: musicManager.timestampDate,
+                    elapsedTime: musicManager.elapsedTime,
+                    playbackRate: musicManager.playbackRate,
+                    isPlaying: musicManager.isPlaying
+                ) { newValue in
+                    MusicManager.shared.seek(to: newValue)
+                }
+                .frame(height: 24)
+                transport
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .buttonStyle(PlainButtonStyle())
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            AlbumArtView(vm: vm, albumArtNamespace: albumArtNamespace)
+                .frame(width: artSize, height: artSize)
+
+            GeometryReader { geo in
+                VStack(alignment: .leading, spacing: 1) {
+                    Spacer(minLength: 0)
+                    MarqueeText(
+                        musicManager.songTitle,
+                        font: .system(size: 13, weight: .semibold),
+                        color: .white,
+                        frameWidth: geo.size.width
+                    )
+                    MarqueeText(
+                        musicManager.artistName,
+                        font: .system(size: 11),
+                        color: playerColorTinting
+                            ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.6)
+                            : .gray,
+                        frameWidth: geo.size.width
+                    )
+                    Spacer(minLength: 0)
+                }
+            }
+            .frame(height: artSize)
+
+            // AudioSpectrumView tints itself, so no outer gradient/mask —
+            // that would just fight the colour it already applies.
+            if !musicManager.isPlayerIdle {
+                AudioSpectrumView(
+                    isPlaying: musicManager.isPlaying,
+                    tintColor: coloredSpectrogram
+                        ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.6)
+                        : .gray
+                )
+                .frame(width: 18, height: 14)
+                .frame(height: artSize)
+            }
+        }
+    }
+
+    /// Same slot preference as the full layout, so the buttons a user
+    /// configured there are the ones they get here.
+    private var transport: some View {
+        // Pad/trim to the configured slot count locally — NotchHomeView's
+        // `padded` helper is fileprivate to that file, and widening its
+        // access just for this would be a worse trade than four lines here.
+        let count = min(max(slotLimit, MusicControlButton.minSlotCount), MusicControlButton.maxSlotCount)
+        var slots = slotConfig
+        if slots.count < count {
+            slots += Array(repeating: .none, count: count - slots.count)
+        }
+        slots = Array(slots.prefix(count))
+
+        return HStack(spacing: 4) {
+            ForEach(Array(slots.enumerated()), id: \.offset) { _, slot in
+                slotView(for: slot)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    @ViewBuilder
+    private func slotView(for slot: MusicControlButton) -> some View {
+        switch slot {
+        case .shuffle:
+            HoverButton(icon: "shuffle", iconColor: musicManager.isShuffled ? .red : .primary, scale: .medium) {
+                MusicManager.shared.toggleShuffle()
+            }
+        case .previous:
+            HoverButton(icon: "backward.fill", scale: .medium) {
+                MusicManager.shared.previousTrack()
+            }
+        case .playPause:
+            HoverButton(icon: musicManager.isPlaying ? "pause.fill" : "play.fill", scale: .large) {
+                MusicManager.shared.togglePlay()
+            }
+        case .next:
+            HoverButton(icon: "forward.fill", scale: .medium) {
+                MusicManager.shared.nextTrack()
+            }
+        case .repeatMode:
+            HoverButton(icon: repeatIcon, iconColor: repeatIconColor, scale: .medium) {
+                MusicManager.shared.toggleRepeat()
+            }
+        case .none:
+            EmptyView()
+        default:
+            // Slots that only make sense in the full layout (mirror,
+            // calendar, and anything added later) are skipped rather than
+            // rendered half-working in a player-only view.
+            EmptyView()
+        }
+    }
+
+    private var repeatIcon: String {
+        switch musicManager.repeatMode {
+        case .one: "repeat.1"
+        default: "repeat"
+        }
+    }
+
+    private var repeatIconColor: Color {
+        musicManager.repeatMode == .off ? .primary : .red
+    }
+
+    private var idleState: some View {
+        VStack(spacing: 6) {
+            Image(systemName: "music.note")
+                .font(.system(size: 20, weight: .light))
+                .foregroundStyle(.gray)
+            Text("Nothing playing")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.gray)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/boringNotch/components/Notch/CompactHomeView.swift
+++ b/boringNotch/components/Notch/CompactHomeView.swift
@@ -56,11 +56,11 @@ struct CompactHomeView: View {
                     .padding(.top, 6)
 
                 transport
-                    .padding(.top, 4)
+                    .padding(.top, 2)
             }
             .padding(.horizontal, 12)
-            .padding(.top, 6)
-            .padding(.bottom, 10)
+            .padding(.top, 15)
+            .padding(.bottom, 3)
             .frame(maxWidth: .infinity)
             .buttonStyle(PlainButtonStyle())
         }
@@ -145,6 +145,29 @@ struct CompactHomeView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .center)
+        .frame(height: playPauseSize)
+    }
+
+    /// Atoll's control dimensions: 36pt secondary buttons with 18pt glyphs,
+    /// a 54pt play/pause with a 26pt glyph. HoverButton's 30/40 is what made
+    /// this row read undersized against the rest of the panel.
+    private let controlSize: CGFloat = 36
+    private let playPauseSize: CGFloat = 54
+
+    private func compactControl(
+        icon: String,
+        size: CGFloat,
+        glyph: CGFloat,
+        tint: Color = .white,
+        action: @escaping () -> Void
+    ) -> some View {
+        CompactControlButton(
+            icon: icon,
+            frameSize: size,
+            glyphSize: glyph,
+            tint: tint,
+            action: action
+        )
     }
 
     /// Fixed five, deliberately not the musicControlSlots preference. That
@@ -159,23 +182,28 @@ struct CompactHomeView: View {
     private func slotView(for slot: MusicControlButton) -> some View {
         switch slot {
         case .shuffle:
-            HoverButton(icon: "shuffle", iconColor: musicManager.isShuffled ? .red : .primary, scale: .medium) {
-                MusicManager.shared.toggleShuffle()
-            }
+            compactControl(
+                icon: "shuffle",
+                size: controlSize,
+                glyph: 18,
+                tint: musicManager.isShuffled ? .red : .white
+            ) { MusicManager.shared.toggleShuffle() }
         case .previous:
-            HoverButton(icon: "backward.fill", scale: .medium) {
+            compactControl(icon: "backward.fill", size: controlSize, glyph: 18) {
                 MusicManager.shared.previousTrack()
             }
         case .playPause:
-            HoverButton(icon: musicManager.isPlaying ? "pause.fill" : "play.fill", scale: .large) {
-                MusicManager.shared.togglePlay()
-            }
+            compactControl(
+                icon: musicManager.isPlaying ? "pause.fill" : "play.fill",
+                size: playPauseSize,
+                glyph: 26
+            ) { MusicManager.shared.togglePlay() }
         case .next:
-            HoverButton(icon: "forward.fill", scale: .medium) {
+            compactControl(icon: "forward.fill", size: controlSize, glyph: 18) {
                 MusicManager.shared.nextTrack()
             }
         case .repeatMode:
-            HoverButton(icon: repeatIcon, iconColor: repeatIconColor, scale: .medium) {
+            compactControl(icon: repeatIcon, size: controlSize, glyph: 18, tint: repeatIconColor) {
                 MusicManager.shared.toggleRepeat()
             }
         case .none:
@@ -190,7 +218,7 @@ struct CompactHomeView: View {
     /// Shows where audio is going and switches it, via a popover device
     /// picker.
     private var mediaOutputButton: some View {
-        HoverButton(icon: routeSymbol, scale: .medium) {
+        compactControl(icon: routeSymbol, size: controlSize, glyph: 18) {
             // Enumerate on open rather than polling: devices come and go
             // (AirPods connecting, a display waking) and a list built at
             // launch would be stale by the time anyone opened it.
@@ -304,5 +332,40 @@ struct AudioOutputPicker: View {
             }
         }
         .frame(minWidth: 220)
+    }
+}
+
+/// Transport button matching Atoll's MinimalisticSquircircleButton: a
+/// squircle that fills faintly on hover, sized independently of its glyph
+/// so a 54pt play/pause and a 36pt skip share the same visual language.
+///
+/// Not HoverButton — that's fixed at 30/40pt with a capsule fill, which
+/// reads undersized against this layout's 50pt artwork.
+private struct CompactControlButton: View {
+    let icon: String
+    let frameSize: CGFloat
+    let glyphSize: CGFloat
+    let tint: Color
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            RoundedRectangle(cornerRadius: frameSize * 0.4, style: .continuous)
+                .fill(isHovering ? Color.white.opacity(0.12) : .clear)
+                .frame(width: frameSize, height: frameSize)
+                .overlay {
+                    Image(systemName: icon)
+                        .font(.system(size: glyphSize, weight: .medium))
+                        .foregroundStyle(tint)
+                        .contentTransition(.symbolEffect(.replace))
+                }
+                .contentShape(RoundedRectangle(cornerRadius: frameSize * 0.4, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            withAnimation(.easeOut(duration: 0.18)) { isHovering = hovering }
+        }
     }
 }

--- a/boringNotch/components/Notch/CompactHomeView.swift
+++ b/boringNotch/components/Notch/CompactHomeView.swift
@@ -5,10 +5,18 @@
 //  A smaller open-notch layout: just the now-playing essentials — art,
 //  title, scrubber, transport — with no tab bar, calendar or mirror.
 //
-//  Deliberately built on the same pieces the full layout uses
-//  (MusicSliderView, HoverButton, MarqueeText, the musicControlSlots
-//  preference) rather than a parallel implementation, so a fix to seeking
-//  or the control slots applies to both layouts instead of drifting.
+//  Layout and proportions follow Atoll's MinimalisticMusicPlayerView
+//  (https://github.com/Ebullioscopic/Atoll, GPL-3.0, itself a boring.notch
+//  fork): 50pt album art, 12/10pt title and artist, a fixed-width
+//  visualizer block on the right sized to match the trailing time label so
+//  the bars centre over it, an inline progress row with a counting-down
+//  remaining time, and a 10pt-spaced transport row.
+//
+//  Built on this project's own MusicSliderView / HoverButton /
+//  MarqueeText and the musicControlSlots preference rather than porting
+//  Atoll's ~1500-line view wholesale, so seeking and the configured
+//  transport buttons stay identical between the two layouts instead of
+//  drifting apart.
 //
 
 import Defaults
@@ -28,98 +36,128 @@ struct CompactHomeView: View {
     @Default(.coloredSpectrogram) private var coloredSpectrogram
     @Default(.playerColorTinting) private var playerColorTinting
 
-    private let artSize: CGFloat = 56
+    private let albumArtWidth: CGFloat = 50
+    private let headerSpacing: CGFloat = 10
+    /// Matches the trailing time label's width in the row below, so the
+    /// visualizer's bars sit centred over "-0:00" rather than drifting.
+    private let vizBlockWidth: CGFloat = 42
+    private let vizBarWidth: CGFloat = 24
 
     var body: some View {
-        if musicManager.isPlayerIdle && !musicManager.isPlaying {
+        if !musicManager.isPlaying && musicManager.isPlayerIdle {
             idleState
         } else {
-            VStack(spacing: 8) {
+            VStack(spacing: 0) {
                 header
-                MusicSliderView(
-                    sliderValue: $sliderValue,
-                    duration: $musicManager.songDuration,
-                    lastDragged: $lastDragged,
-                    color: musicManager.avgColor,
-                    dragging: $dragging,
-                    currentDate: Date(),
-                    timestampDate: musicManager.timestampDate,
-                    elapsedTime: musicManager.elapsedTime,
-                    playbackRate: musicManager.playbackRate,
-                    isPlaying: musicManager.isPlaying
-                ) { newValue in
-                    MusicManager.shared.seek(to: newValue)
-                }
-                .frame(height: 24)
+                    .frame(height: albumArtWidth)
+
+                progressRow
+                    .padding(.top, 6)
+
                 transport
+                    .padding(.top, 4)
             }
             .padding(.horizontal, 12)
-            .padding(.vertical, 10)
+            .padding(.top, 6)
+            .padding(.bottom, 10)
+            .frame(maxWidth: .infinity)
             .buttonStyle(PlainButtonStyle())
         }
     }
 
-    private var header: some View {
-        HStack(spacing: 10) {
-            AlbumArtView(vm: vm, albumArtNamespace: albumArtNamespace)
-                .frame(width: artSize, height: artSize)
+    // MARK: - Header
 
-            GeometryReader { geo in
+    private var header: some View {
+        GeometryReader { geo in
+            let textWidth = max(
+                0,
+                geo.size.width - albumArtWidth - headerSpacing - (vizBlockWidth + headerSpacing)
+            )
+
+            HStack(alignment: .center, spacing: headerSpacing) {
+                AlbumArtView(vm: vm, albumArtNamespace: albumArtNamespace)
+                    .frame(width: albumArtWidth, height: albumArtWidth)
+
                 VStack(alignment: .leading, spacing: 1) {
-                    Spacer(minLength: 0)
                     MarqueeText(
                         musicManager.songTitle,
-                        font: .system(size: 13, weight: .semibold),
+                        font: .system(size: 12, weight: .semibold),
                         color: .white,
-                        frameWidth: geo.size.width
+                        frameWidth: textWidth
                     )
-                    MarqueeText(
-                        musicManager.artistName,
-                        font: .system(size: 11),
-                        color: playerColorTinting
-                            ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.6)
-                            : .gray,
-                        frameWidth: geo.size.width
-                    )
-                    Spacer(minLength: 0)
-                }
-            }
-            .frame(height: artSize)
 
-            // AudioSpectrumView tints itself, so no outer gradient/mask —
-            // that would just fight the colour it already applies.
-            if !musicManager.isPlayerIdle {
-                AudioSpectrumView(
-                    isPlaying: musicManager.isPlaying,
-                    tintColor: coloredSpectrogram
-                        ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.6)
-                        : .gray
-                )
-                .frame(width: 18, height: 14)
-                .frame(height: artSize)
+                    Text(musicManager.artistName)
+                        .font(.system(size: 10))
+                        .foregroundStyle(
+                            playerColorTinting
+                                ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.6)
+                                : .gray
+                        )
+                        .lineLimit(1)
+                }
+                .frame(width: textWidth, alignment: .leading)
+
+                ZStack {
+                    AudioSpectrumView(
+                        isPlaying: musicManager.isPlaying,
+                        tintColor: coloredSpectrogram
+                            ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.6)
+                            : .gray
+                    )
+                    .frame(width: vizBarWidth, height: 16)
+                }
+                .frame(width: vizBlockWidth)
             }
         }
     }
 
-    /// Same slot preference as the full layout, so the buttons a user
-    /// configured there are the ones they get here.
+    // MARK: - Progress
+
+    private var progressRow: some View {
+        TimelineView(.animation(minimumInterval: musicManager.playbackRate > 0 ? 0.1 : nil)) { timeline in
+            MusicSliderView(
+                sliderValue: $sliderValue,
+                duration: $musicManager.songDuration,
+                lastDragged: $lastDragged,
+                color: musicManager.avgColor,
+                dragging: $dragging,
+                currentDate: timeline.date,
+                timestampDate: musicManager.timestampDate,
+                elapsedTime: musicManager.elapsedTime,
+                playbackRate: musicManager.playbackRate,
+                isPlaying: musicManager.isPlaying,
+                onValueChange: { MusicManager.shared.seek(to: $0) },
+                labelLayout: .inline,
+                trailingLabel: .remaining,
+                restingTrackHeight: 7,
+                draggingTrackHeight: 11
+            )
+        }
+        .onAppear { sliderValue = musicManager.elapsedTime }
+    }
+
+    // MARK: - Transport
+
+    /// Uses the same slot preference as the full layout, so the buttons
+    /// configured there are the ones that appear here.
     private var transport: some View {
-        // Pad/trim to the configured slot count locally — NotchHomeView's
-        // `padded` helper is fileprivate to that file, and widening its
-        // access just for this would be a worse trade than four lines here.
+        HStack(spacing: 10) {
+            ForEach(Array(displayedSlots.enumerated()), id: \.offset) { _, slot in
+                slotView(for: slot)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private var displayedSlots: [MusicControlButton] {
+        // Padding is done here rather than via NotchHomeView's `padded`
+        // helper, which is fileprivate to that file.
         let count = min(max(slotLimit, MusicControlButton.minSlotCount), MusicControlButton.maxSlotCount)
         var slots = slotConfig
         if slots.count < count {
             slots += Array(repeating: .none, count: count - slots.count)
         }
-        slots = Array(slots.prefix(count))
-
-        return HStack(spacing: 4) {
-            ForEach(Array(slots.enumerated()), id: \.offset) { _, slot in
-                slotView(for: slot)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .center)
+        return Array(slots.prefix(count))
     }
 
     @ViewBuilder
@@ -148,18 +186,14 @@ struct CompactHomeView: View {
         case .none:
             EmptyView()
         default:
-            // Slots that only make sense in the full layout (mirror,
-            // calendar, and anything added later) are skipped rather than
-            // rendered half-working in a player-only view.
+            // Slots that only make sense in the full layout are skipped
+            // rather than rendered half-working in a player-only view.
             EmptyView()
         }
     }
 
     private var repeatIcon: String {
-        switch musicManager.repeatMode {
-        case .one: "repeat.1"
-        default: "repeat"
-        }
+        musicManager.repeatMode == .one ? "repeat.1" : "repeat"
     }
 
     private var repeatIconColor: Color {
@@ -167,11 +201,11 @@ struct CompactHomeView: View {
     }
 
     private var idleState: some View {
-        VStack(spacing: 6) {
-            Image(systemName: "music.note")
-                .font(.system(size: 20, weight: .light))
+        VStack(spacing: 8) {
+            Image(systemName: "music.note.slash")
+                .font(.system(size: 24, weight: .light))
                 .foregroundStyle(.gray)
-            Text("Nothing playing")
+            Text("Nothing Playing")
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(.gray)
         }

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -276,6 +276,8 @@ struct MusicControlsView: View {
             HoverButton(icon: repeatIcon, iconColor: repeatIconColor, scale: .medium) {
                 MusicManager.shared.toggleRepeat()
             }
+        case .mediaOutput:
+            MediaOutputSlotButton()
         case .volume:
             VolumeControlView()
         case .favorite:

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -481,37 +481,111 @@ struct MusicSliderView: View {
     let isPlaying: Bool
     var onValueChange: (Double) -> Void
 
+    // Layout options, ported from Atoll (GPL-3.0, itself a boring.notch
+    // fork) so the compact layout can put the times either side of the
+    // track. Defaults reproduce the previous stacked/duration look exactly,
+    // so the standard layout is untouched.
+    var labelLayout: TimeLabelLayout = .stacked
+    var trailingLabel: TrailingLabel = .duration
+    var restingTrackHeight: CGFloat = 5
+    var draggingTrackHeight: CGFloat = 9
+
+    enum TimeLabelLayout {
+        /// Times on a row beneath the track.
+        case stacked
+        /// Times flanking the track on the same row.
+        case inline
+    }
+
+    enum TrailingLabel {
+        case duration
+        /// Counts down: "-2:56".
+        case remaining
+    }
 
     var body: some View {
-        VStack {
-            CustomSlider(
-                value: $sliderValue,
-                range: 0...duration,
-                color: Defaults[.sliderColor] == SliderColorEnum.albumArt
-                    ? Color(nsColor: color).ensureMinimumBrightness(factor: 0.8)
-                    : Defaults[.sliderColor] == SliderColorEnum.accent ? .effectiveAccent : .white,
-                dragging: $dragging,
-                lastDragged: $lastDragged,
-                onValueChange: onValueChange
-            )
-            .frame(height: 10, alignment: .center)
-
-            HStack {
-                Text(timeString(from: sliderValue))
-                Spacer()
-                Text(timeString(from: duration))
+        Group {
+            switch labelLayout {
+            case .stacked: stackedContent
+            case .inline: inlineContent
             }
-            .fontWeight(.medium)
-            .foregroundColor(
-                Defaults[.playerColorTinting]
-                    ? Color(nsColor: color).ensureMinimumBrightness(factor: 0.6) : .gray
-            )
-            .font(.caption)
         }
         .onChange(of: currentDate) {
            guard !dragging, timestampDate.timeIntervalSince(lastDragged) > -1 else { return }
             sliderValue = MusicManager.shared.estimatedPlaybackPosition(at: currentDate)
         }
+    }
+
+    private var stackedContent: some View {
+        VStack {
+            sliderCore
+                .frame(height: sliderFrameHeight, alignment: .center)
+
+            HStack {
+                Text(timeString(from: sliderValue))
+                Spacer()
+                Text(trailingTimeText)
+            }
+            .fontWeight(.medium)
+            .foregroundColor(timeLabelColor)
+            .font(.caption)
+        }
+    }
+
+    private var inlineContent: some View {
+        HStack(spacing: 6) {
+            Text(timeString(from: sliderValue))
+                .font(inlineLabelFont)
+                .foregroundColor(timeLabelColor)
+                .frame(width: 36, alignment: .leading)
+
+            sliderCore
+                .frame(height: sliderFrameHeight)
+                .frame(maxWidth: .infinity)
+
+            Text(trailingTimeText)
+                .font(inlineLabelFont)
+                .foregroundColor(timeLabelColor)
+                .frame(width: 42, alignment: .trailing)
+        }
+    }
+
+    private var sliderCore: some View {
+        CustomSlider(
+            value: $sliderValue,
+            range: 0...duration,
+            color: Defaults[.sliderColor] == SliderColorEnum.albumArt
+                ? Color(nsColor: color).ensureMinimumBrightness(factor: 0.8)
+                : Defaults[.sliderColor] == SliderColorEnum.accent ? .effectiveAccent : .white,
+            dragging: $dragging,
+            lastDragged: $lastDragged,
+            onValueChange: onValueChange,
+            restingTrackHeight: restingTrackHeight,
+            draggingTrackHeight: draggingTrackHeight
+        )
+    }
+
+    private var timeLabelColor: Color {
+        Defaults[.playerColorTinting]
+            ? Color(nsColor: color).ensureMinimumBrightness(factor: 0.6) : .gray
+    }
+
+    private var trailingTimeText: String {
+        switch trailingLabel {
+        case .duration:
+            return timeString(from: duration)
+        case .remaining:
+            return "-" + timeString(from: max(duration - sliderValue, 0))
+        }
+    }
+
+    /// Monospaced digits so the label doesn't jitter as the numbers tick.
+    private var inlineLabelFont: Font {
+        .system(size: 11, weight: .medium).monospacedDigit()
+    }
+
+    private var sliderFrameHeight: CGFloat {
+        max(restingTrackHeight, draggingTrackHeight) + 1
     }
 
     func timeString(from seconds: Double) -> String {
@@ -537,11 +611,15 @@ struct CustomSlider: View {
     @Binding var lastDragged: Date
     var onValueChange: ((Double) -> Void)?
     var onDragChange: ((Double) -> Void)?
+    /// Defaults match the previous hard-coded 5/9 so the standard layout is
+    /// unchanged; the compact layout passes a chunkier track.
+    var restingTrackHeight: CGFloat = 5
+    var draggingTrackHeight: CGFloat = 9
 
     var body: some View {
         GeometryReader { geometry in
             let width = geometry.size.width
-            let height = CGFloat(dragging ? 9 : 5)
+            let height = CGFloat(dragging ? draggingTrackHeight : restingTrackHeight)
             let rangeSpan = range.upperBound - range.lowerBound
 
             let progress = rangeSpan == .zero ? 0 : (value - range.lowerBound) / rangeSpan
@@ -557,7 +635,7 @@ struct CustomSlider: View {
                     .frame(width: filledTrackWidth, height: height)
             }
             .cornerRadius(height / 2)
-            .frame(height: 10)
+            .frame(height: max(restingTrackHeight, draggingTrackHeight) + 1)
             .contentShape(Rectangle())
             .gesture(
                 DragGesture(minimumDistance: 0)

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -153,6 +153,10 @@ struct NotificationExpandedView: View {
         // notification go rather than pinning it forever.
         .onAppear {
             manager.holdActive()
+            // Cycling the stack rebuilds this view for a different
+            // notification (.id below), so a half-typed reply only survives
+            // if it's restored from the manager rather than kept in @State.
+            replyText = manager.draft(for: notification.id)
             if kind == .reply { replyFocused = true }
         }
         // The single teardown point for both the key-window grant and the
@@ -202,10 +206,11 @@ struct NotificationExpandedView: View {
             // so hold it for the whole compose session.
             beginComposing()
         }
-        .onChange(of: replyText) { _, _ in
-            // Stop the timer's clock is exactly what typing should do — a
-            // keystroke is the clearest possible "still here" signal, so it
-            // gets an uncapped hold rather than the notch-open cap.
+        .onChange(of: replyText) { _, text in
+            manager.setDraft(text, for: notification.id)
+            // Stopping the timer's clock is exactly what typing should do —
+            // a keystroke is the clearest possible "still here" signal, so
+            // it gets an uncapped hold rather than the notch-open cap.
             if replyFocused { manager.holdWhileTyping() }
         }
     }
@@ -284,24 +289,30 @@ struct NotificationExpandedView: View {
     private var queuedBadge: some View {
         let queued = manager.queued
         if !queued.isEmpty {
-            HStack(spacing: 3) {
-                if let bundleID = singleQueuedAppBundleID {
-                    AppIcon(for: bundleID)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 11, height: 11)
-                        .clipShape(RoundedRectangle(cornerRadius: 3))
+            Button {
+                manager.cycleToNextQueued()
+            } label: {
+                HStack(spacing: 3) {
+                    if let bundleID = singleQueuedAppBundleID {
+                        AppIcon(for: bundleID)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 11, height: 11)
+                            .clipShape(RoundedRectangle(cornerRadius: 3))
+                    }
+                    Text("+\(queued.count)")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.9))
                 }
-                Text("+\(queued.count)")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.9))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(.white.opacity(0.14), in: Capsule())
+                .contentShape(Capsule())
             }
-            .padding(.horizontal, 5)
-            .padding(.vertical, 2)
-            .background(.white.opacity(0.14), in: Capsule())
+            .buttonStyle(ScaleDownButtonStyle())
             .transition(.scale.combined(with: .opacity))
             .animation(.smooth(duration: 0.2), value: queued.count)
-            .help("\(queued.count) more waiting")
+            .help("Tap to see the next of \(queued.count) waiting")
         }
     }
 
@@ -534,6 +545,7 @@ struct NotificationExpandedView: View {
             // actually sitting on the clipboard.
             didSend = outcome == .sent
             didHandOff = outcome == .handedOffToApp
+            manager.clearDraft(for: notification.id)
             try? await Task.sleep(for: .milliseconds(1200))
             manager.dismissActive(token: notification.id)
         }

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -544,7 +544,10 @@ struct NotificationExpandedView: View {
             // both would tell the user their message went out when it's
             // actually sitting on the clipboard.
             didSend = outcome == .sent
-            didHandOff = outcome == .handedOffToApp
+            // A drafted reply isn't sent either — same honest treatment as
+            // the clipboard hand-off, since the user still has to press
+            // send in WhatsApp.
+            didHandOff = outcome == .handedOffToApp || outcome == .draftedInApp
             manager.clearDraft(for: notification.id)
             try? await Task.sleep(for: .milliseconds(1200))
             manager.dismissActive(token: notification.id)

--- a/boringNotch/components/Notch/NotificationLiveActivity.swift
+++ b/boringNotch/components/Notch/NotificationLiveActivity.swift
@@ -164,6 +164,7 @@ struct NotificationExpandedView: View {
         .onDisappear {
             manager.resumeDismiss()
             hostWindow?.wantsKeyForTextInput = false
+            manager.isComposingReply = false
             endComposing()
         }
         // Apply a pending key request once the window resolves —
@@ -184,12 +185,16 @@ struct NotificationExpandedView: View {
                 // Both are released in onDisappear instead, which is the
                 // only unambiguous "done" signal.
                 manager.holdActive()
+                manager.isComposingReply = false
                 return
             }
             // The window can only accept keystrokes while it's key — see
             // BoringNotchSkyLightWindow.wantsKeyForTextInput.
             hostWindow?.wantsKeyForTextInput = true
             manager.holdWhileTyping()
+            // Newer notifications queue instead of replacing this one while
+            // the field has focus.
+            manager.isComposingReply = true
             // Clicking into the field changes window key status, which
             // rebuilds tracking areas and fires a spurious hover-exit —
             // that's what closed the notch the instant you tapped the
@@ -258,6 +263,8 @@ struct NotificationExpandedView: View {
                 .font(.system(size: 11))
                 .foregroundStyle(.tertiary)
                 .fixedSize()
+
+            queuedBadge
         }
         // Clears the close button, which overlays the card rather than
         // taking a layout slot — reserved here, on the one row it can
@@ -270,6 +277,41 @@ struct NotificationExpandedView: View {
     /// Deliberately not HoverButton's default 30pt sizing — that reads as a
     /// full toolbar control; a notification's close button wants to be
     /// closer to iOS's compact circular dismiss.
+    /// What's waiting behind this notification. Shows the app's icon when
+    /// everything queued is from one app, so a burst from one conversation
+    /// reads as "2 more from WhatsApp" rather than an anonymous count.
+    @ViewBuilder
+    private var queuedBadge: some View {
+        let queued = manager.queued
+        if !queued.isEmpty {
+            HStack(spacing: 3) {
+                if let bundleID = singleQueuedAppBundleID {
+                    AppIcon(for: bundleID)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 11, height: 11)
+                        .clipShape(RoundedRectangle(cornerRadius: 3))
+                }
+                Text("+\(queued.count)")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.9))
+            }
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(.white.opacity(0.14), in: Capsule())
+            .transition(.scale.combined(with: .opacity))
+            .animation(.smooth(duration: 0.2), value: queued.count)
+            .help("\(queued.count) more waiting")
+        }
+    }
+
+    /// The shared bundle ID when every queued notification came from the
+    /// same app, else nil.
+    private var singleQueuedAppBundleID: String? {
+        let ids = Set(manager.queued.compactMap(\.bundleID))
+        return ids.count == 1 ? ids.first : nil
+    }
+
     private var dismissButton: some View {
         Button {
             manager.dismissActive(token: notification.id)

--- a/boringNotch/components/NotificationDebugWindow.swift
+++ b/boringNotch/components/NotificationDebugWindow.swift
@@ -89,6 +89,8 @@ struct NotificationDebugView: View {
                 lastResult = "replied via the live banner"
             case .handedOffToApp:
                 lastResult = "banner gone — copied to clipboard and opened the app"
+            case .draftedInApp:
+                lastResult = "banner gone — opened the conversation with the text pre-filled"
             }
         }
     }

--- a/boringNotch/components/Settings/Views/GeneralSettingsView.swift
+++ b/boringNotch/components/Settings/Views/GeneralSettingsView.swift
@@ -289,5 +289,15 @@ struct GeneralSettings: View {
         } header: {
             Text("Notch behavior")
         }
+
+        Section {
+            Defaults.Toggle(key: .compactMode) {
+                Text("Compact mode")
+            }
+        } footer: {
+            Text("Shows a smaller opened notch with just the music player — no tabs, calendar or mirror.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
     }
 }

--- a/boringNotch/helpers/AudioOutputRouteResolver.swift
+++ b/boringNotch/helpers/AudioOutputRouteResolver.swift
@@ -26,6 +26,22 @@ final class AudioOutputRouteResolver {
     private let stateQueue = DispatchQueue(label: "AudioOutputRouteResolver.state")
     private var cachedRouteKind: AudioOutputRouteKind = .unknown
 
+    /// Symbol for the current output route, independent of volume level —
+    /// for the media-output button, which shows *where* audio is going
+    /// rather than how loud it is. Built-in output reads as the machine
+    /// itself (a laptop), matching how macOS's own output picker shows it.
+    func outputRouteSymbol() -> String {
+        let routeKind = stateQueue.sync { cachedRouteKind }
+        switch routeKind {
+        case .airPods: return "airpods"
+        case .airPodsPro: return "airpodspro"
+        case .airPodsMax: return "airpodsmax"
+        case .wiredHeadphones, .bluetoothHeadphones: return "headphones"
+        case .externalSpeaker: return "hifispeaker"
+        case .builtInSpeaker, .unknown: return "laptopcomputer"
+        }
+    }
+
     func volumeSymbol(for value: CGFloat) -> String {
         let clampedValue = max(0, min(1, value))
         let routeKind = stateQueue.sync { cachedRouteKind }

--- a/boringNotch/managers/AudioRouteManager.swift
+++ b/boringNotch/managers/AudioRouteManager.swift
@@ -1,0 +1,207 @@
+//
+//  AudioRouteManager.swift
+//  boringNotch
+//
+//  Lists the Mac's audio output devices and switches the system default
+//  between them, for the compact player's media-output button.
+//
+//  Adapted from Atoll's AudioRouteManager
+//  (https://github.com/Ebullioscopic/Atoll, GPL-3.0, itself a boring.notch
+//  fork).
+//
+//  Distinct from AudioOutputRouteResolver, which only classifies the
+//  *current* route into an icon for the OSD. This one enumerates every
+//  device and can change which is active.
+//
+
+import Combine
+import CoreAudio
+import Foundation
+
+struct AudioOutputDevice: Identifiable, Equatable {
+    let id: AudioDeviceID
+    let name: String
+    let transportType: UInt32
+
+    /// Name first, transport second: a name match is more specific than the
+    /// transport ("AirPods Pro" over Bluetooth beats a generic headphones
+    /// glyph), and matches how macOS's own output menu labels things.
+    var iconName: String {
+        let normalized = name.lowercased()
+
+        if normalized.contains("airpods max") { return "airpodsmax" }
+        if normalized.contains("airpods pro") { return "airpodspro" }
+        if normalized.contains("airpods") { return "airpods" }
+        if normalized.contains("macbook") { return "laptopcomputer" }
+        if normalized.contains("homepod") { return "homepod" }
+        if normalized.contains("headphone") || normalized.contains("headset") || normalized.contains("beats") {
+            return "headphones"
+        }
+        if normalized.contains("display") || normalized.contains("monitor") { return "display" }
+
+        switch transportType {
+        case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE:
+            return normalized.contains("speaker") ? "hifispeaker" : "headphones"
+        case kAudioDeviceTransportTypeAirPlay:
+            return "airplayaudio"
+        case kAudioDeviceTransportTypeDisplayPort, kAudioDeviceTransportTypeHDMI:
+            return "tv"
+        case kAudioDeviceTransportTypeUSB:
+            return "hifispeaker"
+        case kAudioDeviceTransportTypeBuiltIn:
+            return "laptopcomputer"
+        default:
+            return "speaker.wave.2"
+        }
+    }
+}
+
+@MainActor
+final class AudioRouteManager: ObservableObject {
+    static let shared = AudioRouteManager()
+
+    @Published private(set) var devices: [AudioOutputDevice] = []
+    @Published private(set) var activeDeviceID: AudioDeviceID = 0
+
+    var activeDevice: AudioOutputDevice? {
+        devices.first { $0.id == activeDeviceID }
+    }
+
+    /// CoreAudio property reads block, so they stay off the main thread —
+    /// the picker opens from a click and shouldn't stutter the notch.
+    private let queue = DispatchQueue(label: "boringNotch.AudioRouteManager")
+
+    private init() {}
+
+    func refreshDevices() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            let defaultID = Self.fetchDefaultOutputDevice()
+            let found = Self.fetchOutputDeviceIDs().compactMap(Self.makeDevice)
+            // Active device first, then alphabetical — the one you're using
+            // is the one you're most likely looking for.
+            let sorted = found.sorted { lhs, rhs in
+                if lhs.id == defaultID { return true }
+                if rhs.id == defaultID { return false }
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+            Task { @MainActor in
+                self.activeDeviceID = defaultID
+                self.devices = sorted
+            }
+        }
+    }
+
+    func select(_ device: AudioOutputDevice) {
+        queue.async { [weak self] in
+            guard Self.setDefaultOutputDevice(device.id) else { return }
+            Task { @MainActor in
+                self?.activeDeviceID = device.id
+                self?.refreshDevices()
+            }
+        }
+    }
+
+    // MARK: - CoreAudio
+
+    private static func fetchDefaultOutputDevice() -> AudioDeviceID {
+        var deviceID = AudioDeviceID()
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
+        )
+        return status == noErr ? deviceID : 0
+    }
+
+    @discardableResult
+    private static func setDefaultOutputDevice(_ deviceID: AudioDeviceID) -> Bool {
+        var target = deviceID
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        return AudioObjectSetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address, 0, nil,
+            UInt32(MemoryLayout<AudioDeviceID>.size),
+            &target
+        ) == noErr
+    }
+
+    private static func fetchOutputDeviceIDs() -> [AudioDeviceID] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size
+        ) == noErr else { return [] }
+
+        var ids = [AudioDeviceID](repeating: 0, count: Int(size) / MemoryLayout<AudioDeviceID>.size)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &ids
+        ) == noErr else { return [] }
+
+        // Every device is returned, inputs included — keep only the ones
+        // that actually have output streams, or the picker would offer
+        // microphones as places to send audio.
+        return ids.filter(hasOutputStreams)
+    }
+
+    private static func hasOutputStreams(_ deviceID: AudioDeviceID) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreams,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &size) == noErr else {
+            return false
+        }
+        return size > 0
+    }
+
+    private static func makeDevice(_ deviceID: AudioDeviceID) -> AudioOutputDevice? {
+        guard let name = stringProperty(deviceID, kAudioObjectPropertyName), !name.isEmpty else {
+            return nil
+        }
+        return AudioOutputDevice(id: deviceID, name: name, transportType: transportType(deviceID))
+    }
+
+    private static func stringProperty(_ deviceID: AudioDeviceID, _ selector: AudioObjectPropertySelector) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size = UInt32(MemoryLayout<CFString?>.size)
+        var value: CFString?
+        let status = withUnsafeMutablePointer(to: &value) { pointer in
+            AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, pointer)
+        }
+        guard status == noErr else { return nil }
+        return value as String?
+    }
+
+    private static func transportType(_ deviceID: AudioDeviceID) -> UInt32 {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &value) == noErr else {
+            return 0
+        }
+        return value
+    }
+}

--- a/boringNotch/managers/ContactAvatarManager.swift
+++ b/boringNotch/managers/ContactAvatarManager.swift
@@ -73,6 +73,44 @@ final class ContactAvatarManager: ObservableObject {
         return image
     }
 
+    /// Phone number for a contact, digits only and international, suitable
+    /// for a whatsapp:// deep link — or nil when it can't be resolved
+    /// *confidently*.
+    ///
+    /// The bar is deliberately high, because the cost of being wrong is
+    /// dropping someone's private reply into a stranger's chat:
+    ///
+    ///  - exactly one matching contact, else the name is ambiguous
+    ///  - the stored number must already carry a country code (leading "+").
+    ///    A local-format number can't be made international without guessing
+    ///    the country, and a wrong guess is a wrong person.
+    ///
+    /// Group chats resolve to nothing here, which is correct — a group name
+    /// isn't a contact and has no single number to send to.
+    func phoneNumber(forContactNamed name: String) -> String? {
+        guard isAuthorized else { return nil }
+
+        let keys = [CNContactPhoneNumbersKey as CNKeyDescriptor]
+        guard let contacts = try? store.unifiedContacts(
+            matching: CNContact.predicateForContacts(matchingName: name),
+            keysToFetch: keys
+        ), contacts.count == 1 else { return nil }
+
+        // Prefer an explicitly mobile number; a landline won't reach
+        // WhatsApp at all.
+        let numbers = contacts[0].phoneNumbers
+        let preferred = numbers.first {
+            $0.label == CNLabelPhoneNumberMobile || $0.label == CNLabelPhoneNumberiPhone
+        } ?? numbers.first
+
+        guard let raw = preferred?.value.stringValue else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("+") else { return nil }
+
+        let digits = trimmed.filter(\.isNumber)
+        return digits.isEmpty ? nil : digits
+    }
+
     /// Call once, e.g. when notification live activity starts, so the first
     /// banner isn't blocked on a permission prompt mid-render.
     func requestAccessIfNeeded() async {

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -75,6 +75,26 @@ final class SystemNotificationManager: ObservableObject {
     /// The notification the notch is currently showing, if any.
     @Published var activeNotification: SystemNotification?
 
+    /// Notifications that arrived while the user was mid-reply, held back
+    /// rather than shown. Promoted one at a time once they're done.
+    @Published private(set) var queued: [SystemNotification] = []
+
+    /// Set by the reply UI while its field has focus. Newer notifications
+    /// queue instead of replacing the active one during this — yanking a
+    /// message out from under someone mid-sentence loses what they typed.
+    var isComposingReply = false {
+        didSet {
+            guard oldValue, !isComposingReply else { return }
+            // Finished composing and the notification is already gone (sent
+            // or dismissed) — nothing will promote the queue, so do it here.
+            if activeNotification == nil { promoteNextQueued() }
+        }
+    }
+
+    /// Queued banners are all held alive off-screen, so this can't grow
+    /// without bound — past a handful, the oldest are dropped and released.
+    private let queueLimit = 5
+
     /// How long the closed notch shows a notification before handing the
     /// pill back to whatever was there before (usually music). Only applies
     /// while the notch is closed and unhovered — hovering or opening it
@@ -125,6 +145,17 @@ final class SystemNotificationManager: ObservableObject {
     func stop() {
         XPCHelperClient.shared.stopNotificationWatching()
         isWatching = false
+        releaseQueued()
+    }
+
+    /// Frees every queued notification's held banner. Anything still queued
+    /// is holding a parked, off-screen window, so dropping the queue without
+    /// this would strand them.
+    private func releaseQueued() {
+        for notification in queued {
+            XPCHelperClient.shared.releaseNotification(token: notification.id)
+        }
+        queued.removeAll()
     }
 
     // MARK: - Incoming banners
@@ -157,9 +188,38 @@ final class SystemNotificationManager: ObservableObject {
             NSLog("[boringNotch] filtered out: \(notification.appName ?? "-") bundle=\(notification.bundleID ?? "nil")")
             return
         }
-        NSLog("[boringNotch] showing in notch: \(notification.appName ?? "-")")
-        show(notification)
+
+        // Hold the banner either way: a queued notification still needs its
+        // reply field alive for when it's promoted, and holding is what
+        // keeps that possible past the banner's few seconds on screen.
         holdSystemBanner(notification)
+
+        if isComposingReply, activeNotification != nil {
+            enqueue(notification)
+            return
+        }
+
+        show(notification)
+    }
+
+    private func enqueue(_ notification: SystemNotification) {
+        queued.removeAll { $0.id == notification.id }
+        queued.append(notification)
+
+        // Oldest out first. Their held banners are released on the way, or
+        // they'd stay parked off-screen with nothing left to free them.
+        while queued.count > queueLimit {
+            let dropped = queued.removeFirst()
+            XPCHelperClient.shared.releaseNotification(token: dropped.id)
+        }
+    }
+
+    /// Shows the oldest queued notification, if any. Oldest first so a burst
+    /// is read in the order it arrived.
+    private func promoteNextQueued() {
+        guard !queued.isEmpty else { return }
+        let next = queued.removeFirst()
+        show(next)
     }
 
     /// Holds the system banner open for as long as the notch is showing the
@@ -234,6 +294,12 @@ final class SystemNotificationManager: ObservableObject {
             XPCHelperClient.shared.releaseNotification(token: id)
         }
         withAnimation(.smooth) { activeNotification = nil }
+
+        // Anything that queued up behind a reply gets its turn now. Skipped
+        // while still composing — the reply field can be focused for a beat
+        // after a send, and promoting there would replace the "sent"
+        // confirmation before it's been seen.
+        if !isComposingReply { promoteNextQueued() }
     }
 
     /// Keeps the notification up for as long as the reply field is being
@@ -288,6 +354,7 @@ final class SystemNotificationManager: ObservableObject {
 
     func clear() {
         notifications.removeAll()
+        releaseQueued()
         dismissActive()
     }
 

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -408,6 +408,10 @@ final class SystemNotificationManager: ObservableObject {
         /// The banner was gone, so the draft went to the clipboard and the
         /// app was opened for the user to paste.
         case handedOffToApp
+        /// Opened the conversation with the text already in its compose
+        /// box. Better than the clipboard, but still not sent — the user
+        /// presses send themselves.
+        case draftedInApp
     }
 
     /// Sends an inline reply.
@@ -440,6 +444,26 @@ final class SystemNotificationManager: ObservableObject {
             playSentSound()
             dismissActive(token: notification.id)
             return .sent
+        }
+
+        // WhatsApp exposes no scripting interface, but its URL scheme can
+        // open a specific conversation with text pre-filled — far better
+        // than the clipboard, which leaves the user to find the chat and
+        // paste. Needs a phone number, which only comes from Contacts and
+        // only when it resolves unambiguously (see phoneNumber(for:)).
+        if notification.bundleID == "net.whatsapp.WhatsApp",
+           let sender = notification.sender,
+           let phone = ContactAvatarManager.shared.phoneNumber(forContactNamed: sender),
+           let encoded = text.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+           // whatsapp:// rather than wa.me — the scheme is registered to
+           // WhatsApp.app directly, so it opens the app instead of bouncing
+           // the message text through a browser.
+           let url = URL(string: "whatsapp://send?phone=\(phone)&text=\(encoded)") {
+            NSLog("[boringNotch] reply drafted in WhatsApp conversation for \(sender)")
+            NSWorkspace.shared.open(url)
+            playHandOffSound()
+            dismissActive(token: notification.id)
+            return .draftedInApp
         }
 
         NSLog("[boringNotch] reply could not be delivered (banner gone) — handing off to \(notification.appName ?? "app")")

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -199,6 +199,19 @@ final class SystemNotificationManager: ObservableObject {
     }
 
     private func show(_ notification: SystemNotification) {
+        // A newer notification replaces the active one directly here rather
+        // than going through dismissActive, so its hold was never being
+        // released: dismissActive only releases whatever activeNotification
+        // happens to be *when it runs*, and by the time a superseded
+        // notification would be dismissed it's already been overwritten.
+        // The result was a parked, off-screen banner window that never came
+        // back — and since the same window can get reused by
+        // notificationcenterui for its own real Notification Center panel,
+        // that panel could end up opening off-screen too, which is why the
+        // system clock stopped visibly doing anything.
+        if let previous = activeNotification, previous.id != notification.id {
+            XPCHelperClient.shared.releaseNotification(token: previous.id)
+        }
         withAnimation(.smooth) { activeNotification = notification }
         dismissTask?.cancel()
         dismissTask = Task { [weak self] in

--- a/boringNotch/managers/SystemNotificationManager.swift
+++ b/boringNotch/managers/SystemNotificationManager.swift
@@ -154,6 +154,7 @@ final class SystemNotificationManager: ObservableObject {
     private func releaseQueued() {
         for notification in queued {
             XPCHelperClient.shared.releaseNotification(token: notification.id)
+            clearDraft(for: notification.id)
         }
         queued.removeAll()
     }
@@ -211,7 +212,43 @@ final class SystemNotificationManager: ObservableObject {
         while queued.count > queueLimit {
             let dropped = queued.removeFirst()
             XPCHelperClient.shared.releaseNotification(token: dropped.id)
+            clearDraft(for: dropped.id)
         }
+    }
+
+    /// Rotates the stack: shows the next queued notification and sends the
+    /// current one to the back, so repeated taps cycle through everything
+    /// and always come back around rather than discarding as they go.
+    func cycleToNextQueued() {
+        guard let next = queued.first else { return }
+        queued.removeFirst()
+        if let current = activeNotification {
+            queued.append(current)
+        }
+        show(next, releasingPrevious: false)
+    }
+
+    // MARK: - Reply drafts
+
+    /// Half-typed replies, keyed by notification. Cycling the stack tears
+    /// the compose view down and rebuilds it for a different notification,
+    /// so without this a draft would vanish the moment you looked at
+    /// something else — the same lost-typing problem the queue exists to
+    /// prevent.
+    private var replyDrafts: [String: String] = [:]
+
+    func draft(for id: String) -> String { replyDrafts[id] ?? "" }
+
+    func setDraft(_ text: String, for id: String) {
+        if text.isEmpty {
+            replyDrafts.removeValue(forKey: id)
+        } else {
+            replyDrafts[id] = text
+        }
+    }
+
+    func clearDraft(for id: String) {
+        replyDrafts.removeValue(forKey: id)
     }
 
     /// Shows the oldest queued notification, if any. Oldest first so a burst
@@ -258,7 +295,11 @@ final class SystemNotificationManager: ObservableObject {
         }
     }
 
-    private func show(_ notification: SystemNotification) {
+    /// `releasingPrevious: false` when rotating through the stack — the
+    /// outgoing notification goes back into the queue rather than away, and
+    /// it needs to keep its held banner or it won't be replyable when it
+    /// comes back around.
+    private func show(_ notification: SystemNotification, releasingPrevious: Bool = true) {
         // A newer notification replaces the active one directly here rather
         // than going through dismissActive, so its hold was never being
         // released: dismissActive only releases whatever activeNotification
@@ -269,7 +310,7 @@ final class SystemNotificationManager: ObservableObject {
         // notificationcenterui for its own real Notification Center panel,
         // that panel could end up opening off-screen too, which is why the
         // system clock stopped visibly doing anything.
-        if let previous = activeNotification, previous.id != notification.id {
+        if releasingPrevious, let previous = activeNotification, previous.id != notification.id {
             XPCHelperClient.shared.releaseNotification(token: previous.id)
         }
         withAnimation(.smooth) { activeNotification = notification }
@@ -292,6 +333,7 @@ final class SystemNotificationManager: ObservableObject {
         // has moved on.
         if let id = activeNotification?.id {
             XPCHelperClient.shared.releaseNotification(token: id)
+            clearDraft(for: id)
         }
         withAnimation(.smooth) { activeNotification = nil }
 

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -308,6 +308,12 @@ extension Defaults.Keys {
     static let osdReplacement = Key<Bool>("osdReplacement", default: false)
     static let inlineOSD = Key<Bool>("inlineOSD", default: false)
 
+    // MARK: Layout
+    /// Swaps the opened notch for a smaller, player-only layout: no tab
+    /// bar, calendar or mirror. Off by default so existing users keep the
+    /// layout they already have.
+    static let compactMode = Key<Bool>("compactMode", default: false)
+
     // MARK: Notifications
     /// Off by default: mirroring banners needs Accessibility access.
     static let notificationLiveActivity = Key<Bool>("notificationLiveActivity", default: false)

--- a/boringNotch/models/MusicControlButton.swift
+++ b/boringNotch/models/MusicControlButton.swift
@@ -17,16 +17,20 @@ enum MusicControlButton: String, CaseIterable, Identifiable, Codable, Defaults.S
     case favorite
     case goBackward
     case goForward
+    case mediaOutput
     case none
 
     var id: String { rawValue }
 
+    /// Shuffle and media output round out the default row. The previous
+    /// default left two empty slots, so a fresh install showed only three
+    /// transport buttons with dead space either side.
     static let defaultLayout: [MusicControlButton] = [
-        .none,
+        .shuffle,
         .previous,
         .playPause,
         .next,
-        .none
+        .mediaOutput
     ]
 
     static let minSlotCount: Int = 3
@@ -41,7 +45,8 @@ enum MusicControlButton: String, CaseIterable, Identifiable, Codable, Defaults.S
         .favorite,
         .volume,
         .goBackward,
-        .goForward
+        .goForward,
+        .mediaOutput
     ]
 
     var label: String {
@@ -64,6 +69,8 @@ enum MusicControlButton: String, CaseIterable, Identifiable, Codable, Defaults.S
             return "Backward 15s"
         case .goForward:
             return "Forward 15s"
+        case .mediaOutput:
+            return "Audio output"
         case .none:
             return "Empty slot"
         }
@@ -89,6 +96,10 @@ enum MusicControlButton: String, CaseIterable, Identifiable, Codable, Defaults.S
             return "gobackward.15"
         case .goForward:
             return "goforward.15"
+        case .mediaOutput:
+            // Placeholder for the settings picker; the live button swaps in
+            // the actual route's glyph (laptop / headphones / AirPods).
+            return "laptopcomputer"
         case .none:
             return ""
         }

--- a/boringNotch/sizing/matters.swift
+++ b/boringNotch/sizing/matters.swift
@@ -17,6 +17,13 @@ let openNotchSize: CGSize = .init(width: 640, height: 190)
 let windowSize: CGSize = .init(width: openNotchSize.width, height: openNotchSize.height + shadowPadding)
 let cornerRadiusInsets: (opened: (top: CGFloat, bottom: CGFloat), closed: (top: CGFloat, bottom: CGFloat)) = (opened: (top: 19, bottom: 24), closed: (top: 6, bottom: 14))
 
+/// Compact mode uses a much rounder opened shape than the standard layout
+/// — matching Atoll's minimalisticCornerRadiusInsets (35/35 against the
+/// standard 19/24). At compact's smaller size the standard radius reads
+/// square; the rounder corners are what make it look like a pill rather
+/// than a shrunken panel.
+let compactCornerRadiusInsets: (opened: (top: CGFloat, bottom: CGFloat), closed: (top: CGFloat, bottom: CGFloat)) = (opened: (top: 35, bottom: 35), closed: cornerRadiusInsets.closed)
+
 // Horizontal gap between closed-state live-activity content (album art / waveform)
 // and the physical notch edge. Without this margin the hardware bezel clips the
 // adjacent content since the spacer rect used to be narrower than the physical notch.


### PR DESCRIPTION
**Stack 2 of 4.** Based on #1503; base for #3. Split out of #1496 for reviewability.

## Summary
- **Compact mode**: a player-only opened notch matching Atoll's layout and dimensions (420x180 pinned, then narrowed 20% to 336pt), full transport row, media-output device switching, shuffle/output in both layouts, cached track state instead of "Nothing Playing", hover-collapse fix
- **Notification hardening** (interleaved in history, kept in order): held-banner leak fix that could block the real Notification Center, queue mid-reply arrivals, browsable queued-notification badge stack, WhatsApp replies drafted in-conversation
- Inline song-change peek layout fix; battery fill scales with width

## Test plan
- [x] `xcodebuild -scheme boringNotch build` at this tip — clean
- [ ] Manual: enable compact mode → open notch → transport controls; queue two notifications mid-reply