### PR TITLE
Fix: harmonize "menu bar" spelling in notch sizing settings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,7 +81,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -110,6 +110,6 @@ jobs:
           build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         category: "/language:${{matrix.language}}"

--- a/boringNotch/Localizable.xcstrings
+++ b/boringNotch/Localizable.xcstrings
@@ -12709,12 +12709,12 @@
         }
       }
     },
-    "Match menubar height" : {
+    "Match menu bar height" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Match menubar height"
+            "value" : "Match menu bar height"
           }
         },
         "cs" : {
@@ -12732,13 +12732,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Match menubar height"
+            "value" : "Match menu bar height"
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Match menubar height"
+            "value" : "Match menu bar height"
           }
         },
         "es" : {
@@ -12756,7 +12756,7 @@
         "hu" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Match menubar height"
+            "value" : "Match menu bar height"
           }
         },
         "it" : {
@@ -12780,13 +12780,13 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Match menubar height"
+            "value" : "Match menu bar height"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Match menubar height"
+            "value" : "Match menu bar height"
           }
         },
         "tr" : {
@@ -12798,7 +12798,7 @@
         "uk" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Match menubar height"
+            "value" : "Match menu bar height"
           }
         },
         "zh-Hans" : {

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -227,7 +227,7 @@ struct GeneralSettings: View {
                     }
                 }
                 Picker("Notch height on non-notch displays", selection: $nonNotchHeightMode) {
-                    Text("Match menubar height")
+                    Text("Match menu bar height")
                         .tag(WindowHeightMode.matchMenuBar)
                     Text("Match real notch height")
                         .tag(WindowHeightMode.matchRealNotchSize)

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -57,7 +57,7 @@ enum MirrorShapeEnum: String, Defaults.Serializable {
 }
 
 enum WindowHeightMode: String, Defaults.Serializable {
-    case matchMenuBar = "Match menubar height"
+    case matchMenuBar = "Match menu bar height"
     case matchRealNotchSize = "Match real notch height"
     case custom = "Custom height"
 }


### PR DESCRIPTION
### Summary
In **General > Notch sizing**, the option for non-notch displays previously read `"Match menubar height"` while the option for notch displays read `"Match menu bar height"`. 

<img width="685" height="592" alt="boringNotch menubar typo" src="https://github.com/user-attachments/assets/82a6c4e2-2d6c-4ebe-927d-07de8484cc80" />

This PR updates the string to `"Match menu bar height"` to ensure internal consistency and align with Apple's macOS Human Interface Guidelines.

### Changes
- Updated `"Match menubar height"` to `"Match menu bar height"`.