### PR TITLE
Add vertically stacked day timelines to a Calendar pane

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		217E98660932EA6BAA76F87B /* CalendarDayStackGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32F504B9483216E11C38DDB /* CalendarDayStackGeometry.swift */; };
+		13BE21C4FC43D5F04303E3C1 /* CalendarDayScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3BE341C1C567C92B1BB2FE /* CalendarDayScrollView.swift */; };
+		7E1C2233844F784535BDFB98 /* CalendarTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B815BD96164CD14B66C2AE83 /* CalendarTimelineView.swift */; };
 		E2269C28E2B54A91B18A84BC /* HomeCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BB304B8FAD46558ECC1E05 /* HomeCalendarView.swift */; };
 		F6D1CC2D5E6F4344873AE017 /* HomeCalendarTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631501C38B2A4B27B4E35987 /* HomeCalendarTimelineView.swift */; };
 		AEF093035C8E42138C29A58F /* HomeCalendarScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DF65860F824982ADD7CA90 /* HomeCalendarScrollView.swift */; };
@@ -228,6 +231,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		D32F504B9483216E11C38DDB /* CalendarDayStackGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarDayStackGeometry.swift; sourceTree = "<group>"; };
+		1E3BE341C1C567C92B1BB2FE /* CalendarDayScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarDayScrollView.swift; sourceTree = "<group>"; };
+		B815BD96164CD14B66C2AE83 /* CalendarTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTimelineView.swift; sourceTree = "<group>"; };
 		21BB304B8FAD46558ECC1E05 /* HomeCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarView.swift; sourceTree = "<group>"; };
 		631501C38B2A4B27B4E35987 /* HomeCalendarTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarTimelineView.swift; sourceTree = "<group>"; };
 		54DF65860F824982ADD7CA90 /* HomeCalendarScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarScrollView.swift; sourceTree = "<group>"; };
@@ -709,6 +715,9 @@
 		14C08BB72C8DE49E000F8AA0 /* Calendar */ = {
 			isa = PBXGroup;
 			children = (
+				D32F504B9483216E11C38DDB /* CalendarDayStackGeometry.swift */,
+				1E3BE341C1C567C92B1BB2FE /* CalendarDayScrollView.swift */,
+				B815BD96164CD14B66C2AE83 /* CalendarTimelineView.swift */,
 				14C08BB82C8DE4B1000F8AA0 /* BoringCalendar.swift */,
 				21BB304B8FAD46558ECC1E05 /* HomeCalendarView.swift */,
 				631501C38B2A4B27B4E35987 /* HomeCalendarTimelineView.swift */,
@@ -1127,6 +1136,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				217E98660932EA6BAA76F87B /* CalendarDayStackGeometry.swift in Sources */,
+				13BE21C4FC43D5F04303E3C1 /* CalendarDayScrollView.swift in Sources */,
+				7E1C2233844F784535BDFB98 /* CalendarTimelineView.swift in Sources */,
 				115C12EC2ED3D003009754CA /* OpenNotchOSD.swift in Sources */,
 				14C08BB92C8DE4B1000F8AA0 /* BoringCalendar.swift in Sources */,
 				E2269C28E2B54A91B18A84BC /* HomeCalendarView.swift in Sources */,

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		ECA61DF2A3514227AE5AA6A1 /* HomeCalendarGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DB1CE831874CF099493DE6 /* HomeCalendarGeometry.swift */; };
 		496A7E65CD21464891126DC6 /* CalendarTodayShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6DB69B1F13439FB0563335 /* CalendarTodayShortcut.swift */; };
 		D90FCC73D2E74963876919B5 /* CalendarTimelineGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36BDAE2AAD04EB4BB47EAB3 /* CalendarTimelineGeometry.swift */; };
+		9F5D435D4B7645A5A8C99D31 /* CalendarScaleControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DBB6C43E2F34090B7DAF180 /* CalendarScaleControl.swift */; };
 		569FE036E08449AF8F597113 /* CalendarMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048863E7FD57471FA6624048 /* CalendarMonthView.swift */; };
 		A3810CF638D840DB810683A6 /* CalendarMonthGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B5174C0EF14A268F12DB6A /* CalendarMonthGeometry.swift */; };
 		07FE456E7AEA085D9FCA6D97 /* MeetingLinkDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B2A5E5F4D28F1DD9CD0B09 /* MeetingLinkDetector.swift */; };
@@ -240,6 +241,7 @@
 		33DB1CE831874CF099493DE6 /* HomeCalendarGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarGeometry.swift; sourceTree = "<group>"; };
 		CE6DB69B1F13439FB0563335 /* CalendarTodayShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTodayShortcut.swift; sourceTree = "<group>"; };
 		F36BDAE2AAD04EB4BB47EAB3 /* CalendarTimelineGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTimelineGeometry.swift; sourceTree = "<group>"; };
+		5DBB6C43E2F34090B7DAF180 /* CalendarScaleControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarScaleControl.swift; sourceTree = "<group>"; };
 		048863E7FD57471FA6624048 /* CalendarMonthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMonthView.swift; sourceTree = "<group>"; };
 		A7B5174C0EF14A268F12DB6A /* CalendarMonthGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMonthGeometry.swift; sourceTree = "<group>"; };
 		0268933F488E47DFB58E48CF /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
@@ -725,6 +727,7 @@
 				33DB1CE831874CF099493DE6 /* HomeCalendarGeometry.swift */,
 				CE6DB69B1F13439FB0563335 /* CalendarTodayShortcut.swift */,
 				F36BDAE2AAD04EB4BB47EAB3 /* CalendarTimelineGeometry.swift */,
+				5DBB6C43E2F34090B7DAF180 /* CalendarScaleControl.swift */,
 				048863E7FD57471FA6624048 /* CalendarMonthView.swift */,
 				A7B5174C0EF14A268F12DB6A /* CalendarMonthGeometry.swift */,
 			);
@@ -1147,6 +1150,7 @@
 				ECA61DF2A3514227AE5AA6A1 /* HomeCalendarGeometry.swift in Sources */,
 				496A7E65CD21464891126DC6 /* CalendarTodayShortcut.swift in Sources */,
 				D90FCC73D2E74963876919B5 /* CalendarTimelineGeometry.swift in Sources */,
+				9F5D435D4B7645A5A8C99D31 /* CalendarScaleControl.swift in Sources */,
 				569FE036E08449AF8F597113 /* CalendarMonthView.swift in Sources */,
 				A3810CF638D840DB810683A6 /* CalendarMonthGeometry.swift in Sources */,
 				5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */,

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E2269C28E2B54A91B18A84BC /* HomeCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BB304B8FAD46558ECC1E05 /* HomeCalendarView.swift */; };
+		F6D1CC2D5E6F4344873AE017 /* HomeCalendarTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631501C38B2A4B27B4E35987 /* HomeCalendarTimelineView.swift */; };
+		AEF093035C8E42138C29A58F /* HomeCalendarScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DF65860F824982ADD7CA90 /* HomeCalendarScrollView.swift */; };
+		ECA61DF2A3514227AE5AA6A1 /* HomeCalendarGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DB1CE831874CF099493DE6 /* HomeCalendarGeometry.swift */; };
+		496A7E65CD21464891126DC6 /* CalendarTodayShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6DB69B1F13439FB0563335 /* CalendarTodayShortcut.swift */; };
+		D90FCC73D2E74963876919B5 /* CalendarTimelineGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36BDAE2AAD04EB4BB47EAB3 /* CalendarTimelineGeometry.swift */; };
+		569FE036E08449AF8F597113 /* CalendarMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048863E7FD57471FA6624048 /* CalendarMonthView.swift */; };
+		A3810CF638D840DB810683A6 /* CalendarMonthGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B5174C0EF14A268F12DB6A /* CalendarMonthGeometry.swift */; };
 		07FE456E7AEA085D9FCA6D97 /* MeetingLinkDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B2A5E5F4D28F1DD9CD0B09 /* MeetingLinkDetector.swift */; };
 		1100290C2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1100290B2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift */; };
 		110029272E84FD4C00035A57 /* TemporaryFileStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110029262E84FD4C00035A57 /* TemporaryFileStorageService.swift */; };
@@ -220,6 +228,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		21BB304B8FAD46558ECC1E05 /* HomeCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarView.swift; sourceTree = "<group>"; };
+		631501C38B2A4B27B4E35987 /* HomeCalendarTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarTimelineView.swift; sourceTree = "<group>"; };
+		54DF65860F824982ADD7CA90 /* HomeCalendarScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarScrollView.swift; sourceTree = "<group>"; };
+		33DB1CE831874CF099493DE6 /* HomeCalendarGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarGeometry.swift; sourceTree = "<group>"; };
+		CE6DB69B1F13439FB0563335 /* CalendarTodayShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTodayShortcut.swift; sourceTree = "<group>"; };
+		F36BDAE2AAD04EB4BB47EAB3 /* CalendarTimelineGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTimelineGeometry.swift; sourceTree = "<group>"; };
+		048863E7FD57471FA6624048 /* CalendarMonthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMonthView.swift; sourceTree = "<group>"; };
+		A7B5174C0EF14A268F12DB6A /* CalendarMonthGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMonthGeometry.swift; sourceTree = "<group>"; };
 		0268933F488E47DFB58E48CF /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		033B8885979E4EA1A78E8ADC /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		1100290B2E847E2800035A57 /* NSItemProvider+LoadHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSItemProvider+LoadHelpers.swift"; sourceTree = "<group>"; };
@@ -694,6 +710,14 @@
 			isa = PBXGroup;
 			children = (
 				14C08BB82C8DE4B1000F8AA0 /* BoringCalendar.swift */,
+				21BB304B8FAD46558ECC1E05 /* HomeCalendarView.swift */,
+				631501C38B2A4B27B4E35987 /* HomeCalendarTimelineView.swift */,
+				54DF65860F824982ADD7CA90 /* HomeCalendarScrollView.swift */,
+				33DB1CE831874CF099493DE6 /* HomeCalendarGeometry.swift */,
+				CE6DB69B1F13439FB0563335 /* CalendarTodayShortcut.swift */,
+				F36BDAE2AAD04EB4BB47EAB3 /* CalendarTimelineGeometry.swift */,
+				048863E7FD57471FA6624048 /* CalendarMonthView.swift */,
+				A7B5174C0EF14A268F12DB6A /* CalendarMonthGeometry.swift */,
 			);
 			path = Calendar;
 			sourceTree = "<group>";
@@ -1105,6 +1129,14 @@
 			files = (
 				115C12EC2ED3D003009754CA /* OpenNotchOSD.swift in Sources */,
 				14C08BB92C8DE4B1000F8AA0 /* BoringCalendar.swift in Sources */,
+				E2269C28E2B54A91B18A84BC /* HomeCalendarView.swift in Sources */,
+				F6D1CC2D5E6F4344873AE017 /* HomeCalendarTimelineView.swift in Sources */,
+				AEF093035C8E42138C29A58F /* HomeCalendarScrollView.swift in Sources */,
+				ECA61DF2A3514227AE5AA6A1 /* HomeCalendarGeometry.swift in Sources */,
+				496A7E65CD21464891126DC6 /* CalendarTodayShortcut.swift in Sources */,
+				D90FCC73D2E74963876919B5 /* CalendarTimelineGeometry.swift in Sources */,
+				569FE036E08449AF8F597113 /* CalendarMonthView.swift in Sources */,
+				A3810CF638D840DB810683A6 /* CalendarMonthGeometry.swift in Sources */,
 				5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */,
 				1100292A2E8691B400035A57 /* FileShareView.swift in Sources */,
 				147163982C5D35B70068B555 /* MusicVisualizer.swift in Sources */,

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		ECA61DF2A3514227AE5AA6A1 /* HomeCalendarGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DB1CE831874CF099493DE6 /* HomeCalendarGeometry.swift */; };
 		496A7E65CD21464891126DC6 /* CalendarTodayShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6DB69B1F13439FB0563335 /* CalendarTodayShortcut.swift */; };
 		D90FCC73D2E74963876919B5 /* CalendarTimelineGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36BDAE2AAD04EB4BB47EAB3 /* CalendarTimelineGeometry.swift */; };
+		9F5D435D4B7645A5A8C99D31 /* CalendarScaleControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DBB6C43E2F34090B7DAF180 /* CalendarScaleControl.swift */; };
 		569FE036E08449AF8F597113 /* CalendarMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048863E7FD57471FA6624048 /* CalendarMonthView.swift */; };
 		A3810CF638D840DB810683A6 /* CalendarMonthGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B5174C0EF14A268F12DB6A /* CalendarMonthGeometry.swift */; };
 		07FE456E7AEA085D9FCA6D97 /* MeetingLinkDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B2A5E5F4D28F1DD9CD0B09 /* MeetingLinkDetector.swift */; };
@@ -234,6 +235,7 @@
 		33DB1CE831874CF099493DE6 /* HomeCalendarGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCalendarGeometry.swift; sourceTree = "<group>"; };
 		CE6DB69B1F13439FB0563335 /* CalendarTodayShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTodayShortcut.swift; sourceTree = "<group>"; };
 		F36BDAE2AAD04EB4BB47EAB3 /* CalendarTimelineGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTimelineGeometry.swift; sourceTree = "<group>"; };
+		5DBB6C43E2F34090B7DAF180 /* CalendarScaleControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarScaleControl.swift; sourceTree = "<group>"; };
 		048863E7FD57471FA6624048 /* CalendarMonthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMonthView.swift; sourceTree = "<group>"; };
 		A7B5174C0EF14A268F12DB6A /* CalendarMonthGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMonthGeometry.swift; sourceTree = "<group>"; };
 		0268933F488E47DFB58E48CF /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
@@ -716,6 +718,7 @@
 				33DB1CE831874CF099493DE6 /* HomeCalendarGeometry.swift */,
 				CE6DB69B1F13439FB0563335 /* CalendarTodayShortcut.swift */,
 				F36BDAE2AAD04EB4BB47EAB3 /* CalendarTimelineGeometry.swift */,
+				5DBB6C43E2F34090B7DAF180 /* CalendarScaleControl.swift */,
 				048863E7FD57471FA6624048 /* CalendarMonthView.swift */,
 				A7B5174C0EF14A268F12DB6A /* CalendarMonthGeometry.swift */,
 			);
@@ -1135,6 +1138,7 @@
 				ECA61DF2A3514227AE5AA6A1 /* HomeCalendarGeometry.swift in Sources */,
 				496A7E65CD21464891126DC6 /* CalendarTodayShortcut.swift in Sources */,
 				D90FCC73D2E74963876919B5 /* CalendarTimelineGeometry.swift in Sources */,
+				9F5D435D4B7645A5A8C99D31 /* CalendarScaleControl.swift in Sources */,
 				569FE036E08449AF8F597113 /* CalendarMonthView.swift in Sources */,
 				A3810CF638D840DB810683A6 /* CalendarMonthGeometry.swift in Sources */,
 				5955950D2E900ED800C66711 /* ApplicationRelauncher.swift in Sources */,

--- a/boringNotch/BoringViewCoordinator.swift
+++ b/boringNotch/BoringViewCoordinator.swift
@@ -45,6 +45,7 @@ struct ExpandedItem {
 final class BoringViewCoordinator: ObservableObject {
     static let shared = BoringViewCoordinator()
 
+    @Published var calendarDate = Date()
     @Published var currentView: NotchViews = .home
     @Published var helloAnimationRunning: Bool = false
     private var osdEnableTask: Task<Void, Never>?

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -40,6 +40,7 @@ struct ContentView: View {
     @Namespace var albumArtNamespace
 
     @Default(.showNotHumanFace) var showNotHumanFace
+    @Default(.showCalendar) private var showCalendar
 
     // Use standardized animations from StandardAnimations enum
     private let animationSpring = StandardAnimations.interactive
@@ -305,6 +306,13 @@ struct ContentView: View {
                                 }
                             }
                         }
+                    }
+                    .onChange(of: coordinator.currentView) { _, view in
+                        guard vm.notchState == .open else { return }
+                        withAnimation(.smooth(duration: 0.2)) { vm.notchSize = notchOpenSize(for: view) }
+                    }
+                    .onChange(of: showCalendar) { _, enabled in
+                        if !enabled && coordinator.currentView == .calendar { coordinator.currentView = .home }
                     }
                     .onChange(of: vm.notchState) { _, newState in
                         if newState == .closed && isHovering {
@@ -577,6 +585,8 @@ struct ContentView: View {
                                 dropInteraction: vm.dropInteraction,
                                 animation: vm.animation
                             )
+                        case .calendar:
+                            CalendarTimelineView()
                         }
                     }
                 }

--- a/boringNotch/Providers/CalendarServiceProviding.swift
+++ b/boringNotch/Providers/CalendarServiceProviding.swift
@@ -14,6 +14,7 @@ protocol CalendarServiceProviding {
     func requestAccess(to type: EKEntityType) async throws -> Bool
     func calendars() async -> [CalendarModel]
     func events(from start: Date, to end: Date, calendars: [String]) async -> [EventModel]
+    func setReminderCompleted(reminderID: String, completed: Bool) async
 }
 
 class CalendarService: CalendarServiceProviding {
@@ -55,27 +56,28 @@ class CalendarService: CalendarServiceProviding {
     }
     
     func events(from start: Date, to end: Date, calendars ids: [String]) async -> [EventModel] {
-        let allCalendars = await self.calendars()
-        let filteredCalendars = allCalendars.filter { ids.isEmpty || ids.contains($0.id) }
-        let ekCalendars = filteredCalendars.compactMap { calendarModel in
-            store.calendars(for: .event).first { $0.calendarIdentifier == calendarModel.id } ??
-            store.calendars(for: .reminder).first { $0.calendarIdentifier == calendarModel.id }
-        }
+        let identifiers = Set(ids)
+        guard !identifiers.isEmpty else { return [] }
         
         var events: [EventModel] = []
         
         // Fetch regular events
         if hasAccess(to: .event) {
-            let eventCalendars = ekCalendars.filter { store.calendars(for: .event).contains($0) }
-            let predicate = store.predicateForEvents(withStart: start, end: end, calendars: eventCalendars)
-            let ekEvents = store.events(matching: predicate)
-            events.append(contentsOf: ekEvents.compactMap { EventModel(from: $0) })
+            let calendars = store.calendars(for: .event).filter { identifiers.contains($0.calendarIdentifier) }
+            // An empty EventKit calendar list can mean every calendar, so skip it.
+            if !calendars.isEmpty {
+                let predicate = store.predicateForEvents(withStart: start, end: end, calendars: calendars)
+                let ekEvents = store.events(matching: predicate)
+                events.append(contentsOf: ekEvents.compactMap { EventModel(from: $0) })
+            }
         }
         
         // Fetch reminders
         if hasAccess(to: .reminder) {
-            let reminderCalendars = ekCalendars.filter { store.calendars(for: .reminder).contains($0) }
-            events.append(contentsOf: await fetchReminders(from: start, to: end, calendars: reminderCalendars))
+            let calendars = store.calendars(for: .reminder).filter { identifiers.contains($0.calendarIdentifier) }
+            if !calendars.isEmpty {
+                events.append(contentsOf: await fetchReminders(from: start, to: end, calendars: calendars))
+            }
         }
         
         return events.sorted { $0.start < $1.start }

--- a/boringNotch/components/Calendar/CalendarDayScrollView.swift
+++ b/boringNotch/components/Calendar/CalendarDayScrollView.swift
@@ -1,0 +1,197 @@
+//
+//  CalendarDayScrollView.swift
+//  boringNotch
+//
+
+import AppKit
+import SwiftUI
+
+/// A frozen day gutter beside a shared two-axis timeline viewport.
+struct CalendarDayScrollView<Labels: View, Content: View>: NSViewRepresentable {
+    let days: [CalendarDayStackGeometry.Day]
+    let visibleRanges: [DateInterval]
+    let targetDay: Date
+    let targetTime: Date
+    let focusCurrentTime: Bool
+    let resetID: Int
+    let onScroll: (CalendarDayStackGeometry.Position, Bool) -> Void
+    let onPositionApplied: (Int) -> Void
+    @ViewBuilder let labels: () -> Labels
+    @ViewBuilder let content: () -> Content
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> CalendarDayScrollContainer {
+        let container = CalendarDayScrollContainer()
+        let coordinator = context.coordinator
+        let hosting = NSHostingView(rootView: content())
+        let labelHosting = NSHostingView(rootView: labels())
+        hosting.isFlipped = true
+        labelHosting.isFlipped = true
+        hosting.sizingOptions = []
+        labelHosting.sizingOptions = []
+        container.scrollView.documentView = hosting
+        container.gutter.documentView = labelHosting
+        coordinator.hosting = hosting
+        coordinator.labelHosting = labelHosting
+        container.scrollView.contentView.postsBoundsChangedNotifications = true
+        coordinator.observer = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification, object: container.scrollView.contentView, queue: .main
+        ) { [weak container, weak coordinator] _ in
+            guard let container, let coordinator else { return }
+            let origin = container.scrollView.contentView.bounds.origin
+            container.gutter.scroll(to: NSPoint(x: 0, y: origin.y))
+            let vertical = abs(origin.y - coordinator.lastOrigin.y) > 0.1
+            let moved = vertical || abs(origin.x - coordinator.lastOrigin.x) > 0.1
+            coordinator.lastOrigin = origin
+            guard moved, !coordinator.updating, !container.scrollView.applyingPendingPosition,
+                  let position = CalendarDayStackGeometry.position(at: origin.y, in: coordinator.days) else { return }
+            coordinator.onScroll?(position, vertical)
+        }
+        return container
+    }
+
+    func updateNSView(_ container: CalendarDayScrollContainer, context: Context) {
+        let coordinator = context.coordinator
+        let origin = container.scrollView.requestedOrigin
+        let previousPosition = CalendarDayStackGeometry.position(at: origin.y, in: coordinator.days)
+        let oldRange = previousPosition.flatMap { coordinator.ranges[$0.day] }
+        let previousTime = oldRange.map { min($0.end, $0.start.addingTimeInterval(origin.x / CalendarDayStackGeometry.pointsPerHour * 3600)) }
+        let ranges = Dictionary(uniqueKeysWithValues: zip(days, visibleRanges).map { ($0.0.id, $0.1) })
+        let changedWindow = coordinator.days.first?.id != days.first?.id
+        let changedRanges = coordinator.ranges != ranges
+        let shouldReset = coordinator.resetID != resetID
+        if shouldReset { coordinator.pendingResetID = resetID }
+        coordinator.updating = true
+        coordinator.days = days
+        coordinator.ranges = ranges
+        coordinator.resetID = resetID
+        coordinator.onScroll = onScroll
+        coordinator.onPositionApplied = onPositionApplied
+        let width = (visibleRanges.map(\.duration).max() ?? 12 * 3600) / 3600 * CalendarDayStackGeometry.pointsPerHour
+        let height = CalendarDayStackGeometry.documentHeight(for: days)
+        coordinator.hosting?.rootView = content()
+        coordinator.hosting?.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        coordinator.labelHosting?.rootView = labels()
+        coordinator.labelHosting?.frame = NSRect(x: 0, y: 0, width: 47, height: height)
+        if changedWindow || changedRanges || shouldReset {
+            let position = shouldReset ? CalendarDayStackGeometry.Position(day: targetDay, intraDayOffset: 0)
+                : previousPosition ?? .init(day: targetDay, intraDayOffset: 0)
+            let time = shouldReset ? targetTime : previousTime ?? targetTime
+            let range = ranges[position.day] ?? visibleRanges.first
+            let x = (range.map { CalendarTimelineGeometry.position(of: time, in: $0, pointsPerHour: CalendarDayStackGeometry.pointsPerHour) } ?? 0)
+                - (shouldReset && focusCurrentTime ? CalendarDayStackGeometry.pointsPerHour : 0)
+            let beforeHours = shouldReset && time >= position.day && range.map { time < $0.start } == true
+            let y = CalendarDayStackGeometry.offset(of: position, in: days) - (beforeHours ? CalendarDayStackGeometry.rowSpacing : 0)
+            let appliedID = coordinator.pendingResetID
+            container.scrollView.move(to: NSPoint(x: x, y: y)) {
+                guard let appliedID else { return }
+                DispatchQueue.main.async { [weak coordinator] in
+                    guard let coordinator, coordinator.pendingResetID == appliedID, coordinator.resetID == appliedID else { return }
+                    coordinator.pendingResetID = nil
+                    coordinator.onPositionApplied?(appliedID)
+                }
+            }
+        }
+        let updatedOrigin = container.scrollView.contentView.bounds.origin
+        container.gutter.scroll(to: NSPoint(x: 0, y: updatedOrigin.y))
+        coordinator.lastOrigin = updatedOrigin
+        coordinator.updating = false
+    }
+
+    static func dismantleNSView(_ container: CalendarDayScrollContainer, coordinator: Coordinator) {
+        if let observer = coordinator.observer { NotificationCenter.default.removeObserver(observer) }
+        coordinator.observer = nil
+        coordinator.onScroll = nil
+        coordinator.onPositionApplied = nil
+        container.scrollView.documentView = nil
+        container.gutter.documentView = nil
+    }
+
+    final class Coordinator {
+        var hosting: NSHostingView<Content>?
+        var labelHosting: NSHostingView<Labels>?
+        var days: [CalendarDayStackGeometry.Day] = []
+        var ranges: [Date: DateInterval] = [:]
+        var resetID: Int?
+        var pendingResetID: Int?
+        var observer: NSObjectProtocol?
+        var updating = false
+        var lastOrigin = NSPoint.zero
+        var onScroll: ((CalendarDayStackGeometry.Position, Bool) -> Void)?
+        var onPositionApplied: ((Int) -> Void)?
+    }
+}
+
+final class CalendarDayScrollContainer: NSView {
+    let scrollView = CalendarDayNativeScrollView()
+    let gutter = NSClipView()
+    override var isFlipped: Bool { true }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        scrollView.hasHorizontalScroller = false
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = false
+        scrollView.scrollerStyle = .overlay
+        scrollView.verticalScroller?.controlSize = .small
+        scrollView.horizontalScrollElasticity = .none
+        scrollView.verticalScrollElasticity = .none
+        gutter.drawsBackground = false
+        addSubview(gutter)
+        addSubview(scrollView)
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    override func layout() {
+        super.layout()
+        gutter.frame = NSRect(x: 0, y: 0, width: 47, height: bounds.height)
+        scrollView.frame = NSRect(x: 55, y: 0, width: max(0, bounds.width - 55), height: bounds.height)
+        scrollView.needsLayout = true
+        scrollView.layoutSubtreeIfNeeded()
+    }
+
+    override func scrollWheel(with event: NSEvent) { scrollView.scrollWheel(with: event) }
+}
+
+final class CalendarDayNativeScrollView: NSScrollView {
+    private var pendingPosition: NSPoint?
+    private var pendingCompletion: (() -> Void)?
+    private(set) var applyingPendingPosition = false
+    var requestedOrigin: NSPoint { pendingPosition ?? contentView.bounds.origin }
+
+    override func layout() {
+        super.layout()
+        if let point = pendingPosition, contentView.bounds.width > 0, contentView.bounds.height > 0 {
+            applyingPendingPosition = true
+            move(to: point, onApplied: pendingCompletion)
+            applyingPendingPosition = false
+        }
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        let scale: CGFloat = event.hasPreciseScrollingDeltas ? 1 : 12
+        // Each axis keeps its job: days travel vertically, hours horizontally.
+        move(to: NSPoint(x: contentView.bounds.minX - event.scrollingDeltaX * scale,
+                         y: contentView.bounds.minY - event.scrollingDeltaY * scale))
+    }
+
+    func move(to point: NSPoint, onApplied: (() -> Void)? = nil) {
+        guard contentView.bounds.width > 0, contentView.bounds.height > 0 else {
+            pendingPosition = point
+            pendingCompletion = onApplied
+            return
+        }
+        pendingPosition = nil
+        pendingCompletion = nil
+        let size = documentView?.frame.size ?? .zero
+        let maximumX = max(0, size.width - contentView.bounds.width)
+        let maximumY = max(0, size.height - contentView.bounds.height)
+        contentView.scroll(to: NSPoint(x: min(max(0, point.x), maximumX), y: min(max(0, point.y), maximumY)))
+        reflectScrolledClipView(contentView)
+        onApplied?()
+    }
+}

--- a/boringNotch/components/Calendar/CalendarDayScrollView.swift
+++ b/boringNotch/components/Calendar/CalendarDayScrollView.swift
@@ -73,7 +73,7 @@ struct CalendarDayScrollView<Labels: View, Content: View>: NSViewRepresentable {
         coordinator.hosting?.rootView = content()
         coordinator.hosting?.frame = NSRect(x: 0, y: 0, width: width, height: height)
         coordinator.labelHosting?.rootView = labels()
-        coordinator.labelHosting?.frame = NSRect(x: 0, y: 0, width: 47, height: height)
+        coordinator.labelHosting?.frame = NSRect(x: 0, y: 0, width: 68, height: height)
         if changedWindow || changedRanges || shouldReset {
             let position = shouldReset ? CalendarDayStackGeometry.Position(day: targetDay, intraDayOffset: 0)
                 : previousPosition ?? .init(day: targetDay, intraDayOffset: 0)
@@ -148,8 +148,8 @@ final class CalendarDayScrollContainer: NSView {
 
     override func layout() {
         super.layout()
-        gutter.frame = NSRect(x: 0, y: 0, width: 47, height: bounds.height)
-        scrollView.frame = NSRect(x: 55, y: 0, width: max(0, bounds.width - 55), height: bounds.height)
+        gutter.frame = NSRect(x: 0, y: 0, width: 68, height: bounds.height)
+        scrollView.frame = NSRect(x: 76, y: 0, width: max(0, bounds.width - 76), height: bounds.height)
         scrollView.needsLayout = true
         scrollView.layoutSubtreeIfNeeded()
     }

--- a/boringNotch/components/Calendar/CalendarDayScrollView.swift
+++ b/boringNotch/components/Calendar/CalendarDayScrollView.swift
@@ -14,6 +14,7 @@ struct CalendarDayScrollView<Labels: View, Content: View>: NSViewRepresentable {
     let targetTime: Date
     let focusCurrentTime: Bool
     let resetID: Int
+    var pointsPerHour = CalendarDayStackGeometry.pointsPerHour
     let onScroll: (CalendarDayStackGeometry.Position, Bool) -> Void
     let onPositionApplied: (Int) -> Void
     @ViewBuilder let labels: () -> Labels
@@ -56,7 +57,11 @@ struct CalendarDayScrollView<Labels: View, Content: View>: NSViewRepresentable {
         let origin = container.scrollView.requestedOrigin
         let previousPosition = CalendarDayStackGeometry.position(at: origin.y, in: coordinator.days)
         let oldRange = previousPosition.flatMap { coordinator.ranges[$0.day] }
-        let previousTime = oldRange.map { min($0.end, $0.start.addingTimeInterval(origin.x / CalendarDayStackGeometry.pointsPerHour * 3600)) }
+        let changedScale = coordinator.pointsPerHour != pointsPerHour
+        let anchorOffset = changedScale ? container.scrollView.contentView.bounds.width / 2 : 0
+        let previousTime = oldRange.map {
+            min($0.end, $0.start.addingTimeInterval((origin.x + anchorOffset) / coordinator.pointsPerHour * 3600))
+        }
         let ranges = Dictionary(uniqueKeysWithValues: zip(days, visibleRanges).map { ($0.0.id, $0.1) })
         let changedWindow = coordinator.days.first?.id != days.first?.id
         let changedRanges = coordinator.ranges != ranges
@@ -65,22 +70,23 @@ struct CalendarDayScrollView<Labels: View, Content: View>: NSViewRepresentable {
         coordinator.updating = true
         coordinator.days = days
         coordinator.ranges = ranges
+        coordinator.pointsPerHour = pointsPerHour
         coordinator.resetID = resetID
         coordinator.onScroll = onScroll
         coordinator.onPositionApplied = onPositionApplied
-        let width = (visibleRanges.map(\.duration).max() ?? 12 * 3600) / 3600 * CalendarDayStackGeometry.pointsPerHour
+        let width = (visibleRanges.map(\.duration).max() ?? 12 * 3600) / 3600 * pointsPerHour
         let height = CalendarDayStackGeometry.documentHeight(for: days)
         coordinator.hosting?.rootView = content()
         coordinator.hosting?.frame = NSRect(x: 0, y: 0, width: width, height: height)
         coordinator.labelHosting?.rootView = labels()
         coordinator.labelHosting?.frame = NSRect(x: 0, y: 0, width: 68, height: height)
-        if changedWindow || changedRanges || shouldReset {
+        if changedWindow || changedRanges || changedScale || shouldReset {
             let position = shouldReset ? CalendarDayStackGeometry.Position(day: targetDay, intraDayOffset: 0)
                 : previousPosition ?? .init(day: targetDay, intraDayOffset: 0)
             let time = shouldReset ? targetTime : previousTime ?? targetTime
             let range = ranges[position.day] ?? visibleRanges.first
-            let x = (range.map { CalendarTimelineGeometry.position(of: time, in: $0, pointsPerHour: CalendarDayStackGeometry.pointsPerHour) } ?? 0)
-                - (shouldReset && focusCurrentTime ? CalendarDayStackGeometry.pointsPerHour : 0)
+            let x = (range.map { CalendarTimelineGeometry.position(of: time, in: $0, pointsPerHour: pointsPerHour) } ?? 0)
+                - (shouldReset ? (focusCurrentTime ? pointsPerHour : 0) : anchorOffset)
             let beforeHours = shouldReset && time >= position.day && range.map { time < $0.start } == true
             let y = CalendarDayStackGeometry.offset(of: position, in: days) - (beforeHours ? CalendarDayStackGeometry.rowSpacing : 0)
             let appliedID = coordinator.pendingResetID
@@ -113,6 +119,7 @@ struct CalendarDayScrollView<Labels: View, Content: View>: NSViewRepresentable {
         var labelHosting: NSHostingView<Labels>?
         var days: [CalendarDayStackGeometry.Day] = []
         var ranges: [Date: DateInterval] = [:]
+        var pointsPerHour = CalendarDayStackGeometry.pointsPerHour
         var resetID: Int?
         var pendingResetID: Int?
         var observer: NSObjectProtocol?

--- a/boringNotch/components/Calendar/CalendarDayStackGeometry.swift
+++ b/boringNotch/components/Calendar/CalendarDayStackGeometry.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Days keep a fixed row height while their horizontal timeline preserves elapsed time.
 enum CalendarDayStackGeometry {
     static let rowHeight = 94.0
-    static let rowSpacing = 12.0
+    static let rowSpacing = 16.0
     static let rowStride = rowHeight + rowSpacing
     static let pointsPerHour = 96.0
 

--- a/boringNotch/components/Calendar/CalendarDayStackGeometry.swift
+++ b/boringNotch/components/Calendar/CalendarDayStackGeometry.swift
@@ -1,0 +1,71 @@
+//
+//  CalendarDayStackGeometry.swift
+//  boringNotch
+//
+
+import Foundation
+
+/// Days keep a fixed row height while their horizontal timeline preserves elapsed time.
+enum CalendarDayStackGeometry {
+    static let rowHeight = 94.0
+    static let rowSpacing = 12.0
+    static let rowStride = rowHeight + rowSpacing
+    static let pointsPerHour = 96.0
+
+    struct Day: Identifiable {
+        let interval: DateInterval
+
+        var id: Date { interval.start }
+    }
+
+    struct Position: Equatable {
+        let day: Date
+        let intraDayOffset: Double
+    }
+
+    static func days(centeredOn date: Date, calendar: Calendar = .current) -> [Day] {
+        let center = calendar.startOfDay(for: date)
+        return (-3...3).compactMap { offset in
+            guard let day = calendar.date(byAdding: .day, value: offset, to: center),
+                  let interval = calendar.dateInterval(of: .day, for: day) else { return nil }
+            return Day(interval: interval)
+        }
+    }
+
+    static func span(of days: [Day]) -> DateInterval? {
+        guard let first = days.first, let last = days.last else { return nil }
+        return DateInterval(start: first.interval.start, end: last.interval.end)
+    }
+
+    static func position(at offset: Double, in days: [Day]) -> Position? {
+        guard !days.isEmpty else { return nil }
+        let y = min(max(offset, 0), documentHeight(for: days))
+        let index = min(Int(floor(y / rowStride)), days.count - 1)
+        return Position(day: days[index].id, intraDayOffset: y - Double(index) * rowStride)
+    }
+
+    static func offset(of position: Position, in days: [Day]) -> Double {
+        guard let first = days.first else { return 0 }
+        guard let index = days.firstIndex(where: { $0.id == position.day }) else {
+            return position.day < first.id ? 0 : documentHeight(for: days)
+        }
+        let y = Double(index) * rowStride + min(max(position.intraDayOffset, 0), rowStride)
+        return min(y, documentHeight(for: days))
+    }
+
+    static func needsRecentering(position: Position, in days: [Day]) -> Bool {
+        guard let index = days.firstIndex(where: { $0.id == position.day }) else { return true }
+        return index < 1 || index >= days.count - 3
+    }
+
+    static func documentHeight(for days: [Day]) -> Double {
+        max(0, Double(days.count) * rowStride - rowSpacing)
+    }
+
+    static func hiddenTimeOffset(for date: Date, in day: DateInterval, visibleRange: DateInterval) -> Double? {
+        guard date >= day.start && date < day.end else { return nil }
+        if date < visibleRange.start { return -rowSpacing / 2 }
+        if date >= visibleRange.end { return rowHeight + rowSpacing / 2 }
+        return nil
+    }
+}

--- a/boringNotch/components/Calendar/CalendarMonthGeometry.swift
+++ b/boringNotch/components/Calendar/CalendarMonthGeometry.swift
@@ -1,0 +1,19 @@
+//
+//  CalendarMonthGeometry.swift
+//  boringNotch
+//
+
+import Foundation
+
+enum CalendarMonthGeometry {
+    static func cells(containing date: Date, calendar: Calendar) -> [Date?] {
+        guard let month = calendar.dateInterval(of: .month, for: date),
+              let days = calendar.range(of: .day, in: .month, for: date) else { return [] }
+        let leading = (calendar.component(.weekday, from: month.start) - calendar.firstWeekday + 7) % 7
+        return (0..<42).map { index in
+            let day = index - leading
+            guard day >= 0, day < days.count else { return nil }
+            return calendar.date(byAdding: .day, value: day, to: month.start)
+        }
+    }
+}

--- a/boringNotch/components/Calendar/CalendarMonthView.swift
+++ b/boringNotch/components/Calendar/CalendarMonthView.swift
@@ -1,0 +1,136 @@
+//
+//  CalendarMonthView.swift
+//  boringNotch
+//
+//  Calendar timeline and month presentation.
+//
+
+import Defaults
+import SwiftUI
+
+/// A quiet date overview beside the player; selecting a day opens its timeline.
+struct CalendarMonthView: View {
+    var showTimeline: (() -> Void)? = nil
+    var selectDate: ((Date) -> Void)? = nil
+    @ObservedObject private var coordinator = BoringViewCoordinator.shared
+    @Default(.weekStartDay) private var weekStartDay
+    @State private var displayedMonth = Date()
+    private let columnSpacing: CGFloat = 9
+
+    private var cells: [Date?] {
+        let cells = CalendarMonthGeometry.cells(containing: displayedMonth, calendar: calendar)
+        let rows = ((cells.lastIndex { $0 != nil } ?? 0) / 7) + 1
+        return Array(cells.prefix(rows * 7))
+    }
+
+    private var daySize: CGFloat { min(19, 96 / CGFloat(max(1, cells.count / 7))) }
+
+    private var calendar: Calendar {
+        var calendar = Calendar.current
+        calendar.firstWeekday = weekStartDay.firstWeekday
+        return calendar
+    }
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 60)) { context in
+            VStack(spacing: 2) {
+                header(today: context.date)
+                HStack(spacing: columnSpacing) {
+                    ForEach(0..<7, id: \.self) { index in
+                        let weekday = (calendar.firstWeekday - 1 + index) % 7
+                        Text(calendar.veryShortStandaloneWeekdaySymbols[weekday])
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(.gray)
+                            .frame(width: daySize, height: 11)
+                    }
+                }
+                LazyVGrid(columns: Array(repeating: GridItem(.fixed(daySize), spacing: columnSpacing), count: 7), spacing: 0) {
+                    ForEach(Array(cells.enumerated()), id: \.offset) { _, date in
+                        if let date {
+                            dayButton(date, today: context.date)
+                        } else {
+                            Color.clear.frame(width: daySize, height: daySize)
+                                .accessibilityHidden(true)
+                        }
+                    }
+                }
+            }
+            .frame(width: 7 * daySize + 6 * columnSpacing, height: 130, alignment: .top)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .calendarTodayShortcut { showToday() }
+            .onChange(of: calendar.startOfDay(for: context.date)) { oldDay, newDay in
+                if calendar.isDate(displayedMonth, equalTo: oldDay, toGranularity: .month) {
+                    displayedMonth = newDay
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func header(today: Date) -> some View {
+        HStack(spacing: 5) {
+            Text(displayedMonth.formatted(.dateTime.month(.abbreviated)))
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.white)
+            Text(displayedMonth.formatted(.dateTime.year()))
+                .font(.system(size: 10))
+                .foregroundStyle(.gray)
+            Spacer(minLength: 0)
+            if !calendar.isDate(displayedMonth, equalTo: today, toGranularity: .month) {
+                Button("Today", action: showToday)
+                    .font(.system(size: 9, weight: .medium))
+                    .help("Today (T)")
+            }
+            monthArrow("chevron.left", offset: -1)
+            monthArrow("chevron.right", offset: 1)
+            if let showTimeline {
+                Button(action: showTimeline) {
+                    Image(systemName: "chart.bar.xaxis")
+                        .font(.system(size: 10))
+                        .frame(width: 18, height: 19)
+                }
+                .accessibilityLabel("Show day timeline")
+                .help("Show day timeline")
+            }
+        }
+        .frame(height: 19)
+    }
+
+    private func showToday() {
+        let today = Date()
+        displayedMonth = today
+        coordinator.calendarDate = today
+    }
+
+    private func monthArrow(_ symbol: String, offset: Int) -> some View {
+        Button {
+            let start = calendar.dateInterval(of: .month, for: displayedMonth)?.start ?? displayedMonth
+            displayedMonth = calendar.date(byAdding: .month, value: offset, to: start) ?? start
+        } label: {
+            Image(systemName: symbol)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.gray)
+                .frame(width: 16, height: 19)
+                .contentShape(Rectangle())
+        }
+        .accessibilityLabel(offset < 0 ? "Previous month" : "Next month")
+    }
+
+    private func dayButton(_ date: Date, today: Date) -> some View {
+        let isToday = calendar.isDate(date, inSameDayAs: today)
+        return Button {
+            coordinator.calendarDate = date
+            selectDate?(date)
+        } label: {
+            Text("\(calendar.component(.day, from: date))")
+                .font(.system(size: daySize > 16 ? 11 : 10, weight: isToday ? .bold : .medium, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(isToday ? .white : calendar.isDateInWeekend(date) ? Color.gray : Color.white.opacity(0.86))
+                .frame(width: daySize, height: daySize)
+                .background(isToday ? Color.red : .clear, in: RoundedRectangle(cornerRadius: 5))
+                .contentShape(Rectangle())
+        }
+        .accessibilityLabel(date.formatted(date: .complete, time: .omitted))
+        .help("Show timeline for \(date.formatted(date: .abbreviated, time: .omitted))")
+    }
+}

--- a/boringNotch/components/Calendar/CalendarScaleControl.swift
+++ b/boringNotch/components/Calendar/CalendarScaleControl.swift
@@ -9,6 +9,7 @@ struct CalendarScaleControl: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @GestureState private var isDragging = false
     @State private var dragOrigin: Double?
+    @State private var hasDragged = false
     @State private var isHovered = false
 
     private var lowerBound: Double {
@@ -50,8 +51,10 @@ struct CalendarScaleControl: View {
                 .onChanged { value in
                     if dragOrigin == nil {
                         dragOrigin = effectiveScale
+                        hasDragged = false
                         SharingStateManager.shared.beginInteraction()
                     }
+                    hasDragged = hasDragged || hypot(value.translation.width, value.translation.height) >= 4
                     let proposed = (dragOrigin ?? 1.0) + value.translation.width / 160
                     setScale(proposed)
                     if proposed < lowerBound || proposed > CalendarTimelineScale.range.upperBound {
@@ -59,7 +62,13 @@ struct CalendarScaleControl: View {
                         dragOrigin = max(lowerBound, CalendarTimelineScale.clamped(proposed)) - value.translation.width / 160
                     }
                 }
-                .onEnded { _ in finishDragging() }
+                .onEnded { value in
+                    // A round trip is still a drag, even when the pointer comes home.
+                    if dragOrigin != nil, !hasDragged, hypot(value.translation.width, value.translation.height) < 4 {
+                        setScale(1.0)
+                    }
+                    finishDragging()
+                }
         )
         .onChange(of: isDragging) { _, active in
             if !active { finishDragging() }
@@ -75,11 +84,11 @@ struct CalendarScaleControl: View {
                 .disabled(fitsDay)
             Button("Reset to 100%") { setScale(1.0) }
         }
-        .help("Timeline scale: \(scaleDescription). Drag left or right; right-click for Fit Day or reset.")
+        .help("Timeline scale: \(scaleDescription). Drag to zoom; click to reset to 100%; right-click for Fit Day.")
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Timeline scale")
         .accessibilityValue(fitsDay ? "Fit day" : "\(Int((effectiveScale * 100).rounded())) percent")
-        .accessibilityHint("Adjusts horizontal time spacing in both calendar timelines.")
+        .accessibilityHint("Drag to adjust time spacing. Click to reset to 100%.")
         .accessibilityAdjustableAction { direction in
             switch direction {
             case .increment: setScale(effectiveScale + 0.05)
@@ -100,6 +109,7 @@ struct CalendarScaleControl: View {
     private func finishDragging() {
         guard dragOrigin != nil else { return }
         dragOrigin = nil
+        hasDragged = false
         SharingStateManager.shared.endInteraction()
     }
 }

--- a/boringNotch/components/Calendar/CalendarScaleControl.swift
+++ b/boringNotch/components/Calendar/CalendarScaleControl.swift
@@ -1,0 +1,87 @@
+import Defaults
+import SwiftUI
+
+/// A stationary thumbwheel; dragging changes time spacing without resizing the control.
+struct CalendarScaleControl: View {
+    @Default(.calendarTimelineScale) private var scale
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @GestureState private var isDragging = false
+    @State private var dragOrigin: Double?
+    @State private var isHovered = false
+
+    private var percentage: Int {
+        Int((CalendarTimelineScale.clamped(scale) * 100).rounded())
+    }
+
+    var body: some View {
+        Canvas { context, size in
+            let phase = reduceMotion ? 0 : (CalendarTimelineScale.clamped(scale) * 40).truncatingRemainder(dividingBy: 5)
+            for index in -1...6 {
+                let x = CGFloat(index) * 5 + phase
+                let distance = abs(x - size.width / 2) / (size.width / 2)
+                let height = max(4, 12 - distance * 7)
+                let tick = CGRect(x: x, y: (size.height - height) / 2, width: 1.5, height: height)
+                context.fill(Path(roundedRect: tick, cornerRadius: 0.75), with: .color(.white.opacity(max(0.25, 1 - distance * 0.6))))
+            }
+        }
+        .frame(width: 24, height: 16)
+        .clipped()
+        .frame(width: 32, height: 20)
+        .background(.white.opacity(isHovered || isDragging ? 0.16 : 0.08), in: RoundedRectangle(cornerRadius: 5))
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
+        .highPriorityGesture(
+            DragGesture(minimumDistance: 0)
+                .updating($isDragging) { _, active, _ in active = true }
+                .onChanged { value in
+                    if dragOrigin == nil {
+                        dragOrigin = CalendarTimelineScale.clamped(scale)
+                        SharingStateManager.shared.beginInteraction()
+                    }
+                    let proposed = (dragOrigin ?? 1.0) + value.translation.width / 160
+                    setScale(proposed)
+                    if !CalendarTimelineScale.range.contains(proposed) {
+                        // Reverse immediately at a limit, without unwinding the overshoot first.
+                        dragOrigin = CalendarTimelineScale.clamped(proposed) - value.translation.width / 160
+                    }
+                }
+                .onEnded { _ in finishDragging() }
+        )
+        .onChange(of: isDragging) { _, active in
+            if !active { finishDragging() }
+        }
+        .onDisappear { finishDragging() }
+        .contextMenu {
+            Button("Zoom In") { setScale(scale + 0.05) }
+                .disabled(CalendarTimelineScale.clamped(scale) >= CalendarTimelineScale.range.upperBound)
+            Button("Zoom Out") { setScale(scale - 0.05) }
+                .disabled(CalendarTimelineScale.clamped(scale) <= CalendarTimelineScale.range.lowerBound)
+            Divider()
+            Button("Reset to 100%") { setScale(1.0) }
+        }
+        .help("Timeline scale: \(percentage)%. Drag left or right; right-click to reset.")
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Timeline scale")
+        .accessibilityValue("\(percentage) percent")
+        .accessibilityHint("Adjusts horizontal time spacing in both calendar timelines.")
+        .accessibilityAdjustableAction { direction in
+            switch direction {
+            case .increment: setScale(scale + 0.05)
+            case .decrement: setScale(scale - 0.05)
+            @unknown default: break
+            }
+        }
+        .accessibilityAction(named: "Reset to 100%") { setScale(1.0) }
+    }
+
+    private func setScale(_ value: Double) {
+        let next = (CalendarTimelineScale.clamped(value) * 100).rounded() / 100
+        if scale != next { scale = next }
+    }
+
+    private func finishDragging() {
+        guard dragOrigin != nil else { return }
+        dragOrigin = nil
+        SharingStateManager.shared.endInteraction()
+    }
+}

--- a/boringNotch/components/Calendar/CalendarScaleControl.swift
+++ b/boringNotch/components/Calendar/CalendarScaleControl.swift
@@ -3,19 +3,33 @@ import SwiftUI
 
 /// A stationary thumbwheel; dragging changes time spacing without resizing the control.
 struct CalendarScaleControl: View {
+    var minimumScale: Double = 0
+
     @Default(.calendarTimelineScale) private var scale
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @GestureState private var isDragging = false
     @State private var dragOrigin: Double?
     @State private var isHovered = false
 
-    private var percentage: Int {
-        Int((CalendarTimelineScale.clamped(scale) * 100).rounded())
+    private var lowerBound: Double {
+        CalendarTimelineScale.clamped(minimumScale)
+    }
+
+    private var effectiveScale: Double {
+        max(lowerBound, CalendarTimelineScale.clamped(scale))
+    }
+
+    private var fitsDay: Bool {
+        CalendarTimelineScale.clamped(scale) <= lowerBound
+    }
+
+    private var scaleDescription: String {
+        fitsDay ? "Fit day" : "\(Int((effectiveScale * 100).rounded()))%"
     }
 
     var body: some View {
         Canvas { context, size in
-            let phase = reduceMotion ? 0 : (CalendarTimelineScale.clamped(scale) * 40).truncatingRemainder(dividingBy: 5)
+            let phase = reduceMotion ? 0 : (effectiveScale * 40).truncatingRemainder(dividingBy: 5)
             for index in -1...6 {
                 let x = CGFloat(index) * 5 + phase
                 let distance = abs(x - size.width / 2) / (size.width / 2)
@@ -35,14 +49,14 @@ struct CalendarScaleControl: View {
                 .updating($isDragging) { _, active, _ in active = true }
                 .onChanged { value in
                     if dragOrigin == nil {
-                        dragOrigin = CalendarTimelineScale.clamped(scale)
+                        dragOrigin = effectiveScale
                         SharingStateManager.shared.beginInteraction()
                     }
                     let proposed = (dragOrigin ?? 1.0) + value.translation.width / 160
                     setScale(proposed)
-                    if !CalendarTimelineScale.range.contains(proposed) {
+                    if proposed < lowerBound || proposed > CalendarTimelineScale.range.upperBound {
                         // Reverse immediately at a limit, without unwinding the overshoot first.
-                        dragOrigin = CalendarTimelineScale.clamped(proposed) - value.translation.width / 160
+                        dragOrigin = max(lowerBound, CalendarTimelineScale.clamped(proposed)) - value.translation.width / 160
                     }
                 }
                 .onEnded { _ in finishDragging() }
@@ -52,30 +66,34 @@ struct CalendarScaleControl: View {
         }
         .onDisappear { finishDragging() }
         .contextMenu {
-            Button("Zoom In") { setScale(scale + 0.05) }
-                .disabled(CalendarTimelineScale.clamped(scale) >= CalendarTimelineScale.range.upperBound)
-            Button("Zoom Out") { setScale(scale - 0.05) }
-                .disabled(CalendarTimelineScale.clamped(scale) <= CalendarTimelineScale.range.lowerBound)
+            Button("Zoom In") { setScale(effectiveScale + 0.05) }
+                .disabled(effectiveScale >= CalendarTimelineScale.range.upperBound)
+            Button("Zoom Out") { setScale(effectiveScale - 0.05) }
+                .disabled(fitsDay)
             Divider()
+            Button("Fit Day") { setScale(0) }
+                .disabled(fitsDay)
             Button("Reset to 100%") { setScale(1.0) }
         }
-        .help("Timeline scale: \(percentage)%. Drag left or right; right-click to reset.")
+        .help("Timeline scale: \(scaleDescription). Drag left or right; right-click for Fit Day or reset.")
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Timeline scale")
-        .accessibilityValue("\(percentage) percent")
+        .accessibilityValue(fitsDay ? "Fit day" : "\(Int((effectiveScale * 100).rounded())) percent")
         .accessibilityHint("Adjusts horizontal time spacing in both calendar timelines.")
         .accessibilityAdjustableAction { direction in
             switch direction {
-            case .increment: setScale(scale + 0.05)
-            case .decrement: setScale(scale - 0.05)
+            case .increment: setScale(effectiveScale + 0.05)
+            case .decrement: setScale(effectiveScale - 0.05)
             @unknown default: break
             }
         }
+        .accessibilityAction(named: "Fit Day") { setScale(0) }
         .accessibilityAction(named: "Reset to 100%") { setScale(1.0) }
     }
 
     private func setScale(_ value: Double) {
-        let next = (CalendarTimelineScale.clamped(value) * 100).rounded() / 100
+        let rounded = (CalendarTimelineScale.clamped(value) * 100).rounded() / 100
+        let next = value <= lowerBound || rounded <= lowerBound ? 0 : rounded
         if scale != next { scale = next }
     }
 

--- a/boringNotch/components/Calendar/CalendarScaleControl.swift
+++ b/boringNotch/components/Calendar/CalendarScaleControl.swift
@@ -1,11 +1,10 @@
-import Defaults
 import SwiftUI
 
 /// A stationary thumbwheel; dragging changes time spacing without resizing the control.
 struct CalendarScaleControl: View {
+    @Binding var scale: Double
     var minimumScale: Double = 0
 
-    @Default(.calendarTimelineScale) private var scale
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @GestureState private var isDragging = false
     @State private var dragOrigin: Double?

--- a/boringNotch/components/Calendar/CalendarTimelineGeometry.swift
+++ b/boringNotch/components/Calendar/CalendarTimelineGeometry.swift
@@ -195,11 +195,14 @@ enum CalendarTimelineGeometry {
 
 /// Horizontal density changes time geometry, never the event typography.
 enum CalendarTimelineScale {
-    static let range = 0.75...2.5
+    static let range = 0.0...2.5
 
     static func clamped(_ value: Double) -> Double {
         value.isFinite ? min(max(value, range.lowerBound), range.upperBound) : 1
     }
 
-    static func pointsPerHour(for value: Double) -> Double { 96 * clamped(value) }
+    static func pointsPerHour(for value: Double, fitting viewportWidth: Double = 0, duration: TimeInterval = 12 * 3600) -> Double {
+        let fit = duration > 0 && viewportWidth > 0 ? viewportWidth / (duration / 3600) : (value <= 0 ? 96 : 0)
+        return max(fit, 96 * clamped(value))
+    }
 }

--- a/boringNotch/components/Calendar/CalendarTimelineGeometry.swift
+++ b/boringNotch/components/Calendar/CalendarTimelineGeometry.swift
@@ -1,0 +1,165 @@
+//
+//  CalendarTimelineGeometry.swift
+//  boringNotch
+//
+
+import Foundation
+
+/// All positions use elapsed time within a calendar day, including 23- and 25-hour days.
+enum CalendarTimelineGeometry {
+    static let pointsPerHour = 92.0
+    static let minimumHitWidth = 24.0
+
+    struct Interval {
+        let id: String
+        let start: Date
+        let end: Date
+        let isAllDay: Bool
+        let isReminder: Bool
+
+        init(id: String, start: Date, end: Date, isAllDay: Bool = false, isReminder: Bool = false) {
+            self.id = id
+            self.start = start
+            self.end = end
+            self.isAllDay = isAllDay
+            self.isReminder = isReminder
+        }
+    }
+
+    struct Placement: Identifiable {
+        let id: String
+        let x: Double
+        let width: Double
+        let hitX: Double
+        let hitWidth: Double
+        let lane: Int
+    }
+
+    static func dayInterval(for date: Date, calendar: Calendar = .current) -> DateInterval {
+        let start = calendar.startOfDay(for: date)
+        let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start
+        return DateInterval(start: start, end: end)
+    }
+
+    /// Show local daytime by default, retaining the hours needed for timed events.
+    static func visibleRange(in day: DateInterval, events: [Interval], calendar: Calendar = .current) -> DateInterval {
+        var start = localBoundary(at: 7 * 60, in: day, calendar: calendar)
+        var end = localBoundary(at: 19 * 60, in: day, calendar: calendar)
+        for event in events where !event.isAllDay && !event.isReminder && event.end >= event.start {
+            let instant = event.start == event.end
+            guard event.start < day.end,
+                  event.end > day.start || (instant && event.start >= day.start) else { continue }
+            let clippedStart = max(event.start, day.start)
+            let clippedEnd = min(event.end, day.end)
+            if clippedStart < start {
+                let hour = calendar.component(.hour, from: clippedStart)
+                let roundedStart = localBoundary(at: hour * 60, in: day, calendar: calendar)
+                start = max(day.start, min(clippedStart, roundedStart))
+            }
+            if clippedEnd > end || (instant && clippedEnd >= end) {
+                // A point event at the right boundary still needs a visible hit target.
+                let effectiveEnd = instant ? min(day.end, clippedEnd.addingTimeInterval(1)) : clippedEnd
+                let time = calendar.dateComponents([.hour, .minute, .second, .nanosecond], from: effectiveEnd)
+                let exactHour = time.minute == 0 && time.second == 0 && time.nanosecond == 0
+                let nextHour = (time.hour ?? 23) + 1
+                // Round the wall clock, not a 3,600-second bucket: some DST changes last half an hour.
+                let roundedEnd = exactHour ? effectiveEnd : localBoundary(at: nextHour * 60, in: day, calendar: calendar)
+                end = min(day.end, max(effectiveEnd, roundedEnd))
+            }
+        }
+        return DateInterval(start: max(day.start, start), end: min(day.end, end))
+    }
+
+    /// Stacked days share the same local hour bounds, even when their dates differ.
+    static func sharedVisibleRanges(in days: [DateInterval], events: [Interval], calendar: Calendar = .current) -> [DateInterval] {
+        let ranges = days.map { visibleRange(in: $0, events: events, calendar: calendar) }
+        func minuteOfDay(_ date: Date, day: DateInterval) -> Int {
+            if date >= day.end { return 24 * 60 }
+            let time = calendar.dateComponents([.hour, .minute], from: date)
+            return (time.hour ?? 0) * 60 + (time.minute ?? 0)
+        }
+        guard let firstMinute = zip(days, ranges).map({ minuteOfDay($0.1.start, day: $0.0) }).min(),
+              let lastMinute = zip(days, ranges).map({ minuteOfDay($0.1.end, day: $0.0) }).max() else { return [] }
+        return zip(days, ranges).map { day, ownRange in
+            // Keep actual occurrences included through repeated or skipped local hours.
+            return DateInterval(start: max(day.start, min(localBoundary(at: firstMinute, in: day, calendar: calendar), ownRange.start)),
+                                end: min(day.end, max(localBoundary(at: lastMinute, in: day, calendar: calendar), ownRange.end)))
+        }
+    }
+
+    private static func localBoundary(at minute: Int, in day: DateInterval, calendar: Calendar) -> Date {
+        if minute == 0 { return day.start }
+        if minute >= 24 * 60 { return day.end }
+        var components = calendar.dateComponents([.era, .year, .month, .day], from: day.start)
+        components.hour = minute / 60
+        components.minute = minute % 60
+        components.second = 0
+        // Construct on this date: searching for a missing hour can jump to tomorrow.
+        return calendar.date(from: components) ?? day.start
+    }
+
+    static func position(of date: Date, in day: DateInterval, pointsPerHour: Double = pointsPerHour) -> Double {
+        min(max(date.timeIntervalSince(day.start), 0), day.duration) / 3600 * pointsPerHour
+    }
+
+    static func hourTicks(in day: DateInterval) -> [Date] {
+        // Advancing actual hours preserves both occurrences of a repeated autumn hour.
+        var ticks = stride(from: 0.0, through: day.duration, by: 3600).map {
+            day.start.addingTimeInterval($0)
+        }
+        if ticks.last != day.end { ticks.append(day.end) }
+        return ticks
+    }
+
+    static func layout(_ intervals: [Interval], in day: DateInterval, pointsPerHour: Double = pointsPerHour) -> [Placement] {
+        let dayWidth = day.duration / 3600 * pointsPerHour
+        var laneEnds: [Double] = []
+        return intervals
+            .filter {
+                $0.start < day.end && $0.end >= $0.start &&
+                    ($0.end > day.start || ($0.start == $0.end && $0.start >= day.start))
+            }
+            .sorted {
+                if $0.start != $1.start { return $0.start < $1.start }
+                if $0.end != $1.end { return $0.end > $1.end }
+                return $0.id < $1.id
+            }
+            .map { interval in
+                let x = position(of: interval.start, in: day, pointsPerHour: pointsPerHour)
+                let width = position(of: interval.end, in: day, pointsPerHour: pointsPerHour) - x
+                let hitWidth = min(max(width, minimumHitWidth), dayWidth)
+                let hitX = max(0, min(x - (hitWidth - width) / 2, dayWidth - hitWidth))
+                // Tiny meetings get a usable target, without pretending they last longer.
+                let lane = laneEnds.firstIndex(where: { $0 <= hitX }) ?? laneEnds.count
+                if lane == laneEnds.count {
+                    laneEnds.append(hitX + hitWidth)
+                } else {
+                    laneEnds[lane] = hitX + hitWidth
+                }
+                return Placement(id: interval.id, x: x, width: width,
+                                 hitX: hitX, hitWidth: hitWidth, lane: lane)
+            }
+    }
+
+    /// Independent overlap clusters can each use the full available row height.
+    static func clusterLaneCounts(for placements: [Placement]) -> [String: Int] {
+        var counts: [String: Int] = [:]
+        var cluster: [Placement] = []
+        var clusterEnd = -Double.infinity
+        func finishCluster() {
+            let count = (cluster.map(\.lane).max() ?? 0) + 1
+            for placement in cluster { counts[placement.id] = count }
+        }
+        for placement in placements.sorted(by: { $0.hitX < $1.hitX }) {
+            if placement.hitX >= clusterEnd {
+                finishCluster()
+                cluster = []
+                clusterEnd = -Double.infinity
+            }
+            cluster.append(placement)
+            clusterEnd = max(clusterEnd, placement.hitX + placement.hitWidth)
+        }
+        finishCluster()
+        return counts
+    }
+}

--- a/boringNotch/components/Calendar/CalendarTimelineGeometry.swift
+++ b/boringNotch/components/Calendar/CalendarTimelineGeometry.swift
@@ -102,6 +102,35 @@ enum CalendarTimelineGeometry {
         min(max(date.timeIntervalSince(day.start), 0), day.duration) / 3600 * pointsPerHour
     }
 
+    struct HourLabel: Identifiable {
+        let id: Date
+        let x: Double
+        let width: Double
+    }
+
+    /// Pack measured labels without shrinking text, including cropped endpoints and DST suffixes.
+    static func hourLabels(in day: DateInterval, pointsPerHour: Double, widths: [Double],
+                           avoiding exclusions: [Range<Double>] = []) -> [HourLabel] {
+        let ticks = hourTicks(in: day)
+        let totalWidth = day.duration / 3600 * pointsPerHour
+        let candidates = zip(ticks, widths).map { tick, width in
+            HourLabel(id: tick, x: min(max(0, position(of: tick, in: day, pointsPerHour: pointsPerHour) + 4),
+                                      max(0, totalWidth - width)), width: width)
+        }.filter { label in
+            label.width <= totalWidth && !exclusions.contains { $0.overlaps((label.x - 4)..<(label.x + label.width + 4)) }
+        }
+        // The end of the day gets a seat before the remaining labels line up.
+        guard let last = candidates.last else { return [] }
+        var result: [HourLabel] = []
+        var previousEnd = -Double.infinity
+        for label in candidates.dropLast() where label.x >= previousEnd + 6 && label.x + label.width + 6 <= last.x {
+            result.append(label)
+            previousEnd = label.x + label.width
+        }
+        result.append(last)
+        return result
+    }
+
     static func hourTicks(in day: DateInterval) -> [Date] {
         // Advancing actual hours preserves both occurrences of a repeated autumn hour.
         var ticks = stride(from: 0.0, through: day.duration, by: 3600).map {
@@ -162,4 +191,15 @@ enum CalendarTimelineGeometry {
         finishCluster()
         return counts
     }
+}
+
+/// Horizontal density changes time geometry, never the event typography.
+enum CalendarTimelineScale {
+    static let range = 0.75...2.5
+
+    static func clamped(_ value: Double) -> Double {
+        value.isFinite ? min(max(value, range.lowerBound), range.upperBound) : 1
+    }
+
+    static func pointsPerHour(for value: Double) -> Double { 96 * clamped(value) }
 }

--- a/boringNotch/components/Calendar/CalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/CalendarTimelineView.swift
@@ -417,7 +417,7 @@ private struct CalendarTimelineTrack: View {
                         .fill(color)
                         .frame(width: 2)
                     if placement.width > 28 {
-                        VStack(alignment: .leading, spacing: laneHeight > 40 ? 3 : 1) {
+                        VStack(alignment: .leading, spacing: laneHeight >= 52 ? 6 : 1) {
                             Text(event.title)
                                 .font(.system(size: 11, weight: .medium))
                                 .lineLimit(laneHeight >= 52 ? 3 : 1)
@@ -430,6 +430,7 @@ private struct CalendarTimelineTrack: View {
                                     .truncationMode(.tail)
                             }
                         }
+                        .multilineTextAlignment(.leading)
                         Spacer(minLength: 0)
                     }
                 }

--- a/boringNotch/components/Calendar/CalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/CalendarTimelineView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct CalendarTimelineView: View {
     @ObservedObject private var manager = CalendarManager.shared
     @ObservedObject private var coordinator = BoringViewCoordinator.shared
+    @Default(.calendarTimelineScale) private var timelineScale
     @Default(.hideAllDayEvents) private var hideAllDayEvents
     @Default(.hideCompletedReminders) private var hideCompletedReminders
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -38,6 +39,7 @@ struct CalendarTimelineView: View {
         _targetTime = State(initialValue: Self.initialTime(for: date))
     }
 
+    private var pointsPerHour: Double { CalendarTimelineScale.pointsPerHour(for: timelineScale) }
     private var days: [CalendarDayStackGeometry.Day] { CalendarDayStackGeometry.days(centeredOn: windowCenter) }
     private var hasAccess: Bool { calendarAccess == .fullAccess || reminderAccess == .fullAccess }
     private var requestID: String { "\(days.first?.id.timeIntervalSince1970 ?? 0)-\(reloadID)" }
@@ -56,9 +58,9 @@ struct CalendarTimelineView: View {
                 ZStack(alignment: .bottom) {
                     TimelineView(.periodic(from: .now, by: 30)) { context in
                         let ranges = visibleRanges
-                        let width = (ranges.map(\.duration).max() ?? 12 * 3600) / 3600 * CalendarDayStackGeometry.pointsPerHour
+                        let width = (ranges.map(\.duration).max() ?? 12 * 3600) / 3600 * pointsPerHour
                         CalendarDayScrollView(days: days, visibleRanges: ranges, targetDay: targetDay, targetTime: targetTime,
-                                              focusCurrentTime: todayResetID == resetID, resetID: resetID,
+                                              focusCurrentTime: todayResetID == resetID, resetID: resetID, pointsPerHour: pointsPerHour,
                                               onScroll: didScroll, onPositionApplied: didPosition) {
                             VStack(spacing: CalendarDayStackGeometry.rowSpacing) {
                                 ForEach(days) { day in dayLabel(day, now: context.date) }
@@ -67,7 +69,7 @@ struct CalendarTimelineView: View {
                             VStack(alignment: .leading, spacing: CalendarDayStackGeometry.rowSpacing) {
                                 ForEach(Array(days.enumerated()), id: \.element.id) { index, day in
                                     CalendarTimelineTrack(day: day.interval, range: ranges[index], events: events(on: day.interval).filter { !$0.isAllDay && !$0.type.isReminder },
-                                                          selectedEvent: selectedEvent, now: context.date, width: width, highlighted: todayHighlighted) {
+                                                          selectedEvent: selectedEvent, now: context.date, width: width, highlighted: todayHighlighted, pointsPerHour: pointsPerHour) {
                                         select($0, on: day.id)
                                     }
                                 }
@@ -117,6 +119,7 @@ struct CalendarTimelineView: View {
             if loading { ProgressView().controlSize(.mini) }
             Spacer(minLength: 8)
             Text("↕ DAYS   ↔ HOURS").font(.system(size: 9, weight: .medium)).foregroundStyle(.white.opacity(0.4))
+            CalendarScaleControl()
             dayArrow("chevron.up", offset: -1)
             Button("Today", action: goToToday)
                 .font(.system(size: 11, weight: .medium))
@@ -228,8 +231,8 @@ struct CalendarTimelineView: View {
 
     private func selectedBlockIsShort(_ event: EventModel) -> Bool {
         let day = visibleRange(for: targetDay)
-        let start = CalendarTimelineGeometry.position(of: event.start, in: day, pointsPerHour: CalendarDayStackGeometry.pointsPerHour)
-        let end = CalendarTimelineGeometry.position(of: event.end, in: day, pointsPerHour: CalendarDayStackGeometry.pointsPerHour)
+        let start = CalendarTimelineGeometry.position(of: event.start, in: day, pointsPerHour: pointsPerHour)
+        let end = CalendarTimelineGeometry.position(of: event.end, in: day, pointsPerHour: pointsPerHour)
         return end - start <= 28
     }
 
@@ -330,7 +333,7 @@ private struct CalendarTimelineTrack: View {
     let now: Date
     let width: CGFloat
     let highlighted: Bool
-    private var pointsPerHour: Double { CalendarDayStackGeometry.pointsPerHour }
+    let pointsPerHour: Double
     let select: (EventModel) -> Void
 
     private var placements: [CalendarTimelineGeometry.Placement] {
@@ -377,17 +380,9 @@ private struct CalendarTimelineTrack: View {
             }
             .frame(width: width, height: 76, alignment: .topLeading)
             ZStack(alignment: .topLeading) {
-                ForEach(CalendarTimelineGeometry.hourTicks(in: range), id: \.self) { tick in
-                    let labelWidth = CGFloat(pointsPerHour - 4)
-                    let tickX = CGFloat(CalendarTimelineGeometry.position(of: tick, in: range, pointsPerHour: pointsPerHour))
-                    let maximumX = max(0, CGFloat(range.duration / 3600 * pointsPerHour) - labelWidth)
-                    let alignment: Alignment = tick == range.start ? .leading : tick == range.end ? .trailing : .center
-                    Text(tickLabel(tick)).font(.system(size: 11, weight: .medium, design: .monospaced))
-                        .lineLimit(1).truncationMode(.tail)
-                        .frame(width: labelWidth, height: 16, alignment: alignment)
-                        .foregroundStyle(.white.opacity(0.4))
-                        .offset(x: min(max(0, tickX - labelWidth / 2), maximumX))
-                }
+                let badgeLeading = Double(min(max(0, CGFloat(progress) - badgeWidth / 2), max(0, width - badgeWidth)))
+                CalendarTimelineHourLabels(range: range, pointsPerHour: pointsPerHour,
+                                           exclusions: currentDay ? [badgeLeading..<(badgeLeading + Double(badgeWidth))] : [], format: tickLabel)
                 if currentDay {
                     CalendarTimelineTimeBadge(time: now, highlighted: highlighted)
                         .offset(x: min(max(0, CGFloat(progress) - badgeWidth / 2), max(0, width - badgeWidth)))

--- a/boringNotch/components/Calendar/CalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/CalendarTimelineView.swift
@@ -81,10 +81,10 @@ struct CalendarTimelineView: View {
                             .background(.black)
                     }
                 }
-                .frame(height: 202)
+                .frame(height: 204)
                 .clipped()
             } else {
-                permissionState.frame(height: 202)
+                permissionState.frame(height: 204)
             }
         }
         .foregroundStyle(.white)
@@ -166,7 +166,7 @@ struct CalendarTimelineView: View {
             Spacer(minLength: 0)
         }
         .padding(.top, 2)
-        .frame(width: 47, height: CalendarDayStackGeometry.rowHeight, alignment: .topLeading)
+        .frame(width: 68, height: CalendarDayStackGeometry.rowHeight, alignment: .topLeading)
         .overlay(alignment: .trailing) {
             Path { path in
                 path.move(to: CGPoint(x: 0, y: 0))
@@ -183,7 +183,7 @@ struct CalendarTimelineView: View {
         .overlay(alignment: .topLeading) {
             if let y = CalendarDayStackGeometry.hiddenTimeOffset(for: now, in: day.interval, visibleRange: visibleRange(for: day.id)) {
                 CalendarTimelineTimeBadge(time: now, highlighted: todayHighlighted)
-                    .frame(width: 47, height: 12).offset(y: y - 6)
+                    .frame(width: 68, height: 16).offset(y: y - 8)
                     .allowsHitTesting(false)
             }
         }
@@ -342,7 +342,8 @@ private struct CalendarTimelineTrack: View {
         let counts = CalendarTimelineGeometry.clusterLaneCounts(for: layout)
         let currentDay = now >= range.start && now < range.end
         let progress = CalendarTimelineGeometry.position(of: now, in: range, pointsPerHour: pointsPerHour)
-        VStack(spacing: 4) {
+        let badgeWidth = CalendarTimelineTimeBadge.width(for: now)
+        VStack(spacing: 2) {
             ZStack(alignment: .topLeading) {
                 RoundedRectangle(cornerRadius: 8).fill(.white.opacity(0.035))
                     .frame(width: range.duration / 3600 * pointsPerHour)
@@ -377,16 +378,22 @@ private struct CalendarTimelineTrack: View {
             .frame(width: width, height: 76, alignment: .topLeading)
             ZStack(alignment: .topLeading) {
                 ForEach(CalendarTimelineGeometry.hourTicks(in: range), id: \.self) { tick in
-                    Text(tickLabel(tick)).font(.system(size: 9, weight: .medium, design: .monospaced))
+                    let labelWidth = CGFloat(pointsPerHour - 4)
+                    let tickX = CGFloat(CalendarTimelineGeometry.position(of: tick, in: range, pointsPerHour: pointsPerHour))
+                    let maximumX = max(0, CGFloat(range.duration / 3600 * pointsPerHour) - labelWidth)
+                    let alignment: Alignment = tick == range.start ? .leading : tick == range.end ? .trailing : .center
+                    Text(tickLabel(tick)).font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .lineLimit(1).truncationMode(.tail)
+                        .frame(width: labelWidth, height: 16, alignment: alignment)
                         .foregroundStyle(.white.opacity(0.4))
-                        .offset(x: tick == range.end ? max(0, range.duration / 3600 * pointsPerHour - 31) : CalendarTimelineGeometry.position(of: tick, in: range, pointsPerHour: pointsPerHour) + 4)
+                        .offset(x: min(max(0, tickX - labelWidth / 2), maximumX))
                 }
                 if currentDay {
                     CalendarTimelineTimeBadge(time: now, highlighted: highlighted)
-                        .offset(x: max(0, progress - 19))
+                        .offset(x: min(max(0, CGFloat(progress) - badgeWidth / 2), max(0, width - badgeWidth)))
                 }
             }
-            .frame(width: width, height: 14, alignment: .topLeading)
+            .frame(width: width, height: 16, alignment: .topLeading)
         }
         .frame(width: width, height: CalendarDayStackGeometry.rowHeight)
         .overlay(alignment: .topLeading) {
@@ -412,13 +419,15 @@ private struct CalendarTimelineTrack: View {
                     if placement.width > 28 {
                         VStack(alignment: .leading, spacing: laneHeight > 40 ? 3 : 1) {
                             Text(event.title)
-                                .font(.system(size: laneHeight > 40 ? 11 : 9, weight: .medium))
-                                .lineLimit(laneHeight > 40 ? 3 : laneHeight > 30 ? 2 : 1)
-                            if let location = event.location, !location.isEmpty {
+                                .font(.system(size: 11, weight: .medium))
+                                .lineLimit(laneHeight >= 52 ? 2 : 1)
+                                .truncationMode(.tail)
+                            if laneHeight > 30, let location = event.location, !location.isEmpty {
                                 Text(location.replacingOccurrences(of: "\n", with: ", "))
-                                    .font(.system(size: laneHeight > 40 ? 9 : 7))
+                                    .font(.system(size: 9))
                                     .foregroundStyle(color.opacity(0.85))
-                                    .lineLimit(laneHeight > 40 ? 2 : 1)
+                                    .lineLimit(laneHeight >= 52 ? 2 : 1)
+                                    .truncationMode(.tail)
                             }
                         }
                         Spacer(minLength: 0)
@@ -447,7 +456,7 @@ private struct CalendarTimelineTrack: View {
     }
 
     private func tickLabel(_ tick: Date) -> String {
-        let format = Date.FormatStyle.dateTime.hour(.twoDigits(amPM: .omitted)).minute(.twoDigits)
+        let format = Date.FormatStyle.dateTime.hour().minute()
         let label = tick.formatted(format)
         let repeats = CalendarTimelineGeometry.hourTicks(in: range).filter {
             $0 < range.end && $0.formatted(format) == label
@@ -481,10 +490,17 @@ private struct CalendarTimelineTimeBadge: View {
     let time: Date
     let highlighted: Bool
 
+    static func width(for time: Date) -> CGFloat {
+        let label = time.formatted(date: .omitted, time: .shortened) as NSString
+        let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .semibold)
+        return ceil(label.size(withAttributes: [.font: font]).width) + 10
+    }
+
     var body: some View {
-        Text(time.formatted(.dateTime.hour(.twoDigits(amPM: .omitted)).minute(.twoDigits)))
-            .font(.system(size: 9, weight: .semibold, design: .monospaced))
-            .foregroundStyle(.white).padding(.horizontal, 4)
+        Text(time.formatted(date: .omitted, time: .shortened))
+            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+            .foregroundStyle(.white).padding(.horizontal, 5)
+            .frame(width: Self.width(for: time), height: 16)
             .background(.red, in: Capsule())
             .overlay { Capsule().stroke(.white.opacity(highlighted ? 0.95 : 0), lineWidth: 1.5) }
             .shadow(color: .red.opacity(highlighted ? 0.7 : 0), radius: highlighted ? 6 : 0)

--- a/boringNotch/components/Calendar/CalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/CalendarTimelineView.swift
@@ -1,0 +1,570 @@
+//
+//  CalendarTimelineView.swift
+//  boringNotch
+//
+
+import Defaults
+import EventKit
+import SwiftUI
+
+@MainActor
+struct CalendarTimelineView: View {
+    @ObservedObject private var manager = CalendarManager.shared
+    @ObservedObject private var coordinator = BoringViewCoordinator.shared
+    @Default(.hideAllDayEvents) private var hideAllDayEvents
+    @Default(.hideCompletedReminders) private var hideCompletedReminders
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var windowCenter: Date
+    @State private var displayedDate: Date
+    @State private var targetDay: Date
+    @State private var targetTime: Date
+    @State private var events: [EventModel] = []
+    @State private var selectedEvent: EventModel?
+    @State private var reloadID = 0
+    @State private var resetID = 0
+    @State private var todayResetID: Int?
+    @State private var todayFlashID = 0
+    @State private var todayHighlighted = false
+    @State private var pendingInitialPosition = true
+    @State private var loading = true
+    @State private var calendarAccess = EKEventStore.authorizationStatus(for: .event)
+    @State private var reminderAccess = EKEventStore.authorizationStatus(for: .reminder)
+
+    init() {
+        let date = Calendar.current.startOfDay(for: BoringViewCoordinator.shared.calendarDate)
+        _windowCenter = State(initialValue: date)
+        _displayedDate = State(initialValue: date)
+        _targetDay = State(initialValue: date)
+        _targetTime = State(initialValue: Self.initialTime(for: date))
+    }
+
+    private var days: [CalendarDayStackGeometry.Day] { CalendarDayStackGeometry.days(centeredOn: windowCenter) }
+    private var hasAccess: Bool { calendarAccess == .fullAccess || reminderAccess == .fullAccess }
+    private var requestID: String { "\(days.first?.id.timeIntervalSince1970 ?? 0)-\(reloadID)" }
+    private var visibleEvents: [EventModel] {
+        events.filter {
+            if $0.isAllDay && hideAllDayEvents { return false }
+            if case .reminder(let completed) = $0.type { return !hideCompletedReminders || !completed }
+            return true
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            header
+            if hasAccess {
+                ZStack(alignment: .bottom) {
+                    TimelineView(.periodic(from: .now, by: 30)) { context in
+                        let ranges = visibleRanges
+                        let width = (ranges.map(\.duration).max() ?? 12 * 3600) / 3600 * CalendarDayStackGeometry.pointsPerHour
+                        CalendarDayScrollView(days: days, visibleRanges: ranges, targetDay: targetDay, targetTime: targetTime,
+                                              focusCurrentTime: todayResetID == resetID, resetID: resetID,
+                                              onScroll: didScroll, onPositionApplied: didPosition) {
+                            VStack(spacing: CalendarDayStackGeometry.rowSpacing) {
+                                ForEach(days) { day in dayLabel(day, now: context.date) }
+                            }
+                        } content: {
+                            VStack(alignment: .leading, spacing: CalendarDayStackGeometry.rowSpacing) {
+                                ForEach(Array(days.enumerated()), id: \.element.id) { index, day in
+                                    CalendarTimelineTrack(day: day.interval, range: ranges[index], events: events(on: day.interval).filter { !$0.isAllDay && !$0.type.isReminder },
+                                                          selectedEvent: selectedEvent, now: context.date, width: width, highlighted: todayHighlighted) {
+                                        select($0, on: day.id)
+                                    }
+                                }
+                            }
+                            .background(.black)
+                        }
+                    }
+                    if let selectedEvent {
+                        CalendarTimelineDetails(event: selectedEvent, showIdentity: selectedBlockIsShort(selectedEvent)) { self.selectedEvent = nil }
+                            .frame(height: 100)
+                            .background(.black)
+                    }
+                }
+                .frame(height: 202)
+                .clipped()
+            } else {
+                permissionState.frame(height: 202)
+            }
+        }
+        .foregroundStyle(.white)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .frame(height: 238, alignment: .top)
+        .calendarTodayShortcut { goToToday() }
+        .task(id: requestID) { await reload() }
+        .task(id: todayFlashID) {
+            guard todayFlashID > 0 else { return }
+            withAnimation(nil) { todayHighlighted = true }
+            do { try await Task.sleep(for: .milliseconds(700)) } catch { return }
+            withAnimation(reduceMotion ? nil : .easeOut(duration: 0.45)) { todayHighlighted = false }
+        }
+        .onDisappear { todayHighlighted = false; todayResetID = nil; todayFlashID = 0 }
+        .onChange(of: manager.selectedCalendarIDs) { _, _ in reloadID += 1 }
+        .onChange(of: coordinator.calendarDate) { _, date in
+            if !Calendar.current.isDate(date, inSameDayAs: displayedDate) { jump(to: date) }
+        }
+        .onChange(of: visibleEvents) { _, events in
+            if let selectedEvent, !events.contains(where: { $0.timelineID == selectedEvent.timelineID }) { self.selectedEvent = nil }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .EKEventStoreChanged)) { _ in reloadID += 1 }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in reloadID += 1 }
+        .onExitCommand { selectedEvent = nil }
+    }
+
+    private var header: some View {
+        HStack(spacing: 9) {
+            Text(displayedDate.formatted(.dateTime.month(.wide).year())).font(.system(size: 14, weight: .semibold))
+            if loading { ProgressView().controlSize(.mini) }
+            Spacer(minLength: 8)
+            Text("↕ DAYS   ↔ HOURS").font(.system(size: 9, weight: .medium)).foregroundStyle(.white.opacity(0.4))
+            dayArrow("chevron.up", offset: -1)
+            Button("Today", action: goToToday)
+                .font(.system(size: 11, weight: .medium))
+                .padding(.horizontal, 9).padding(.vertical, 5)
+                .background(.white.opacity(0.09), in: Capsule()).help("Today (T)")
+            dayArrow("chevron.down", offset: 1)
+        }
+        .buttonStyle(.plain).frame(height: 26)
+    }
+
+    private func dayArrow(_ symbol: String, offset: Int) -> some View {
+        Button {
+            if let date = Calendar.current.date(byAdding: .day, value: offset, to: displayedDate) { jump(to: date) }
+        } label: {
+            Image(systemName: symbol).font(.system(size: 11)).frame(width: 22, height: 24)
+        }
+        .help(offset < 0 ? "Previous day" : "Next day")
+        .accessibilityLabel(offset < 0 ? "Previous day" : "Next day")
+    }
+
+    private func dayLabel(_ day: CalendarDayStackGeometry.Day, now: Date) -> some View {
+        let today = Calendar.current.isDate(day.id, inSameDayAs: now)
+        let dayEvents = events(on: day.interval)
+        return VStack(alignment: .leading, spacing: 4) {
+            Text(day.id.formatted(.dateTime.weekday(.abbreviated)).uppercased())
+                .font(.system(size: 9, weight: .semibold)).foregroundStyle(today ? .red : .white.opacity(0.5))
+            Text(day.id.formatted(.dateTime.day()))
+                .font(.system(size: 23, weight: .semibold, design: .rounded)).foregroundStyle(today ? .red : .white)
+            Text(today ? "TODAY" : day.id.formatted(.dateTime.month(.abbreviated)).uppercased())
+                .font(.system(size: 8, weight: .medium)).foregroundStyle(.white.opacity(0.35))
+            if !dayEvents.isEmpty {
+                Menu {
+                    ForEach(dayEvents, id: \.timelineID) { event in
+                        Button { select(event, on: day.id) } label: {
+                            Text("\(event.type.isReminder ? "Reminder" : event.isAllDay ? "All-day" : event.start.formatted(date: .omitted, time: .shortened)): \(event.title)")
+                        }
+                    }
+                } label: {
+                    Label("\(dayEvents.count)", systemImage: "rectangle.stack")
+                        .font(.system(size: 10, weight: .medium)).foregroundStyle(.white.opacity(0.65))
+                }
+                .menuStyle(.borderlessButton).fixedSize()
+                .help("All events and reminders for this day").accessibilityLabel("\(dayEvents.count) events and reminders")
+            } else if !loading {
+                Text("Free day").font(.system(size: 8)).foregroundStyle(.white.opacity(0.35))
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.top, 2)
+        .frame(width: 47, height: CalendarDayStackGeometry.rowHeight, alignment: .topLeading)
+        .overlay(alignment: .trailing) {
+            Path { path in
+                path.move(to: CGPoint(x: 0, y: 0))
+                path.addLine(to: CGPoint(x: 6, y: 0))
+                path.addLine(to: CGPoint(x: 6, y: 8))
+                path.move(to: CGPoint(x: 6, y: 82))
+                path.addLine(to: CGPoint(x: 6, y: 90))
+                path.addLine(to: CGPoint(x: 0, y: 90))
+            }
+            .stroke(.red.opacity(0.5), style: StrokeStyle(lineWidth: 1.25, lineCap: .round, lineJoin: .round))
+            .frame(width: 7, height: 90).padding(.trailing, 1)
+            .allowsHitTesting(false).accessibilityHidden(true)
+        }
+        .overlay(alignment: .topLeading) {
+            if let y = CalendarDayStackGeometry.hiddenTimeOffset(for: now, in: day.interval, visibleRange: visibleRange(for: day.id)) {
+                CalendarTimelineTimeBadge(time: now, highlighted: todayHighlighted)
+                    .frame(width: 47, height: 12).offset(y: y - 6)
+                    .allowsHitTesting(false)
+            }
+        }
+    }
+
+    private var visibleRanges: [DateInterval] {
+        CalendarTimelineGeometry.sharedVisibleRanges(in: days.map(\.interval), events: events.map {
+            .init(id: $0.timelineID, start: $0.start, end: $0.end, isAllDay: $0.isAllDay, isReminder: $0.type.isReminder)
+        })
+    }
+
+    private func visibleRange(for date: Date) -> DateInterval {
+        let day = CalendarTimelineGeometry.dayInterval(for: date)
+        guard let index = days.firstIndex(where: { $0.id == day.start }) else {
+            return CalendarTimelineGeometry.visibleRange(in: day, events: [])
+        }
+        return visibleRanges[index]
+    }
+
+    private func events(on day: DateInterval) -> [EventModel] {
+        visibleEvents.filter {
+            if $0.type.isReminder { return $0.start >= day.start && $0.start < day.end }
+            return $0.start < day.end && ($0.end > day.start || ($0.start == $0.end && $0.start >= day.start))
+        }
+    }
+
+    private func select(_ event: EventModel, on date: Date) {
+        todayResetID = nil
+        todayHighlighted = false
+        selectedEvent = event
+        windowCenter = date
+        displayedDate = date
+        targetDay = date
+        coordinator.calendarDate = date
+        let day = CalendarTimelineGeometry.dayInterval(for: date)
+        if !event.isAllDay && !event.type.isReminder {
+            targetTime = max(event.start, day.start).addingTimeInterval(-3600)
+        }
+        pendingInitialPosition = false
+        resetID += 1
+    }
+
+    private func selectedBlockIsShort(_ event: EventModel) -> Bool {
+        let day = visibleRange(for: targetDay)
+        let start = CalendarTimelineGeometry.position(of: event.start, in: day, pointsPerHour: CalendarDayStackGeometry.pointsPerHour)
+        let end = CalendarTimelineGeometry.position(of: event.end, in: day, pointsPerHour: CalendarDayStackGeometry.pointsPerHour)
+        return end - start <= 28
+    }
+
+    private func didScroll(to position: CalendarDayStackGeometry.Position, vertical: Bool) {
+        pendingInitialPosition = false
+        todayResetID = nil
+        todayHighlighted = false
+        if vertical { selectedEvent = nil }
+        if vertical && !Calendar.current.isDate(displayedDate, inSameDayAs: position.day) {
+            displayedDate = position.day
+            coordinator.calendarDate = position.day
+        }
+        if CalendarDayStackGeometry.needsRecentering(position: position, in: days) { windowCenter = position.day }
+    }
+
+    private func jump(to date: Date, currentTime: Bool = false) {
+        todayResetID = nil
+        todayHighlighted = false
+        let day = Calendar.current.startOfDay(for: date)
+        selectedEvent = nil
+        windowCenter = day
+        displayedDate = day
+        targetDay = day
+        coordinator.calendarDate = day
+        targetTime = Self.initialTime(for: day, currentTime: currentTime)
+        pendingInitialPosition = !currentTime
+        resetID += 1
+    }
+
+    private func goToToday() {
+        jump(to: Date(), currentTime: true)
+        todayResetID = resetID
+    }
+
+    private func didPosition(_ appliedID: Int) {
+        guard appliedID == todayResetID else { return }
+        todayFlashID += 1
+    }
+
+    private static func initialTime(for date: Date, currentTime: Bool = false) -> Date {
+        if currentTime { return Date() }
+        if Defaults[.autoScrollToNextEvent] && Calendar.current.isDateInToday(date) {
+            return Date().addingTimeInterval(-3600)
+        }
+        return Calendar.current.date(bySettingHour: 8, minute: 0, second: 0, of: date) ?? date
+    }
+
+    private func reload() async {
+        calendarAccess = EKEventStore.authorizationStatus(for: .event)
+        reminderAccess = EKEventStore.authorizationStatus(for: .reminder)
+        guard hasAccess, let span = CalendarDayStackGeometry.span(of: days) else {
+            events = []
+            selectedEvent = nil
+            loading = false
+            return
+        }
+        loading = true
+        let result = await manager.events(from: span.start, to: span.end)
+        guard !Task.isCancelled, span == CalendarDayStackGeometry.span(of: days) else { return }
+        events = result
+        if let selectedEvent { self.selectedEvent = result.first { $0.timelineID == selectedEvent.timelineID } }
+        if pendingInitialPosition {
+            pendingInitialPosition = false
+            if Defaults[.autoScrollToNextEvent], !Calendar.current.isDateInToday(displayedDate) {
+                let day = CalendarTimelineGeometry.dayInterval(for: displayedDate)
+                if let first = events(on: day).first(where: { !$0.isAllDay && !$0.type.isReminder }) {
+                    targetTime = max(first.start, day.start).addingTimeInterval(-3600)
+                    resetID += 1
+                }
+            }
+        }
+        loading = false
+    }
+
+    private var permissionState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "calendar.badge.exclamationmark").font(.system(size: 24, weight: .light)).foregroundStyle(.white.opacity(0.5))
+            Text("Your days, at a glance").font(.system(size: 13, weight: .medium))
+            Text("Allow calendar access to see your events here.").font(.system(size: 11)).foregroundStyle(.white.opacity(0.5))
+            Button(calendarAccess == .notDetermined ? "Connect Calendar" : "Open Calendar Privacy Settings") {
+                if calendarAccess == .notDetermined {
+                    Task { await manager.checkCalendarAuthorization(); reloadID += 1 }
+                } else if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars") {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+            .buttonStyle(.bordered).controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct CalendarTimelineTrack: View {
+    let day: DateInterval
+    let range: DateInterval
+    let events: [EventModel]
+    let selectedEvent: EventModel?
+    let now: Date
+    let width: CGFloat
+    let highlighted: Bool
+    private var pointsPerHour: Double { CalendarDayStackGeometry.pointsPerHour }
+    let select: (EventModel) -> Void
+
+    private var placements: [CalendarTimelineGeometry.Placement] {
+        CalendarTimelineGeometry.layout(events.map { .init(id: $0.timelineID, start: $0.start, end: $0.end) }, in: range, pointsPerHour: pointsPerHour)
+    }
+
+    var body: some View {
+        let layout = placements
+        let counts = CalendarTimelineGeometry.clusterLaneCounts(for: layout)
+        let currentDay = now >= range.start && now < range.end
+        let progress = CalendarTimelineGeometry.position(of: now, in: range, pointsPerHour: pointsPerHour)
+        VStack(spacing: 4) {
+            ZStack(alignment: .topLeading) {
+                RoundedRectangle(cornerRadius: 8).fill(.white.opacity(0.035))
+                    .frame(width: range.duration / 3600 * pointsPerHour)
+                Rectangle().fill(.white.opacity(0.025)).frame(width: progress).allowsHitTesting(false)
+                ForEach(CalendarTimelineGeometry.hourTicks(in: range), id: \.self) { tick in
+                    Rectangle().fill(.white.opacity(0.07)).frame(width: 1)
+                        .offset(x: CalendarTimelineGeometry.position(of: tick, in: range, pointsPerHour: pointsPerHour)).allowsHitTesting(false)
+                }
+                ForEach(layout.filter { $0.lane < 2 }) { placement in
+                    if let event = events.first(where: { $0.timelineID == placement.id }) {
+                        let count = counts[placement.id] ?? 1
+                        let laneHeight: CGFloat = count == 1 ? 76 : count == 2 ? 38 : 28
+                        eventBlock(event, placement: placement, laneHeight: laneHeight)
+                    }
+                }
+                ForEach(overflowGroups(layout)) { group in
+                    Menu {
+                        ForEach(group.events, id: \.timelineID) { event in Button(event.title) { select(event) } }
+                    } label: {
+                        Text("+\(group.events.count) overlapping").font(.system(size: 8, weight: .medium))
+                            .lineLimit(1).frame(width: group.width, height: 18, alignment: .leading)
+                            .background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 4))
+                    }
+                    .menuStyle(.borderlessButton).fixedSize().offset(x: group.x, y: 58)
+                }
+                if currentDay {
+                    Rectangle().fill(.red).frame(width: 1.5)
+                        .shadow(color: .red.opacity(highlighted ? 0.9 : 0), radius: highlighted ? 6 : 0)
+                        .offset(x: progress).allowsHitTesting(false)
+                }
+            }
+            .frame(width: width, height: 76, alignment: .topLeading)
+            ZStack(alignment: .topLeading) {
+                ForEach(CalendarTimelineGeometry.hourTicks(in: range), id: \.self) { tick in
+                    Text(tickLabel(tick)).font(.system(size: 9, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.4))
+                        .offset(x: tick == range.end ? max(0, range.duration / 3600 * pointsPerHour - 31) : CalendarTimelineGeometry.position(of: tick, in: range, pointsPerHour: pointsPerHour) + 4)
+                }
+                if currentDay {
+                    CalendarTimelineTimeBadge(time: now, highlighted: highlighted)
+                        .offset(x: max(0, progress - 19))
+                }
+            }
+            .frame(width: width, height: 14, alignment: .topLeading)
+        }
+        .frame(width: width, height: CalendarDayStackGeometry.rowHeight)
+        .overlay(alignment: .topLeading) {
+            if let y = CalendarDayStackGeometry.hiddenTimeOffset(for: now, in: day, visibleRange: range) {
+                Rectangle().fill(.red.opacity(0.7)).frame(width: width, height: 1)
+                    .shadow(color: .red.opacity(highlighted ? 0.8 : 0), radius: highlighted ? 5 : 0)
+                    .offset(y: y - 0.5).allowsHitTesting(false).accessibilityHidden(true)
+            }
+        }
+    }
+
+    private func eventBlock(_ event: EventModel, placement: CalendarTimelineGeometry.Placement, laneHeight: CGFloat) -> some View {
+        let color = Color(event.calendar.color)
+        let isSelected = event.timelineID == selectedEvent?.timelineID
+        let blockHeight = laneHeight - 4
+        return Button { select(event) } label: {
+            ZStack(alignment: .leading) {
+                Color.clear
+                HStack(spacing: 4) {
+                    RoundedRectangle(cornerRadius: 1)
+                        .fill(color)
+                        .frame(width: 2)
+                    if placement.width > 28 {
+                        VStack(alignment: .leading, spacing: laneHeight > 40 ? 3 : 1) {
+                            Text(event.title)
+                                .font(.system(size: laneHeight > 40 ? 11 : 9, weight: .medium))
+                                .lineLimit(laneHeight > 40 ? 3 : laneHeight > 30 ? 2 : 1)
+                            if let location = event.location, !location.isEmpty {
+                                Text(location.replacingOccurrences(of: "\n", with: ", "))
+                                    .font(.system(size: laneHeight > 40 ? 9 : 7))
+                                    .foregroundStyle(color.opacity(0.85))
+                                    .lineLimit(laneHeight > 40 ? 2 : 1)
+                            }
+                        }
+                        Spacer(minLength: 0)
+                    }
+                }
+                .padding(.vertical, laneHeight > 40 ? 4 : 2)
+                .padding(.horizontal, placement.width > 28 ? 4 : 0)
+                .frame(width: max(1, placement.width), height: blockHeight, alignment: .leading)
+                .background(color.opacity(isSelected ? 0.3 : 0.15), in: RoundedRectangle(cornerRadius: 5))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 5)
+                        .strokeBorder(isSelected ? color : color.opacity(0.22), lineWidth: 1)
+                }
+                .clipped()
+                .offset(x: placement.x - placement.hitX)
+            }
+            .frame(width: placement.hitWidth, height: blockHeight)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .opacity(event.end < now && Calendar.current.isDateInToday(day.start) ? 0.55 : 1)
+        .offset(x: placement.hitX, y: CGFloat(placement.lane) * laneHeight + 2)
+        .help("\(event.title)\n\(event.start.formatted(date: .omitted, time: .shortened)) – \(event.end.formatted(date: .omitted, time: .shortened))\(event.location.map { "\n\($0)" } ?? "")")
+        .accessibilityLabel("\(event.title), \(event.start.formatted(date: .omitted, time: .shortened)) to \(event.end.formatted(date: .omitted, time: .shortened)), \(event.location ?? "")")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private func tickLabel(_ tick: Date) -> String {
+        let format = Date.FormatStyle.dateTime.hour(.twoDigits(amPM: .omitted)).minute(.twoDigits)
+        let label = tick.formatted(format)
+        let repeats = CalendarTimelineGeometry.hourTicks(in: range).filter {
+            $0 < range.end && $0.formatted(format) == label
+        }.count > 1
+        return repeats ? "\(label) \(TimeZone.current.abbreviation(for: tick) ?? "")" : label
+    }
+    private struct OverflowGroup: Identifiable {
+        let id: String
+        var x: CGFloat
+        var width: CGFloat
+        var events: [EventModel]
+    }
+
+    private func overflowGroups(_ placements: [CalendarTimelineGeometry.Placement]) -> [OverflowGroup] {
+        var groups: [OverflowGroup] = []
+        for placement in placements.filter({ $0.lane >= 2 }).sorted(by: { $0.hitX < $1.hitX }) {
+            guard let event = events.first(where: { $0.timelineID == placement.id }) else { continue }
+            if let last = groups.last, last.x + last.width >= placement.hitX {
+                groups[groups.count - 1].width = max(last.x + last.width, placement.hitX + placement.hitWidth) - last.x
+                groups[groups.count - 1].events.append(event)
+            } else {
+                groups.append(.init(id: placement.id, x: placement.hitX, width: placement.hitWidth, events: [event]))
+            }
+        }
+        return groups
+    }
+
+}
+
+private struct CalendarTimelineTimeBadge: View {
+    let time: Date
+    let highlighted: Bool
+
+    var body: some View {
+        Text(time.formatted(.dateTime.hour(.twoDigits(amPM: .omitted)).minute(.twoDigits)))
+            .font(.system(size: 9, weight: .semibold, design: .monospaced))
+            .foregroundStyle(.white).padding(.horizontal, 4)
+            .background(.red, in: Capsule())
+            .overlay { Capsule().stroke(.white.opacity(highlighted ? 0.95 : 0), lineWidth: 1.5) }
+            .shadow(color: .red.opacity(highlighted ? 0.7 : 0), radius: highlighted ? 6 : 0)
+            .accessibilityLabel("Current time \(time.formatted(date: .omitted, time: .shortened))")
+    }
+}
+
+private struct CalendarTimelineDetails: View {
+    @Environment(\.openURL) private var openURL
+    let event: EventModel
+    let showIdentity: Bool
+    let close: () -> Void
+
+    private var duration: String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.day, .hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        return formatter.string(from: max(0, event.end.timeIntervalSince(event.start))) ?? ""
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Button(action: close) {
+                Image(systemName: "arrow.uturn.backward").font(.system(size: 11, weight: .medium))
+                    .frame(width: 28, height: 28).background(.white.opacity(0.07), in: Circle())
+            }
+            .buttonStyle(.plain).help("Back to days").accessibilityLabel("Back to days")
+            ScrollView(.vertical) {
+                VStack(alignment: .leading, spacing: 6) {
+                    if showIdentity || event.isAllDay || event.type.isReminder {
+                        Text(event.title).font(.system(size: 11, weight: .semibold))
+                        if let location = event.location, !location.isEmpty {
+                            Text(location).font(.system(size: 10)).foregroundStyle(.white.opacity(0.6))
+                        }
+                    }
+                    HStack(spacing: 8) {
+                        Circle().fill(Color(event.calendar.color)).frame(width: 5, height: 5)
+                        Text(event.calendar.title).lineLimit(1)
+                        Text("·").foregroundStyle(.white.opacity(0.3))
+                        Text(timeDescription)
+                        if !event.isAllDay && !event.type.isReminder {
+                            Text("· \(duration)").foregroundStyle(.white.opacity(0.4))
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    .font(.system(size: 10, weight: .medium)).foregroundStyle(.white.opacity(0.8))
+                    if let notes = event.notes?.trimmingCharacters(in: .whitespacesAndNewlines), !notes.isEmpty {
+                        Text(notes).font(.system(size: 10)).foregroundStyle(.white.opacity(0.6)).textSelection(.enabled)
+                    }
+                    if !event.participants.isEmpty {
+                        Label(event.participants.map { $0.name + ($0.isOrganizer ? " (organizer)" : "") }.joined(separator: ", "), systemImage: "person.2")
+                            .font(.system(size: 10)).foregroundStyle(.white.opacity(0.6))
+                    }
+                    if let url = event.url {
+                        Link(destination: url) { Label(url.host ?? "Event link", systemImage: "link").font(.system(size: 10)) }
+                    }
+                    if let zone = event.timeZone, zone != .current {
+                        Text("Event time zone: \(zone.identifier)").font(.system(size: 9)).foregroundStyle(.white.opacity(0.4))
+                    }
+                    Button(event.type.isReminder ? "Open in Reminders ↗" : "Open in Calendar ↗") {
+                        if let url = event.calendarAppURL() { openURL(url) }
+                    }
+                    .font(.system(size: 10, weight: .medium)).buttonStyle(.plain).foregroundStyle(.white.opacity(0.8))
+                }
+                .frame(maxWidth: .infinity, alignment: .leading).padding(.trailing, 6)
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private var timeDescription: String {
+        if event.isAllDay { return "All-day" }
+        if event.type.isReminder { return "Due \(event.start.formatted(date: .omitted, time: .shortened))" }
+        let sameDay = Calendar.current.isDate(event.start, inSameDayAs: event.end)
+        return "\(event.start.formatted(date: sameDay ? .omitted : .abbreviated, time: .shortened)) – \(event.end.formatted(date: sameDay ? .omitted : .abbreviated, time: .shortened))"
+    }
+}
+
+private extension EventModel {
+    var timelineID: String { "\(id)-\(start.timeIntervalSince1970)" }
+}

--- a/boringNotch/components/Calendar/CalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/CalendarTimelineView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct CalendarTimelineView: View {
     @ObservedObject private var manager = CalendarManager.shared
     @ObservedObject private var coordinator = BoringViewCoordinator.shared
-    @Default(.calendarTimelineScale) private var timelineScale
+    @Default(.calendarPaneTimelineScale) private var timelineScale
     @Default(.hideAllDayEvents) private var hideAllDayEvents
     @Default(.hideCompletedReminders) private var hideCompletedReminders
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -128,7 +128,7 @@ struct CalendarTimelineView: View {
             if loading { ProgressView().controlSize(.mini) }
             Spacer(minLength: 8)
             Text("↕ DAYS   ↔ HOURS").font(.system(size: 9, weight: .medium)).foregroundStyle(.white.opacity(0.4))
-            CalendarScaleControl(minimumScale: fitScale)
+            CalendarScaleControl(scale: $timelineScale, minimumScale: fitScale)
             dayArrow("chevron.up", offset: -1)
             Button("Today", action: goToToday)
                 .font(.system(size: 11, weight: .medium))

--- a/boringNotch/components/Calendar/CalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/CalendarTimelineView.swift
@@ -15,6 +15,7 @@ struct CalendarTimelineView: View {
     @Default(.hideAllDayEvents) private var hideAllDayEvents
     @Default(.hideCompletedReminders) private var hideCompletedReminders
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var viewportWidth = 524.0
     @State private var windowCenter: Date
     @State private var displayedDate: Date
     @State private var targetDay: Date
@@ -39,7 +40,9 @@ struct CalendarTimelineView: View {
         _targetTime = State(initialValue: Self.initialTime(for: date))
     }
 
-    private var pointsPerHour: Double { CalendarTimelineScale.pointsPerHour(for: timelineScale) }
+    private var fitScale: Double { viewportWidth / ((visibleRanges.map(\.duration).max() ?? 12 * 3600) / 3600) / 96 }
+    private var pointsPerHour: Double { CalendarTimelineScale.pointsPerHour(for: timelineScale, fitting: viewportWidth,
+                                                                          duration: visibleRanges.map(\.duration).max() ?? 12 * 3600) }
     private var days: [CalendarDayStackGeometry.Day] { CalendarDayStackGeometry.days(centeredOn: windowCenter) }
     private var hasAccess: Bool { calendarAccess == .fullAccess || reminderAccess == .fullAccess }
     private var requestID: String { "\(days.first?.id.timeIntervalSince1970 ?? 0)-\(reloadID)" }
@@ -84,6 +87,12 @@ struct CalendarTimelineView: View {
                     }
                 }
                 .frame(height: 204)
+                .background {
+                    GeometryReader { proxy in
+                        Color.clear.onAppear { viewportWidth = max(0, Double(proxy.size.width) - 76) }
+                            .onChange(of: proxy.size.width) { _, width in viewportWidth = max(0, Double(width) - 76) }
+                    }
+                }
                 .clipped()
             } else {
                 permissionState.frame(height: 204)
@@ -119,7 +128,7 @@ struct CalendarTimelineView: View {
             if loading { ProgressView().controlSize(.mini) }
             Spacer(minLength: 8)
             Text("↕ DAYS   ↔ HOURS").font(.system(size: 9, weight: .medium)).foregroundStyle(.white.opacity(0.4))
-            CalendarScaleControl()
+            CalendarScaleControl(minimumScale: fitScale)
             dayArrow("chevron.up", offset: -1)
             Button("Today", action: goToToday)
                 .font(.system(size: 11, weight: .medium))
@@ -233,7 +242,7 @@ struct CalendarTimelineView: View {
         let day = visibleRange(for: targetDay)
         let start = CalendarTimelineGeometry.position(of: event.start, in: day, pointsPerHour: pointsPerHour)
         let end = CalendarTimelineGeometry.position(of: event.end, in: day, pointsPerHour: pointsPerHour)
-        return end - start <= 28
+        return end - start < 52
     }
 
     private func didScroll(to position: CalendarDayStackGeometry.Position, vertical: Bool) {
@@ -411,7 +420,7 @@ private struct CalendarTimelineTrack: View {
                     RoundedRectangle(cornerRadius: 1)
                         .fill(color)
                         .frame(width: 2)
-                    if placement.width > 28 {
+                    if placement.width >= 52 {
                         VStack(alignment: .leading, spacing: laneHeight >= 52 ? 6 : 1) {
                             Text(event.title)
                                 .font(.system(size: 11, weight: .medium))
@@ -430,7 +439,7 @@ private struct CalendarTimelineTrack: View {
                     }
                 }
                 .padding(.vertical, laneHeight > 40 ? 4 : 2)
-                .padding(.horizontal, placement.width > 28 ? 4 : 0)
+                .padding(.horizontal, placement.width >= 52 ? 4 : 0)
                 .frame(width: max(1, placement.width), height: blockHeight, alignment: .leading)
                 .background(color.opacity(isSelected ? 0.3 : 0.15), in: RoundedRectangle(cornerRadius: 5))
                 .overlay {

--- a/boringNotch/components/Calendar/CalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/CalendarTimelineView.swift
@@ -420,13 +420,13 @@ private struct CalendarTimelineTrack: View {
                         VStack(alignment: .leading, spacing: laneHeight > 40 ? 3 : 1) {
                             Text(event.title)
                                 .font(.system(size: 11, weight: .medium))
-                                .lineLimit(laneHeight >= 52 ? 2 : 1)
+                                .lineLimit(laneHeight >= 52 ? 3 : 1)
                                 .truncationMode(.tail)
                             if laneHeight > 30, let location = event.location, !location.isEmpty {
                                 Text(location.replacingOccurrences(of: "\n", with: ", "))
                                     .font(.system(size: 9))
                                     .foregroundStyle(color.opacity(0.85))
-                                    .lineLimit(laneHeight >= 52 ? 2 : 1)
+                                    .lineLimit(1)
                                     .truncationMode(.tail)
                             }
                         }

--- a/boringNotch/components/Calendar/CalendarTodayShortcut.swift
+++ b/boringNotch/components/Calendar/CalendarTodayShortcut.swift
@@ -44,6 +44,7 @@ enum CalendarTodayShortcutRouting {
         guard event.type == .keyDown, event.window === window, window.isKeyWindow,
               (event.keyCode == 17 || event.charactersIgnoringModifiers?.lowercased() == "t"),
               event.modifierFlags.intersection([.command, .control, .option, .function]).isEmpty else { return false }
+        if (window as? CalendarKeyboardFocusProviding)?.wantsKeyForTextInput == true { return false }
         if let editor = window.firstResponder as? NSTextView, editor.isEditable { return false }
         return true
     }

--- a/boringNotch/components/Calendar/CalendarTodayShortcut.swift
+++ b/boringNotch/components/Calendar/CalendarTodayShortcut.swift
@@ -1,0 +1,119 @@
+//
+//  CalendarTodayShortcut.swift
+//  boringNotch
+//
+//  Calendar timeline and month presentation.
+//
+
+import AppKit
+import SwiftUI
+
+@MainActor
+protocol CalendarKeyboardFocusProviding: AnyObject {
+    var wantsKeyForTextInput: Bool { get }
+    func setCalendarFocus(_ requested: Bool, owner: AnyObject)
+}
+
+extension View {
+    func calendarTodayShortcut(_ action: @escaping () -> Void) -> some View {
+        background(CalendarTodayKeyHandler(action: action))
+    }
+}
+
+/// The notch is a nonactivating panel, so its calendar needs an explicit key responder.
+private struct CalendarTodayKeyHandler: NSViewRepresentable {
+    let action: () -> Void
+
+    func makeNSView(context: Context) -> CalendarTodayKeyView {
+        CalendarTodayKeyView(action: action)
+    }
+
+    func updateNSView(_ view: CalendarTodayKeyView, context: Context) {
+        view.action = action
+    }
+
+    static func dismantleNSView(_ view: CalendarTodayKeyView, coordinator: ()) {
+        view.removeMonitor()
+    }
+}
+
+@MainActor
+enum CalendarTodayShortcutRouting {
+    static func shouldHandle(_ event: NSEvent, in window: NSWindow) -> Bool {
+        // ANSI T stays available when another keyboard layout maps it to a different letter.
+        guard event.type == .keyDown, event.window === window, window.isKeyWindow,
+              (event.keyCode == 17 || event.charactersIgnoringModifiers?.lowercased() == "t"),
+              event.modifierFlags.intersection([.command, .control, .option, .function]).isEmpty else { return false }
+        if let editor = window.firstResponder as? NSTextView, editor.isEditable { return false }
+        return true
+    }
+}
+
+@MainActor
+final class CalendarTodayKeyView: NSView {
+    var action: () -> Void
+    private var monitor: Any?
+    private weak var focusWindow: NSWindow?
+
+    init(action: @escaping () -> Void) {
+        self.action = action
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) { return nil }
+    override var acceptsFirstResponder: Bool { true }
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        removeMonitor()
+        guard let window else { return }
+        focusWindow = window
+        monitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .leftMouseDown, .rightMouseDown, .otherMouseDown, .scrollWheel]) { [weak self] event in
+            guard let self else { return event }
+            return self.handleLocalEvent(event)
+        }
+        DispatchQueue.main.async { [weak self, weak window] in
+            guard let self, let window, self.window === window, self.monitor != nil else { return }
+            // Claim only this panel; the application behind it keeps its place.
+            self.claimCalendarFocus(in: window)
+        }
+    }
+
+    func handleLocalEvent(_ event: NSEvent) -> NSEvent? {
+        guard monitor != nil, let window, event.window === window else { return event }
+        switch event.type {
+        case .leftMouseDown, .rightMouseDown, .otherMouseDown, .scrollWheel:
+            claimCalendarFocus(in: window)
+            return event
+        default:
+            guard CalendarTodayShortcutRouting.shouldHandle(event, in: window) else { return event }
+            if !event.isARepeat { action() }
+            return nil
+        }
+    }
+
+    private func claimCalendarFocus(in window: NSWindow) {
+        let focusProvider = window as? CalendarKeyboardFocusProviding
+        guard focusProvider?.wantsKeyForTextInput != true else { return }
+        focusProvider?.setCalendarFocus(true, owner: self)
+        if !window.isKeyWindow { window.makeKey() }
+        if let text = window.firstResponder as? NSTextView,
+           text.window === window, !text.isEditable, !text.isHiddenOrHasHiddenAncestor { return }
+        // Calendar has selectable details, but no editor; an old Clipboard editor must let go.
+        window.makeFirstResponder(self)
+    }
+
+    func removeMonitor() {
+        if let monitor { NSEvent.removeMonitor(monitor) }
+        monitor = nil
+        let wasFirstResponder = focusWindow?.firstResponder === self
+        if wasFirstResponder { focusWindow?.makeFirstResponder(nil) }
+        if let provider = focusWindow as? CalendarKeyboardFocusProviding {
+            provider.setCalendarFocus(false, owner: self)
+        } else if wasFirstResponder {
+            focusWindow?.resignKey()
+        }
+        focusWindow = nil
+    }
+}

--- a/boringNotch/components/Calendar/HomeCalendarGeometry.swift
+++ b/boringNotch/components/Calendar/HomeCalendarGeometry.swift
@@ -15,10 +15,12 @@ enum HomeCalendarGeometry {
     struct Day: Identifiable, Equatable {
         let interval: DateInterval
         let visibleInterval: DateInterval
+        let pointsPerHour: Double
 
-        init(interval: DateInterval, visibleInterval: DateInterval? = nil) {
+        init(interval: DateInterval, visibleInterval: DateInterval? = nil, pointsPerHour: Double = HomeCalendarGeometry.pointsPerHour) {
             self.interval = interval
             self.visibleInterval = visibleInterval ?? interval
+            self.pointsPerHour = pointsPerHour
         }
 
         var id: Date { interval.start }
@@ -26,12 +28,12 @@ enum HomeCalendarGeometry {
         func isTimeVisible(_ date: Date) -> Bool { date >= visibleInterval.start && date < visibleInterval.end }
     }
 
-    static func days(centeredOn date: Date, events: [CalendarTimelineGeometry.Interval] = [], calendar: Calendar = .current) -> [Day] {
+    static func days(centeredOn date: Date, events: [CalendarTimelineGeometry.Interval] = [], pointsPerHour: Double = pointsPerHour, calendar: Calendar = .current) -> [Day] {
         let center = calendar.startOfDay(for: date)
         return (-3...3).compactMap { offset in
             guard let day = calendar.date(byAdding: .day, value: offset, to: center),
                   let interval = calendar.dateInterval(of: .day, for: day) else { return nil }
-            return Day(interval: interval, visibleInterval: CalendarTimelineGeometry.visibleRange(in: interval, events: events, calendar: calendar))
+            return Day(interval: interval, visibleInterval: CalendarTimelineGeometry.visibleRange(in: interval, events: events, calendar: calendar), pointsPerHour: pointsPerHour)
         }
     }
 
@@ -48,7 +50,7 @@ enum HomeCalendarGeometry {
         var offset = 0.0
         for (index, day) in days.enumerated() {
             if date < day.interval.end {
-                return offset + CalendarTimelineGeometry.position(of: date, in: day.visibleInterval, pointsPerHour: pointsPerHour)
+                return offset + CalendarTimelineGeometry.position(of: date, in: day.visibleInterval, pointsPerHour: day.pointsPerHour)
             }
             offset += day.width
             if index < days.count - 1 { offset += daySpacing }
@@ -60,7 +62,7 @@ enum HomeCalendarGeometry {
         var remaining = max(0, offset)
         for (index, day) in days.enumerated() {
             if remaining < day.width || index == days.count - 1 {
-                return day.visibleInterval.start.addingTimeInterval(min(remaining / pointsPerHour * 3600, day.visibleInterval.duration))
+                return day.visibleInterval.start.addingTimeInterval(min(remaining / day.pointsPerHour * 3600, day.visibleInterval.duration))
             }
             remaining -= day.width
             // A gap announces the next day; it never invents minutes between them.
@@ -100,7 +102,7 @@ enum HomeCalendarGeometry {
             return offset(of: date, in: days)
         }
         let leading = offset(of: day.interval.start, in: days)
-        let local = CalendarTimelineGeometry.position(of: date, in: day.visibleInterval, pointsPerHour: pointsPerHour)
+        let local = CalendarTimelineGeometry.position(of: date, in: day.visibleInterval, pointsPerHour: day.pointsPerHour)
         return leading + min(local, max(0, day.width - max(0, viewportWidth)))
     }
 

--- a/boringNotch/components/Calendar/HomeCalendarGeometry.swift
+++ b/boringNotch/components/Calendar/HomeCalendarGeometry.swift
@@ -1,0 +1,111 @@
+//
+//  HomeCalendarGeometry.swift
+//  boringNotch
+//
+//  Calendar timeline and month presentation.
+//
+
+import Foundation
+
+/// A rolling window with one elapsed-time scale and each day's unused nights removed.
+enum HomeCalendarGeometry {
+    static let pointsPerHour = 96.0
+    static let daySpacing = 18.0
+
+    struct Day: Identifiable, Equatable {
+        let interval: DateInterval
+        let visibleInterval: DateInterval
+
+        init(interval: DateInterval, visibleInterval: DateInterval? = nil) {
+            self.interval = interval
+            self.visibleInterval = visibleInterval ?? interval
+        }
+
+        var id: Date { interval.start }
+        var width: Double { visibleInterval.duration / 3600 * pointsPerHour }
+        func isTimeVisible(_ date: Date) -> Bool { date >= visibleInterval.start && date < visibleInterval.end }
+    }
+
+    static func days(centeredOn date: Date, events: [CalendarTimelineGeometry.Interval] = [], calendar: Calendar = .current) -> [Day] {
+        let center = calendar.startOfDay(for: date)
+        return (-3...3).compactMap { offset in
+            guard let day = calendar.date(byAdding: .day, value: offset, to: center),
+                  let interval = calendar.dateInterval(of: .day, for: day) else { return nil }
+            return Day(interval: interval, visibleInterval: CalendarTimelineGeometry.visibleRange(in: interval, events: events, calendar: calendar))
+        }
+    }
+
+    static func span(of days: [Day]) -> DateInterval? {
+        guard let first = days.first, let last = days.last else { return nil }
+        return DateInterval(start: first.interval.start, end: last.interval.end)
+    }
+
+    static func width(of days: [Day]) -> Double {
+        days.reduce(0) { $0 + $1.width } + Double(max(0, days.count - 1)) * daySpacing
+    }
+
+    static func offset(of date: Date, in days: [Day]) -> Double {
+        var offset = 0.0
+        for (index, day) in days.enumerated() {
+            if date < day.interval.end {
+                return offset + CalendarTimelineGeometry.position(of: date, in: day.visibleInterval, pointsPerHour: pointsPerHour)
+            }
+            offset += day.width
+            if index < days.count - 1 { offset += daySpacing }
+        }
+        return offset
+    }
+
+    static func date(at offset: Double, in days: [Day]) -> Date? {
+        var remaining = max(0, offset)
+        for (index, day) in days.enumerated() {
+            if remaining < day.width || index == days.count - 1 {
+                return day.visibleInterval.start.addingTimeInterval(min(remaining / pointsPerHour * 3600, day.visibleInterval.duration))
+            }
+            remaining -= day.width
+            // A gap announces the next day; it never invents minutes between them.
+            if remaining < daySpacing { return days[index + 1].visibleInterval.start }
+            remaining -= daySpacing
+        }
+        return nil
+    }
+
+    /// Hidden hours share a visual gap; its midpoint marks now without pretending the gap is a time scale.
+    static func gapOffset(of date: Date, in days: [Day]) -> Double? {
+        guard let index = days.firstIndex(where: { date >= $0.interval.start && date < $0.interval.end }) else { return nil }
+        let day = days[index]
+        let leading = offset(of: day.id, in: days)
+        if date < day.visibleInterval.start, index > 0 { return leading - daySpacing / 2 }
+        if date >= day.visibleInterval.end, index < days.count - 1 { return leading + day.width + daySpacing / 2 }
+        return nil
+    }
+
+    static func currentTimeOffset(of date: Date, in days: [Day]) -> Double? {
+        guard days.contains(where: { date >= $0.interval.start && date < $0.interval.end }) else { return nil }
+        return gapOffset(of: date, in: days) ?? offset(of: date, in: days)
+    }
+
+    /// Preserve the exact pixel anchor when a rolling window changes, including inside a gap.
+    static func rebasedOffset(_ value: Double, from oldDays: [Day], to newDays: [Day]) -> Double {
+        guard let date = date(at: value, in: oldDays) else { return 0 }
+        return offset(of: date, in: newDays) + value - offset(of: date, in: oldDays)
+    }
+
+    /// Reset the whole viewport inside its requested day, even before 07:00 or after 19:00.
+    static func viewportOffset(near date: Date, on requestedDay: Date, viewportWidth: Double, in days: [Day], centered: Bool = false) -> Double {
+        if centered, let marker = currentTimeOffset(of: date, in: days) {
+            return min(max(0, marker - viewportWidth / 2), max(0, width(of: days) - viewportWidth))
+        }
+        guard let day = days.first(where: { requestedDay >= $0.interval.start && requestedDay < $0.interval.end }) else {
+            return offset(of: date, in: days)
+        }
+        let leading = offset(of: day.interval.start, in: days)
+        let local = CalendarTimelineGeometry.position(of: date, in: day.visibleInterval, pointsPerHour: pointsPerHour)
+        return leading + min(local, max(0, day.width - max(0, viewportWidth)))
+    }
+
+    static func needsRecentering(visibleDate: Date, in days: [Day], calendar: Calendar = .current) -> Bool {
+        guard days.count >= 3 else { return true }
+        return visibleDate < days[1].interval.start || visibleDate >= days[days.count - 2].interval.end
+    }
+}

--- a/boringNotch/components/Calendar/HomeCalendarScrollView.swift
+++ b/boringNotch/components/Calendar/HomeCalendarScrollView.swift
@@ -1,0 +1,127 @@
+//
+//  HomeCalendarScrollView.swift
+//  boringNotch
+//
+//  Calendar timeline and month presentation.
+//
+
+import AppKit
+import SwiftUI
+
+/// Native wheel routing and viewport preservation for the continuous Home timeline.
+struct HomeCalendarScrollView<Content: View>: NSViewRepresentable {
+    let days: [HomeCalendarGeometry.Day]
+    let targetDay: Date
+    let targetDate: Date
+    let resetID: Int
+    var centerTarget = false
+    var onPositioned: () -> Void = {}
+    let height: CGFloat
+    let onScroll: (Date) -> Void
+    @ViewBuilder let content: () -> Content
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> HomeCalendarNativeScrollView {
+        let scrollView = HomeCalendarNativeScrollView()
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        scrollView.hasHorizontalScroller = false
+        scrollView.hasVerticalScroller = false
+        scrollView.horizontalScrollElasticity = .none
+        scrollView.verticalScrollElasticity = .none
+        let hosting = NSHostingView(rootView: content())
+        hosting.sizingOptions = []
+        scrollView.documentView = hosting
+        context.coordinator.hosting = hosting
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: HomeCalendarNativeScrollView, context: Context) {
+        let coordinator = context.coordinator
+        let rebasedOffset = HomeCalendarGeometry.rebasedOffset(scrollView.contentView.bounds.minX, from: coordinator.days, to: days)
+        let changedLayout = coordinator.days != days
+        let shouldReset = coordinator.resetID != resetID
+        coordinator.days = days
+        coordinator.resetID = resetID
+        let width = HomeCalendarGeometry.width(of: days)
+        coordinator.hosting?.rootView = content()
+        coordinator.hosting?.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        if shouldReset {
+            scrollView.position(on: targetDay, near: targetDate, in: days, centered: centerTarget) {
+                DispatchQueue.main.async { [weak coordinator] in
+                    guard coordinator?.resetID == resetID else { return }
+                    onPositioned()
+                }
+            }
+        } else if changedLayout {
+            scrollView.move(to: rebasedOffset)
+        }
+        scrollView.didScroll = { [weak scrollView, weak coordinator] in
+            guard let scrollView, let coordinator else { return }
+            let center = scrollView.contentView.bounds.midX
+            if let date = HomeCalendarGeometry.date(at: center, in: coordinator.days) {
+                onScroll(date)
+            }
+        }
+    }
+
+    static func dismantleNSView(_ scrollView: HomeCalendarNativeScrollView, coordinator: Coordinator) {
+        scrollView.didScroll = nil
+        scrollView.documentView = nil
+        coordinator.hosting = nil
+    }
+
+    final class Coordinator {
+        var hosting: NSHostingView<Content>?
+        var days: [HomeCalendarGeometry.Day] = []
+        var resetID: Int?
+    }
+}
+
+final class HomeCalendarNativeScrollView: NSScrollView {
+    var didScroll: (() -> Void)?
+    private struct PendingPosition {
+        let day: Date
+        let date: Date
+        let days: [HomeCalendarGeometry.Day]
+        let centered: Bool
+        let completion: (() -> Void)?
+    }
+    private var pendingPosition: PendingPosition?
+
+    override func layout() {
+        super.layout()
+        applyPendingPosition()
+    }
+
+    func position(on day: Date, near date: Date, in days: [HomeCalendarGeometry.Day], centered: Bool = false, completion: (() -> Void)? = nil) {
+        pendingPosition = PendingPosition(day: day, date: date, days: days, centered: centered, completion: completion)
+        needsLayout = true
+        applyPendingPosition()
+    }
+
+    private func applyPendingPosition() {
+        guard let request = pendingPosition, contentView.bounds.width > 0 else { return }
+        pendingPosition = nil
+        move(to: HomeCalendarGeometry.viewportOffset(near: request.date, on: request.day,
+                                                    viewportWidth: contentView.bounds.width, in: request.days, centered: request.centered))
+        request.completion?()
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        pendingPosition = nil
+        // One lane, one direction: a mouse wheel should not need a Shift-key secret handshake.
+        let delta = abs(event.scrollingDeltaX) > abs(event.scrollingDeltaY)
+            ? event.scrollingDeltaX : event.scrollingDeltaY
+        let distance = delta * (event.hasPreciseScrollingDeltas ? 1 : 12)
+        move(to: contentView.bounds.minX - distance)
+        didScroll?()
+    }
+
+    func move(to offset: CGFloat) {
+        let maximum = max(0, (documentView?.frame.width ?? 0) - contentView.bounds.width)
+        contentView.scroll(to: NSPoint(x: min(max(0, offset), maximum), y: 0))
+        reflectScrolledClipView(contentView)
+    }
+}

--- a/boringNotch/components/Calendar/HomeCalendarScrollView.swift
+++ b/boringNotch/components/Calendar/HomeCalendarScrollView.swift
@@ -39,7 +39,10 @@ struct HomeCalendarScrollView<Content: View>: NSViewRepresentable {
 
     func updateNSView(_ scrollView: HomeCalendarNativeScrollView, context: Context) {
         let coordinator = context.coordinator
-        let rebasedOffset = HomeCalendarGeometry.rebasedOffset(scrollView.contentView.bounds.minX, from: coordinator.days, to: days)
+        let changedScale = coordinator.days.first?.pointsPerHour != days.first?.pointsPerHour
+        let anchorOffset = changedScale ? scrollView.contentView.bounds.width / 2 : 0
+        let rebasedOffset = HomeCalendarGeometry.rebasedOffset(scrollView.contentView.bounds.minX + anchorOffset,
+                                                              from: coordinator.days, to: days) - anchorOffset
         let changedLayout = coordinator.days != days
         let shouldReset = coordinator.resetID != resetID
         coordinator.days = days

--- a/boringNotch/components/Calendar/HomeCalendarScrollView.swift
+++ b/boringNotch/components/Calendar/HomeCalendarScrollView.swift
@@ -17,6 +17,7 @@ struct HomeCalendarScrollView<Content: View>: NSViewRepresentable {
     var centerTarget = false
     var onPositioned: () -> Void = {}
     let height: CGFloat
+    var fitDay = false
     let onScroll: (Date) -> Void
     @ViewBuilder let content: () -> Content
 
@@ -44,19 +45,25 @@ struct HomeCalendarScrollView<Content: View>: NSViewRepresentable {
         let rebasedOffset = HomeCalendarGeometry.rebasedOffset(scrollView.contentView.bounds.minX + anchorOffset,
                                                               from: coordinator.days, to: days) - anchorOffset
         let changedLayout = coordinator.days != days
+        let enteredFitDay = fitDay && !coordinator.fitDay
+        let resizedFitDay = fitDay && changedScale && coordinator.targetDay == targetDay
         let shouldReset = coordinator.resetID != resetID
         coordinator.days = days
+        coordinator.fitDay = fitDay
+        coordinator.targetDay = targetDay
         coordinator.resetID = resetID
         let width = HomeCalendarGeometry.width(of: days)
         coordinator.hosting?.rootView = content()
         coordinator.hosting?.frame = NSRect(x: 0, y: 0, width: width, height: height)
         if shouldReset {
-            scrollView.position(on: targetDay, near: targetDate, in: days, centered: centerTarget) {
+            scrollView.position(on: targetDay, near: fitDay && !centerTarget ? targetDay : targetDate, in: days, centered: centerTarget) {
                 DispatchQueue.main.async { [weak coordinator] in
                     guard coordinator?.resetID == resetID else { return }
                     onPositioned()
                 }
             }
+        } else if enteredFitDay || resizedFitDay {
+            scrollView.move(to: HomeCalendarGeometry.offset(of: Calendar.current.startOfDay(for: targetDay), in: days))
         } else if changedLayout {
             scrollView.move(to: rebasedOffset)
         }
@@ -78,6 +85,8 @@ struct HomeCalendarScrollView<Content: View>: NSViewRepresentable {
     final class Coordinator {
         var hosting: NSHostingView<Content>?
         var days: [HomeCalendarGeometry.Day] = []
+        var targetDay: Date?
+        var fitDay = false
         var resetID: Int?
     }
 }

--- a/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
@@ -358,6 +358,7 @@ private struct HomeCalendarDayLane: View {
                     .padding(.horizontal, 4)
                     .background(.black)
                     .offset(x: 39)
+                    .opacity(showDayCaption ? 1 : 0)
                 if isToday {
                     Text(now.formatted(.dateTime.hour().minute()))
                         .font(.system(size: 11, weight: .semibold, design: .monospaced))
@@ -428,22 +429,29 @@ private struct HomeCalendarDayLane: View {
         CalendarTimelineGeometry.position(of: date, in: day.visibleInterval, pointsPerHour: day.pointsPerHour)
     }
 
-    private var hourLabelExclusions: [Range<Double>] {
-        let dayLabel = day.interval.start.formatted(.dateTime.weekday(.abbreviated).day()).uppercased()
-        let dayLabelWidth = Double(ceil((dayLabel as NSString).size(withAttributes: [
+    private var dayCaptionRange: Range<Double> {
+        let label = day.interval.start.formatted(.dateTime.weekday(.abbreviated).day()).uppercased()
+        let width = Double(ceil((label as NSString).size(withAttributes: [
             .font: NSFont.systemFont(ofSize: 8, weight: .bold)
         ]).width)) + 8
-        var exclusions = [39..<(39 + dayLabelWidth)]
-        let markerLeading: Double
+        return 39..<(39 + width)
+    }
+
+    private var timeMarkerRange: Range<Double>? {
+        let leading: Double
         if let gapMarkerOffset {
-            markerLeading = gapMarkerOffset - homeCalendarTimeCapsuleWidth / 2
+            leading = gapMarkerOffset - homeCalendarTimeCapsuleWidth / 2
         } else if day.isTimeVisible(now) {
-            markerLeading = min(max(0, position(now) - homeCalendarTimeCapsuleWidth / 2), day.width - homeCalendarTimeCapsuleWidth)
+            leading = min(max(0, position(now) - homeCalendarTimeCapsuleWidth / 2), day.width - homeCalendarTimeCapsuleWidth)
         } else {
-            return exclusions
+            return nil
         }
-        exclusions.append(markerLeading..<(markerLeading + homeCalendarTimeCapsuleWidth))
-        return exclusions
+        return leading..<(leading + homeCalendarTimeCapsuleWidth)
+    }
+
+    private var showDayCaption: Bool { timeMarkerRange.map { !$0.overlaps(dayCaptionRange) } ?? true }
+    private var hourLabelExclusions: [Range<Double>] {
+        [showDayCaption ? dayCaptionRange : nil, timeMarkerRange].compactMap { $0 }
     }
 
     private func tickLabel(_ tick: Date) -> String {

--- a/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
@@ -1,0 +1,551 @@
+//
+//  HomeCalendarTimelineView.swift
+//  boringNotch
+//
+//  Calendar timeline and month presentation.
+//
+
+import Defaults
+import EventKit
+import SwiftUI
+
+/// A continuous strip of time beside the player, with a bounded rolling data window.
+@MainActor
+struct HomeCalendarTimelineView: View {
+    let showMonth: () -> Void
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ObservedObject private var manager = CalendarManager.shared
+    @ObservedObject private var coordinator = BoringViewCoordinator.shared
+    @Default(.hideAllDayEvents) private var hideAllDayEvents
+    @Default(.hideCompletedReminders) private var hideCompletedReminders
+    @State private var windowCenter: Date
+    @State private var displayedDate: Date
+    @State private var targetDate: Date
+    @State private var resetID = 0
+    @State private var centerTarget: Bool
+    @State private var awaitingHighlight = false
+    @State private var highlightID = 0
+    @State private var highlightNow = false
+    @State private var reloadID = 0
+    @State private var events: [EventModel] = []
+    @State private var selectedEvent: EventModel?
+    @State private var pendingInitialPosition = true
+    @State private var loading = true
+    @State private var calendarAccess = EKEventStore.authorizationStatus(for: .event)
+    @State private var reminderAccess = EKEventStore.authorizationStatus(for: .reminder)
+
+    init(showMonth: @escaping () -> Void) {
+        self.showMonth = showMonth
+        let date = BoringViewCoordinator.shared.calendarDate
+        _windowCenter = State(initialValue: date)
+        _displayedDate = State(initialValue: date)
+        _targetDate = State(initialValue: Self.initialPosition(for: date))
+        _centerTarget = State(initialValue: Defaults[.autoScrollToNextEvent] && Calendar.current.isDateInToday(date))
+    }
+
+    private var days: [HomeCalendarGeometry.Day] {
+        HomeCalendarGeometry.days(centeredOn: windowCenter, events: events.map {
+            .init(id: $0.homeTimelineID, start: $0.start, end: $0.end,
+                  isAllDay: $0.isAllDay, isReminder: $0.type.isReminder)
+        })
+    }
+    private var hasAccess: Bool { calendarAccess == .fullAccess || reminderAccess == .fullAccess }
+    private var requestID: String { "\(Calendar.current.startOfDay(for: windowCenter).timeIntervalSince1970)-\(reloadID)" }
+    private var visibleEvents: [EventModel] {
+        events.filter {
+            if $0.isAllDay && hideAllDayEvents { return false }
+            if case .reminder(let completed) = $0.type { return !hideCompletedReminders || !completed }
+            return true
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 6) {
+            header
+            if hasAccess {
+                ZStack {
+                    TimelineView(.periodic(from: .now, by: 30)) { context in
+                        HomeCalendarScrollView(days: days, targetDay: displayedDate, targetDate: targetDate, resetID: resetID, centerTarget: centerTarget, onPositioned: didPosition,
+                                               height: 100, onScroll: didScroll) {
+                            HStack(spacing: HomeCalendarGeometry.daySpacing) {
+                                ForEach(days) { day in
+                                    HomeCalendarDayLane(day: day, events: timedEvents(on: day.interval), now: context.date, highlightNow: highlightNow,
+                                                        gapMarkerOffset: HomeCalendarGeometry.gapOffset(of: context.date, in: days).map { $0 - HomeCalendarGeometry.offset(of: day.id, in: days) }) {
+                                        selectedEvent = $0
+                                    }
+                                }
+                            }
+                            .frame(height: 100)
+                            .background(.black)
+                            .overlay(alignment: .topLeading) {
+                                if let position = HomeCalendarGeometry.gapOffset(of: context.date, in: days) {
+                                    HomeCalendarGapTimeMarker(now: context.date, highlighted: highlightNow)
+                                        .offset(x: position - 30)
+                                }
+                            }
+                        }
+                    }
+                    if let selectedEvent {
+                        HomeCalendarEventDetails(event: selectedEvent) { self.selectedEvent = nil }
+                    }
+                }
+                .frame(height: 100)
+                .clipped()
+            } else {
+                permissionState.frame(height: 100)
+            }
+        }
+        .foregroundStyle(.white)
+        .frame(height: 130, alignment: .top)
+        .calendarTodayShortcut { jump(to: Date(), showCurrentTime: true) }
+        .task(id: requestID) { await reload() }
+        .task(id: highlightID) {
+            guard highlightID > 0 else { return }
+            highlightNow = true
+            do { try await Task.sleep(for: .milliseconds(700)) } catch { return }
+            if reduceMotion { highlightNow = false }
+            else { withAnimation(.easeOut(duration: 0.45)) { highlightNow = false } }
+        }
+        .onChange(of: manager.selectedCalendarIDs) { _, _ in reloadID += 1 }
+        .onChange(of: coordinator.calendarDate) { _, date in
+            if !Calendar.current.isDate(date, inSameDayAs: displayedDate) { jump(to: date) }
+        }
+        .onChange(of: visibleEvents) { _, events in
+            if let selectedEvent, !events.contains(where: { $0.homeTimelineID == selectedEvent.homeTimelineID }) {
+                self.selectedEvent = nil
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .EKEventStoreChanged)) { _ in reloadID += 1 }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in reloadID += 1 }
+    }
+
+    private var header: some View {
+        HStack(spacing: 5) {
+            Text(displayedDate.formatted(.dateTime.weekday(.abbreviated).day().month(.abbreviated)))
+                .font(.system(size: 11, weight: .semibold))
+                .lineLimit(1)
+            if loading { ProgressView().controlSize(.mini) }
+            Spacer(minLength: 0)
+            let day = CalendarTimelineGeometry.dayInterval(for: displayedDate)
+            let special = visibleEvents.filter {
+                if $0.type.isReminder { return $0.start >= day.start && $0.start < day.end }
+                return $0.isAllDay && $0.start < day.end && $0.end > day.start
+            }
+            if !special.isEmpty {
+                Menu {
+                    ForEach(special, id: \.homeTimelineID) { event in
+                        Button("\(event.type.isReminder ? "Reminder" : "All-day"): \(event.title)") {
+                            selectedEvent = event
+                        }
+                    }
+                } label: {
+                    Label("\(special.count)", systemImage: "rectangle.stack")
+                        .font(.system(size: 9))
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .help("All-day events and reminders")
+                .accessibilityLabel("\(special.count) all-day events and reminders")
+            }
+            dayArrow("chevron.left", offset: -1)
+            Button("Today") { jump(to: Date(), showCurrentTime: true) }
+                .help("Today (T)")
+                .font(.system(size: 9, weight: .medium))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .background(.white.opacity(0.08), in: Capsule())
+            dayArrow("chevron.right", offset: 1)
+            Button(action: showMonth) {
+                Image(systemName: "calendar")
+                    .font(.system(size: 10))
+                    .frame(width: 20, height: 20)
+                    .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 5))
+            }
+            .help("Show month")
+            .accessibilityLabel("Show month calendar")
+        }
+        .buttonStyle(.plain)
+        .frame(height: 21)
+    }
+
+    private func dayArrow(_ symbol: String, offset: Int) -> some View {
+        Button {
+            if let date = Calendar.current.date(byAdding: .day, value: offset, to: displayedDate) { jump(to: date) }
+        } label: {
+            Image(systemName: symbol).font(.system(size: 9)).frame(width: 15, height: 20)
+        }
+        .help(offset < 0 ? "Previous day" : "Next day")
+        .accessibilityLabel(offset < 0 ? "Previous day" : "Next day")
+    }
+
+    private func timedEvents(on day: DateInterval) -> [EventModel] {
+        visibleEvents.filter {
+            !$0.isAllDay && !$0.type.isReminder && $0.start < day.end &&
+                ($0.end > day.start || ($0.start == $0.end && $0.start >= day.start))
+        }
+    }
+
+    private func didScroll(to date: Date) {
+        pendingInitialPosition = false
+        awaitingHighlight = false
+        if !Calendar.current.isDate(date, inSameDayAs: displayedDate) {
+            displayedDate = date
+            coordinator.calendarDate = date
+        }
+        if HomeCalendarGeometry.needsRecentering(visibleDate: date, in: days) {
+            windowCenter = date
+        }
+    }
+
+    private func didPosition() {
+        guard awaitingHighlight, !loading, !pendingInitialPosition else { return }
+        awaitingHighlight = false
+        highlightID += 1
+    }
+
+    private func jump(to date: Date, showCurrentTime: Bool = false) {
+        let needsReload = !Calendar.current.isDate(date, inSameDayAs: windowCenter)
+        selectedEvent = nil
+        displayedDate = date
+        windowCenter = date
+        coordinator.calendarDate = date
+        targetDate = showCurrentTime ? Date() : Self.initialPosition(for: date)
+        centerTarget = showCurrentTime || (Defaults[.autoScrollToNextEvent] && Calendar.current.isDateInToday(date))
+        awaitingHighlight = showCurrentTime
+        pendingInitialPosition = !showCurrentTime || loading || needsReload
+        resetID += 1
+    }
+
+    private static func initialPosition(for date: Date) -> Date {
+        if Defaults[.autoScrollToNextEvent] && Calendar.current.isDateInToday(date) {
+            return Date()
+        }
+        return Calendar.current.date(bySettingHour: 8, minute: 0, second: 0, of: date) ?? date
+    }
+
+    private func reload() async {
+        calendarAccess = EKEventStore.authorizationStatus(for: .event)
+        reminderAccess = EKEventStore.authorizationStatus(for: .reminder)
+        guard hasAccess, let span = HomeCalendarGeometry.span(of: days) else {
+            events = []
+            loading = false
+            return
+        }
+        loading = true
+        let result = await manager.events(from: span.start, to: span.end)
+        guard !Task.isCancelled, span == HomeCalendarGeometry.span(of: days) else { return }
+        events = result
+        if let selectedEvent {
+            self.selectedEvent = result.first { $0.homeTimelineID == selectedEvent.homeTimelineID }
+        }
+        if pendingInitialPosition {
+            pendingInitialPosition = false
+            if Defaults[.autoScrollToNextEvent], !Calendar.current.isDateInToday(displayedDate) {
+                let day = CalendarTimelineGeometry.dayInterval(for: displayedDate)
+                if let first = timedEvents(on: day).first {
+                    targetDate = max(first.start, day.start).addingTimeInterval(-1800)
+                }
+            }
+            resetID += 1
+        }
+        loading = false
+    }
+
+    private var permissionState: some View {
+        VStack(spacing: 7) {
+            Image(systemName: "calendar.badge.exclamationmark").font(.system(size: 18))
+                .foregroundStyle(.white.opacity(0.5))
+            Text("Your day, on a timeline").font(.system(size: 11, weight: .medium))
+            Button(calendarAccess == .notDetermined ? "Connect Calendar" : "Calendar Privacy Settings") {
+                if calendarAccess == .notDetermined {
+                    Task { await manager.checkCalendarAuthorization(); reloadID += 1 }
+                } else if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars") {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+            .buttonStyle(.bordered).controlSize(.mini)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct HomeCalendarDayLane: View {
+    let day: HomeCalendarGeometry.Day
+    let events: [EventModel]
+    let now: Date
+    let highlightNow: Bool
+    let gapMarkerOffset: Double?
+    let select: (EventModel) -> Void
+
+    private var layout: [CalendarTimelineGeometry.Placement] {
+        CalendarTimelineGeometry.layout(events.map { .init(id: $0.homeTimelineID, start: $0.start, end: $0.end) },
+                                        in: day.visibleInterval, pointsPerHour: HomeCalendarGeometry.pointsPerHour)
+    }
+
+    var body: some View {
+        let placements = layout
+        let laneCounts = CalendarTimelineGeometry.clusterLaneCounts(for: placements)
+        let progress = position(now)
+        let isToday = day.isTimeVisible(now)
+        VStack(spacing: 4) {
+            ZStack(alignment: .topLeading) {
+                RoundedRectangle(cornerRadius: 5).fill(.white.opacity(0.035))
+                Rectangle().fill(.white.opacity(0.025)).frame(width: progress)
+                ForEach(CalendarTimelineGeometry.hourTicks(in: day.visibleInterval).dropLast(), id: \.self) { tick in
+                    Rectangle().fill(.white.opacity(0.06)).frame(width: 1).offset(x: position(tick))
+                }
+                ForEach(placements.filter { $0.lane < 2 }) { placement in
+                    if let event = events.first(where: { $0.homeTimelineID == placement.id }) {
+                        let count = laneCounts[placement.id] ?? 1
+                        let laneHeight: CGFloat = count == 1 ? 80 : count == 2 ? 40 : 30
+                        eventBlock(event, placement: placement, laneHeight: laneHeight)
+                    }
+                }
+                ForEach(overflowGroups(placements)) { group in
+                    Menu {
+                        ForEach(group.events, id: \.homeTimelineID) { event in
+                            Button(event.title) { select(event) }
+                        }
+                    } label: {
+                        Text("+\(group.events.count) overlapping")
+                            .font(.system(size: 8, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.7))
+                            .lineLimit(1)
+                            .frame(width: group.width, height: 18, alignment: .leading)
+                            .background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 4))
+                    }
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
+                    .offset(x: group.x, y: 62)
+                    .help("\(group.events.count) more overlapping events")
+                }
+                if isToday {
+                    Rectangle().fill(.red).frame(width: 1.5)
+                        .overlay { Rectangle().fill(.red.opacity(highlightNow ? 0.18 : 0)).frame(width: 9) }
+                        .offset(x: progress)
+                        .allowsHitTesting(false)
+                }
+            }
+            .frame(width: day.width, height: 80, alignment: .topLeading)
+            ZStack(alignment: .topLeading) {
+                ForEach(CalendarTimelineGeometry.hourTicks(in: day.visibleInterval), id: \.self) { tick in
+                    Text(tickLabel(tick))
+                        .font(.system(size: 9, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.4))
+                        .opacity(isTickUnderGapMarker(tick) ? 0 : 1)
+                        .offset(x: min(position(tick) + 4, day.width - 34))
+                }
+                Text(day.interval.start.formatted(.dateTime.weekday(.abbreviated).day()).uppercased())
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(.red.opacity(0.75))
+                    .padding(.horizontal, 4)
+                    .background(.black)
+                    .offset(x: 39)
+                if isToday {
+                    Text(now.formatted(.dateTime.hour().minute()))
+                        .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                        .padding(.horizontal, 4)
+                        .background(.red, in: Capsule())
+                        .overlay { Capsule().stroke(.white.opacity(highlightNow ? 0.9 : 0), lineWidth: 1) }
+                        .offset(x: min(max(0, progress - 18), day.width - 52))
+                }
+            }
+            .frame(width: day.width, height: 16, alignment: .topLeading)
+        }
+        .frame(width: day.width, height: 100)
+        .overlay(alignment: .topLeading) {
+            DayBoundaryBrackets().stroke(.red.opacity(0.65), style: StrokeStyle(lineWidth: 1.25, lineCap: .round, lineJoin: .round))
+                .frame(width: day.width - 2, height: 76)
+                .offset(x: 1, y: 2)
+                .allowsHitTesting(false)
+                .accessibilityLabel("Start of \(day.interval.start.formatted(date: .complete, time: .omitted))")
+        }
+    }
+
+    private func eventBlock(_ event: EventModel, placement: CalendarTimelineGeometry.Placement, laneHeight: CGFloat) -> some View {
+        let color = Color(event.calendar.color)
+        let tall = laneHeight > 40
+        return Button { select(event) } label: {
+            ZStack(alignment: .leading) {
+                Color.clear
+                HStack(spacing: 4) {
+                    RoundedRectangle(cornerRadius: 1).fill(color).frame(width: 2)
+                    if placement.width > 28 {
+                        VStack(alignment: .leading, spacing: tall ? 4 : 1) {
+                            Text(event.title)
+                                .font(.system(size: tall ? 11 : 9, weight: .medium))
+                                .lineLimit(tall ? 3 : laneHeight > 30 ? 2 : 1)
+                            if let location = event.location, !location.isEmpty {
+                                Text(location.replacingOccurrences(of: "\n", with: ", "))
+                                    .font(.system(size: tall ? 9 : 7))
+                                    .foregroundStyle(color.opacity(0.9))
+                                    .lineLimit(tall ? 2 : 1)
+                            }
+                        }
+                        Spacer(minLength: 0)
+                    }
+                }
+                .padding(.vertical, tall ? 5 : 2)
+                .padding(.horizontal, placement.width > 28 ? 4 : 0)
+                .frame(width: max(1, placement.width), height: laneHeight - 4, alignment: .leading)
+                .background(color.opacity(0.16), in: RoundedRectangle(cornerRadius: 5))
+                .overlay { RoundedRectangle(cornerRadius: 5).strokeBorder(color.opacity(0.3), lineWidth: 1) }
+                .clipped()
+                .offset(x: placement.x - placement.hitX)
+            }
+            .frame(width: placement.hitWidth, height: laneHeight - 4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .offset(x: placement.hitX, y: CGFloat(placement.lane) * laneHeight + 2)
+        .opacity(event.end < now && Calendar.current.isDateInToday(day.interval.start) ? 0.55 : 1)
+        .help("\(event.title)\n\(event.start.formatted(date: .omitted, time: .shortened)) – \(event.end.formatted(date: .omitted, time: .shortened))\(event.location.map { "\n\($0)" } ?? "")")
+        .accessibilityLabel("\(event.title), \(event.start.formatted(date: .omitted, time: .shortened)) to \(event.end.formatted(date: .omitted, time: .shortened)), \(event.location ?? "")")
+    }
+
+    private func position(_ date: Date) -> Double {
+        CalendarTimelineGeometry.position(of: date, in: day.visibleInterval, pointsPerHour: HomeCalendarGeometry.pointsPerHour)
+    }
+
+    private func isTickUnderGapMarker(_ tick: Date) -> Bool {
+        guard let gapMarkerOffset else { return false }
+        let leading = min(position(tick) + 4, day.width - 34)
+        return leading < gapMarkerOffset + 30 && leading + 34 > gapMarkerOffset - 30
+    }
+
+    private func tickLabel(_ tick: Date) -> String {
+        let format = Date.FormatStyle.dateTime.hour(.twoDigits(amPM: .omitted)).minute(.twoDigits)
+        let label = tick.formatted(format)
+        let repeats = CalendarTimelineGeometry.hourTicks(in: day.visibleInterval).dropLast().filter { $0.formatted(format) == label }.count > 1
+        return repeats ? "\(label) \(TimeZone.current.abbreviation(for: tick) ?? "")" : label
+    }
+
+    private struct OverflowGroup: Identifiable {
+        let id: String
+        var x: CGFloat
+        var width: CGFloat
+        var events: [EventModel]
+    }
+
+    private func overflowGroups(_ placements: [CalendarTimelineGeometry.Placement]) -> [OverflowGroup] {
+        var groups: [OverflowGroup] = []
+        for placement in placements.filter({ $0.lane >= 2 }).sorted(by: { $0.hitX < $1.hitX }) {
+            guard let event = events.first(where: { $0.homeTimelineID == placement.id }) else { continue }
+            if let last = groups.last, last.x + last.width >= placement.hitX {
+                groups[groups.count - 1].width = max(last.x + last.width, placement.hitX + placement.hitWidth) - last.x
+                groups[groups.count - 1].events.append(event)
+            } else {
+                groups.append(.init(id: placement.id, x: placement.hitX, width: placement.hitWidth, events: [event]))
+            }
+        }
+        return groups
+    }
+}
+
+private struct HomeCalendarGapTimeMarker: View {
+    let now: Date
+    let highlighted: Bool
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Rectangle().fill(.red).frame(width: 1.5, height: 80)
+                .overlay { Rectangle().fill(.red.opacity(highlighted ? 0.18 : 0)).frame(width: 9) }
+            Text(now.formatted(.dateTime.hour().minute()))
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .fixedSize()
+                .padding(.horizontal, 4)
+                .background(.red, in: Capsule())
+                .overlay { Capsule().stroke(.white.opacity(highlighted ? 0.9 : 0), lineWidth: 1) }
+        }
+        .frame(width: 60, height: 100, alignment: .top)
+        .allowsHitTesting(false)
+        .accessibilityLabel("Current time \(now.formatted(date: .omitted, time: .shortened)), between displayed day ranges")
+    }
+}
+
+private struct DayBoundaryBrackets: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        for x in [rect.minX, rect.maxX] {
+            let inward = x == rect.minX ? 6.0 : -6.0
+            path.move(to: CGPoint(x: x + inward, y: rect.minY))
+            path.addLines([CGPoint(x: x, y: rect.minY), CGPoint(x: x, y: rect.minY + 8)])
+            path.move(to: CGPoint(x: x + inward, y: rect.maxY))
+            path.addLines([CGPoint(x: x, y: rect.maxY), CGPoint(x: x, y: rect.maxY - 8)])
+        }
+        return path
+    }
+}
+
+private struct HomeCalendarEventDetails: View {
+    @Environment(\.openURL) private var openURL
+    let event: EventModel
+    let close: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Button(action: close) {
+                Image(systemName: "arrow.uturn.backward").font(.system(size: 10))
+                    .frame(width: 23, height: 23)
+                    .background(.white.opacity(0.08), in: Circle())
+            }
+            .buttonStyle(.plain)
+            .help("Back to timeline")
+            .accessibilityLabel("Back to timeline")
+            ScrollView(.vertical) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(event.title).font(.system(size: 11, weight: .semibold))
+                    Text(timeDescription).font(.system(size: 9, weight: .medium)).foregroundStyle(.white.opacity(0.8))
+                    if let location = event.location, !location.isEmpty {
+                        Text(location.replacingOccurrences(of: "\n", with: ", "))
+                            .font(.system(size: 9)).foregroundStyle(.white.opacity(0.6))
+                    }
+                    Text(event.calendar.title).font(.system(size: 9)).foregroundStyle(Color(event.calendar.color))
+                    if let notes = event.notes?.trimmingCharacters(in: .whitespacesAndNewlines), !notes.isEmpty {
+                        Text(notes).font(.system(size: 9)).foregroundStyle(.white.opacity(0.6)).textSelection(.enabled)
+                    }
+                    if !event.participants.isEmpty {
+                        Label(event.participants.map { $0.name + ($0.isOrganizer ? " (organizer)" : "") }.joined(separator: ", "), systemImage: "person.2")
+                            .font(.system(size: 9)).foregroundStyle(.white.opacity(0.6))
+                    }
+                    if let meeting = event.meetingLink {
+                        Link(destination: meeting.url) {
+                            Label("Join \(meeting.provider.displayName)", systemImage: "video")
+                        }
+                        .font(.system(size: 9, weight: .medium))
+                    }
+                    if let url = event.url, url != event.meetingLink?.url {
+                        Link(destination: url) { Label(url.host ?? "Event link", systemImage: "link").font(.system(size: 9)) }
+                    }
+                    if let zone = event.timeZone, zone != .current {
+                        Text("Event time zone: \(zone.identifier)").font(.system(size: 8)).foregroundStyle(.white.opacity(0.4))
+                    }
+                    Button(event.type.isReminder ? "Open in Reminders ↗" : "Open in Calendar ↗") {
+                        if let url = event.calendarAppURL() { openURL(url) }
+                    }
+                    .buttonStyle(.plain).font(.system(size: 9, weight: .medium))
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.trailing, 4)
+            }
+        }
+        .padding(7)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Color(white: 0.045), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var timeDescription: String {
+        if event.isAllDay { return "All-day" }
+        if event.type.isReminder { return "Due \(event.start.formatted(date: .omitted, time: .shortened))" }
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.day, .hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        let duration = formatter.string(from: max(0, event.end.timeIntervalSince(event.start))) ?? ""
+        let sameDay = Calendar.current.isDate(event.start, inSameDayAs: event.end)
+        return "\(event.start.formatted(date: sameDay ? .omitted : .abbreviated, time: .shortened)) – \(event.end.formatted(date: sameDay ? .omitted : .abbreviated, time: .shortened)) · \(duration)"
+    }
+}
+
+private extension EventModel {
+    var homeTimelineID: String { "\(id)-\(start.timeIntervalSince1970)" }
+}

--- a/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
@@ -378,7 +378,7 @@ private struct HomeCalendarDayLane: View {
                         VStack(alignment: .leading, spacing: tall ? 4 : 2) {
                             Text(event.title)
                                 .font(.system(size: 11, weight: .medium))
-                                .lineLimit(tall ? 2 : 1)
+                                .lineLimit(tall ? 3 : 1)
                                 .truncationMode(.tail)
                             if laneHeight > 30, let location = event.location, !location.isEmpty {
                                 Text(location.replacingOccurrences(of: "\n", with: ", "))

--- a/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
@@ -10,7 +10,6 @@ import EventKit
 import SwiftUI
 
 private let homeCalendarTimeCapsuleWidth = 72.0
-private let homeCalendarHourLabelWidth = 42.0
 
 /// A continuous strip of time beside the player, with a bounded rolling data window.
 @MainActor
@@ -19,6 +18,7 @@ struct HomeCalendarTimelineView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject private var manager = CalendarManager.shared
     @ObservedObject private var coordinator = BoringViewCoordinator.shared
+    @Default(.calendarTimelineScale) private var timelineScale
     @Default(.hideAllDayEvents) private var hideAllDayEvents
     @Default(.hideCompletedReminders) private var hideCompletedReminders
     @State private var windowCenter: Date
@@ -50,7 +50,7 @@ struct HomeCalendarTimelineView: View {
         HomeCalendarGeometry.days(centeredOn: windowCenter, events: events.map {
             .init(id: $0.homeTimelineID, start: $0.start, end: $0.end,
                   isAllDay: $0.isAllDay, isReminder: $0.type.isReminder)
-        })
+        }, pointsPerHour: CalendarTimelineScale.pointsPerHour(for: timelineScale))
     }
     private var hasAccess: Bool { calendarAccess == .fullAccess || reminderAccess == .fullAccess }
     private var requestID: String { "\(Calendar.current.startOfDay(for: windowCenter).timeIntervalSince1970)-\(reloadID)" }
@@ -150,6 +150,7 @@ struct HomeCalendarTimelineView: View {
                 .help("All-day events and reminders")
                 .accessibilityLabel("\(special.count) all-day events and reminders")
             }
+            CalendarScaleControl()
             dayArrow("chevron.left", offset: -1)
             Button("Today") { jump(to: Date(), showCurrentTime: true) }
                 .help("Today (T)")
@@ -282,7 +283,7 @@ private struct HomeCalendarDayLane: View {
 
     private var layout: [CalendarTimelineGeometry.Placement] {
         CalendarTimelineGeometry.layout(events.map { .init(id: $0.homeTimelineID, start: $0.start, end: $0.end) },
-                                        in: day.visibleInterval, pointsPerHour: HomeCalendarGeometry.pointsPerHour)
+                                        in: day.visibleInterval, pointsPerHour: day.pointsPerHour)
     }
 
     var body: some View {
@@ -331,13 +332,8 @@ private struct HomeCalendarDayLane: View {
             }
             .frame(width: day.width, height: 80, alignment: .topLeading)
             ZStack(alignment: .topLeading) {
-                ForEach(CalendarTimelineGeometry.hourTicks(in: day.visibleInterval), id: \.self) { tick in
-                    Text(tickLabel(tick))
-                        .font(.system(size: 11, weight: .medium, design: .monospaced))
-                        .foregroundStyle(.white.opacity(0.4))
-                        .opacity(isTickUnderTimeMarker(tick) ? 0 : 1)
-                        .offset(x: min(position(tick) + 4, day.width - homeCalendarHourLabelWidth))
-                }
+                CalendarTimelineHourLabels(range: day.visibleInterval, pointsPerHour: day.pointsPerHour,
+                                           exclusions: hourLabelExclusions, format: tickLabel)
                 Text(day.interval.start.formatted(.dateTime.weekday(.abbreviated).day()).uppercased())
                     .font(.system(size: 8, weight: .bold))
                     .foregroundStyle(.red.opacity(0.75))
@@ -411,20 +407,25 @@ private struct HomeCalendarDayLane: View {
     }
 
     private func position(_ date: Date) -> Double {
-        CalendarTimelineGeometry.position(of: date, in: day.visibleInterval, pointsPerHour: HomeCalendarGeometry.pointsPerHour)
+        CalendarTimelineGeometry.position(of: date, in: day.visibleInterval, pointsPerHour: day.pointsPerHour)
     }
 
-    private func isTickUnderTimeMarker(_ tick: Date) -> Bool {
+    private var hourLabelExclusions: [Range<Double>] {
+        let dayLabel = day.interval.start.formatted(.dateTime.weekday(.abbreviated).day()).uppercased()
+        let dayLabelWidth = Double(ceil((dayLabel as NSString).size(withAttributes: [
+            .font: NSFont.systemFont(ofSize: 8, weight: .bold)
+        ]).width)) + 8
+        var exclusions = [39..<(39 + dayLabelWidth)]
         let markerLeading: Double
         if let gapMarkerOffset {
             markerLeading = gapMarkerOffset - homeCalendarTimeCapsuleWidth / 2
         } else if day.isTimeVisible(now) {
             markerLeading = min(max(0, position(now) - homeCalendarTimeCapsuleWidth / 2), day.width - homeCalendarTimeCapsuleWidth)
         } else {
-            return false
+            return exclusions
         }
-        let leading = min(position(tick) + 4, day.width - homeCalendarHourLabelWidth)
-        return leading < markerLeading + homeCalendarTimeCapsuleWidth && leading + homeCalendarHourLabelWidth > markerLeading
+        exclusions.append(markerLeading..<(markerLeading + homeCalendarTimeCapsuleWidth))
+        return exclusions
     }
 
     private func tickLabel(_ tick: Date) -> String {
@@ -563,4 +564,33 @@ private struct HomeCalendarEventDetails: View {
 
 private extension EventModel {
     var homeTimelineID: String { "\(id)-\(start.timeIntervalSince1970)" }
+}
+
+/// Shared measured hour labels for the Home strip and the stacked Calendar pane.
+struct CalendarTimelineHourLabels: View {
+    let range: DateInterval
+    let pointsPerHour: Double
+    var exclusions: [Range<Double>] = []
+    let format: (Date) -> String
+
+    var body: some View {
+        let ticks = CalendarTimelineGeometry.hourTicks(in: range)
+        let strings = Dictionary(uniqueKeysWithValues: ticks.map { ($0, format($0)) })
+        let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .medium)
+        let widths = ticks.map { Double(ceil(((strings[$0] ?? "") as NSString).size(withAttributes: [.font: font]).width)) + 1 }
+        let labels = CalendarTimelineGeometry.hourLabels(in: range, pointsPerHour: pointsPerHour,
+                                                         widths: widths, avoiding: exclusions)
+        ZStack(alignment: .topLeading) {
+            ForEach(labels) { label in
+                Text(strings[label.id] ?? "")
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .fixedSize()
+                    .frame(width: label.width, height: 16, alignment: .leading)
+                    .foregroundStyle(.white.opacity(0.4))
+                    .offset(x: label.x)
+            }
+        }
+        .frame(width: range.duration / 3600 * pointsPerHour, height: 16, alignment: .topLeading)
+        .allowsHitTesting(false)
+    }
 }

--- a/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
@@ -9,6 +9,9 @@ import Defaults
 import EventKit
 import SwiftUI
 
+private let homeCalendarTimeCapsuleWidth = 72.0
+private let homeCalendarHourLabelWidth = 42.0
+
 /// A continuous strip of time beside the player, with a bounded rolling data window.
 @MainActor
 struct HomeCalendarTimelineView: View {
@@ -80,7 +83,7 @@ struct HomeCalendarTimelineView: View {
                             .overlay(alignment: .topLeading) {
                                 if let position = HomeCalendarGeometry.gapOffset(of: context.date, in: days) {
                                     HomeCalendarGapTimeMarker(now: context.date, highlighted: highlightNow)
-                                        .offset(x: position - 30)
+                                        .offset(x: position - homeCalendarTimeCapsuleWidth / 2)
                                 }
                             }
                         }
@@ -330,10 +333,10 @@ private struct HomeCalendarDayLane: View {
             ZStack(alignment: .topLeading) {
                 ForEach(CalendarTimelineGeometry.hourTicks(in: day.visibleInterval), id: \.self) { tick in
                     Text(tickLabel(tick))
-                        .font(.system(size: 9, weight: .medium, design: .monospaced))
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
                         .foregroundStyle(.white.opacity(0.4))
-                        .opacity(isTickUnderGapMarker(tick) ? 0 : 1)
-                        .offset(x: min(position(tick) + 4, day.width - 34))
+                        .opacity(isTickUnderTimeMarker(tick) ? 0 : 1)
+                        .offset(x: min(position(tick) + 4, day.width - homeCalendarHourLabelWidth))
                 }
                 Text(day.interval.start.formatted(.dateTime.weekday(.abbreviated).day()).uppercased())
                     .font(.system(size: 8, weight: .bold))
@@ -343,11 +346,12 @@ private struct HomeCalendarDayLane: View {
                     .offset(x: 39)
                 if isToday {
                     Text(now.formatted(.dateTime.hour().minute()))
-                        .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
                         .padding(.horizontal, 4)
                         .background(.red, in: Capsule())
                         .overlay { Capsule().stroke(.white.opacity(highlightNow ? 0.9 : 0), lineWidth: 1) }
-                        .offset(x: min(max(0, progress - 18), day.width - 52))
+                        .frame(width: homeCalendarTimeCapsuleWidth)
+                        .offset(x: min(max(0, progress - homeCalendarTimeCapsuleWidth / 2), day.width - homeCalendarTimeCapsuleWidth))
                 }
             }
             .frame(width: day.width, height: 16, alignment: .topLeading)
@@ -371,15 +375,17 @@ private struct HomeCalendarDayLane: View {
                 HStack(spacing: 4) {
                     RoundedRectangle(cornerRadius: 1).fill(color).frame(width: 2)
                     if placement.width > 28 {
-                        VStack(alignment: .leading, spacing: tall ? 4 : 1) {
+                        VStack(alignment: .leading, spacing: tall ? 4 : 2) {
                             Text(event.title)
-                                .font(.system(size: tall ? 11 : 9, weight: .medium))
-                                .lineLimit(tall ? 3 : laneHeight > 30 ? 2 : 1)
-                            if let location = event.location, !location.isEmpty {
+                                .font(.system(size: 11, weight: .medium))
+                                .lineLimit(tall ? 2 : 1)
+                                .truncationMode(.tail)
+                            if laneHeight > 30, let location = event.location, !location.isEmpty {
                                 Text(location.replacingOccurrences(of: "\n", with: ", "))
-                                    .font(.system(size: tall ? 9 : 7))
+                                    .font(.system(size: 9))
                                     .foregroundStyle(color.opacity(0.9))
-                                    .lineLimit(tall ? 2 : 1)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
                             }
                         }
                         Spacer(minLength: 0)
@@ -407,10 +413,17 @@ private struct HomeCalendarDayLane: View {
         CalendarTimelineGeometry.position(of: date, in: day.visibleInterval, pointsPerHour: HomeCalendarGeometry.pointsPerHour)
     }
 
-    private func isTickUnderGapMarker(_ tick: Date) -> Bool {
-        guard let gapMarkerOffset else { return false }
-        let leading = min(position(tick) + 4, day.width - 34)
-        return leading < gapMarkerOffset + 30 && leading + 34 > gapMarkerOffset - 30
+    private func isTickUnderTimeMarker(_ tick: Date) -> Bool {
+        let markerLeading: Double
+        if let gapMarkerOffset {
+            markerLeading = gapMarkerOffset - homeCalendarTimeCapsuleWidth / 2
+        } else if day.isTimeVisible(now) {
+            markerLeading = min(max(0, position(now) - homeCalendarTimeCapsuleWidth / 2), day.width - homeCalendarTimeCapsuleWidth)
+        } else {
+            return false
+        }
+        let leading = min(position(tick) + 4, day.width - homeCalendarHourLabelWidth)
+        return leading < markerLeading + homeCalendarTimeCapsuleWidth && leading + homeCalendarHourLabelWidth > markerLeading
     }
 
     private func tickLabel(_ tick: Date) -> String {
@@ -451,13 +464,14 @@ private struct HomeCalendarGapTimeMarker: View {
             Rectangle().fill(.red).frame(width: 1.5, height: 80)
                 .overlay { Rectangle().fill(.red.opacity(highlighted ? 0.18 : 0)).frame(width: 9) }
             Text(now.formatted(.dateTime.hour().minute()))
-                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
                 .fixedSize()
                 .padding(.horizontal, 4)
                 .background(.red, in: Capsule())
                 .overlay { Capsule().stroke(.white.opacity(highlighted ? 0.9 : 0), lineWidth: 1) }
+                .frame(width: homeCalendarTimeCapsuleWidth)
         }
-        .frame(width: 60, height: 100, alignment: .top)
+        .frame(width: homeCalendarTimeCapsuleWidth, height: 100, alignment: .top)
         .allowsHitTesting(false)
         .accessibilityLabel("Current time \(now.formatted(date: .omitted, time: .shortened)), between displayed day ranges")
     }

--- a/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
@@ -375,11 +375,12 @@ private struct HomeCalendarDayLane: View {
                 HStack(spacing: 4) {
                     RoundedRectangle(cornerRadius: 1).fill(color).frame(width: 2)
                     if placement.width > 28 {
-                        VStack(alignment: .leading, spacing: tall ? 4 : 2) {
+                        VStack(alignment: .leading, spacing: tall ? 6 : 2) {
                             Text(event.title)
                                 .font(.system(size: 11, weight: .medium))
                                 .lineLimit(tall ? 3 : 1)
                                 .truncationMode(.tail)
+                                .multilineTextAlignment(.leading)
                             if laneHeight > 30, let location = event.location, !location.isEmpty {
                                 Text(location.replacingOccurrences(of: "\n", with: ", "))
                                     .font(.system(size: 9))

--- a/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
@@ -168,7 +168,7 @@ struct HomeCalendarTimelineView: View {
                 .help("All-day events and reminders")
                 .accessibilityLabel("\(special.count) all-day events and reminders")
             }
-            CalendarScaleControl(minimumScale: fitScale)
+            CalendarScaleControl(scale: $timelineScale, minimumScale: fitScale)
             dayArrow("chevron.left", offset: -1)
             Button("Today") { jump(to: Date(), showCurrentTime: true) }
                 .help("Today (T)")

--- a/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
+++ b/boringNotch/components/Calendar/HomeCalendarTimelineView.swift
@@ -21,6 +21,7 @@ struct HomeCalendarTimelineView: View {
     @Default(.calendarTimelineScale) private var timelineScale
     @Default(.hideAllDayEvents) private var hideAllDayEvents
     @Default(.hideCompletedReminders) private var hideCompletedReminders
+    @State private var viewportWidth = 315.0
     @State private var windowCenter: Date
     @State private var displayedDate: Date
     @State private var targetDate: Date
@@ -46,11 +47,22 @@ struct HomeCalendarTimelineView: View {
         _centerTarget = State(initialValue: Defaults[.autoScrollToNextEvent] && Calendar.current.isDateInToday(date))
     }
 
+    private var fitScale: Double {
+        let day = days.first { Calendar.current.isDate($0.id, inSameDayAs: displayedDate) }
+        return viewportWidth / ((day?.visibleInterval.duration ?? 12 * 3600) / 3600) / 96
+    }
+    private var pointsPerHour: Double {
+        let day = CalendarTimelineGeometry.dayInterval(for: displayedDate)
+        let range = CalendarTimelineGeometry.visibleRange(in: day, events: events.map {
+            .init(id: $0.homeTimelineID, start: $0.start, end: $0.end, isAllDay: $0.isAllDay, isReminder: $0.type.isReminder)
+        })
+        return CalendarTimelineScale.pointsPerHour(for: timelineScale, fitting: viewportWidth, duration: range.duration)
+    }
     private var days: [HomeCalendarGeometry.Day] {
         HomeCalendarGeometry.days(centeredOn: windowCenter, events: events.map {
             .init(id: $0.homeTimelineID, start: $0.start, end: $0.end,
                   isAllDay: $0.isAllDay, isReminder: $0.type.isReminder)
-        }, pointsPerHour: CalendarTimelineScale.pointsPerHour(for: timelineScale))
+        }, pointsPerHour: pointsPerHour)
     }
     private var hasAccess: Bool { calendarAccess == .fullAccess || reminderAccess == .fullAccess }
     private var requestID: String { "\(Calendar.current.startOfDay(for: windowCenter).timeIntervalSince1970)-\(reloadID)" }
@@ -68,8 +80,8 @@ struct HomeCalendarTimelineView: View {
             if hasAccess {
                 ZStack {
                     TimelineView(.periodic(from: .now, by: 30)) { context in
-                        HomeCalendarScrollView(days: days, targetDay: displayedDate, targetDate: targetDate, resetID: resetID, centerTarget: centerTarget, onPositioned: didPosition,
-                                               height: 100, onScroll: didScroll) {
+                        HomeCalendarScrollView(days: days, targetDay: displayedDate, targetDate: targetDate, resetID: resetID, centerTarget: centerTarget && (timelineScale > fitScale || awaitingHighlight), onPositioned: didPosition,
+                                               height: 100, fitDay: timelineScale <= fitScale, onScroll: didScroll) {
                             HStack(spacing: HomeCalendarGeometry.daySpacing) {
                                 ForEach(days) { day in
                                     HomeCalendarDayLane(day: day, events: timedEvents(on: day.interval), now: context.date, highlightNow: highlightNow,
@@ -93,6 +105,12 @@ struct HomeCalendarTimelineView: View {
                     }
                 }
                 .frame(height: 100)
+                .background {
+                    GeometryReader { proxy in
+                        Color.clear.onAppear { viewportWidth = proxy.size.width }
+                            .onChange(of: proxy.size.width) { _, width in viewportWidth = width }
+                    }
+                }
                 .clipped()
             } else {
                 permissionState.frame(height: 100)
@@ -150,7 +168,7 @@ struct HomeCalendarTimelineView: View {
                 .help("All-day events and reminders")
                 .accessibilityLabel("\(special.count) all-day events and reminders")
             }
-            CalendarScaleControl()
+            CalendarScaleControl(minimumScale: fitScale)
             dayArrow("chevron.left", offset: -1)
             Button("Today") { jump(to: Date(), showCurrentTime: true) }
                 .help("Today (T)")
@@ -370,7 +388,7 @@ private struct HomeCalendarDayLane: View {
                 Color.clear
                 HStack(spacing: 4) {
                     RoundedRectangle(cornerRadius: 1).fill(color).frame(width: 2)
-                    if placement.width > 28 {
+                    if placement.width >= 52 {
                         VStack(alignment: .leading, spacing: tall ? 6 : 2) {
                             Text(event.title)
                                 .font(.system(size: 11, weight: .medium))
@@ -389,7 +407,7 @@ private struct HomeCalendarDayLane: View {
                     }
                 }
                 .padding(.vertical, tall ? 5 : 2)
-                .padding(.horizontal, placement.width > 28 ? 4 : 0)
+                .padding(.horizontal, placement.width >= 52 ? 4 : 0)
                 .frame(width: max(1, placement.width), height: laneHeight - 4, alignment: .leading)
                 .background(color.opacity(0.16), in: RoundedRectangle(cornerRadius: 5))
                 .overlay { RoundedRectangle(cornerRadius: 5).strokeBorder(color.opacity(0.3), lineWidth: 1) }

--- a/boringNotch/components/Calendar/HomeCalendarView.swift
+++ b/boringNotch/components/Calendar/HomeCalendarView.swift
@@ -1,0 +1,24 @@
+//
+//  HomeCalendarView.swift
+//  boringNotch
+//
+//  Calendar timeline and month presentation.
+//
+
+import Defaults
+import SwiftUI
+
+struct HomeCalendarView: View {
+    @Default(.showMonthOnHome) private var showMonth
+
+    var body: some View {
+        Group {
+            if showMonth {
+                CalendarMonthView(showTimeline: { showMonth = false }, selectDate: { _ in showMonth = false })
+            } else {
+                HomeCalendarTimelineView(showMonth: { showMonth = true })
+            }
+        }
+        .frame(height: 130, alignment: .top)
+    }
+}

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -13,10 +13,11 @@ struct BoringHeader: View {
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     @StateObject var shelfState = ShelfStateViewModel.shared
+    @Default(.showCalendar) private var showCalendar
     var body: some View {
         HStack(spacing: 0) {
             HStack {
-                if (!shelfState.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
+                if showCalendar || ((!shelfState.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf]) {
                     TabSelectionView()
                 } else if vm.notchState == .open {
                     EmptyView()

--- a/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
+++ b/boringNotch/components/Notch/BoringNotchSkyLightWindow.swift
@@ -31,7 +31,7 @@ extension SkyLightOperator {
     }
 }
 
-class BoringNotchSkyLightWindow: NSPanel {
+class BoringNotchSkyLightWindow: NSPanel, CalendarKeyboardFocusProviding {
     private var isSkyLightEnabled: Bool = false
     
     override init(
@@ -165,6 +165,17 @@ class BoringNotchSkyLightWindow: NSPanel {
         }
     }
 
-    override var canBecomeKey: Bool { wantsKeyForTextInput }
+    private var calendarFocusOwners: Set<ObjectIdentifier> = []
+    var wantsKeyForCalendar: Bool { !calendarFocusOwners.isEmpty }
+
+    /// Calendar views release only their own request; notification replies keep text focus.
+    func setCalendarFocus(_ requested: Bool, owner: AnyObject) {
+        let identifier = ObjectIdentifier(owner)
+        if requested { calendarFocusOwners.insert(identifier) }
+        else { calendarFocusOwners.remove(identifier) }
+        if !wantsKeyForCalendar && !wantsKeyForTextInput && isKeyWindow { resignKey() }
+    }
+
+    override var canBecomeKey: Bool { wantsKeyForTextInput || wantsKeyForCalendar }
     override var canBecomeMain: Bool { false }
 }

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -17,12 +17,20 @@ struct MusicPlayerView: View {
     let albumArtNamespace: Namespace.ID
     let horizontalMediaGestureFeedback: CGFloat
     @Binding var isHoveringMusicArea: Bool
+    var compactForCalendar = false
 
     var body: some View {
-        HStack {
-            AlbumArtView(vm: vm, albumArtNamespace: albumArtNamespace).frame(width: 120).padding(.all, 5 * (vm.notchSize.height / 190))
-            MusicControlsView(horizontalMediaGestureFeedback: horizontalMediaGestureFeedback)
-                .compositingGroup()
+        Group {
+            if compactForCalendar {
+                MusicControlsView(horizontalMediaGestureFeedback: horizontalMediaGestureFeedback,
+                                  compactArtworkNamespace: albumArtNamespace)
+            } else {
+                HStack {
+                    AlbumArtView(vm: vm, albumArtNamespace: albumArtNamespace).frame(width: 120).padding(.all, 5 * (vm.notchSize.height / 190))
+                    MusicControlsView(horizontalMediaGestureFeedback: horizontalMediaGestureFeedback)
+                        .compositingGroup()
+                }
+            }
         }
         .contentShape(Rectangle())
         .onHover { hovering in
@@ -38,6 +46,7 @@ struct AlbumArtView: View {
     @ObservedObject var musicManager = MusicManager.shared
     @ObservedObject var vm: BoringViewModel
     let albumArtNamespace: Namespace.ID
+    var compactForCalendar = false
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
@@ -106,8 +115,8 @@ struct AlbumArtView: View {
             appIcon(for: musicManager.bundleIdentifier ?? MediaAppBundleID.appleMusic)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
-                .frame(width: 30, height: 30)
-                .offset(x: 10, y: 10)
+                .frame(width: compactForCalendar ? 20 : 30, height: compactForCalendar ? 20 : 30)
+                .offset(x: compactForCalendar ? 5 : 10, y: compactForCalendar ? 5 : 10)
                 .transition(.scale.combined(with: .opacity))
                 .zIndex(2)
         }
@@ -119,6 +128,7 @@ struct MusicControlsView: View {
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var webcamManager = WebcamManager.shared
     let horizontalMediaGestureFeedback: CGFloat
+    var compactArtworkNamespace: Namespace.ID?
     @State private var sliderValue: Double = 0
     @State private var dragging: Bool = false
     @State private var lastDragged: Date = .distantPast
@@ -126,8 +136,17 @@ struct MusicControlsView: View {
     @Default(.musicControlSlotLimit) private var slotLimit
 
     var body: some View {
-        VStack(alignment: .leading) {
-            songInfoAndSlider
+        VStack(alignment: .leading, spacing: compactArtworkNamespace == nil ? nil : 0) {
+            if let compactArtworkNamespace {
+                HStack(spacing: 10) {
+                    AlbumArtView(vm: vm, albumArtNamespace: compactArtworkNamespace, compactForCalendar: true)
+                        .frame(width: 80, height: 80)
+                    songInfoAndSlider
+                }
+                .frame(height: 90)
+            } else {
+                songInfoAndSlider
+            }
             slotToolbar
         }
         .buttonStyle(PlainButtonStyle())
@@ -427,6 +446,7 @@ struct NotchHomeView: View {
     @ObservedObject var webcamManager = WebcamManager.shared
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @Default(.showMonthOnHome) private var showMonthOnHome
     let albumArtNamespace: Namespace.ID
     let horizontalMediaGestureFeedback: CGFloat
     @Binding var isHoveringMusicArea: Bool
@@ -445,15 +465,17 @@ struct NotchHomeView: View {
             MusicPlayerView(
                 albumArtNamespace: albumArtNamespace,
                 horizontalMediaGestureFeedback: horizontalMediaGestureFeedback,
-                isHoveringMusicArea: $isHoveringMusicArea
+                isHoveringMusicArea: $isHoveringMusicArea,
+                compactForCalendar: Defaults[.showCalendar]
             )
 
             if Defaults[.showCalendar] {
-                CalendarView()
-                    .frame(width: shouldShowCamera ? 170 : 215)
+                HomeCalendarView()
+                    .frame(width: shouldShowCamera ? 190 : showMonthOnHome ? 240 : 315)
                     .onHover { isHovering in
                         vm.isHoveringCalendar = isHovering
                     }
+                    .onDisappear { vm.isHoveringCalendar = false }
                     .environmentObject(vm)
                     .transition(.opacity)
             }

--- a/boringNotch/components/Settings/SettingsView.swift
+++ b/boringNotch/components/Settings/SettingsView.swift
@@ -15,6 +15,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
     case media
     case notifications
     case calendar
+    case calendarLayout
     case osd
     case battery
     case shelf
@@ -32,6 +33,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .media: "Media"
         case .notifications: "Notifications"
         case .calendar: "Calendar"
+        case .calendarLayout: "Calendar Layout"
         case .osd: "OSD"
         case .battery: "Battery"
         case .shelf: "Shelf"
@@ -49,6 +51,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
         case .media: "play.laptopcomputer"
         case .notifications: "bell.badge"
         case .calendar: "calendar"
+        case .calendarLayout: "arrow.left.and.right"
         case .osd: "dial.medium.fill"
         case .battery: "battery.100.bolt"
         case .shelf: "books.vertical"
@@ -95,6 +98,8 @@ struct SettingsView: View {
                     NotificationSettingsView()
                 case .calendar:
                     CalendarSettings()
+                case .calendarLayout:
+                    CalendarLayoutSettings()
                 case .osd:
                     OSDSettings()
                 case .battery:

--- a/boringNotch/components/Settings/Views/CalendarSettingsView.swift
+++ b/boringNotch/components/Settings/Views/CalendarSettingsView.swift
@@ -154,44 +154,42 @@ struct CalendarSettings: View {
 }
 
 struct CalendarLayoutSettings: View {
-    @Default(.calendarTimelineScale) private var scale
-
-    private var scaleDescription: String {
-        CalendarTimelineScale.clamped(scale) == 0 ? "Fit day" : "\(Int((CalendarTimelineScale.clamped(scale) * 100).rounded()))%"
-    }
-
-    private var boundedScale: Binding<Double> {
-        Binding(
-            get: { CalendarTimelineScale.clamped(scale) },
-            set: { scale = CalendarTimelineScale.clamped($0) }
-        )
-    }
+    @Default(.calendarTimelineScale) private var homeScale
 
     var body: some View {
         Form {
-            Section {
-                LabeledContent("Horizontal scale") {
-                    Text(scaleDescription)
-                        .monospacedDigit()
-                }
-                Slider(value: boundedScale, in: CalendarTimelineScale.range, step: 0.05) {
-                    Text("Horizontal timeline scale")
-                } minimumValueLabel: {
-                    Text("Fit day")
-                } maximumValueLabel: {
-                    Text("250%")
-                }
-                .labelsHidden()
-                .accessibilityValue(CalendarTimelineScale.clamped(scale) == 0 ? "Fit day" : "\(Int((CalendarTimelineScale.clamped(scale) * 100).rounded())) percent")
-
-                Button("Reset to 100%") { scale = 1.0 }
-                    .disabled(CalendarTimelineScale.clamped(scale) == 1.0)
-            } header: {
-                Text("Timeline")
-            } footer: {
-                Text("Applies to the Home and Calendar timelines. The lowest scale fits the whole day; titles hide in narrow event blocks. Text size and day height stay unchanged. Drag the scale wheel in either timeline to adjust it directly.")
-            }
+            scaleSection("Home timeline", scale: $homeScale)
         }
         .navigationTitle("Calendar Layout")
+    }
+
+    private func scaleSection(_ title: LocalizedStringKey, scale: Binding<Double>) -> some View {
+        let value = CalendarTimelineScale.clamped(scale.wrappedValue)
+        let description = value == 0 ? "Fit day" : "\(Int((value * 100).rounded()))%"
+        let boundedScale = Binding(
+            get: { CalendarTimelineScale.clamped(scale.wrappedValue) },
+            set: { scale.wrappedValue = CalendarTimelineScale.clamped($0) }
+        )
+        return Section {
+            LabeledContent("Horizontal scale") {
+                Text(description).monospacedDigit()
+            }
+            Slider(value: boundedScale, in: CalendarTimelineScale.range, step: 0.05) {
+                Text(title)
+            } minimumValueLabel: {
+                Text("Fit day")
+            } maximumValueLabel: {
+                Text("250%")
+            }
+            .labelsHidden()
+            .accessibilityValue(value == 0 ? "Fit day" : "\(Int((value * 100).rounded())) percent")
+
+            Button("Reset to 100%") { scale.wrappedValue = 1.0 }
+                .disabled(value == 1.0)
+        } header: {
+            Text(title)
+        } footer: {
+            Text("This scale applies only to this timeline. Fit day shows the whole day; narrow event blocks hide titles. Drag its wheel to adjust the scale.")
+        }
     }
 }

--- a/boringNotch/components/Settings/Views/CalendarSettingsView.swift
+++ b/boringNotch/components/Settings/Views/CalendarSettingsView.swift
@@ -152,3 +152,42 @@ struct CalendarSettings: View {
         }
     }
 }
+
+struct CalendarLayoutSettings: View {
+    @Default(.calendarTimelineScale) private var scale
+
+    private var boundedScale: Binding<Double> {
+        Binding(
+            get: { CalendarTimelineScale.clamped(scale) },
+            set: { scale = CalendarTimelineScale.clamped($0) }
+        )
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                LabeledContent("Horizontal scale") {
+                    Text("\(Int((CalendarTimelineScale.clamped(scale) * 100).rounded()))%")
+                        .monospacedDigit()
+                }
+                Slider(value: boundedScale, in: CalendarTimelineScale.range, step: 0.05) {
+                    Text("Horizontal timeline scale")
+                } minimumValueLabel: {
+                    Text("75%")
+                } maximumValueLabel: {
+                    Text("250%")
+                }
+                .labelsHidden()
+                .accessibilityValue("\(Int((CalendarTimelineScale.clamped(scale) * 100).rounded())) percent")
+
+                Button("Reset to 100%") { scale = 1.0 }
+                    .disabled(CalendarTimelineScale.clamped(scale) == 1.0)
+            } header: {
+                Text("Timeline")
+            } footer: {
+                Text("Applies to the Home and Calendar timelines. Text size, day height, and the month grid stay unchanged. Drag the scale wheel in either timeline to adjust it directly.")
+            }
+        }
+        .navigationTitle("Calendar Layout")
+    }
+}

--- a/boringNotch/components/Settings/Views/CalendarSettingsView.swift
+++ b/boringNotch/components/Settings/Views/CalendarSettingsView.swift
@@ -156,6 +156,10 @@ struct CalendarSettings: View {
 struct CalendarLayoutSettings: View {
     @Default(.calendarTimelineScale) private var scale
 
+    private var scaleDescription: String {
+        CalendarTimelineScale.clamped(scale) == 0 ? "Fit day" : "\(Int((CalendarTimelineScale.clamped(scale) * 100).rounded()))%"
+    }
+
     private var boundedScale: Binding<Double> {
         Binding(
             get: { CalendarTimelineScale.clamped(scale) },
@@ -167,25 +171,25 @@ struct CalendarLayoutSettings: View {
         Form {
             Section {
                 LabeledContent("Horizontal scale") {
-                    Text("\(Int((CalendarTimelineScale.clamped(scale) * 100).rounded()))%")
+                    Text(scaleDescription)
                         .monospacedDigit()
                 }
                 Slider(value: boundedScale, in: CalendarTimelineScale.range, step: 0.05) {
                     Text("Horizontal timeline scale")
                 } minimumValueLabel: {
-                    Text("75%")
+                    Text("Fit day")
                 } maximumValueLabel: {
                     Text("250%")
                 }
                 .labelsHidden()
-                .accessibilityValue("\(Int((CalendarTimelineScale.clamped(scale) * 100).rounded())) percent")
+                .accessibilityValue(CalendarTimelineScale.clamped(scale) == 0 ? "Fit day" : "\(Int((CalendarTimelineScale.clamped(scale) * 100).rounded())) percent")
 
                 Button("Reset to 100%") { scale = 1.0 }
                     .disabled(CalendarTimelineScale.clamped(scale) == 1.0)
             } header: {
                 Text("Timeline")
             } footer: {
-                Text("Applies to the Home and Calendar timelines. Text size, day height, and the month grid stay unchanged. Drag the scale wheel in either timeline to adjust it directly.")
+                Text("Applies to the Home and Calendar timelines. The lowest scale fits the whole day; titles hide in narrow event blocks. Text size and day height stay unchanged. Drag the scale wheel in either timeline to adjust it directly.")
             }
         }
         .navigationTitle("Calendar Layout")

--- a/boringNotch/components/Settings/Views/CalendarSettingsView.swift
+++ b/boringNotch/components/Settings/Views/CalendarSettingsView.swift
@@ -155,10 +155,12 @@ struct CalendarSettings: View {
 
 struct CalendarLayoutSettings: View {
     @Default(.calendarTimelineScale) private var homeScale
+    @Default(.calendarPaneTimelineScale) private var calendarScale
 
     var body: some View {
         Form {
             scaleSection("Home timeline", scale: $homeScale)
+            scaleSection("Calendar pane", scale: $calendarScale)
         }
         .navigationTitle("Calendar Layout")
     }

--- a/boringNotch/components/Settings/Views/CalendarSettingsView.swift
+++ b/boringNotch/components/Settings/Views/CalendarSettingsView.swift
@@ -63,25 +63,13 @@ struct CalendarSettings: View {
                         }
                     }
                 } else {
-                    List {
-                        ForEach(calendarManager.eventCalendars, id: \.id) { calendar in
-                            Toggle(
-                                isOn: Binding(
-                                    get: { calendarManager.getCalendarSelected(calendar) },
-                                    set: { isSelected in
-                                        Task {
-                                            await calendarManager.setCalendarSelected(
-                                                calendar, isSelected: isSelected)
-                                        }
-                                    }
-                                )
-                            ) {
-                                Text(calendar.title)
-                            }
-                            .accentColor(lighterColor(from: calendar.color))
-                            .disabled(!showCalendar)
-                        }
+                    calendarPicker(calendarManager.eventCalendars)
+                    Button("Refresh Calendars", systemImage: "arrow.clockwise") {
+                        Task { await calendarManager.reloadCalendarAndReminderLists() }
                     }
+                    Text("Includes calendars from every account available to Apple Calendar. Selection applies to both calendar views.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
             Section(header: Text("Reminders")) {
@@ -99,25 +87,7 @@ struct CalendarSettings: View {
                         }
                     }
                 } else {
-                    List {
-                        ForEach(calendarManager.reminderLists, id: \.id) { calendar in
-                            Toggle(
-                                isOn: Binding(
-                                    get: { calendarManager.getCalendarSelected(calendar) },
-                                    set: { isSelected in
-                                        Task {
-                                            await calendarManager.setCalendarSelected(
-                                                calendar, isSelected: isSelected)
-                                        }
-                                    }
-                                )
-                            ) {
-                                Text(calendar.title)
-                            }
-                            .accentColor(lighterColor(from: calendar.color))
-                            .disabled(!showCalendar)
-                        }
-                    }
+                    calendarPicker(calendarManager.reminderLists)
                 }
             }
         }
@@ -130,21 +100,55 @@ struct CalendarSettings: View {
             }
         }
     }
-}
 
-func lighterColor(from nsColor: NSColor, amount: CGFloat = 0.14) -> Color {
-    let srgb = nsColor.usingColorSpace(.sRGB) ?? nsColor
-    var (r, g, b, a): (CGFloat, CGFloat, CGFloat, CGFloat) = (0,0,0,0)
-    srgb.getRed(&r, green: &g, blue: &b, alpha: &a)
+    @ViewBuilder
+    private func calendarPicker(_ calendars: [CalendarModel]) -> some View {
+        if calendars.isEmpty {
+            Text("No calendars available.")
+                .foregroundStyle(.secondary)
+        } else {
+            HStack {
+                Text("\(calendars.filter { calendarManager.getCalendarSelected($0) }.count) of \(calendars.count) selected")
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Select All") {
+                    Task { await calendarManager.setCalendarsSelected(calendars, isSelected: true) }
+                }
+                Button("Deselect All") {
+                    Task { await calendarManager.setCalendarsSelected(calendars, isSelected: false) }
+                }
+            }
+            .controlSize(.small)
 
-    func lighten(_ c: CGFloat) -> CGFloat {
-        let increased = c + (1.0 - c) * amount
-        return min(max(increased, 0), 1)
+            let groups = Dictionary(grouping: calendars, by: \.account)
+            ForEach(groups.keys.sorted(), id: \.self) { account in
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(account)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    ForEach((groups[account] ?? []).sorted {
+                        $0.title.localizedStandardCompare($1.title) == .orderedAscending
+                    }, id: \.id) { calendar in
+                        Toggle(isOn: Binding(
+                            get: { calendarManager.getCalendarSelected(calendar) },
+                            set: { isSelected in
+                                Task { await calendarManager.setCalendarSelected(calendar, isSelected: isSelected) }
+                            }
+                        )) {
+                            HStack(spacing: 8) {
+                                Circle()
+                                    .fill(Color(nsColor: calendar.color))
+                                    .frame(width: 8, height: 8)
+                                    .accessibilityHidden(true)
+                                Text(calendar.title)
+                            }
+                        }
+                        .toggleStyle(.checkbox)
+                        .accessibilityLabel(calendar.title)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
     }
-
-    let nr = lighten(r)
-    let ng = lighten(g)
-    let nb = lighten(b)
-
-    return Color(red: Double(nr), green: Double(ng), blue: Double(nb), opacity: Double(a))
 }

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -5,6 +5,7 @@
 //  Created by Hugo Persson on 2024-08-25.
 //
 
+import Defaults
 import SwiftUI
 
 struct TabModel: Identifiable {
@@ -16,21 +17,28 @@ struct TabModel: Identifiable {
 
 let tabs = [
     TabModel(label: "Home", icon: "house.fill", view: .home),
+    TabModel(label: "Calendar", icon: "calendar", view: .calendar),
     TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
 ]
 
 struct TabSelectionView: View {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
+    @Default(.showCalendar) private var showCalendar
+    @Default(.boringShelf) private var showShelf
     @Namespace var animation
+    private var visibleTabs: [TabModel] {
+        tabs.filter { ($0.view != .calendar || showCalendar) && ($0.view != .shelf || showShelf) }
+    }
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(tabs) { tab in
+            ForEach(visibleTabs) { tab in
                     TabButton(label: tab.label, icon: tab.icon, selected: coordinator.currentView == tab.view) {
                         withAnimation(.smooth) {
                             coordinator.currentView = tab.view
                         }
                     }
                     .frame(height: 26)
+                    .help(tab.label)
                     .foregroundStyle(tab.view == coordinator.currentView ? .white : .gray)
                     .background {
                         if tab.view == coordinator.currentView {

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -20,6 +20,7 @@ enum NotchState {
 
 enum NotchViews {
     case home
+    case calendar
     case shelf
 }
 

--- a/boringNotch/extensions/PanGesture.swift
+++ b/boringNotch/extensions/PanGesture.swift
@@ -19,6 +19,21 @@ enum PanDirection {
     func signed(deltaX: CGFloat, deltaY: CGFloat) -> CGFloat { (isHorizontal ? deltaX : deltaY) * sign }
 }
 
+/// Content scroll views own their wheel events before the notch considers them gestures.
+enum PanGestureScrollRouting {
+    @MainActor static func targetsScrollView(_ event: NSEvent) -> Bool {
+        guard let contentView = event.window?.contentView else { return false }
+        let point = contentView.superview?.convert(event.locationInWindow, from: nil) ?? event.locationInWindow
+        var target = contentView.hitTest(point)
+        while let view = target {
+            // Frozen calendar labels use a clip view and forward their wheel to the timeline.
+            if view is NSScrollView || view is NSClipView { return true }
+            target = view.superview
+        }
+        return false
+    }
+}
+
 extension View {
     func panGesture(direction: PanDirection, threshold: CGFloat = 4, action: @escaping (CGFloat, NSEvent.Phase) -> Void) -> some View {
         self
@@ -91,9 +106,21 @@ private struct ScrollMonitor: NSViewRepresentable {
             // Local monitor for normal in-window scroll events.
             localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.scrollWheel]) { [weak self, weak view] event in
                 guard let self = self, event.window === view?.window else { return event }
+                if PanGestureScrollRouting.targetsScrollView(event) {
+                    self.cancelScrollGesture()
+                    return event
+                }
                 self.handleScroll(event)
                 return event
             }
+        }
+
+        private func cancelScrollGesture() {
+            endTask?.cancel()
+            endTask = nil
+            if active { action(0, .ended) }
+            accumulated = 0
+            active = false
         }
 
         func removeMonitor() {

--- a/boringNotch/managers/CalendarManager.swift
+++ b/boringNotch/managers/CalendarManager.swift
@@ -190,6 +190,16 @@ final class CalendarManager: ObservableObject {
         await updateEvents()
     }
 
+    /// Query the timeline's rolling range without changing the selected calendar day.
+    func events(from start: Date, to end: Date) async -> [EventModel] {
+        await reloadCalendarAndReminderLists()
+        let identifiers = selectedCalendarIDs
+        guard !identifiers.isEmpty else { return [] }
+        let result = await calendarService.events(from: start, to: end, calendars: Array(identifiers))
+        // EventKit treats an empty per-entity calendar list as every calendar.
+        return result.filter { identifiers.contains($0.calendar.id) }
+    }
+
     private func updateEvents() async {
         let calendarIDs = selectedCalendars.map { $0.id }
         let eventsResult = await calendarService.events(

--- a/boringNotch/managers/CalendarManager.swift
+++ b/boringNotch/managers/CalendarManager.swift
@@ -24,14 +24,16 @@ final class CalendarManager: ObservableObject {
     @Published var calendarAuthorizationStatus: EKAuthorizationStatus = .notDetermined
     @Published var reminderAuthorizationStatus: EKAuthorizationStatus = .notDetermined
     private var selectedCalendars: [CalendarModel] = []
-    private let calendarService = CalendarService()
+    private let calendarService: any CalendarServiceProviding
+    private var eventsRequestID = 0
 
     private var eventStoreChangedObserver: NSObjectProtocol?
     /// EventKit can fire EKEventStoreChanged in bursts during syncs; reloads
     /// coalesce so the UI refreshes once per burst instead of per notification.
     private var reloadTask: Task<Void, Never>?
 
-    private init() {
+    init(calendarService: any CalendarServiceProviding = CalendarService()) {
+        self.calendarService = calendarService
         self.currentWeekStartDate = CalendarManager.startOfDay(Date())
         setupEventStoreChangedObserver()
         Task {
@@ -86,20 +88,14 @@ final class CalendarManager: ObservableObject {
             self.calendarAuthorizationStatus = granted ? .fullAccess : .denied
             if granted {
                 await reloadCalendarAndReminderLists()
-                events = await calendarService.events(
-                    from: currentWeekStartDate,
-                    to: Calendar.current.date(byAdding: .day, value: 1, to: currentWeekStartDate)!,
-                    calendars: selectedCalendars.map { $0.id })
+                await updateEvents()
             }
         case .restricted, .denied:
             NSLog("Calendar access denied or restricted")
         case .fullAccess:
             NSLog("Full access")
             await reloadCalendarAndReminderLists()
-            events = await calendarService.events(
-                from: currentWeekStartDate,
-                to: Calendar.current.date(byAdding: .day, value: 1, to: currentWeekStartDate)!,
-                calendars: selectedCalendars.map { $0.id })
+            await updateEvents()
         case .writeOnly:
             NSLog("Write only")
         @unknown default:
@@ -155,28 +151,12 @@ final class CalendarManager: ObservableObject {
     }
 
     func setCalendarSelected(_ calendar: CalendarModel, isSelected: Bool) async {
-        var selectionState = Defaults[.calendarSelectionState]
+        await setCalendarsSelected([calendar], isSelected: isSelected)
+    }
 
-        switch selectionState {
-        case .all:
-            if !isSelected {
-                let identifiers = Set(allCalendars.map { $0.id }).subtracting([calendar.id])
-                selectionState = .selected(identifiers)
-            }
-
-        case .selected(var identifiers):
-            if isSelected {
-                identifiers.insert(calendar.id)
-            } else {
-                identifiers.remove(calendar.id)
-            }
-
-            selectionState =
-                identifiers.isEmpty
-                ? .all : identifiers.count == allCalendars.count ? .all : .selected(identifiers)  // if empty, select all
-        }
-
-        Defaults[.calendarSelectionState] = selectionState
+    func setCalendarsSelected(_ calendars: [CalendarModel], isSelected: Bool) async {
+        Defaults[.calendarSelectionState] = Defaults[.calendarSelectionState].settingSelected(
+            Set(calendars.map(\.id)), isSelected: isSelected, availableIDs: Set(allCalendars.map(\.id)))
         updateSelectedCalendars()
         await updateEvents()
     }
@@ -201,21 +181,24 @@ final class CalendarManager: ObservableObject {
     }
 
     private func updateEvents() async {
+        eventsRequestID += 1
+        let requestID = eventsRequestID
+        let date = currentWeekStartDate
         let calendarIDs = selectedCalendars.map { $0.id }
+        guard let end = Calendar.current.date(byAdding: .day, value: 1, to: date) else { return }
         let eventsResult = await calendarService.events(
-            from: currentWeekStartDate,
-            to: Calendar.current.date(byAdding: .day, value: 1, to: currentWeekStartDate)!,
+            from: date,
+            to: end,
             calendars: calendarIDs
         )
+        guard requestID == eventsRequestID, date == currentWeekStartDate,
+              Set(calendarIDs) == Set(selectedCalendars.map(\.id)) else { return }
         self.events = eventsResult
     }
     
     func setReminderCompleted(reminderID: String, completed: Bool) async {
         await calendarService.setReminderCompleted(reminderID: reminderID, completed: completed)
         // Refresh events after updating
-        events = await calendarService.events(
-            from: currentWeekStartDate,
-            to: Calendar.current.date(byAdding: .day, value: 1, to: currentWeekStartDate)!,
-            calendars: selectedCalendars.map { $0.id })
+        await updateEvents()
     }
 }

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -186,7 +186,7 @@ final class BoringViewModel: NSObject, ObservableObject {
     func open() -> Bool {
         guard !coordinator.firstLaunch, notchState != .open else { return false }
 
-        self.notchSize = openNotchSize
+        self.notchSize = notchOpenSize(for: coordinator.currentView)
         self.notchState = .open
         
         // Force music information update when notch is opened

--- a/boringNotch/models/CalendarModel.swift
+++ b/boringNotch/models/CalendarModel.swift
@@ -7,6 +7,33 @@
 //
 
 import Cocoa
+import Defaults
+
+enum CalendarSelectionState: Codable, Defaults.Serializable {
+    case all
+    case selected(Set<String>)
+
+    func settingSelected(_ calendarIDs: Set<String>, isSelected: Bool, availableIDs: Set<String>) -> Self {
+        var identifiers: Set<String>
+        switch self {
+        case .all:
+            if isSelected { return .all }
+            identifiers = availableIDs
+        case .selected(let selected):
+            identifiers = selected
+        }
+        if isSelected {
+            identifiers.formUnion(calendarIDs)
+        } else {
+            identifiers.subtract(calendarIDs)
+        }
+        // Empty means empty; the last checkbox is not a secret Select All button.
+        if !availableIDs.isEmpty && availableIDs.isSubset(of: identifiers) {
+            return .all
+        }
+        return .selected(identifiers)
+    }
+}
 
 struct CalendarModel: Equatable {
     let id: String

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -360,6 +360,7 @@ extension Defaults.Keys {
     static let showFullEventTitles = Key<Bool>("showFullEventTitles", default: false)
     static let autoScrollToNextEvent = Key<Bool>("autoScrollToNextEvent", default: true)
     static let calendarWeekView = Key<Bool>("calendarWeekView", default: false)
+    static let calendarTimelineScale = Key<Double>("calendarTimelineScale", default: 1.0)
     static let weekStartDay = Key<WeekStartDay>("weekStartDay", default: .system)
     static let joinMeetingOnEventTap = Key<Bool>("joinMeetingOnEventTap", default: true)
     

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -18,11 +18,6 @@ let temporaryDirectory: URL = FileManager.default.urls(for: .cachesDirectory, in
     ?? URL(fileURLWithPath: NSTemporaryDirectory())
 let spacing: CGFloat = 16
 
-enum CalendarSelectionState: Codable, Defaults.Serializable {
-    case all
-    case selected(Set<String>)
-}
-
 enum HideNotchOption: String, Defaults.Serializable {
     case always
     case nowPlayingOnly

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -359,6 +359,7 @@ extension Defaults.Keys {
     static let reverseShelfOrdering = Key<Bool>("reverseShelfOrdering", default: false)
     
     // MARK: Calendar
+    static let showMonthOnHome = Key<Bool>("showMonthOnHome", default: false)
     static let calendarSelectionState = Key<CalendarSelectionState>("calendarSelectionState", default: .all)
     static let hideAllDayEvents = Key<Bool>("hideAllDayEvents", default: false)
     static let showFullEventTitles = Key<Bool>("showFullEventTitles", default: false)

--- a/boringNotch/models/Constants.swift
+++ b/boringNotch/models/Constants.swift
@@ -360,7 +360,9 @@ extension Defaults.Keys {
     static let showFullEventTitles = Key<Bool>("showFullEventTitles", default: false)
     static let autoScrollToNextEvent = Key<Bool>("autoScrollToNextEvent", default: true)
     static let calendarWeekView = Key<Bool>("calendarWeekView", default: false)
+    // Home retains the original preference key for existing installations.
     static let calendarTimelineScale = Key<Double>("calendarTimelineScale", default: 1.0)
+    static let calendarPaneTimelineScale = Key<Double>("calendarPaneTimelineScale", default: 1.0)
     static let weekStartDay = Key<WeekStartDay>("weekStartDay", default: .system)
     static let joinMeetingOnEventTap = Key<Bool>("joinMeetingOnEventTap", default: true)
     

--- a/boringNotch/sizing/matters.swift
+++ b/boringNotch/sizing/matters.swift
@@ -11,7 +11,13 @@ import SwiftUI
 
 let shadowPadding: CGFloat = 20
 let openNotchSize: CGSize = .init(width: 640, height: 190)
-let windowSize: CGSize = .init(width: openNotchSize.width, height: openNotchSize.height + shadowPadding)
+let calendarNotchSize: CGSize = .init(width: 640, height: 310)
+let windowSize: CGSize = .init(width: openNotchSize.width, height: calendarNotchSize.height + shadowPadding)
+
+func notchOpenSize(for view: NotchViews) -> CGSize {
+    view == .calendar ? calendarNotchSize : openNotchSize
+}
+
 let cornerRadiusInsets: (opened: (top: CGFloat, bottom: CGFloat), closed: (top: CGFloat, bottom: CGFloat)) = (opened: (top: 19, bottom: 24), closed: (top: 6, bottom: 14))
 
 /// Compact mode uses a much rounder opened shape than the standard layout

--- a/script/check-calendar-month.sh
+++ b/script/check-calendar-month.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/boring-notch-month-tests.XXXXXX")"
+trap 'rm -rf "$TEST_BUILD_DIR"' EXIT
+
+xcrun swiftc -parse-as-library \
+  "$PROJECT_ROOT/boringNotch/components/Calendar/CalendarMonthGeometry.swift" \
+  "$PROJECT_ROOT/tests/CalendarMonthGeometryTests.swift" \
+  -o "$TEST_BUILD_DIR/calendar-month-tests"
+"$TEST_BUILD_DIR/calendar-month-tests"

--- a/script/check-calendar-scale.sh
+++ b/script/check-calendar-scale.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+test_directory="$(mktemp -d)"
+trap 'rm -rf "$test_directory"' EXIT
+
+swiftc \
+    "$repo_root/boringNotch/components/Calendar/CalendarTimelineGeometry.swift" \
+    "$repo_root/boringNotch/components/Calendar/HomeCalendarGeometry.swift" \
+    "$repo_root/tests/CalendarTimelineScaleTests.swift" \
+    -o "$test_directory/calendar-scale-tests"
+"$test_directory/calendar-scale-tests"

--- a/script/check-calendar-today.sh
+++ b/script/check-calendar-today.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+repo_dir="$(cd "$(dirname "$0")/.." && pwd)"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+swiftc -swift-version 5 \
+    "$repo_dir/boringNotch/components/Calendar/CalendarTodayShortcut.swift" \
+    "$repo_dir/tests/CalendarTodayShortcutTests.swift" \
+    -o "$test_dir/calendar-today-tests"
+"$test_dir/calendar-today-tests"

--- a/script/check_calendar_day_stack.sh
+++ b/script/check_calendar_day_stack.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+test_directory="$(mktemp -d)"
+trap 'rm -rf "$test_directory"' EXIT
+
+swiftc \
+    "$repo_root/boringNotch/components/Calendar/CalendarDayStackGeometry.swift" \
+    "$repo_root/tests/CalendarDayStackGeometryTests.swift" \
+    -o "$test_directory/calendar-day-stack-tests"
+"$test_directory/calendar-day-stack-tests"
+
+swiftc -parse-as-library \
+    "$repo_root/boringNotch/components/Calendar/CalendarTimelineGeometry.swift" \
+    "$repo_root/boringNotch/components/Calendar/CalendarDayStackGeometry.swift" \
+    "$repo_root/boringNotch/components/Calendar/CalendarDayScrollView.swift" \
+    "$repo_root/tests/CalendarDayNativeScrollTests.swift" \
+    -o "$test_directory/calendar-day-native-scroll-tests"
+"$test_directory/calendar-day-native-scroll-tests"

--- a/script/check_calendar_selection.sh
+++ b/script/check_calendar_selection.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+test_directory="$(mktemp -d)"
+trap 'rm -rf "$test_directory"' EXIT
+
+# Build the app first with -derivedDataPath DerivedData, or point this variable
+# at another build's Debug/Release products directory.
+products_directory="${CALENDAR_TEST_PRODUCTS_DIR:-$repo_root/DerivedData/Build/Products/Debug}"
+if [[ ! -f "$products_directory/Defaults.o" && -z "${CALENDAR_TEST_PRODUCTS_DIR:-}" ]]; then
+    products_directory="$repo_root/DerivedData/Build/Products/Release"
+fi
+if [[ ! -f "$products_directory/Defaults.o" || ! -d "$products_directory/Defaults.swiftmodule" ]]; then
+    echo "Build boringNotch with -derivedDataPath DerivedData first, or set CALENDAR_TEST_PRODUCTS_DIR to its build products directory." >&2
+    exit 1
+fi
+
+# Debug dependency builds can include LLVM coverage instrumentation.
+xcrun swiftc -profile-generate -parse-as-library -target "$(uname -m)-apple-macosx14.0" \
+    -I "$products_directory" \
+    "$repo_root/boringNotch/models/CalendarModel.swift" \
+    "$repo_root/boringNotch/models/EventModel.swift" \
+    "$repo_root/boringNotch/models/MeetingLink.swift" \
+    "$repo_root/boringNotch/helpers/Log.swift" \
+    "$repo_root/boringNotch/Providers/MeetingLinkDetector.swift" \
+    "$repo_root/boringNotch/Providers/CalendarServiceProviding.swift" \
+    "$repo_root/boringNotch/managers/CalendarManager.swift" \
+    "$repo_root/tests/CalendarSelectionTests.swift" \
+    "$products_directory/Defaults.o" \
+    -o "$test_directory/calendar-selection-tests"
+LLVM_PROFILE_FILE="$test_directory/calendar-selection.profraw" "$test_directory/calendar-selection-tests"

--- a/script/check_calendar_timeline.sh
+++ b/script/check_calendar_timeline.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+test_directory="$(mktemp -d)"
+trap 'rm -rf "$test_directory"' EXIT
+
+swiftc \
+    "$repo_root/boringNotch/components/Calendar/CalendarTimelineGeometry.swift" \
+    "$repo_root/tests/CalendarTimelineGeometryTests.swift" \
+    -o "$test_directory/calendar-timeline-tests"
+"$test_directory/calendar-timeline-tests"

--- a/script/check_calendar_visible_range.sh
+++ b/script/check_calendar_visible_range.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+test_directory="$(mktemp -d)"
+trap 'rm -rf "$test_directory"' EXIT
+
+swiftc \
+    "$repo_root/boringNotch/components/Calendar/CalendarTimelineGeometry.swift" \
+    "$repo_root/tests/CalendarVisibleRangeTests.swift" \
+    -o "$test_directory/calendar-visible-range-tests"
+"$test_directory/calendar-visible-range-tests"

--- a/script/check_calendar_wheel_routing.sh
+++ b/script/check_calendar_wheel_routing.sh
@@ -2,16 +2,24 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+# Prerequisite: xcodebuild -project boringNotch.xcodeproj -scheme boringNotch -configuration Debug -derivedDataPath DerivedData build
+build_products="${BORING_NOTCH_BUILD_PRODUCTS_DIR:-$repo_root/DerivedData/Build/Products/Debug}"
+if [[ ! -f "$build_products/Defaults.o" ]]; then
+    printf '%s\n' "Missing Defaults.o. Run the Debug build above, or set BORING_NOTCH_BUILD_PRODUCTS_DIR to its products directory." >&2
+    exit 1
+fi
+
 test_directory="$(mktemp -d)"
 trap 'rm -rf "$test_directory"' EXIT
 
-xcrun swiftc -parse-as-library \
-    -I "$repo_root/DerivedData/Build/Products/Release" \
+# Debug package objects may include coverage instrumentation.
+xcrun swiftc -parse-as-library -profile-generate \
+    -I "$build_products" \
     "$repo_root/boringNotch/extensions/PanGesture.swift" \
     "$repo_root/boringNotch/components/Calendar/CalendarTimelineGeometry.swift" \
     "$repo_root/boringNotch/components/Calendar/HomeCalendarGeometry.swift" \
     "$repo_root/boringNotch/components/Calendar/HomeCalendarScrollView.swift" \
     "$repo_root/tests/PanGestureScrollRoutingTests.swift" \
-    "$repo_root/DerivedData/Build/Products/Release/Defaults.o" \
+    "$build_products/Defaults.o" \
     -o "$test_directory/calendar-wheel-tests"
-"$test_directory/calendar-wheel-tests"
+LLVM_PROFILE_FILE="$test_directory/calendar-wheel.profraw" "$test_directory/calendar-wheel-tests"

--- a/script/check_calendar_wheel_routing.sh
+++ b/script/check_calendar_wheel_routing.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+test_directory="$(mktemp -d)"
+trap 'rm -rf "$test_directory"' EXIT
+
+xcrun swiftc -parse-as-library \
+    -I "$repo_root/DerivedData/Build/Products/Release" \
+    "$repo_root/boringNotch/extensions/PanGesture.swift" \
+    "$repo_root/boringNotch/components/Calendar/CalendarTimelineGeometry.swift" \
+    "$repo_root/boringNotch/components/Calendar/HomeCalendarGeometry.swift" \
+    "$repo_root/boringNotch/components/Calendar/HomeCalendarScrollView.swift" \
+    "$repo_root/tests/PanGestureScrollRoutingTests.swift" \
+    "$repo_root/DerivedData/Build/Products/Release/Defaults.o" \
+    -o "$test_directory/calendar-wheel-tests"
+"$test_directory/calendar-wheel-tests"

--- a/script/check_home_calendar.sh
+++ b/script/check_home_calendar.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+test_directory="$(mktemp -d)"
+trap 'rm -rf "$test_directory"' EXIT
+
+swiftc \
+    "$repo_root/boringNotch/components/Calendar/CalendarTimelineGeometry.swift" \
+    "$repo_root/boringNotch/components/Calendar/HomeCalendarGeometry.swift" \
+    "$repo_root/tests/HomeCalendarGeometryTests.swift" \
+    -o "$test_directory/home-calendar-tests"
+"$test_directory/home-calendar-tests"

--- a/tests/CalendarDayNativeScrollTests.swift
+++ b/tests/CalendarDayNativeScrollTests.swift
@@ -99,19 +99,19 @@ private final class CalendarDayScrollTestDocument: NSView {
         scrollView.scrollWheel(with: event(horizontal: -13, vertical: -20))
         expectOrigin(813, maximumY, "A clamped vertical axis does not swallow horizontal movement")
 
-        let container = CalendarDayScrollContainer(frame: NSRect(x: 0, y: 0, width: 600, height: 202))
+        let container = CalendarDayScrollContainer(frame: NSRect(x: 0, y: 0, width: 600, height: 204))
         container.needsLayout = true
         container.layoutSubtreeIfNeeded()
         expect(container.scrollView.hasVerticalScroller, "The day list exposes a vertical scroller")
-        expect(container.gutter.frame == NSRect(x: 0, y: 0, width: 47, height: 202),
-               "Day labels retain their fixed 47-point gutter")
-        expect(container.scrollView.frame == NSRect(x: 55, y: 0, width: 545, height: 202),
+        expect(container.gutter.frame == NSRect(x: 0, y: 0, width: 68, height: 204),
+               "Day labels retain their fixed 68-point gutter")
+        expect(container.scrollView.frame == NSRect(x: 76, y: 0, width: 524, height: 204),
                "The timeline fills the remaining viewport beside the day gutter")
 
         container.scrollView.documentView = CalendarDayScrollTestDocument(
             frame: NSRect(x: 0, y: 0, width: 2400, height: 1800))
         container.gutter.documentView = CalendarDayScrollTestDocument(
-            frame: NSRect(x: 0, y: 0, width: 47, height: 1800))
+            frame: NSRect(x: 0, y: 0, width: 68, height: 1800))
         container.scrollView.tile()
         container.scrollView.move(to: NSPoint(x: 800, y: 300))
         container.gutter.scroll(to: NSPoint(x: 0, y: 300))
@@ -145,26 +145,26 @@ private final class CalendarDayScrollTestDocument: NSView {
 
         let initial = CalendarDayNativeScrollView(frame: .zero)
         initial.borderType = .noBorder
-        initial.documentView = CalendarDayScrollTestDocument(frame: NSRect(x: 0, y: 0, width: 12 * 96, height: 730))
+        initial.documentView = CalendarDayScrollTestDocument(frame: NSRect(x: 0, y: 0, width: 12 * 96, height: 754))
         var initialCallbacks: [NSPoint] = []
-        initial.move(to: NSPoint(x: 12 * 96, y: 318)) {
+        initial.move(to: NSPoint(x: 12 * 96, y: 330)) {
             initialCallbacks.append(initial.contentView.bounds.origin)
         }
-        expect(initial.requestedOrigin == NSPoint(x: 12 * 96, y: 318),
+        expect(initial.requestedOrigin == NSPoint(x: 12 * 96, y: 330),
                "A Today reset after 19:00 is retained until the viewport has a size")
         expect(initialCallbacks.isEmpty, "A zero-size viewport does not complete an unapplied movement")
         initial.needsLayout = true
         initial.layoutSubtreeIfNeeded()
         expect(initialCallbacks.isEmpty, "Layout with no viewport size keeps the completion pending")
-        initial.frame = NSRect(x: 0, y: 0, width: 545, height: 202)
+        initial.frame = NSRect(x: 0, y: 0, width: 524, height: 204)
         initial.needsLayout = true
         initial.layoutSubtreeIfNeeded()
         expect(abs(initial.contentView.bounds.minX - (12 * 96 - initial.contentView.bounds.width)) < 0.01,
                "The first sized layout clamps a late Today reset to the visible daytime window")
-        expect(abs(initial.contentView.bounds.minY - 318) < 0.01,
+        expect(abs(initial.contentView.bounds.minY - 330) < 0.01,
                "Clamping a late hour never moves Today to a different day row")
         expect(initialCallbacks.count == 1, "The first sized layout completes the pending movement exactly once")
-        expect(initialCallbacks.first == NSPoint(x: 12 * 96 - initial.contentView.bounds.width, y: 318),
+        expect(initialCallbacks.first == NSPoint(x: 12 * 96 - initial.contentView.bounds.width, y: 330),
                "A deferred callback observes the final clamped hour and requested day")
         initial.needsLayout = true
         initial.layoutSubtreeIfNeeded()
@@ -174,7 +174,7 @@ private final class CalendarDayScrollTestDocument: NSView {
         let replacement = CalendarDayNativeScrollView(frame: .zero)
         replacement.borderType = .noBorder
         replacement.documentView = CalendarDayScrollTestDocument(
-            frame: NSRect(x: 0, y: 0, width: 12 * 96, height: 730))
+            frame: NSRect(x: 0, y: 0, width: 12 * 96, height: 754))
         var staleCallbackCount = 0
         var replacementCallbacks: [NSPoint] = []
         replacement.move(to: NSPoint(x: 40, y: 80)) { staleCallbackCount += 1 }
@@ -185,7 +185,7 @@ private final class CalendarDayScrollTestDocument: NSView {
                "Neither pending completion fires before the viewport is sized")
         expect(replacement.requestedOrigin == NSPoint(x: 100000, y: -100),
                "The newest pending movement replaces the stale requested position")
-        replacement.frame = NSRect(x: 0, y: 0, width: 545, height: 202)
+        replacement.frame = NSRect(x: 0, y: 0, width: 524, height: 204)
         replacement.needsLayout = true
         replacement.layoutSubtreeIfNeeded()
         expect(staleCallbackCount == 0 && replacementCallbacks.count == 1,

--- a/tests/CalendarDayNativeScrollTests.swift
+++ b/tests/CalendarDayNativeScrollTests.swift
@@ -1,0 +1,213 @@
+//
+//  CalendarDayNativeScrollTests.swift
+//  boringNotch
+//
+
+import AppKit
+
+private final class CalendarDayScrollTestDocument: NSView {
+    override var isFlipped: Bool { true }
+}
+
+@main enum CalendarDayNativeScrollTests {
+    @MainActor static func main() {
+        _ = NSApplication.shared
+        let scrollView = CalendarDayNativeScrollView(frame: NSRect(x: 0, y: 0, width: 320, height: 180))
+        scrollView.borderType = .noBorder
+        scrollView.hasHorizontalScroller = false
+        scrollView.hasVerticalScroller = false
+        scrollView.horizontalScrollElasticity = .none
+        scrollView.verticalScrollElasticity = .none
+        let document = CalendarDayScrollTestDocument(frame: NSRect(x: 0, y: 0, width: 2400, height: 1800))
+        scrollView.documentView = document
+        scrollView.tile()
+        defer { scrollView.documentView = nil }
+
+        var checks = 0
+        func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+            precondition(condition(), message)
+            checks += 1
+        }
+        func expectOrigin(_ x: CGFloat, _ y: CGFloat, _ message: String) {
+            let actual = scrollView.contentView.bounds.origin
+            expect(abs(actual.x - x) < 0.01 && abs(actual.y - y) < 0.01,
+                   "\(message): expected (\(x), \(y)), got \(actual)")
+        }
+        func event(horizontal: Int32 = 0, vertical: Int32 = 0, units: CGScrollEventUnit = .pixel) -> NSEvent {
+            guard let cgEvent = CGEvent(scrollWheelEvent2Source: nil, units: units, wheelCount: 2,
+                                        wheel1: vertical, wheel2: horizontal, wheel3: 0),
+                  let event = NSEvent(cgEvent: cgEvent) else { preconditionFailure("Invalid scroll event fixture") }
+            return event
+        }
+        let start = NSPoint(x: 800, y: 600)
+        func reset() { scrollView.move(to: start) }
+
+        reset()
+        expectOrigin(start.x, start.y, "Programmatic positioning works without a window")
+        let down = event(vertical: -40)
+        expect(down.hasPreciseScrollingDeltas, "Pixel events must exercise precise trackpad routing")
+        expect(down.scrollingDeltaX == 0 && down.scrollingDeltaY == -40, "Pixel fixture preserves the vertical delta")
+        scrollView.scrollWheel(with: down)
+        expectOrigin(800, 640, "Vertical gestures advance days without changing the hour")
+        scrollView.scrollWheel(with: event(vertical: 40))
+        expectOrigin(800, 600, "Reverse vertical gestures return to the previous day position")
+
+        scrollView.scrollWheel(with: event(horizontal: -30))
+        expectOrigin(830, 600, "Horizontal gestures advance hours without changing the day")
+        scrollView.scrollWheel(with: event(horizontal: 30))
+        expectOrigin(800, 600, "Reverse horizontal gestures restore the original hour")
+
+        scrollView.scrollWheel(with: event(horizontal: -17, vertical: -29))
+        expectOrigin(817, 629, "Diagonal gestures retain both independent axes")
+        scrollView.scrollWheel(with: event(horizontal: 17, vertical: 29))
+        expectOrigin(800, 600, "Opposite diagonal gestures cancel each other")
+        scrollView.scrollWheel(with: event(horizontal: 0, vertical: 0))
+        expectOrigin(800, 600, "An empty wheel event leaves the viewport unchanged")
+
+        let coarse = event(horizontal: -2, vertical: -3, units: .line)
+        expect(!coarse.hasPreciseScrollingDeltas, "Line events must exercise coarse mouse-wheel routing")
+        expect(coarse.scrollingDeltaX < 0 && coarse.scrollingDeltaY < 0, "Coarse fixture has two negative deltas")
+        scrollView.scrollWheel(with: coarse)
+        expectOrigin(start.x - coarse.scrollingDeltaX * 12, start.y - coarse.scrollingDeltaY * 12,
+                     "Coarse wheel deltas move twelve points per reported unit on both axes")
+        reset()
+        let coarseVertical = event(vertical: -1, units: .line)
+        scrollView.scrollWheel(with: coarseVertical)
+        expectOrigin(start.x, start.y - coarseVertical.scrollingDeltaY * 12,
+                     "Coarse vertical scrolling never leaks into the hour axis")
+        reset()
+        let coarseHorizontal = event(horizontal: -1, units: .line)
+        scrollView.scrollWheel(with: coarseHorizontal)
+        expectOrigin(start.x - coarseHorizontal.scrollingDeltaX * 12, start.y,
+                     "Coarse horizontal scrolling never leaks into the day axis")
+
+        let maximumX = document.frame.width - scrollView.contentView.bounds.width
+        let maximumY = document.frame.height - scrollView.contentView.bounds.height
+        scrollView.move(to: NSPoint(x: -100, y: -200))
+        expectOrigin(0, 0, "Programmatic movement clamps both lower bounds")
+        scrollView.scrollWheel(with: event(horizontal: 50, vertical: 50))
+        expectOrigin(0, 0, "Outward gestures remain at the lower corner")
+        scrollView.move(to: NSPoint(x: 100000, y: 100000))
+        expectOrigin(maximumX, maximumY, "Programmatic movement clamps both upper bounds")
+        scrollView.scrollWheel(with: event(horizontal: -50, vertical: -50))
+        expectOrigin(maximumX, maximumY, "Outward gestures remain at the upper corner")
+
+        scrollView.move(to: NSPoint(x: 4, y: 600))
+        scrollView.scrollWheel(with: event(horizontal: 20, vertical: -11))
+        expectOrigin(0, 611, "A clamped horizontal axis does not swallow vertical movement")
+        scrollView.move(to: NSPoint(x: 800, y: maximumY - 4))
+        scrollView.scrollWheel(with: event(horizontal: -13, vertical: -20))
+        expectOrigin(813, maximumY, "A clamped vertical axis does not swallow horizontal movement")
+
+        let container = CalendarDayScrollContainer(frame: NSRect(x: 0, y: 0, width: 600, height: 202))
+        container.needsLayout = true
+        container.layoutSubtreeIfNeeded()
+        expect(container.scrollView.hasVerticalScroller, "The day list exposes a vertical scroller")
+        expect(container.gutter.frame == NSRect(x: 0, y: 0, width: 47, height: 202),
+               "Day labels retain their fixed 47-point gutter")
+        expect(container.scrollView.frame == NSRect(x: 55, y: 0, width: 545, height: 202),
+               "The timeline fills the remaining viewport beside the day gutter")
+
+        container.scrollView.documentView = CalendarDayScrollTestDocument(
+            frame: NSRect(x: 0, y: 0, width: 2400, height: 1800))
+        container.gutter.documentView = CalendarDayScrollTestDocument(
+            frame: NSRect(x: 0, y: 0, width: 47, height: 1800))
+        container.scrollView.tile()
+        container.scrollView.move(to: NSPoint(x: 800, y: 300))
+        container.gutter.scroll(to: NSPoint(x: 0, y: 300))
+        let frozenGutterX = container.gutter.frame.minX
+        container.gutter.scrollWheel(with: event(vertical: -40))
+        let afterGutterVertical = container.scrollView.contentView.bounds.origin
+        expect(abs(afterGutterVertical.x - 800) < 0.01 && abs(afterGutterVertical.y - 340) < 0.01,
+               "Wheel events on the gutter must advance days without changing hours; got \(afterGutterVertical)")
+        expect(container.gutter.frame.minX == frozenGutterX,
+               "Vertical gutter gestures must preserve the frozen gutter frame")
+
+        container.gutter.scrollWheel(with: event(horizontal: -30))
+        let afterGutterHorizontal = container.scrollView.contentView.bounds.origin
+        expect(abs(afterGutterHorizontal.x - 830) < 0.01 && abs(afterGutterHorizontal.y - 340) < 0.01,
+               "Wheel events on the gutter must advance hours without changing days; got \(afterGutterHorizontal)")
+        expect(container.gutter.frame.minX == frozenGutterX,
+               "Horizontal gutter gestures must preserve the frozen gutter frame")
+        container.scrollView.documentView = nil
+        container.gutter.documentView = nil
+
+        var immediateCallbacks: [NSPoint] = []
+        scrollView.move(to: NSPoint(x: -100, y: 100000)) {
+            immediateCallbacks.append(scrollView.contentView.bounds.origin)
+        }
+        expect(immediateCallbacks.count == 1, "A sized viewport completes movement exactly once")
+        expect(immediateCallbacks.first == NSPoint(x: 0, y: maximumY),
+               "The immediate callback observes both axes after clamping")
+        scrollView.needsLayout = true
+        scrollView.layoutSubtreeIfNeeded()
+        expect(immediateCallbacks.count == 1, "A later layout never repeats an immediate callback")
+
+        let initial = CalendarDayNativeScrollView(frame: .zero)
+        initial.borderType = .noBorder
+        initial.documentView = CalendarDayScrollTestDocument(frame: NSRect(x: 0, y: 0, width: 12 * 96, height: 730))
+        var initialCallbacks: [NSPoint] = []
+        initial.move(to: NSPoint(x: 12 * 96, y: 318)) {
+            initialCallbacks.append(initial.contentView.bounds.origin)
+        }
+        expect(initial.requestedOrigin == NSPoint(x: 12 * 96, y: 318),
+               "A Today reset after 19:00 is retained until the viewport has a size")
+        expect(initialCallbacks.isEmpty, "A zero-size viewport does not complete an unapplied movement")
+        initial.needsLayout = true
+        initial.layoutSubtreeIfNeeded()
+        expect(initialCallbacks.isEmpty, "Layout with no viewport size keeps the completion pending")
+        initial.frame = NSRect(x: 0, y: 0, width: 545, height: 202)
+        initial.needsLayout = true
+        initial.layoutSubtreeIfNeeded()
+        expect(abs(initial.contentView.bounds.minX - (12 * 96 - initial.contentView.bounds.width)) < 0.01,
+               "The first sized layout clamps a late Today reset to the visible daytime window")
+        expect(abs(initial.contentView.bounds.minY - 318) < 0.01,
+               "Clamping a late hour never moves Today to a different day row")
+        expect(initialCallbacks.count == 1, "The first sized layout completes the pending movement exactly once")
+        expect(initialCallbacks.first == NSPoint(x: 12 * 96 - initial.contentView.bounds.width, y: 318),
+               "A deferred callback observes the final clamped hour and requested day")
+        initial.needsLayout = true
+        initial.layoutSubtreeIfNeeded()
+        expect(initialCallbacks.count == 1, "Further layouts never repeat a deferred callback")
+        initial.documentView = nil
+
+        let replacement = CalendarDayNativeScrollView(frame: .zero)
+        replacement.borderType = .noBorder
+        replacement.documentView = CalendarDayScrollTestDocument(
+            frame: NSRect(x: 0, y: 0, width: 12 * 96, height: 730))
+        var staleCallbackCount = 0
+        var replacementCallbacks: [NSPoint] = []
+        replacement.move(to: NSPoint(x: 40, y: 80)) { staleCallbackCount += 1 }
+        replacement.move(to: NSPoint(x: 100000, y: -100)) {
+            replacementCallbacks.append(replacement.contentView.bounds.origin)
+        }
+        expect(staleCallbackCount == 0 && replacementCallbacks.isEmpty,
+               "Neither pending completion fires before the viewport is sized")
+        expect(replacement.requestedOrigin == NSPoint(x: 100000, y: -100),
+               "The newest pending movement replaces the stale requested position")
+        replacement.frame = NSRect(x: 0, y: 0, width: 545, height: 202)
+        replacement.needsLayout = true
+        replacement.layoutSubtreeIfNeeded()
+        expect(staleCallbackCount == 0 && replacementCallbacks.count == 1,
+               "Only the newest pending completion fires when the viewport becomes ready")
+        expect(replacementCallbacks.first == NSPoint(x: 12 * 96 - replacement.contentView.bounds.width, y: 0),
+               "The replacement callback observes its own clamped coordinates on both axes")
+        replacement.needsLayout = true
+        replacement.layoutSubtreeIfNeeded()
+        expect(staleCallbackCount == 0 && replacementCallbacks.count == 1,
+               "Later layouts do not revive stale or already completed callbacks")
+        replacement.documentView = nil
+
+        // A tiny document has no secret extra days hiding beyond its edges.
+        document.setFrameSize(NSSize(width: 80, height: 60))
+        scrollView.move(to: NSPoint(x: 1000, y: 1000))
+        expectOrigin(0, 0, "A document smaller than the viewport has no scrollable extent")
+        scrollView.scrollWheel(with: event(horizontal: -50, vertical: -50))
+        expectOrigin(0, 0, "Wheel gestures keep a small document at the origin")
+        scrollView.documentView = nil
+        scrollView.move(to: NSPoint(x: 1000, y: 1000))
+        expectOrigin(0, 0, "A missing document safely clamps to the origin")
+
+        print("PASS \(checks) windowless native calendar day-scrolling checks")
+    }
+}

--- a/tests/CalendarDayStackGeometryTests.swift
+++ b/tests/CalendarDayStackGeometryTests.swift
@@ -16,17 +16,17 @@ enum CalendarDayStackGeometryTests {
         require(days[3].id == date("2026-09-07T00:00:00Z"), "The requested day must occupy the middle row")
         require(unwrap(days.first).id == date("2026-09-04T00:00:00Z") && unwrap(days.last).id == date("2026-09-10T00:00:00Z"),
                 "The window must extend three calendar days in each direction")
-        require(CalendarDayStackGeometry.rowHeight == 94 && CalendarDayStackGeometry.rowSpacing == 12
-                && CalendarDayStackGeometry.rowStride == 106 && CalendarDayStackGeometry.pointsPerHour == 96,
+        require(CalendarDayStackGeometry.rowHeight == 94 && CalendarDayStackGeometry.rowSpacing == 16
+                && CalendarDayStackGeometry.rowStride == 110 && CalendarDayStackGeometry.pointsPerHour == 96,
                 "The day stack must use the intended fixed row and horizontal hour dimensions")
         verifyWindow(days)
         verifyHiddenTimeOffsets(in: days[3].interval)
 
         let documentHeight = CalendarDayStackGeometry.documentHeight(for: days)
-        require(documentHeight == 730, "Seven rows must have only six intervening gaps")
+        require(documentHeight == 754, "Seven rows must have only six intervening gaps")
         let twoRowHeight = CalendarDayStackGeometry.documentHeight(for: Array(days.prefix(2)))
-        require(twoRowHeight == 200 && twoRowHeight <= 202,
-                "Two complete day rows and their gap must fit inside the 202-point viewport")
+        require(twoRowHeight == 204 && twoRowHeight <= 204,
+                "Two complete day rows and their gap must fit inside the 204-point viewport")
         require(CalendarDayStackGeometry.position(at: -10, in: days) == .init(day: days[0].id, intraDayOffset: 0),
                 "Negative positions must clamp to the first row")
         require(CalendarDayStackGeometry.position(at: documentHeight + 10, in: days)
@@ -71,17 +71,17 @@ enum CalendarDayStackGeometryTests {
         let visible = DateInterval(start: date("2026-09-07T07:00:00Z"), end: date("2026-09-07T19:00:00Z"))
         let early = date("2026-09-07T04:00:00Z")
         let late = date("2026-09-07T22:58:00Z")
-        require(CalendarDayStackGeometry.hiddenTimeOffset(for: early, in: day, visibleRange: visible) == -6,
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: early, in: day, visibleRange: visible) == -8,
                 "04:00 must appear in the middle of the gap above the daytime row")
-        require(CalendarDayStackGeometry.hiddenTimeOffset(for: late, in: day, visibleRange: visible) == 100,
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: late, in: day, visibleRange: visible) == 102,
                 "22:58 must appear in the middle of the gap below the daytime row")
         require(CalendarDayStackGeometry.hiddenTimeOffset(for: visible.start, in: day, visibleRange: visible) == nil,
                 "Exactly 07:00 belongs to the visible timeline and must not duplicate its marker in the gap")
-        require(CalendarDayStackGeometry.hiddenTimeOffset(for: visible.end, in: day, visibleRange: visible) == 100,
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: visible.end, in: day, visibleRange: visible) == 102,
                 "Exactly 19:00 is outside the half-open visible range and needs the lower gap marker")
         require(CalendarDayStackGeometry.hiddenTimeOffset(for: date("2026-09-07T12:00:00Z"), in: day, visibleRange: visible) == nil,
                 "Visible daytime hours must not produce a hidden-time marker")
-        require(CalendarDayStackGeometry.hiddenTimeOffset(for: day.start, in: day, visibleRange: visible) == -6,
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: day.start, in: day, visibleRange: visible) == -8,
                 "The inclusive midnight day boundary must remain eligible for the upper gap")
         for outside in [day.start.addingTimeInterval(-1), day.end, day.end.addingTimeInterval(4 * 3600)] {
             require(CalendarDayStackGeometry.hiddenTimeOffset(for: outside, in: day, visibleRange: visible) == nil,
@@ -90,7 +90,7 @@ enum CalendarDayStackGeometryTests {
         let extendedLate = DateInterval(start: visible.start, end: date("2026-09-07T23:00:00Z"))
         require(CalendarDayStackGeometry.hiddenTimeOffset(for: late, in: day, visibleRange: extendedLate) == nil,
                 "A late event extending the visible range must suppress the redundant 22:58 gap marker")
-        require(CalendarDayStackGeometry.hiddenTimeOffset(for: extendedLate.end, in: day, visibleRange: extendedLate) == 100,
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: extendedLate.end, in: day, visibleRange: extendedLate) == 102,
                 "The lower gap marker must follow the expanded visible range's exclusive end")
         let extendedEarly = DateInterval(start: date("2026-09-07T03:00:00Z"), end: visible.end)
         require(CalendarDayStackGeometry.hiddenTimeOffset(for: early, in: day, visibleRange: extendedEarly) == nil,
@@ -119,7 +119,7 @@ enum CalendarDayStackGeometryTests {
             require(CalendarDayStackGeometry.offset(of: .init(day: day.id, intraDayOffset: 0), in: days) == rowStart,
                     "DST must never change vertical day-row spacing")
             var fractions = [0.0, 0.123456789, 17.625, 93.999999, 94.0]
-            if index < days.count - 1 { fractions.append(contentsOf: [97.125, 104, 105.999]) }
+            if index < days.count - 1 { fractions.append(contentsOf: [97.125, 104, 109.999]) }
             for fraction in fractions {
                 let y = rowStart + fraction
                 let position = unwrap(CalendarDayStackGeometry.position(at: y, in: days))
@@ -129,7 +129,7 @@ enum CalendarDayStackGeometryTests {
                         "Pixel positions must round-trip within one billionth of a point")
             }
         }
-        require(CalendarDayStackGeometry.documentHeight(for: days) == 730,
+        require(CalendarDayStackGeometry.documentHeight(for: days) == 754,
                 "DST and fractional-hour transitions must not change the document height")
     }
 

--- a/tests/CalendarDayStackGeometryTests.swift
+++ b/tests/CalendarDayStackGeometryTests.swift
@@ -1,0 +1,181 @@
+//
+//  CalendarDayStackGeometryTests.swift
+//  boringNotch
+//
+
+import Foundation
+
+@main
+enum CalendarDayStackGeometryTests {
+    static func main() {
+        let utc = calendar("UTC")
+        let center = date("2026-09-07T12:34:56Z")
+        let days = CalendarDayStackGeometry.days(centeredOn: center, calendar: utc)
+        require(days.count == 7 && Set(days.map(\.id)).count == 7,
+                "The rolling window must contain seven distinct days")
+        require(days[3].id == date("2026-09-07T00:00:00Z"), "The requested day must occupy the middle row")
+        require(unwrap(days.first).id == date("2026-09-04T00:00:00Z") && unwrap(days.last).id == date("2026-09-10T00:00:00Z"),
+                "The window must extend three calendar days in each direction")
+        require(CalendarDayStackGeometry.rowHeight == 94 && CalendarDayStackGeometry.rowSpacing == 12
+                && CalendarDayStackGeometry.rowStride == 106 && CalendarDayStackGeometry.pointsPerHour == 96,
+                "The day stack must use the intended fixed row and horizontal hour dimensions")
+        verifyWindow(days)
+        verifyHiddenTimeOffsets(in: days[3].interval)
+
+        let documentHeight = CalendarDayStackGeometry.documentHeight(for: days)
+        require(documentHeight == 730, "Seven rows must have only six intervening gaps")
+        let twoRowHeight = CalendarDayStackGeometry.documentHeight(for: Array(days.prefix(2)))
+        require(twoRowHeight == 200 && twoRowHeight <= 202,
+                "Two complete day rows and their gap must fit inside the 202-point viewport")
+        require(CalendarDayStackGeometry.position(at: -10, in: days) == .init(day: days[0].id, intraDayOffset: 0),
+                "Negative positions must clamp to the first row")
+        require(CalendarDayStackGeometry.position(at: documentHeight + 10, in: days)
+                == .init(day: days[6].id, intraDayOffset: 94), "Positions beyond the document must clamp to its bottom")
+        require(CalendarDayStackGeometry.offset(of: .init(day: days[0].id, intraDayOffset: -1), in: days) == 0,
+                "Negative within-row offsets must clamp")
+        require(CalendarDayStackGeometry.offset(of: .init(day: days[6].id, intraDayOffset: 200), in: days) == documentHeight,
+                "Oversized within-row offsets must stay inside the document")
+        require(CalendarDayStackGeometry.offset(of: .init(day: days[0].id.addingTimeInterval(-86400), intraDayOffset: 40), in: days) == 0,
+                "Days before the window must clamp to its beginning")
+        require(CalendarDayStackGeometry.offset(of: .init(day: days[6].id.addingTimeInterval(86400), intraDayOffset: 40), in: days) == documentHeight,
+                "Days after the window must clamp to its end")
+        require(CalendarDayStackGeometry.documentHeight(for: []) == 0 && CalendarDayStackGeometry.span(of: []) == nil
+                && CalendarDayStackGeometry.position(at: 0, in: []) == nil, "Empty windows must have no rows or position")
+        require(CalendarDayStackGeometry.offset(of: .init(day: center, intraDayOffset: 0), in: []) == 0,
+                "An empty window must have zero offset")
+
+        for (index, day) in days.enumerated() {
+            let expected = index < 1 || index >= 4
+            require(CalendarDayStackGeometry.needsRecentering(position: .init(day: day.id, intraDayOffset: 17.625), in: days) == expected,
+                    "Recentering must leave enough forward rows for the two-row viewport")
+        }
+        require(CalendarDayStackGeometry.needsRecentering(position: .init(day: center, intraDayOffset: 0), in: []),
+                "A missing day must trigger window initialization")
+
+        let newYork = calendar("America/New_York")
+        verifyDayLength("2026-03-08T12:00:00-04:00", hours: 23, calendar: newYork)
+        verifyDayLength("2026-11-01T12:00:00-05:00", hours: 25, calendar: newYork)
+        let lordHowe = calendar("Australia/Lord_Howe")
+        verifyDayLength("2026-10-04T12:00:00+11:00", hours: 23.5, calendar: lordHowe)
+        verifyDayLength("2026-04-05T12:00:00+10:30", hours: 24.5, calendar: lordHowe)
+
+        for zone in [newYork, lordHowe] {
+            for direction in [-1, 1] {
+                verifyRepeatedRecentering(from: center, direction: direction, calendar: zone)
+            }
+        }
+        print("Calendar day-stack geometry: all checks passed (hidden-time markers, fixed rows, fractional offsets, DST, 2,400 recentered day steps).")
+    }
+
+    private static func verifyHiddenTimeOffsets(in day: DateInterval) {
+        let visible = DateInterval(start: date("2026-09-07T07:00:00Z"), end: date("2026-09-07T19:00:00Z"))
+        let early = date("2026-09-07T04:00:00Z")
+        let late = date("2026-09-07T22:58:00Z")
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: early, in: day, visibleRange: visible) == -6,
+                "04:00 must appear in the middle of the gap above the daytime row")
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: late, in: day, visibleRange: visible) == 100,
+                "22:58 must appear in the middle of the gap below the daytime row")
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: visible.start, in: day, visibleRange: visible) == nil,
+                "Exactly 07:00 belongs to the visible timeline and must not duplicate its marker in the gap")
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: visible.end, in: day, visibleRange: visible) == 100,
+                "Exactly 19:00 is outside the half-open visible range and needs the lower gap marker")
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: date("2026-09-07T12:00:00Z"), in: day, visibleRange: visible) == nil,
+                "Visible daytime hours must not produce a hidden-time marker")
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: day.start, in: day, visibleRange: visible) == -6,
+                "The inclusive midnight day boundary must remain eligible for the upper gap")
+        for outside in [day.start.addingTimeInterval(-1), day.end, day.end.addingTimeInterval(4 * 3600)] {
+            require(CalendarDayStackGeometry.hiddenTimeOffset(for: outside, in: day, visibleRange: visible) == nil,
+                    "Dates outside this half-open day must never produce its hidden-time marker")
+        }
+        let extendedLate = DateInterval(start: visible.start, end: date("2026-09-07T23:00:00Z"))
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: late, in: day, visibleRange: extendedLate) == nil,
+                "A late event extending the visible range must suppress the redundant 22:58 gap marker")
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: extendedLate.end, in: day, visibleRange: extendedLate) == 100,
+                "The lower gap marker must follow the expanded visible range's exclusive end")
+        let extendedEarly = DateInterval(start: date("2026-09-07T03:00:00Z"), end: visible.end)
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: early, in: day, visibleRange: extendedEarly) == nil,
+                "An early event extending the visible range must suppress the redundant 04:00 gap marker")
+        require(CalendarDayStackGeometry.hiddenTimeOffset(for: early, in: day, visibleRange: day) == nil
+                && CalendarDayStackGeometry.hiddenTimeOffset(for: late, in: day, visibleRange: day) == nil,
+                "A fully visible day has no hidden-time markers")
+    }
+
+    private static func verifyDayLength(_ value: String, hours: Double, calendar: Calendar) {
+        let days = CalendarDayStackGeometry.days(centeredOn: date(value), calendar: calendar)
+        require(days[3].interval.duration == hours * 3600, "Calendar day must preserve its elapsed duration: \(value)")
+        verifyWindow(days)
+    }
+
+    private static func verifyWindow(_ days: [CalendarDayStackGeometry.Day]) {
+        require(days.count == 7 && Set(days.map(\.id)).count == 7, "Day identities must remain distinct across DST")
+        let span = unwrap(CalendarDayStackGeometry.span(of: days))
+        require(span.start == days[0].interval.start && span.end == days[6].interval.end,
+                "The fetch span must include the complete seven-day window")
+        for (index, day) in days.enumerated() {
+            if index > 0 {
+                require(days[index - 1].interval.end == day.interval.start, "Day intervals must be contiguous")
+            }
+            let rowStart = Double(index) * CalendarDayStackGeometry.rowStride
+            require(CalendarDayStackGeometry.offset(of: .init(day: day.id, intraDayOffset: 0), in: days) == rowStart,
+                    "DST must never change vertical day-row spacing")
+            var fractions = [0.0, 0.123456789, 17.625, 93.999999, 94.0]
+            if index < days.count - 1 { fractions.append(contentsOf: [97.125, 104, 105.999]) }
+            for fraction in fractions {
+                let y = rowStart + fraction
+                let position = unwrap(CalendarDayStackGeometry.position(at: y, in: days))
+                require(position.day == day.id && abs(position.intraDayOffset - fraction) < 0.000000001,
+                        "Fractional row and gap positions must preserve their exact day-relative placement")
+                require(abs(CalendarDayStackGeometry.offset(of: position, in: days) - y) < 0.000000001,
+                        "Pixel positions must round-trip within one billionth of a point")
+            }
+        }
+        require(CalendarDayStackGeometry.documentHeight(for: days) == 730,
+                "DST and fractional-hour transitions must not change the document height")
+    }
+
+    private static func verifyRepeatedRecentering(from start: Date, direction: Int, calendar: Calendar) {
+        var days = CalendarDayStackGeometry.days(centeredOn: start, calendar: calendar)
+        var position = CalendarDayStackGeometry.Position(day: days[3].id, intraDayOffset: 17.625)
+        let initialDay = position.day
+        var recenterCount = 0
+        for step in 1...600 {
+            // Seven rendered days are a window, not a calendar with an expiry date.
+            let y = CalendarDayStackGeometry.offset(of: position, in: days)
+                + Double(direction) * CalendarDayStackGeometry.rowStride
+            let next = unwrap(CalendarDayStackGeometry.position(at: y, in: days))
+            let expectedDay = unwrap(calendar.date(byAdding: .day, value: direction * step, to: initialDay))
+            require(next.day == expectedDay && next.intraDayOffset == 17.625,
+                    "Scrolling must continue by calendar day without a finite edge or fractional drift")
+            position = next
+            if CalendarDayStackGeometry.needsRecentering(position: position, in: days) {
+                days = CalendarDayStackGeometry.days(centeredOn: position.day, calendar: calendar)
+                let rebasedY = CalendarDayStackGeometry.offset(of: position, in: days)
+                require(CalendarDayStackGeometry.position(at: rebasedY, in: days) == position,
+                        "Recentering must preserve both leading day and fractional within-row offset")
+                require(days.count == 7 && !CalendarDayStackGeometry.needsRecentering(position: position, in: days),
+                        "Recentered windows must remain bounded and allow two visible rows")
+                recenterCount += 1
+            }
+        }
+        require(recenterCount >= 200, "Long scrolling must repeatedly replace the bounded day window")
+    }
+
+    private static func calendar(_ zone: String) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = unwrap(TimeZone(identifier: zone))
+        return calendar
+    }
+
+    private static func date(_ value: String) -> Date {
+        unwrap(ISO8601DateFormatter().date(from: value))
+    }
+
+    private static func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+        precondition(condition(), message)
+    }
+    private static func unwrap<Value>(_ value: Value?, file: StaticString = #file, line: UInt = #line) -> Value {
+        guard let value else { preconditionFailure("Missing test fixture", file: file, line: line) }
+        return value
+    }
+
+}

--- a/tests/CalendarMonthGeometryTests.swift
+++ b/tests/CalendarMonthGeometryTests.swift
@@ -1,0 +1,89 @@
+//
+//  CalendarMonthGeometryTests.swift
+//  boringNotch
+//
+
+import Foundation
+
+@main
+enum CalendarMonthGeometryTests {
+    private static var checks = 0
+    private static var failures = [String]()
+
+    static func main() {
+        let leapFebruary = checkMonth(year: 2024, month: 2, days: 29, firstWeekday: 2)
+        expect(leapFebruary.firstIndex(where: { $0 != nil }) == 3,
+               "February 2024 starts in Thursday's column when Monday is first")
+
+        let normalFebruary = checkMonth(year: 2025, month: 2, days: 28, firstWeekday: 2)
+        expect(normalFebruary.firstIndex(where: { $0 != nil }) == 5,
+               "February 2025 starts in Saturday's column when Monday is first")
+
+        let august = checkMonth(year: 2026, month: 8, days: 31, firstWeekday: 2)
+        expect(august[35] != nil && august[36] == nil,
+               "August 2026 uses a sixth row and ends after Monday 31")
+
+        let sundayFirst = checkMonth(year: 2026, month: 8, days: 31, firstWeekday: 1)
+        expect(sundayFirst.firstIndex(where: { $0 != nil }) == 6,
+               "August 2026 shifts to Saturday's column when Sunday is first")
+        expect(sundayFirst[36] != nil && sundayFirst[37] == nil,
+               "Sunday-first August keeps its final day in the sixth row")
+
+        // The year changes; the grid should resist inviting the neighbors over.
+        let december = checkMonth(year: 2026, month: 12, days: 31, firstWeekday: 2)
+        expect(december[0] == nil && december[32] == nil,
+               "December excludes the adjacent November and January days")
+        let january = checkMonth(year: 2027, month: 1, days: 31, firstWeekday: 2)
+        expect(january[3] == nil && january[35] == nil,
+               "January excludes the adjacent December and February days")
+
+        for firstWeekday in 1...7 {
+            _ = checkMonth(year: 2026, month: 9, days: 30, firstWeekday: firstWeekday)
+        }
+
+        if failures.isEmpty {
+            print("PASS: CalendarMonthGeometry (\(checks) checks)")
+        } else {
+            failures.forEach { print("FAIL: \($0)") }
+            exit(1)
+        }
+    }
+
+    @discardableResult
+    private static func checkMonth(
+        year: Int, month: Int, days: Int, firstWeekday: Int
+    ) -> [Date?] {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = unwrap(TimeZone(secondsFromGMT: 0))
+        calendar.firstWeekday = firstWeekday
+        let date = unwrap(calendar.date(from: DateComponents(year: year, month: month, day: 15)))
+        let cells = CalendarMonthGeometry.cells(containing: date, calendar: calendar)
+        let dates = cells.compactMap { $0 }
+        let label = "\(year)-\(month), first weekday \(firstWeekday)"
+
+        expect(cells.count == 42, "\(label): exactly six complete weeks")
+        expect(dates.count == days, "\(label): correct number of days")
+        expect(dates.allSatisfy {
+            calendar.component(.year, from: $0) == year &&
+            calendar.component(.month, from: $0) == month
+        }, "\(label): every visible date belongs to the requested month")
+        expect(dates.map { calendar.component(.day, from: $0) } == Array(1...days),
+               "\(label): each date appears once in chronological order")
+        expect(cells.enumerated().allSatisfy { index, date in
+            guard let date else { return true }
+            return calendar.component(.weekday, from: date) == (index + firstWeekday - 1) % 7 + 1
+        }, "\(label): every date aligns with its weekday column")
+
+        return cells
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        checks += 1
+        if !condition() { failures.append(message) }
+    }
+    private static func unwrap<Value>(_ value: Value?, file: StaticString = #file, line: UInt = #line) -> Value {
+        guard let value else { preconditionFailure("Missing test fixture", file: file, line: line) }
+        return value
+    }
+
+}

--- a/tests/CalendarSelectionTests.swift
+++ b/tests/CalendarSelectionTests.swift
@@ -1,0 +1,153 @@
+//
+//  CalendarSelectionTests.swift
+//  boringNotch
+//
+
+import AppKit
+import Defaults
+import EventKit
+
+private let testSuiteName = "calendar-selection-tests-\(UUID().uuidString)"
+private let testSuite: UserDefaults = {
+    guard let suite = UserDefaults(suiteName: testSuiteName) else {
+        fatalError("Cannot create isolated calendar test preferences")
+    }
+    return suite
+}()
+
+extension Defaults.Keys {
+    static let calendarSelectionState = Key<CalendarSelectionState>(
+        "calendarSelectionState", default: .all, suite: testSuite)
+}
+
+private actor CalendarSelectionService: CalendarServiceProviding {
+    var available: [CalendarModel]
+    var suspendRequests = false
+    var pending: [(Int, [EventModel], CheckedContinuation<[EventModel], Never>)] = []
+    var requestID = 0
+
+    init(_ calendars: [CalendarModel]) { available = calendars }
+    func requestAccess(to type: EKEntityType) async throws -> Bool { true }
+    func calendars() async -> [CalendarModel] { available }
+    func setReminderCompleted(reminderID: String, completed: Bool) async {}
+    func add(_ calendar: CalendarModel) { available.append(calendar) }
+    func suspend() { suspendRequests = true }
+    func pendingCount() -> Int { pending.count }
+
+    func events(from start: Date, to end: Date, calendars ids: [String]) async -> [EventModel] {
+        requestID += 1
+        let number = requestID
+        let result = available.filter { ids.contains($0.id) }.map { calendar in
+            EventModel(id: calendar.id, start: start, end: end, title: "request-\(number)",
+                       location: nil, notes: nil, url: nil, isAllDay: false,
+                       type: calendar.isReminder ? .reminder(completed: false) : .event(.accepted),
+                       calendar: calendar, participants: [], timeZone: nil,
+                       hasRecurrenceRules: false, priority: nil, meetingLink: nil)
+        }
+        guard suspendRequests else { return result }
+        return await withCheckedContinuation { pending.append((number, result, $0)) }
+    }
+
+    func complete(at index: Int) {
+        let request = pending.remove(at: index)
+        request.2.resume(returning: request.1)
+    }
+}
+
+@main enum CalendarSelectionTests {
+    @MainActor static func main() async {
+        defer { UserDefaults(suiteName: testSuiteName)?.removePersistentDomain(forName: testSuiteName) }
+        let first = calendar("first"), research = calendar("research"), reminder = calendar("reminder", isReminder: true)
+        let service = CalendarSelectionService([first, research, reminder])
+        let manager = CalendarManager(calendarService: service)
+        await manager.reloadCalendarAndReminderLists()
+        require(manager.selectedCalendarIDs == [first.id, research.id, reminder.id], "Default selects every calendar and reminder list")
+
+        await manager.setCalendarsSelected(manager.eventCalendars, isSelected: false)
+        require(manager.selectedCalendarIDs == [reminder.id], "Deselecting events preserves reminder selection")
+        require(manager.events.map(\.calendar.id) == [reminder.id], "Unchecked calendars disappear from legacy events")
+        await manager.setCalendarSelected(reminder, isSelected: false)
+        require(manager.selectedCalendarIDs.isEmpty && manager.events.isEmpty, "The final unchecked box stays empty")
+        let emptyRange = await manager.events(from: Date(), to: Date().addingTimeInterval(86400))
+        require(emptyRange.isEmpty, "An empty selection produces no timeline events")
+        if case .selected(let ids) = Defaults[.calendarSelectionState] { require(ids.isEmpty, "Empty state is persisted") }
+        else { fatalError("Empty selection must not be stored as all") }
+
+        await manager.setCalendarSelected(research, isSelected: true)
+        require(manager.selectedCalendarIDs == [research.id], "One checked calendar does not enable other calendars")
+        await manager.setCalendarsSelected(manager.reminderLists, isSelected: true)
+        require(manager.selectedCalendarIDs == [research.id, reminder.id], "Selecting reminders preserves selected events")
+        let selectedRange = await manager.events(from: Date(), to: Date().addingTimeInterval(86400))
+        require(Set(selectedRange.map(\.calendar.id)) == [research.id, reminder.id], "Timeline range follows the same selection")
+
+        Defaults[.calendarSelectionState] = .selected(["removed-calendar", first.id])
+        manager.updateSelectedCalendars()
+        await manager.setCalendarSelected(research, isSelected: true)
+        require(!manager.selectedCalendarIDs.contains(reminder.id), "Equal ID counts with stale IDs must not select everything")
+        if case .all = Defaults[.calendarSelectionState] { fatalError("Stale IDs must not promote a partial selection") }
+
+        await manager.setCalendarsSelected(manager.allCalendars, isSelected: true)
+        if case .all = Defaults[.calendarSelectionState] {} else { fatalError("Selecting every available calendar restores automatic all") }
+        let future = calendar("newly-added")
+        await service.add(future)
+        await manager.reloadCalendarAndReminderLists()
+        require(manager.selectedCalendarIDs.contains(future.id), "Automatic all includes newly discovered calendars")
+        await manager.setCalendarSelected(future, isSelected: false)
+        let secondFuture = calendar("another-new")
+        await service.add(secondFuture)
+        await manager.reloadCalendarAndReminderLists()
+        require(!manager.selectedCalendarIDs.contains(secondFuture.id), "An explicit selection stays explicit when calendars appear")
+
+        await verifyStaleResults(manager: manager, service: service, calendar: research)
+        let providerEmpty = await CalendarService().events(from: Date(), to: Date().addingTimeInterval(86400), calendars: [])
+        require(providerEmpty.isEmpty, "The provider treats an empty ID array as no calendars")
+        print("Calendar selection: all checks passed (checkboxes, bulk selection, stale IDs, discovery, empty queries, out-of-order refreshes).")
+    }
+
+    @MainActor private static func verifyStaleResults(manager: CalendarManager, service: CalendarSelectionService, calendar: CalendarModel) async {
+        await service.suspend()
+        let first = Task { await manager.setCalendarSelected(calendar, isSelected: false) }
+        await waitForRequests(1, service: service)
+        let middle = Task { await manager.setCalendarSelected(calendar, isSelected: true) }
+        await waitForRequests(2, service: service)
+        let latest = Task { await manager.setCalendarSelected(calendar, isSelected: false) }
+        await waitForRequests(3, service: service)
+        await service.complete(at: 2)
+        await latest.value
+        let expected = manager.events
+        await service.complete(at: 1)
+        await middle.value
+        await service.complete(at: 0)
+        await first.value
+        require(manager.events == expected, "An older A-B-A selection request cannot replace the newest A result")
+
+        let oldDate = Date(timeIntervalSince1970: 1_800_000_000)
+        let newDate = oldDate.addingTimeInterval(86400)
+        let old = Task { await manager.updateCurrentDate(oldDate) }
+        await waitForRequests(1, service: service)
+        let new = Task { await manager.updateCurrentDate(newDate) }
+        await waitForRequests(2, service: service)
+        await service.complete(at: 1)
+        await new.value
+        await service.complete(at: 0)
+        await old.value
+        require(manager.events.allSatisfy { $0.start == Calendar.current.startOfDay(for: newDate) }, "A delayed old-day result cannot replace the current day")
+    }
+
+    private static func waitForRequests(_ count: Int, service: CalendarSelectionService) async {
+        for _ in 0..<2000 {
+            if await service.pendingCount() == count { return }
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        fatalError("Timed out waiting for controlled calendar requests")
+    }
+
+    private static func calendar(_ id: String, isReminder: Bool = false) -> CalendarModel {
+        CalendarModel(id: id, account: "Test account", title: id, color: .blue,
+                      isSubscribed: id == "research", isReminder: isReminder)
+    }
+
+    private static func require(_ condition: Bool, _ message: String) {
+        precondition(condition, message)
+    }
+}

--- a/tests/CalendarTimelineGeometryTests.swift
+++ b/tests/CalendarTimelineGeometryTests.swift
@@ -1,0 +1,99 @@
+//
+//  CalendarTimelineGeometryTests.swift
+//  boringNotch
+//
+
+import Foundation
+
+@main
+enum CalendarTimelineGeometryTests {
+    static func main() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = unwrap(TimeZone(identifier: "America/New_York"))
+        let spring = CalendarTimelineGeometry.dayInterval(for: date("2026-03-08T12:00:00-04:00"), calendar: calendar)
+        let autumn = CalendarTimelineGeometry.dayInterval(for: date("2026-11-01T12:00:00-05:00"), calendar: calendar)
+        require(spring.duration == 23 * 3600, "Spring day must have 23 elapsed hours")
+        require(autumn.duration == 25 * 3600, "Autumn day must have 25 elapsed hours")
+        let autumnTicks = CalendarTimelineGeometry.hourTicks(in: autumn)
+        require(autumnTicks.filter { calendar.component(.hour, from: $0) == 1 }.count == 2,
+                "Both repeated autumn hours must appear")
+        require(CalendarTimelineGeometry.position(of: date("2026-11-01T01:30:00-05:00"), in: autumn) == 2.5 * 92,
+                "Second 01:30 must have its own position")
+        require(CalendarTimelineGeometry.position(of: date("2026-03-08T03:00:00-04:00"), in: spring) == 2 * 92,
+                "Spring 03:00 follows two elapsed hours")
+
+        calendar.timeZone = unwrap(TimeZone(identifier: "Australia/Lord_Howe"))
+        let halfHourDay = CalendarTimelineGeometry.dayInterval(for: date("2026-10-04T12:00:00+11:00"), calendar: calendar)
+        require(halfHourDay.duration == 23.5 * 3600, "Half-hour DST transitions must be preserved")
+        require(CalendarTimelineGeometry.hourTicks(in: halfHourDay).last == halfHourDay.end,
+                "Fractional-hour day must include its ending boundary")
+
+        calendar.timeZone = unwrap(TimeZone(secondsFromGMT: 0))
+        let day = CalendarTimelineGeometry.dayInterval(for: date("2026-09-07T12:00:00Z"), calendar: calendar)
+        let intervals: [CalendarTimelineGeometry.Interval] = [
+            .init(id: "midnight", start: date("2026-09-06T23:30:00Z"), end: date("2026-09-07T01:00:00Z")),
+            .init(id: "long", start: date("2026-09-07T09:00:00Z"), end: date("2026-09-07T11:00:00Z")),
+            .init(id: "overlap", start: date("2026-09-07T10:00:00Z"), end: date("2026-09-07T12:00:00Z")),
+            .init(id: "adjacent", start: date("2026-09-07T12:00:00Z"), end: date("2026-09-07T13:00:00Z")),
+            .init(id: "short", start: date("2026-09-07T14:00:00Z"), end: date("2026-09-07T14:01:00Z")),
+            .init(id: "short-neighbor", start: date("2026-09-07T14:02:00Z"), end: date("2026-09-07T14:03:00Z")),
+            .init(id: "instant", start: date("2026-09-07T15:00:00Z"), end: date("2026-09-07T15:00:00Z")),
+            .init(id: "ends-midnight", start: date("2026-09-06T23:00:00Z"), end: day.start),
+            .init(id: "next-day", start: day.end, end: day.end.addingTimeInterval(3600)),
+            .init(id: "invalid", start: day.start.addingTimeInterval(3600), end: day.start)
+        ]
+        let result = CalendarTimelineGeometry.layout(intervals, in: day)
+        let byID = Dictionary(uniqueKeysWithValues: result.map { ($0.id, $0) })
+        require(result.count == 7, "Exclusive midnight boundary and invalid intervals must be excluded")
+        require(unwrap(byID["midnight"]).x == 0 && unwrap(byID["midnight"]).width == 92, "Overnight event must clip to this day")
+        require(unwrap(byID["long"]).width == 184, "Duration must determine exact block width")
+        require(unwrap(byID["long"]).lane != unwrap(byID["overlap"]).lane, "Overlaps must use separate lanes")
+        require(unwrap(byID["adjacent"]).lane == 0, "Finished lanes must be reused")
+        require(abs(unwrap(byID["short"]).width - 92 / 60) < 0.0001 && unwrap(byID["short"]).hitWidth == 24,
+                "Short event needs exact visible duration and a larger invisible hit target")
+        require(unwrap(byID["short"]).lane != unwrap(byID["short-neighbor"]).lane, "Short event hit targets must not collide")
+        require(unwrap(byID["instant"]).width == 0 && unwrap(byID["instant"]).hitWidth == 24, "Instant event must remain selectable")
+        require(CalendarTimelineGeometry.position(of: day.start.addingTimeInterval(-60), in: day) == 0,
+                "Elapsed progress must clamp before the day")
+        require(CalendarTimelineGeometry.position(of: day.end.addingTimeInterval(60), in: day) == 24 * 92,
+                "Elapsed progress must clamp after the day")
+        let reversed = CalendarTimelineGeometry.layout(intervals.reversed(), in: day)
+        require(result.map { "\($0.id)-\($0.lane)" } == reversed.map { "\($0.id)-\($0.lane)" },
+                "Layout must be deterministic regardless of fetch ordering")
+        require(result.allSatisfy { $0.hitX >= 0 && $0.hitX + $0.hitWidth <= 24 * 92 },
+                "Every selectable target must remain within the scrollable day")
+        let compact = CalendarTimelineGeometry.layout(intervals, in: day, pointsPerHour: 54)
+        let compactByID = Dictionary(uniqueKeysWithValues: compact.map { ($0.id, $0) })
+        require(compact.count == result.count, "Compact layout must preserve every visible event")
+        require(unwrap(compactByID["long"]).width == 108, "Compact blocks must use the compact hour scale")
+        require(abs(unwrap(compactByID["short"]).width - 0.9) < 0.0001 && unwrap(compactByID["short"]).hitWidth == 24,
+                "Compact short events retain full pointer targets without inflated durations")
+        require(unwrap(compactByID["short"]).lane != unwrap(compactByID["short-neighbor"]).lane,
+                "Compact hit targets still require collision-free lanes")
+        require(CalendarTimelineGeometry.position(of: date("2026-11-01T01:30:00-05:00"), in: autumn, pointsPerHour: 54) == 2.5 * 54,
+                "Compact current-time position must use elapsed DST time and compact scale")
+        let laneCounts = CalendarTimelineGeometry.clusterLaneCounts(for: result)
+        require(laneCounts["long"] == 2 && laneCounts["overlap"] == 2,
+                "Intersecting events must share a two-lane cluster")
+        require(laneCounts["adjacent"] == 1 && laneCounts["instant"] == 1,
+                "Later independent events must regain the full row height")
+        require(laneCounts["short"] == 2 && laneCounts["short-neighbor"] == 2,
+                "Expanded short-event targets must participate in overlap clusters")
+        require(CalendarTimelineGeometry.clusterLaneCounts(for: []).isEmpty,
+                "An empty day has no overlap clusters")
+        print("Calendar timeline geometry: 28 checks passed (full/compact scales, DST, midnight, overlap clusters, short targets, progress).")
+    }
+
+    private static func date(_ value: String) -> Date {
+        unwrap(ISO8601DateFormatter().date(from: value))
+    }
+
+    private static func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+        precondition(condition(), message)
+    }
+    private static func unwrap<Value>(_ value: Value?, file: StaticString = #file, line: UInt = #line) -> Value {
+        guard let value else { preconditionFailure("Missing test fixture", file: file, line: line) }
+        return value
+    }
+
+}

--- a/tests/CalendarTimelineScaleTests.swift
+++ b/tests/CalendarTimelineScaleTests.swift
@@ -9,13 +9,15 @@ enum CalendarTimelineScaleTests {
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
         let center = date("2026-09-10T12:34:56Z")
         let original = HomeCalendarGeometry.days(centeredOn: center, calendar: calendar)
-        let densities = [72.0, 96.0, 240.0]
-        expect(CalendarTimelineScale.pointsPerHour(for: -2) == 72, "The minimum scale stays readable at 72 points per hour")
+        let densities = [315.0 / 24, 315.0 / 12, 524.0 / 12, 72.0, 96.0, 240.0]
+        expect(CalendarTimelineScale.pointsPerHour(for: -2, fitting: 315) == 315.0 / 12,
+               "The minimum scale fits the whole displayed day into the viewport")
         expect(CalendarTimelineScale.pointsPerHour(for: 1) == 96, "The default scale retains the existing timeline density")
         expect(CalendarTimelineScale.pointsPerHour(for: 10) == 240, "The maximum scale stays bounded at 240 points per hour")
         for invalid in [Double.nan, .infinity, -.infinity] {
             expect(CalendarTimelineScale.pointsPerHour(for: invalid) == 96, "Invalid stored scale values fall back to the default")
         }
+        verifyFittedDay(start: center)
 
         for density in densities {
             let scaled = rescale(original, to: density)
@@ -85,6 +87,26 @@ enum CalendarTimelineScaleTests {
         print("PASS \(checks) calendar horizontal-scale geometry checks")
     }
 
+    private static func verifyFittedDay(start: Date) {
+        for viewportWidth in [220.0, 315.0, 524.0] {
+            for duration in [12.0, 14.0, 23.0, 23.5, 24.0, 24.5, 25.0] {
+                let interval = DateInterval(start: start, duration: duration * 3600)
+                let density = CalendarTimelineScale.pointsPerHour(for: 0, fitting: viewportWidth, duration: interval.duration)
+                let day = HomeCalendarGeometry.Day(interval: interval, pointsPerHour: density)
+                expect(close(day.width, viewportWidth), "Fit day includes all cropped, overnight and DST hours without horizontal overflow")
+                expect(density > 0 && density.isFinite, "Fitted geometry always has a usable positive density")
+                expect(close(CalendarTimelineScale.pointsPerHour(for: density / 192, fitting: viewportWidth, duration: interval.duration), density),
+                       "Requested density below Fit day never makes the timeline smaller than its pane")
+                let endX = CalendarTimelineGeometry.position(of: interval.end, in: interval, pointsPerHour: density)
+                expect(close(endX, viewportWidth), "The fitted last hour lands exactly at the right pane edge")
+            }
+        }
+        for width in [0.0, -1.0] {
+            let density = CalendarTimelineScale.pointsPerHour(for: 0, fitting: width)
+            expect(density > 0 && density.isFinite, "Pending or collapsed viewport layout cannot produce division by zero")
+        }
+    }
+
     private static func verifyHourLabels(start: Date, densities: [Double]) {
         // Widths sampled from 11-point monospaced 24-hour, 12-hour, Japanese and DST labels.
         for density in densities {
@@ -96,7 +118,9 @@ enum CalendarTimelineScaleTests {
                     let widths = Array(repeating: width, count: ticks.count)
                     for exclusions: [Range<Double>] in [[], [210..<282], [0..<70, (totalWidth - 60)..<totalWidth]] {
                         let labels = CalendarTimelineGeometry.hourLabels(in: range, pointsPerHour: density, widths: widths, avoiding: exclusions)
-                        expect(!labels.isEmpty, "Reasonable ranges retain readable time labels at every density")
+                        if exclusions.isEmpty {
+                            expect(!labels.isEmpty, "Fitted day ranges retain readable time labels at every density")
+                        }
                         for label in labels {
                             expect(label.x >= 0 && label.x + label.width <= totalWidth,
                                    "Complete time labels fit within the day at both endpoints")

--- a/tests/CalendarTimelineScaleTests.swift
+++ b/tests/CalendarTimelineScaleTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+@main
+enum CalendarTimelineScaleTests {
+    private static var checks = 0
+
+    static func main() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let center = date("2026-09-10T12:34:56Z")
+        let original = HomeCalendarGeometry.days(centeredOn: center, calendar: calendar)
+        let densities = [72.0, 96.0, 240.0]
+        expect(CalendarTimelineScale.pointsPerHour(for: -2) == 72, "The minimum scale stays readable at 72 points per hour")
+        expect(CalendarTimelineScale.pointsPerHour(for: 1) == 96, "The default scale retains the existing timeline density")
+        expect(CalendarTimelineScale.pointsPerHour(for: 10) == 240, "The maximum scale stays bounded at 240 points per hour")
+        for invalid in [Double.nan, .infinity, -.infinity] {
+            expect(CalendarTimelineScale.pointsPerHour(for: invalid) == 96, "Invalid stored scale values fall back to the default")
+        }
+
+        for density in densities {
+            let scaled = rescale(original, to: density)
+            expect(scaled.map(\.id) == original.map(\.id), "Scaling keeps day identities and the loaded date window")
+            expect(scaled.map(\.visibleInterval) == original.map(\.visibleInterval), "Scaling keeps cropped daytime bounds")
+            expect(close(scaled[3].width, 12 * density), "Only horizontal duration changes with density")
+            expect(close(HomeCalendarGeometry.width(of: scaled), 7 * 12 * density + 6 * 18),
+                   "Day gaps retain an 18-point width at every scale")
+            let halfHour = center.addingTimeInterval(1800)
+            expect(close(HomeCalendarGeometry.offset(of: halfHour, in: scaled) - HomeCalendarGeometry.offset(of: center, in: scaled), density / 2),
+                   "A half-hour always occupies half the active points per hour")
+            for day in scaled {
+                for minutes in stride(from: 0.0, to: 12 * 60, by: 17) {
+                    let time = day.visibleInterval.start.addingTimeInterval(minutes * 60)
+                    let x = HomeCalendarGeometry.offset(of: time, in: scaled)
+                    expect(close(HomeCalendarGeometry.date(at: x, in: scaled)!.timeIntervalSince(time), 0),
+                           "Pixel/date round trips retain exact minutes at every scale")
+                }
+            }
+            let interval = CalendarTimelineGeometry.Interval(id: "event", start: center, end: halfHour)
+            let placement = CalendarTimelineGeometry.layout([interval], in: scaled[3].visibleInterval, pointsPerHour: density)[0]
+            expect(close(placement.width, density / 2), "Event blocks use the same scale as the hour ruler")
+            expect(placement.hitWidth >= CalendarTimelineGeometry.minimumHitWidth,
+                   "Short-event interaction targets remain usable when zoomed out")
+        }
+
+        for sourceDensity in densities {
+            for destinationDensity in densities {
+                let source = rescale(original, to: sourceDensity)
+                let destination = rescale(original, to: destinationDensity)
+                for viewportWidth in [315.0, 524.0] {
+                    let centerX = HomeCalendarGeometry.offset(of: center, in: source)
+                    let oldOrigin = centerX - viewportWidth / 2
+                    let newOrigin = HomeCalendarGeometry.rebasedOffset(oldOrigin + viewportWidth / 2, from: source, to: destination) - viewportWidth / 2
+                    let visibleCenter = HomeCalendarGeometry.date(at: newOrigin + viewportWidth / 2, in: destination)!
+                    expect(close(visibleCenter.timeIntervalSince(center), 0), "Zoom keeps the viewport's center time under the same pixel")
+
+                    let nextDay = source[4]
+                    for gapOffset in [1.0, 9.0, 17.0] {
+                        let sourceGapPixel = HomeCalendarGeometry.offset(of: nextDay.id, in: source) - gapOffset
+                        let destinationGapPixel = HomeCalendarGeometry.rebasedOffset(sourceGapPixel, from: source, to: destination)
+                        expect(close(HomeCalendarGeometry.offset(of: nextDay.id, in: destination) - destinationGapPixel, gapOffset),
+                               "Zooming within an overnight gap preserves its pixel anchor")
+                    }
+                }
+                let nextWindow = HomeCalendarGeometry.days(centeredOn: center.addingTimeInterval(86400), calendar: calendar)
+                let shifted = rescale(nextWindow, to: destinationDensity)
+                let sourcePosition = HomeCalendarGeometry.offset(of: center, in: source)
+                let shiftedPosition = HomeCalendarGeometry.rebasedOffset(sourcePosition, from: source, to: shifted)
+                expect(close(HomeCalendarGeometry.date(at: shiftedPosition, in: shifted)!.timeIntervalSince(center), 0),
+                       "Simultaneous rolling-window and zoom changes retain the same time")
+            }
+        }
+
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+        let first = date("2026-11-01T01:30:00-04:00")
+        let repeated = date("2026-11-01T01:30:00-05:00")
+        let fallBack = HomeCalendarGeometry.days(centeredOn: first, events: [
+            .init(id: "repeated-hour", start: first, end: repeated.addingTimeInterval(1800))
+        ], calendar: calendar)
+        for density in densities {
+            let scaled = rescale(fallBack, to: density)
+            expect(close(HomeCalendarGeometry.offset(of: repeated, in: scaled) - HomeCalendarGeometry.offset(of: first, in: scaled), density),
+                   "DST's repeated hour remains one elapsed hour apart at every scale")
+        }
+        verifyHourLabels(start: center, densities: densities)
+        print("PASS \(checks) calendar horizontal-scale geometry checks")
+    }
+
+    private static func verifyHourLabels(start: Date, densities: [Double]) {
+        // Widths sampled from 11-point monospaced 24-hour, 12-hour, Japanese and DST labels.
+        for density in densities {
+            for duration in [12.0, 12.5, 25.0] {
+                let range = DateInterval(start: start, duration: duration * 3600)
+                let ticks = CalendarTimelineGeometry.hourTicks(in: range)
+                let totalWidth = duration * density
+                for width in [34.0, 48.0, 55.0, 75.0, 50.0, 130.0] {
+                    let widths = Array(repeating: width, count: ticks.count)
+                    for exclusions: [Range<Double>] in [[], [210..<282], [0..<70, (totalWidth - 60)..<totalWidth]] {
+                        let labels = CalendarTimelineGeometry.hourLabels(in: range, pointsPerHour: density, widths: widths, avoiding: exclusions)
+                        expect(!labels.isEmpty, "Reasonable ranges retain readable time labels at every density")
+                        for label in labels {
+                            expect(label.x >= 0 && label.x + label.width <= totalWidth,
+                                   "Complete time labels fit within the day at both endpoints")
+                            expect(label.width == width, "Labels keep their measured size instead of shrinking")
+                            expect(!exclusions.contains { $0.overlaps((label.x - 4)..<(label.x + label.width + 4)) },
+                                   "Labels leave space for the current-time capsule and day caption")
+                        }
+                        for (left, right) in zip(labels, labels.dropFirst()) {
+                            expect(right.x - (left.x + left.width) >= 6,
+                                   "Adjacent labels keep a six-point gap in all supported formats")
+                        }
+                        if exclusions.isEmpty {
+                            expect(labels.last?.id == range.end, "The final visible hour survives packing near the day boundary")
+                        }
+                    }
+                }
+            }
+        }
+        let tinyRange = DateInterval(start: start, duration: 60)
+        expect(CalendarTimelineGeometry.hourLabels(in: tinyRange, pointsPerHour: 72, widths: [34, 34]).isEmpty,
+               "A label wider than an entire range is omitted rather than overflowing")
+    }
+
+    private static func rescale(_ days: [HomeCalendarGeometry.Day], to density: Double) -> [HomeCalendarGeometry.Day] {
+        days.map { .init(interval: $0.interval, visibleInterval: $0.visibleInterval, pointsPerHour: density) }
+    }
+
+    private static func date(_ value: String) -> Date { ISO8601DateFormatter().date(from: value)! }
+    private static func close(_ left: Double, _ right: Double) -> Bool { abs(left - right) < 0.00001 }
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        precondition(condition(), message)
+        checks += 1
+    }
+}

--- a/tests/CalendarTodayShortcutTests.swift
+++ b/tests/CalendarTodayShortcutTests.swift
@@ -153,6 +153,10 @@ struct CalendarTodayShortcutTests {
         expect(handler.handleLocalEvent(replyClick) === replyClick, "Notification reply clicks remain available")
         expect(panel.firstResponder === editor, "Calendar never replaces an active notification reply editor")
         expect(handler.handleLocalEvent(event()) != nil && actions == beforeReply, "Typing T in a notification reply does not invoke Today")
+        panel.makeFirstResponder(handler)
+        expect(handler.handleLocalEvent(event()) != nil && actions == beforeReply,
+               "Notification reply focus blocks Today before its editor becomes first responder")
+        panel.makeFirstResponder(editor)
         expect(panel.calendarOwners.contains(ObjectIdentifier(handler)), "The calendar owns a scoped key-focus request")
         handler.removeMonitor()
         expect(panel.calendarOwners.isEmpty && panel.wantsKeyForTextInput && panel.isKeyWindow,

--- a/tests/CalendarTodayShortcutTests.swift
+++ b/tests/CalendarTodayShortcutTests.swift
@@ -1,0 +1,166 @@
+//
+//  CalendarTodayShortcutTests.swift
+//  boringNotch
+//
+//  Focused calendar regression checks.
+//
+
+import AppKit
+
+@MainActor
+private final class TestPanel: NSPanel, CalendarKeyboardFocusProviding {
+    var wantsKeyForTextInput = false
+    var calendarOwners: Set<ObjectIdentifier> = []
+    func setCalendarFocus(_ requested: Bool, owner: AnyObject) {
+        if requested { calendarOwners.insert(ObjectIdentifier(owner)) }
+        else { calendarOwners.remove(ObjectIdentifier(owner)) }
+        if calendarOwners.isEmpty && !wantsKeyForTextInput { resignKey() }
+    }
+    var keyForTest = true
+    var keyClaims = 0
+    override var isKeyWindow: Bool { keyForTest }
+    override func makeKey() { keyForTest = true; keyClaims += 1 }
+    override func resignKey() { keyForTest = false }
+}
+
+private final class InteractionEvent: NSEvent {
+    let target: NSWindow
+    let kind: NSEvent.EventType
+    override var window: NSWindow? { target }
+    override var type: NSEvent.EventType { kind }
+
+    init(window: NSWindow, type: NSEvent.EventType) {
+        target = window
+        kind = type
+        super.init()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}
+
+@main
+struct CalendarTodayShortcutTests {
+    @MainActor static func main() {
+        _ = NSApplication.shared
+        let panel = TestPanel(contentRect: .init(x: 0, y: 0, width: 400, height: 200),
+                              styleMask: [.borderless], backing: .buffered, defer: false)
+        let other = TestPanel(contentRect: .zero, styleMask: [.borderless], backing: .buffered, defer: false)
+        var checks = 0
+        func event(_ text: String = "t", flags: NSEvent.ModifierFlags = [], window: NSWindow? = nil,
+                   type: NSEvent.EventType = .keyDown, repeated: Bool = false, keyCode: UInt16 = 17) -> NSEvent {
+            guard let result = NSEvent.keyEvent(with: type, location: .zero, modifierFlags: flags, timestamp: 0,
+                             windowNumber: (window ?? panel).windowNumber, context: nil,
+                             characters: text, charactersIgnoringModifiers: text, isARepeat: repeated, keyCode: keyCode) else {
+                fatalError("Missing keyboard event fixture")
+            }
+            return result
+        }
+        func expect(_ condition: Bool, _ message: String) {
+            precondition(condition, message)
+            checks += 1
+        }
+        expect(CalendarTodayShortcutRouting.shouldHandle(event(), in: panel), "Plain T returns to today")
+        expect(CalendarTodayShortcutRouting.shouldHandle(event("T", flags: .shift), in: panel), "Uppercase T is supported")
+        expect(CalendarTodayShortcutRouting.shouldHandle(event("T", flags: .capsLock), in: panel), "Caps Lock does not change the shortcut")
+        expect(CalendarTodayShortcutRouting.shouldHandle(event("е", keyCode: 17), in: panel), "Physical T works with the Russian layout")
+        expect(!CalendarTodayShortcutRouting.shouldHandle(event("е", keyCode: 14), in: panel), "The same foreign letter on another physical key is unaffected")
+        expect(CalendarTodayShortcutRouting.shouldHandle(event("t", keyCode: 14), in: panel), "Literal T is supported on alternate keyboard layouts")
+        expect(!CalendarTodayShortcutRouting.shouldHandle(event("е", flags: .command, keyCode: 17), in: panel), "Physical T preserves modified shortcuts")
+        for flags: NSEvent.ModifierFlags in [.command, .control, .option, .function, [.command, .shift]] {
+            expect(!CalendarTodayShortcutRouting.shouldHandle(event(flags: flags), in: panel), "Modified shortcuts keep their original actions")
+        }
+        expect(!CalendarTodayShortcutRouting.shouldHandle(event("x", keyCode: 7), in: panel), "Other letters are unaffected")
+        expect(!CalendarTodayShortcutRouting.shouldHandle(event(type: .keyUp), in: panel), "Key up does not repeat the action")
+        expect(!CalendarTodayShortcutRouting.shouldHandle(event(window: other), in: panel), "Other windows are unaffected")
+        panel.keyForTest = false
+        expect(!CalendarTodayShortcutRouting.shouldHandle(event(), in: panel), "A background calendar does not capture typing")
+        panel.keyForTest = true
+        let editor = NSTextView(frame: .init(x: 0, y: 0, width: 100, height: 50))
+        panel.contentView?.addSubview(editor)
+        editor.isEditable = true
+        panel.makeFirstResponder(editor)
+        expect(!CalendarTodayShortcutRouting.shouldHandle(event(), in: panel), "Typing T in editable text is preserved")
+        expect(!CalendarTodayShortcutRouting.shouldHandle(event("е", keyCode: 17), in: panel), "Typing with the Russian layout in editable text is preserved")
+        editor.isEditable = false
+        expect(CalendarTodayShortcutRouting.shouldHandle(event(), in: panel), "Selectable event details still allow Today")
+
+        var actions = 0
+        let handler = CalendarTodayKeyView { actions += 1 }
+        panel.contentView?.addSubview(handler)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        panel.makeFirstResponder(nil)
+        let interactions: [NSEvent.EventType] = [.leftMouseDown, .rightMouseDown, .otherMouseDown, .scrollWheel]
+        for type in interactions {
+            panel.keyForTest = false
+            let claims = panel.keyClaims
+            let previousActions = actions
+            let interaction = InteractionEvent(window: panel, type: type)
+            expect(handler.handleLocalEvent(interaction) === interaction, "Calendar interactions reach their original controls")
+            expect(panel.isKeyWindow && panel.keyClaims == claims + 1, "Calendar interaction recovers lost key status")
+            expect(panel.firstResponder === handler, "Calendar interaction restores its responder")
+            expect(actions == previousActions, "Interaction does not invoke Today")
+            expect(handler.handleLocalEvent(event()) == nil && actions == previousActions + 1, "T works after focus recovery")
+            expect(handler.handleLocalEvent(event(repeated: true)) == nil && actions == previousActions + 1, "Held T does not repeat Today")
+        }
+
+        let beforeRussianKey = actions
+        expect(handler.handleLocalEvent(event("е", keyCode: 17)) == nil && actions == beforeRussianKey + 1,
+               "A physical T event invokes Today after interaction recovery in the Russian layout")
+
+        // Reproduce a Clipboard field editor lingering after its tab disappears.
+        editor.isEditable = true
+        editor.isFieldEditor = true
+        panel.makeFirstResponder(editor)
+        let claims = panel.keyClaims
+        let previousActions = actions
+        let click = InteractionEvent(window: panel, type: .leftMouseDown)
+        expect(handler.handleLocalEvent(event()) != nil && actions == previousActions, "T alone preserves text editing")
+        expect(handler.handleLocalEvent(click) === click, "A calendar click is forwarded after Clipboard")
+        expect(panel.firstResponder === handler && panel.keyClaims == claims, "A key panel still replaces the stale Clipboard editor")
+        expect(handler.handleLocalEvent(event()) == nil && actions == previousActions + 1, "T works after clearing the stale editor")
+
+        editor.isEditable = false
+        panel.makeFirstResponder(editor)
+        panel.keyForTest = false
+        let wheel = InteractionEvent(window: panel, type: .scrollWheel)
+        let beforeSelection = actions
+        expect(handler.handleLocalEvent(wheel) === wheel, "Scrolling selectable details is forwarded")
+        expect(panel.isKeyWindow && panel.firstResponder === editor, "Read-only text keeps its selection responder")
+        expect(actions == beforeSelection, "Scrolling selected text does not invoke Today")
+        expect(handler.handleLocalEvent(event()) == nil && actions == beforeSelection + 1, "Selected text still supports Today")
+
+        panel.keyForTest = false
+        let beforeOtherWindow = actions
+        let claimsBeforeOtherWindow = panel.keyClaims
+        for type in interactions {
+            let interaction = InteractionEvent(window: other, type: type)
+            expect(handler.handleLocalEvent(interaction) === interaction, "Other-window interactions are forwarded")
+        }
+        let otherKey = event(window: other)
+        expect(handler.handleLocalEvent(otherKey) === otherKey, "Other-window typing is forwarded")
+        expect(!panel.isKeyWindow && panel.keyClaims == claimsBeforeOtherWindow && actions == beforeOtherWindow,
+               "Other-window events cannot claim focus or invoke Today")
+        let unfocusedKey = event()
+        expect(handler.handleLocalEvent(unfocusedKey) === unfocusedKey && !panel.isKeyWindow,
+               "Keyboard input alone never takes focus from another application")
+
+        panel.wantsKeyForTextInput = true
+        editor.isEditable = true
+        panel.makeFirstResponder(editor)
+        panel.keyForTest = true
+        let beforeReply = actions
+        let replyClick = InteractionEvent(window: panel, type: .leftMouseDown)
+        expect(handler.handleLocalEvent(replyClick) === replyClick, "Notification reply clicks remain available")
+        expect(panel.firstResponder === editor, "Calendar never replaces an active notification reply editor")
+        expect(handler.handleLocalEvent(event()) != nil && actions == beforeReply, "Typing T in a notification reply does not invoke Today")
+        expect(panel.calendarOwners.contains(ObjectIdentifier(handler)), "The calendar owns a scoped key-focus request")
+        handler.removeMonitor()
+        expect(panel.calendarOwners.isEmpty && panel.wantsKeyForTextInput && panel.isKeyWindow,
+               "Calendar teardown releases only its focus request and preserves notification reply key access")
+        panel.wantsKeyForTextInput = false
+        panel.keyForTest = false
+        expect(handler.handleLocalEvent(click) === click && !panel.isKeyWindow, "A dismantled calendar cannot reclaim focus")
+        expect(handler.handleLocalEvent(event()) != nil && actions == beforeOtherWindow, "A dismantled calendar cannot invoke Today")
+        print("PASS \(checks) scoped calendar Today shortcut checks")
+    }
+}

--- a/tests/CalendarVisibleRangeTests.swift
+++ b/tests/CalendarVisibleRangeTests.swift
@@ -1,0 +1,230 @@
+//
+//  CalendarVisibleRangeTests.swift
+//  boringNotch
+//
+
+import Foundation
+
+@main
+enum CalendarVisibleRangeTests {
+    private typealias Geometry = CalendarTimelineGeometry
+    private typealias Event = CalendarTimelineGeometry.Interval
+    private static var failures: [String] = []
+    private static var checks = 0
+
+    static func main() {
+        let utc = calendar("UTC")
+        let day = day("2026-09-07T12:00:00Z", calendar: utc)
+        let defaultRange = Geometry.visibleRange(in: day, events: [], calendar: utc)
+        expectRange(defaultRange, "2026-09-07T07:00:00Z", "2026-09-07T19:00:00Z", "Empty day uses local daytime")
+        let inside = event("inside", "2026-09-07T09:15:00Z", "2026-09-07T11:45:00Z")
+        require(Geometry.visibleRange(in: day, events: [inside], calendar: utc) == defaultRange,
+                "Normal events inside daytime must not expand the crop")
+
+        let early = event("early", "2026-09-07T06:30:00Z", "2026-09-07T08:00:00Z")
+        let late = event("late", "2026-09-07T20:00:00Z", "2026-09-07T21:15:00Z")
+        let expanded = Geometry.visibleRange(in: day, events: [early, late], calendar: utc)
+        expectRange(expanded, "2026-09-07T06:00:00Z", "2026-09-07T22:00:00Z", "Events expand to enclosing hours")
+        require(Geometry.visibleRange(in: day, events: [late, early], calendar: utc) == expanded,
+                "Event fetch order must not change the crop")
+        expectRange(Geometry.visibleRange(in: day, events: [event("exact-end", "2026-09-07T20:00:00Z", "2026-09-07T21:00:00Z")], calendar: utc),
+                    "2026-09-07T07:00:00Z", "2026-09-07T21:00:00Z", "Exact ending hours must not gain an unnecessary hour")
+
+        let overnight = event("overnight", "2026-09-07T23:30:00Z", "2026-09-08T01:15:00Z")
+        expectRange(Geometry.visibleRange(in: day, events: [overnight], calendar: utc),
+                    "2026-09-07T07:00:00Z", "2026-09-08T00:00:00Z", "An outgoing overnight event clips to the last day boundary")
+        let followingDay = self.day("2026-09-08T12:00:00Z", calendar: utc)
+        expectRange(Geometry.visibleRange(in: followingDay, events: [overnight], calendar: utc),
+                    "2026-09-08T00:00:00Z", "2026-09-08T19:00:00Z", "An incoming overnight event starts at the first day boundary")
+        let spanning = event("spanning", "2026-09-06T22:00:00Z", "2026-09-08T02:00:00Z")
+        require(Geometry.visibleRange(in: day, events: [spanning], calendar: utc) == day,
+                "A timed event spanning the entire day must retain the complete day")
+
+        let allDay = event("all-day", "2026-09-07T00:00:00Z", "2026-09-08T00:00:00Z", isAllDay: true)
+        let reminder = event("reminder", "2026-09-07T04:00:00Z", "2026-09-07T04:00:00Z", isReminder: true)
+        let lateReminder = event("late-reminder", "2026-09-07T23:00:00Z", "2026-09-07T23:00:00Z", isReminder: true)
+        require(Geometry.visibleRange(in: day, events: [allDay, reminder, lateReminder], calendar: utc) == defaultRange,
+                "All-day items and reminders must not expose unused night hours")
+        let outside = [
+            event("previous", "2026-09-06T20:00:00Z", "2026-09-07T00:00:00Z"),
+            event("next", "2026-09-08T00:00:00Z", "2026-09-08T02:00:00Z"),
+            event("next-instant", "2026-09-08T00:00:00Z", "2026-09-08T00:00:00Z")
+        ]
+        require(Geometry.visibleRange(in: day, events: outside, calendar: utc) == defaultRange,
+                "Outside events and exclusive midnight boundaries must not change this day")
+        let invalid = event("invalid", "2026-09-07T23:00:00Z", "2026-09-07T02:00:00Z")
+        require(Geometry.visibleRange(in: day, events: [invalid], calendar: utc) == defaultRange,
+                "Malformed negative-duration events must not expand either crop boundary")
+
+        for value in ["2026-09-07T19:00:00Z", "2026-09-07T21:00:00Z", "2026-09-07T23:59:59Z"] {
+            let instant = event("instant", value, value)
+            let range = Geometry.visibleRange(in: day, events: [instant], calendar: utc)
+            require(range.start <= instant.start && range.end > instant.start && range.end <= day.end,
+                    "Late point events need a strictly later visible boundary: \(value)")
+            let placements = Geometry.layout([instant], in: range)
+            require(placements.count == 1 && placements[0].hitWidth > 0,
+                    "A late point event must remain selectable after cropping")
+        }
+        expectRange(Geometry.visibleRange(in: day, events: [event("at-19", "2026-09-07T19:00:00Z", "2026-09-07T19:00:00Z")], calendar: utc),
+                    "2026-09-07T07:00:00Z", "2026-09-07T20:00:00Z", "A point event at 19:00 must retain the next enclosing hour")
+
+        verifyDST()
+        verifySharedRanges(calendar: utc)
+        verifyScrollBounds(defaultRange: defaultRange, expanded: expanded)
+        for failure in failures { FileHandle.standardError.write(Data("FAIL: \(failure)\n".utf8)) }
+        precondition(failures.isEmpty, "\(failures.count) visible-range checks failed")
+        print("Calendar visible-range: \(checks) checks passed (night cropping, event boundaries, shared hours, DST, marker and scroll rebasing).")
+    }
+
+    private static func verifyDST() {
+        let newYork = calendar("America/New_York")
+        let spring = day("2026-03-08T12:00:00-04:00", calendar: newYork)
+        let autumn = day("2026-11-01T12:00:00-05:00", calendar: newYork)
+        require(spring.duration == 23 * 3600 && autumn.duration == 25 * 3600, "DST fixtures must contain 23 and 25 actual hours")
+        let springDefault = Geometry.visibleRange(in: spring, events: [], calendar: newYork)
+        let autumnDefault = Geometry.visibleRange(in: autumn, events: [], calendar: newYork)
+        expectRange(springDefault, "2026-03-08T07:00:00-04:00", "2026-03-08T19:00:00-04:00", "Spring daytime keeps local 07–19")
+        expectRange(autumnDefault, "2026-11-01T07:00:00-05:00", "2026-11-01T19:00:00-05:00", "Autumn daytime keeps local 07–19")
+        require(springDefault.duration == 12 * 3600 && autumnDefault.duration == 12 * 3600,
+                "Daytime crops must remain twelve elapsed hours on both DST dates")
+        let springEarly = event("spring-early", "2026-03-08T01:30:00-05:00", "2026-03-08T03:30:00-04:00")
+        let springRange = Geometry.visibleRange(in: spring, events: [springEarly], calendar: newYork)
+        expectRange(springRange, "2026-03-08T01:00:00-05:00", "2026-03-08T19:00:00-04:00", "Spring early events preserve skipped local hours")
+        require(springRange.duration == 17 * 3600, "Spring crop must use actual elapsed duration")
+        let autumnEvents = [
+            event("first-hour", "2026-11-01T01:15:00-04:00", "2026-11-01T01:45:00-04:00"),
+            event("second-hour", "2026-11-01T01:15:00-05:00", "2026-11-01T02:15:00-05:00")
+        ]
+        let autumnRange = Geometry.visibleRange(in: autumn, events: autumnEvents, calendar: newYork)
+        expectRange(autumnRange, "2026-11-01T01:00:00-04:00", "2026-11-01T19:00:00-05:00", "Autumn crop includes both repeated hours")
+        let firstX = Geometry.position(of: autumnEvents[0].start, in: autumnRange)
+        let secondX = Geometry.position(of: autumnEvents[1].start, in: autumnRange)
+        require(secondX - firstX == Geometry.pointsPerHour, "Repeated local times retain distinct horizontal positions")
+
+        let lordHowe = calendar("Australia/Lord_Howe")
+        let halfSpring = day("2026-10-04T12:00:00+11:00", calendar: lordHowe)
+        let halfAutumn = day("2026-04-05T12:00:00+10:30", calendar: lordHowe)
+        require(halfSpring.duration == 23.5 * 3600 && halfAutumn.duration == 24.5 * 3600,
+                "Lord Howe fixtures must preserve half-hour DST transitions")
+        for halfDay in [halfSpring, halfAutumn] {
+            let range = Geometry.visibleRange(in: halfDay, events: [], calendar: lordHowe)
+            require(lordHowe.component(.hour, from: range.start) == 7 && lordHowe.component(.hour, from: range.end) == 19
+                    && range.duration == 12 * 3600, "Half-hour time changes must not shift local daytime bounds")
+        }
+        let halfEarly = event("half-early", "2026-10-04T01:45:00+10:30", "2026-10-04T02:45:00+11:00")
+        let halfRange = Geometry.visibleRange(in: halfSpring, events: [halfEarly], calendar: lordHowe)
+        expectRange(halfRange, "2026-10-04T01:00:00+10:30", "2026-10-04T19:00:00+11:00", "Half-hour spring crop retains the early event")
+        require(halfRange.duration == 17.5 * 3600, "Half-hour crop must retain its fractional elapsed duration")
+
+        let springDays = [day("2026-03-07T12:00:00-05:00", calendar: newYork), spring, day("2026-03-09T12:00:00-04:00", calendar: newYork)]
+        let sharedSpring = Geometry.sharedVisibleRanges(in: springDays, events: [springEarly], calendar: newYork)
+        require(sharedSpring.map(\.duration) == [18 * 3600, 17 * 3600, 18 * 3600],
+                "Shared local hours must allow differing elapsed widths across DST")
+        require(sharedSpring.allSatisfy { newYork.component(.hour, from: $0.start) == 1 && newYork.component(.hour, from: $0.end) == 19 },
+                "Every shared spring row must display the same local start and end hours")
+        let autumnDays = [day("2026-10-31T12:00:00-04:00", calendar: newYork), autumn, day("2026-11-02T12:00:00-05:00", calendar: newYork)]
+        let sharedAutumn = Geometry.sharedVisibleRanges(in: autumnDays, events: autumnEvents, calendar: newYork)
+        require(sharedAutumn[1].start <= autumnEvents[0].start && sharedAutumn[1].end > autumnEvents[1].end,
+                "Mapping shared autumn bounds must not drop either repeated-hour event")
+
+        let halfNeighbor = day("2026-10-03T12:00:00+10:30", calendar: lordHowe)
+        let atTwo = event("normal-two", "2026-10-03T02:15:00+10:30", "2026-10-03T03:00:00+10:30")
+        let afterGap = event("after-gap", "2026-10-04T02:45:00+11:00", "2026-10-04T03:00:00+11:00")
+        let sharedGap = Geometry.sharedVisibleRanges(in: [halfNeighbor, halfSpring], events: [atTwo, afterGap], calendar: lordHowe)
+        require(sharedGap[0].start == date("2026-10-03T02:00:00+10:30")
+                && sharedGap[1].start == date("2026-10-04T02:30:00+11:00"),
+                "A shared hour skipped by fractional DST must resolve to the first valid instant on its own day; got \(sharedGap)")
+        require(sharedGap[1].start <= afterGap.start, "Resolving a skipped local boundary must preserve its timed event")
+        let fullSpring = Event(id: "full-spring", start: spring.start, end: spring.end)
+        require(Geometry.sharedVisibleRanges(in: springDays, events: [fullSpring], calendar: newYork) == springDays,
+                "Shared midnight bounds must retain each day's own 23- or 24-hour duration")
+
+        let santiago = calendar("America/Santiago")
+        let lateRollbackDays = [day("2026-04-03T12:00:00-03:00", calendar: santiago), day("2026-04-04T12:00:00-03:00", calendar: santiago)]
+        let firstLateHour = event("late-rollback", "2026-04-04T23:10:00-03:00", "2026-04-04T23:30:00-03:00")
+        let sharedRollback = Geometry.sharedVisibleRanges(in: lateRollbackDays, events: [firstLateHour], calendar: santiago)
+        require(sharedRollback[0].end == lateRollbackDays[0].end,
+                "A repeated late hour must not hide the enclosing midnight boundary on normal neighboring days")
+    }
+
+    private static func verifySharedRanges(calendar: Calendar) {
+        let days = [day("2026-09-06T12:00:00Z", calendar: calendar), day("2026-09-07T12:00:00Z", calendar: calendar), day("2026-09-08T12:00:00Z", calendar: calendar)]
+        require(Geometry.sharedVisibleRanges(in: [], events: [], calendar: calendar).isEmpty, "Empty loaded windows must produce no shared ranges")
+        let defaults = Geometry.sharedVisibleRanges(in: days, events: [], calendar: calendar)
+        require(defaults.count == days.count && defaults.allSatisfy { $0.duration == 12 * 3600 },
+                "Empty loaded days must each retain daytime")
+        let early = event("shared-early", "2026-09-06T06:30:00Z", "2026-09-06T07:30:00Z")
+        let late = event("shared-late", "2026-09-08T20:45:00Z", "2026-09-08T21:15:00Z")
+        for events in [[early], [late], [early, late]] {
+            let ranges = Geometry.sharedVisibleRanges(in: days, events: events, calendar: calendar)
+            let startHour = events.contains(where: { $0.id == early.id }) ? 6 : 7
+            let endHour = events.contains(where: { $0.id == late.id }) ? 22 : 19
+            for (day, range) in zip(days, ranges) {
+                require(calendar.isDate(range.start, inSameDayAs: day.start)
+                        && calendar.component(.hour, from: range.start) == startHour
+                        && calendar.component(.hour, from: range.end) == endHour,
+                        "Shared hours must apply to every loaded row, including rows without events")
+            }
+        }
+        let overnight = event("shared-overnight", "2026-09-06T23:30:00Z", "2026-09-07T01:15:00Z")
+        require(Geometry.sharedVisibleRanges(in: days, events: [overnight], calendar: calendar) == days,
+                "Shared overnight boundaries must map midnight and next midnight onto each corresponding day")
+        let unloaded = event("unloaded", "2026-09-07T02:00:00Z", "2026-09-07T23:00:00Z")
+        let sparseDays = [days[0], days[2]]
+        require(Geometry.sharedVisibleRanges(in: sparseDays, events: [unloaded], calendar: calendar)
+                == Geometry.sharedVisibleRanges(in: sparseDays, events: [], calendar: calendar),
+                "Events on an unloaded intervening day must not expand sparse visible rows")
+    }
+
+    private static func verifyScrollBounds(defaultRange: DateInterval, expanded: DateInterval) {
+        let afterHours = date("2026-09-07T21:00:00Z")
+        let width = defaultRange.duration / 3600 * Geometry.pointsPerHour
+        require(Geometry.position(of: afterHours, in: defaultRange) == width, "After-hours Today positioning must clamp to the crop end")
+        func markerVisible(_ now: Date) -> Bool { now >= defaultRange.start && now < defaultRange.end }
+        require(!markerVisible(afterHours) && !markerVisible(defaultRange.end), "Current-time markers must be absent at and after the exclusive crop end")
+        require(markerVisible(defaultRange.start) && markerVisible(date("2026-09-07T12:00:00Z")),
+                "Current-time markers remain visible at the crop start and during daytime")
+        let visibleDate = date("2026-09-07T10:17:31Z")
+        let oldX = Geometry.position(of: visibleDate, in: defaultRange)
+        let newX = Geometry.position(of: visibleDate, in: expanded)
+        let restoredOld = defaultRange.start.addingTimeInterval(oldX / Geometry.pointsPerHour * 3600)
+        let restoredNew = expanded.start.addingTimeInterval(newX / Geometry.pointsPerHour * 3600)
+        require(abs(restoredOld.timeIntervalSince(visibleDate)) < 0.000001
+                && abs(restoredNew.timeIntervalSince(visibleDate)) < 0.000001,
+                "Rebasing a crop with an earlier start must preserve the absolute visible date")
+        require(abs(newX - oldX - Geometry.pointsPerHour) < 0.000001,
+                "An extra earlier hour must shift the scroll offset by exactly one hour of points")
+    }
+
+    private static func event(_ id: String, _ start: String, _ end: String, isAllDay: Bool = false, isReminder: Bool = false) -> Event {
+        Event(id: id, start: date(start), end: date(end), isAllDay: isAllDay, isReminder: isReminder)
+    }
+
+    private static func expectRange(_ range: DateInterval, _ start: String, _ end: String, _ message: String) {
+        require(range.start == date(start) && range.end == date(end), "\(message): got \(range)")
+    }
+
+    private static func day(_ value: String, calendar: Calendar) -> DateInterval {
+        Geometry.dayInterval(for: date(value), calendar: calendar)
+    }
+
+    private static func calendar(_ zone: String) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = unwrap(TimeZone(identifier: zone))
+        return calendar
+    }
+
+    private static func date(_ value: String) -> Date {
+        unwrap(ISO8601DateFormatter().date(from: value))
+    }
+
+    private static func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+        checks += 1
+        if !condition() { failures.append(message) }
+    }
+    private static func unwrap<Value>(_ value: Value?, file: StaticString = #file, line: UInt = #line) -> Value {
+        guard let value else { preconditionFailure("Missing test fixture", file: file, line: line) }
+        return value
+    }
+
+}

--- a/tests/HomeCalendarGeometryTests.swift
+++ b/tests/HomeCalendarGeometryTests.swift
@@ -1,0 +1,267 @@
+//
+//  HomeCalendarGeometryTests.swift
+//  boringNotch
+//
+//  Focused calendar regression checks.
+//
+
+import Foundation
+
+@main
+enum HomeCalendarGeometryTests {
+    static func main() {
+        let utc = calendar("UTC")
+        let center = date("2026-09-07T12:34:56Z")
+        let days = HomeCalendarGeometry.days(centeredOn: center, calendar: utc)
+        require(days.count == 7, "The rendered window must contain exactly seven days")
+        require(Set(days.map(\.id)).count == 7, "Every day must have a stable, distinct midnight identity")
+        require(days[3].id == date("2026-09-07T00:00:00Z"), "The requested date must occupy the middle day")
+        require(fixture(days.first).id == date("2026-09-04T00:00:00Z") && fixture(days.last).id == date("2026-09-10T00:00:00Z"),
+                "The window must extend three calendar days in each direction")
+        require(days.allSatisfy { $0.width == 12 * 96 }, "Empty days show only07–19 at96 points per elapsed hour")
+        require(HomeCalendarGeometry.offset(of: center.addingTimeInterval(50 * 60), in: days)
+                - HomeCalendarGeometry.offset(of: center, in: days) == 80,
+                "A 50-minute class must receive 80 points for readable title wrapping")
+        verifyContinuousMapping(days)
+
+        let span = fixture(HomeCalendarGeometry.span(of: days))
+        let width = HomeCalendarGeometry.width(of: days)
+        require(HomeCalendarGeometry.offset(of: span.start.addingTimeInterval(-1), in: days) == 0,
+                "Dates before the window must clamp to its start")
+        require(HomeCalendarGeometry.offset(of: span.end.addingTimeInterval(1), in: days) == width,
+                "Dates after the window must clamp to its end")
+        require(HomeCalendarGeometry.date(at: -1, in: days) == fixture(days.first).visibleInterval.start, "Negative offsets must clamp to the window start")
+        require(HomeCalendarGeometry.date(at: width + 1, in: days) == fixture(days.last).visibleInterval.end,
+                "Offsets past the window must clamp to its end")
+        require(HomeCalendarGeometry.span(of: []) == nil && HomeCalendarGeometry.date(at: 0, in: []) == nil,
+                "An empty window has no date interval")
+        require(HomeCalendarGeometry.offset(of: center, in: []) == 0, "An empty window has zero offset")
+        require(HomeCalendarGeometry.needsRecentering(visibleDate: center, in: []), "An empty window must be initialized")
+
+        require(HomeCalendarGeometry.needsRecentering(visibleDate: days[1].id.addingTimeInterval(-0.001), in: days),
+                "Entering the first day must trigger recentering")
+        require(!HomeCalendarGeometry.needsRecentering(visibleDate: days[1].id, in: days),
+                "The second day start remains inside the safe window")
+        require(!HomeCalendarGeometry.needsRecentering(visibleDate: days[5].interval.end.addingTimeInterval(-0.001), in: days),
+                "The penultimate day remains inside the safe window")
+        require(HomeCalendarGeometry.needsRecentering(visibleDate: days[5].interval.end, in: days),
+                "Entering the last day must trigger recentering")
+        require(HomeCalendarGeometry.needsRecentering(visibleDate: span.start.addingTimeInterval(-86400), in: days)
+                && HomeCalendarGeometry.needsRecentering(visibleDate: span.end.addingTimeInterval(86400), in: days),
+                "Dates outside either edge must trigger recentering")
+
+        let newYork = calendar("America/New_York")
+        verifyDayLength("2026-03-08T12:00:00-04:00", hours: 23, calendar: newYork)
+        verifyDayLength("2026-11-01T12:00:00-05:00", hours: 25, calendar: newYork)
+        let firstOneThirty = date("2026-11-01T01:30:00-04:00")
+        let secondOneThirty = date("2026-11-01T01:30:00-05:00")
+        let autumn = HomeCalendarGeometry.days(centeredOn: date("2026-11-01T12:00:00-05:00"), events: [
+            .init(id: "repeated-hour", start: firstOneThirty, end: secondOneThirty.addingTimeInterval(1800))
+        ], calendar: newYork)
+        require(HomeCalendarGeometry.offset(of: secondOneThirty, in: autumn)
+                - HomeCalendarGeometry.offset(of: firstOneThirty, in: autumn) == 96,
+                "Repeated local times must retain separate positions one elapsed hour apart")
+
+        let lordHowe = calendar("Australia/Lord_Howe")
+        verifyDayLength("2026-10-04T12:00:00+11:00", hours: 23.5, calendar: lordHowe)
+        verifyDayLength("2026-04-05T12:00:00+10:30", hours: 24.5, calendar: lordHowe)
+        verifyDayLength("2026-09-07T12:00:00+05:45", hours: 24, calendar: calendar("Asia/Kathmandu"))
+
+        for zone in [newYork, lordHowe] {
+            for direction in [-1.0, 1.0] {
+                verifyRepeatedRecentering(from: center, direction: direction, calendar: zone)
+            }
+        }
+        verifyCroppedHours(calendar: utc)
+        verifyDayGaps(calendar: utc)
+        verifyCurrentTimeGap(calendar: utc)
+        print("Home calendar geometry: all checks passed (cropped 07–19 window, day gaps/current-time centering, early/late/overnight events, reset bounds, DST, inverse mapping, 2,400 scrolling steps).")
+    }
+
+    private static func verifyDayLength(_ value: String, hours: Double, calendar: Calendar) {
+        let days = HomeCalendarGeometry.days(centeredOn: date(value), calendar: calendar)
+        require(days[3].interval.duration == hours * 3600, "Calendar day must preserve its actual duration: \(value)")
+        require(days[3].width == 12 * 96, "Default daytime width remains12 local hours when DST changes overnight: \(value)")
+        verifyContinuousMapping(days)
+    }
+
+    private static func verifyContinuousMapping(_ days: [HomeCalendarGeometry.Day]) {
+        var x = 0.0
+        for (index, day) in days.enumerated() {
+            require(HomeCalendarGeometry.offset(of: day.id, in: days) == x, "Day boundaries must include only the explicit visual gaps")
+            if index > 0 {
+                require(days[index - 1].interval.end == day.interval.start, "Calendar days must form a contiguous interval")
+            }
+            for fraction in [0.0, 0.1234567, 0.5, 0.999999] {
+                let original = day.visibleInterval.start.addingTimeInterval(day.visibleInterval.duration * fraction)
+                let offset = HomeCalendarGeometry.offset(of: original, in: days)
+                let restored = fixture(HomeCalendarGeometry.date(at: offset, in: days))
+                require(abs(restored.timeIntervalSince(original)) < 0.000001,
+                        "Elapsed date-to-offset mapping must round-trip within one microsecond")
+            }
+            x += day.width
+            if index < days.count - 1 { x += HomeCalendarGeometry.daySpacing }
+        }
+        require(HomeCalendarGeometry.offset(of: fixture(days.last).interval.end, in: days) == x,
+                "The document width must equal day widths plus one gap between adjacent days")
+    }
+
+    private static func verifyRepeatedRecentering(from start: Date, direction: Double, calendar: Calendar) {
+        var days = HomeCalendarGeometry.days(centeredOn: start, calendar: calendar)
+        var visibleDate = start
+        var recenterCount = 0
+        for _ in 0..<600 {
+            // Keep walking: seven rendered days must never become the end of the calendar.
+            let previous = visibleDate
+            let offset = HomeCalendarGeometry.offset(of: visibleDate, in: days) + direction * 6 * 96
+            visibleDate = fixture(HomeCalendarGeometry.date(at: offset, in: days))
+            let mappedOffset = HomeCalendarGeometry.offset(of: visibleDate, in: days)
+            require(mappedOffset - offset >= -0.000001 && mappedOffset - offset <= HomeCalendarGeometry.daySpacing,
+                    "Scroll mapping may skip only the visual gap, never a rendered time or the window boundary")
+            require(visibleDate.timeIntervalSince(previous) * direction > 0,
+                    "Scrolling must advance through cropped nights in the requested direction")
+            if HomeCalendarGeometry.needsRecentering(visibleDate: visibleDate, in: days, calendar: calendar) {
+                days = HomeCalendarGeometry.days(centeredOn: visibleDate, calendar: calendar)
+                let rebasedOffset = HomeCalendarGeometry.offset(of: visibleDate, in: days)
+                let restoredLeadingDate = fixture(HomeCalendarGeometry.date(at: rebasedOffset, in: days))
+                require(abs(restoredLeadingDate.timeIntervalSince(visibleDate)) < 0.000001,
+                        "Rebasing must preserve the viewport leading date without a visible jump")
+                require(days.count == 7 && !HomeCalendarGeometry.needsRecentering(visibleDate: visibleDate, in: days),
+                        "Recentered windows must remain bounded and put the viewport safely inside")
+                recenterCount += 1
+            }
+        }
+        require(recenterCount >= 75, "Scrolling must repeatedly replace the bounded window")
+
+    }
+
+
+    private static func verifyCroppedHours(calendar: Calendar) {
+        let today = date("2026-09-07T12:00:00Z")
+        let empty = HomeCalendarGeometry.days(centeredOn: today, calendar: calendar)
+        require(empty[3].visibleInterval == DateInterval(start: date("2026-09-07T07:00:00Z"), end: date("2026-09-07T19:00:00Z")),
+                "A day with no timed events hides both nights")
+        let early = CalendarTimelineGeometry.Interval(id: "early", start: date("2026-09-07T05:15:00Z"), end: date("2026-09-07T06:00:00Z"))
+        let late = CalendarTimelineGeometry.Interval(id: "late", start: date("2026-09-08T21:00:00Z"), end: date("2026-09-08T22:15:00Z"))
+        let ranged = HomeCalendarGeometry.days(centeredOn: today, events: [early, late], calendar: calendar)
+        require(ranged[3].visibleInterval.start == date("2026-09-07T05:00:00Z") && ranged[3].width == 14 * 96,
+                "An early class extends only its own day's leading range")
+        require(ranged[4].visibleInterval.end == date("2026-09-08T23:00:00Z") && ranged[4].width == 16 * 96,
+                "A late class extends only its own day's trailing range")
+        verifyContinuousMapping(ranged)
+        let seam = HomeCalendarGeometry.offset(of: ranged[3].visibleInterval.end, in: ranged)
+        require(HomeCalendarGeometry.date(at: seam, in: ranged) == ranged[4].visibleInterval.start,
+                "The visual gap points to the next visible day without adding hidden-night time")
+        require(HomeCalendarGeometry.date(at: HomeCalendarGeometry.offset(of: today, in: ranged), in: ranged) == today,
+                "Changing loaded ranges preserves a visible time when rebasing offsets")
+        let ignored = HomeCalendarGeometry.days(centeredOn: today, events: [
+            .init(id: "all-day", start: date("2026-09-07T00:00:00Z"), end: date("2026-09-08T00:00:00Z"), isAllDay: true),
+            .init(id: "reminder", start: date("2026-09-07T02:00:00Z"), end: date("2026-09-07T02:00:00Z"), isReminder: true)
+        ], calendar: calendar)
+        require(ignored == empty, "All-day events and reminders never expose the nights")
+        let overnight = HomeCalendarGeometry.days(centeredOn: today, events: [
+            .init(id: "overnight", start: date("2026-09-07T23:00:00Z"), end: date("2026-09-08T02:00:00Z"))
+        ], calendar: calendar)
+        require(overnight[3].visibleInterval.end == overnight[3].interval.end && overnight[4].visibleInterval.start == overnight[4].interval.start,
+                "An overnight event extends both intersected day ranges to midnight")
+        require(!empty[3].isTimeVisible(date("2026-09-07T06:59:59Z")) && !empty[3].isTimeVisible(date("2026-09-07T19:00:00Z")),
+                "The current-time marker is hidden outside the displayed hours")
+        require(empty[3].isTimeVisible(date("2026-09-07T07:00:00Z")) && empty[3].isTimeVisible(date("2026-09-07T18:59:59Z")),
+                "The current-time marker remains visible inside the displayed hours")
+        let leading = HomeCalendarGeometry.offset(of: empty[3].id, in: empty)
+        for target in [date("2026-09-06T23:30:00Z"), date("2026-09-07T06:00:00Z"), date("2026-09-07T18:30:00Z"), date("2026-09-07T23:30:00Z")] {
+            let offset = HomeCalendarGeometry.viewportOffset(near: target, on: today, viewportWidth: 315, in: empty)
+            require(offset >= leading && offset + 315 <= leading + empty[3].width,
+                    "Today and initial resets keep the complete viewport inside the requested day")
+            let center = fixture(HomeCalendarGeometry.date(at: offset + 157.5, in: empty))
+            require(calendar.isDate(center, inSameDayAs: today), "A late Today reset must not select tomorrow")
+        }
+        require(HomeCalendarGeometry.viewportOffset(near: today, on: today, viewportWidth: 2000, in: empty) == leading,
+                "An oversized viewport anchors at the requested day's start")
+    }
+
+    private static func verifyDayGaps(calendar: Calendar) {
+        let today = date("2026-09-07T12:00:00Z")
+        let days = HomeCalendarGeometry.days(centeredOn: today, calendar: calendar)
+        require(HomeCalendarGeometry.width(of: []) == 0, "An empty strip has no gap")
+        require(HomeCalendarGeometry.width(of: [days[3]]) == days[3].width, "A single day has no trailing gap")
+        require(HomeCalendarGeometry.width(of: days) == days.reduce(0) { $0 + $1.width } + 6 * HomeCalendarGeometry.daySpacing,
+                "Seven days have exactly six visual gaps")
+        let shifted = HomeCalendarGeometry.days(centeredOn: today.addingTimeInterval(86400), calendar: calendar)
+        for index in 1..<5 {
+            let preceding = days[index]
+            let following = days[index + 1]
+            let gapStart = HomeCalendarGeometry.offset(of: preceding.id, in: days) + preceding.width
+            let nextStart = HomeCalendarGeometry.offset(of: following.id, in: days)
+            require(nextStart - gapStart == HomeCalendarGeometry.daySpacing,
+                    "Adjacent day ranges must be separated by exactly18 points")
+            for fraction in [0.0, 0.25, 0.5, 0.999999] {
+                let offset = gapStart + HomeCalendarGeometry.daySpacing * fraction
+                require(HomeCalendarGeometry.date(at: offset, in: days) == following.visibleInterval.start,
+                        "Every pixel in a gap consistently announces the next visible day")
+                let rebased = HomeCalendarGeometry.rebasedOffset(offset, from: days, to: shifted)
+                let newNextStart = HomeCalendarGeometry.offset(of: following.id, in: shifted)
+                require(abs((nextStart - offset) - (newNextStart - rebased)) < 0.000001,
+                        "Recentering preserves the exact leading pixel even when it falls inside a gap")
+                let restored = HomeCalendarGeometry.rebasedOffset(rebased, from: shifted, to: days)
+                require(abs(restored - offset) < 0.000001, "Gap anchors rebase reversibly in either scroll direction")
+            }
+            require(HomeCalendarGeometry.date(at: nextStart, in: days) == following.visibleInterval.start,
+                    "The first pixel after the gap is exactly the next displayed start time")
+            let beforeGap = fixture(HomeCalendarGeometry.date(at: gapStart - 0.01, in: days))
+            require(beforeGap < preceding.visibleInterval.end && beforeGap > preceding.visibleInterval.end.addingTimeInterval(-1),
+                    "The final rendered instant remains on the preceding day")
+            let lateReset = HomeCalendarGeometry.viewportOffset(near: preceding.interval.end, on: preceding.id, viewportWidth: 315, in: days)
+            require(lateReset + 315 == gapStart, "A late Today viewport ends before the visual gap")
+        }
+    }
+
+    private static func verifyCurrentTimeGap(calendar: Calendar) {
+        let today = date("2026-09-07T12:00:00Z")
+        let days = HomeCalendarGeometry.days(centeredOn: today, calendar: calendar)
+        let leading = HomeCalendarGeometry.offset(of: days[3].id, in: days)
+        let late = date("2026-09-07T22:58:00Z")
+        let early = date("2026-09-07T05:12:00Z")
+        require(HomeCalendarGeometry.gapOffset(of: late, in: days) == leading + days[3].width + 9,
+                "Hidden evening time appears in the following visual gap")
+        require(HomeCalendarGeometry.gapOffset(of: early, in: days) == leading - 9,
+                "Hidden morning time appears in the preceding visual gap")
+        require(HomeCalendarGeometry.gapOffset(of: today, in: days) == nil,
+                "Visible time keeps its ordinary in-day marker")
+        require(HomeCalendarGeometry.currentTimeOffset(of: today, in: days) == HomeCalendarGeometry.offset(of: today, in: days),
+                "Centering a visible time preserves its accurate elapsed-time position")
+        require(HomeCalendarGeometry.currentTimeOffset(of: days[0].id.addingTimeInterval(-1), in: days) == nil,
+                "A date outside the loaded window has no current-time marker")
+        for now in [early, today, late, date("2026-09-07T19:00:00Z")] {
+            let marker = fixture(HomeCalendarGeometry.currentTimeOffset(of: now, in: days))
+            let viewport = HomeCalendarGeometry.viewportOffset(near: now, on: today, viewportWidth: 315, in: days, centered: true)
+            require(abs(viewport + 157.5 - marker) < 0.000001,
+                    "Today centers the actual marker even when it is in an overnight gap")
+            require(calendar.isDate(now, inSameDayAs: today), "A marker target retains its actual current-day identity")
+        }
+        let extended = HomeCalendarGeometry.days(centeredOn: today, events: [
+            .init(id: "late", start: date("2026-09-07T22:00:00Z"), end: date("2026-09-07T23:00:00Z"))
+        ], calendar: calendar)
+        require(HomeCalendarGeometry.gapOffset(of: late, in: extended) == nil,
+                "An event that exposes the current time moves the marker out of the gap onto the elapsed-time ruler")
+    }
+
+    private static func calendar(_ zone: String) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = fixture(TimeZone(identifier: zone))
+        return calendar
+    }
+
+    private static func date(_ value: String) -> Date {
+        fixture(ISO8601DateFormatter().date(from: value))
+    }
+
+    private static func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+        precondition(condition(), message)
+    }
+}
+
+private func fixture<T>(_ value: T?) -> T {
+    guard let value else { fatalError("Missing calendar test fixture") }
+    return value
+}

--- a/tests/PanGestureScrollRoutingTests.swift
+++ b/tests/PanGestureScrollRoutingTests.swift
@@ -1,0 +1,147 @@
+//
+//  PanGestureScrollRoutingTests.swift
+//  boringNotch
+//
+//  Focused calendar regression checks.
+//
+
+import AppKit
+import Defaults
+import SwiftUI
+
+extension Defaults.Keys {
+    static let normalizeGestureDirection = Key<Bool>("panRoutingTestNormalizeDirection", default: false)
+}
+
+private struct ScrollRoutingFixture: View {
+    private let days = HomeCalendarGeometry.days(centeredOn: Date())
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Color.gray.frame(width: 250, height: 130)
+            HomeCalendarScrollView(days: days, targetDay: Date(), targetDate: Date(), resetID: 0, height: 100, onScroll: { _ in }) {
+                Color.blue.frame(width: HomeCalendarGeometry.width(of: days), height: 100)
+            }
+            .frame(width: 315, height: 100)
+        }
+        .frame(width: 565, height: 130)
+        .panGesture(direction: .up) { _, _ in }
+        .panGesture(direction: .down) { _, _ in }
+        .panGesture(direction: .left) { _, _ in }
+        .panGesture(direction: .right) { _, _ in }
+    }
+}
+
+@main enum PanGestureScrollRoutingTests {
+    @MainActor static func descendants(_ view: NSView) -> [NSView] {
+        [view] + view.subviews.flatMap(descendants)
+    }
+
+    @MainActor static func main() {
+        _ = NSApplication.shared
+        NSApp.setActivationPolicy(.prohibited)
+        let window = NSWindow(contentRect: NSRect(x: -20000, y: -20000, width: 565, height: 130), styleMask: .borderless, backing: .buffered, defer: false)
+        let host = NSHostingView(rootView: ScrollRoutingFixture())
+        window.contentView = host
+        window.orderFrontRegardless()
+        defer { window.orderOut(nil) }
+        host.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.08))
+        host.layoutSubtreeIfNeeded()
+
+        let scrollView = fixture(descendants(host).compactMap { $0 as? HomeCalendarNativeScrollView }.first)
+        var checks = 0
+        func event(at point: NSPoint) -> NSEvent {
+            fixture(NSEvent.mouseEvent(with: .mouseMoved, location: point, modifierFlags: [], timestamp: 0,
+                               windowNumber: window.windowNumber, context: nil, eventNumber: 0,
+                               clickCount: 0, pressure: 0))
+        }
+        // Exercise the actual nested SwiftUI hosting view, clip view, and native scroll view.
+        for x in [1.0, 100, 200, 314] {
+            for y in [1.0, 50, 99] {
+                let point = scrollView.convert(NSPoint(x: x, y: y), to: nil)
+                precondition(PanGestureScrollRouting.targetsScrollView(event(at: point)), "Calendar point must keep wheel ownership: \(x),\(y)")
+                checks += 1
+            }
+        }
+        for point in [NSPoint(x: 40, y: 60), NSPoint(x: 200, y: 60), NSPoint(x: 400, y: 125)] {
+            precondition(!PanGestureScrollRouting.targetsScrollView(event(at: point)), "Music/header must retain notch gestures")
+            checks += 1
+        }
+
+        scrollView.move(to: 1000)
+        let initial = scrollView.contentView.bounds.minX
+        for delta: Int32 in [-50, 50] {
+            let wheel = fixture(NSEvent(cgEvent: fixture(CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 1,
+                                                wheel1: delta, wheel2: 0, wheel3: 0))))
+            let old = scrollView.contentView.bounds.minX
+            scrollView.scrollWheel(with: wheel)
+            let new = scrollView.contentView.bounds.minX
+            precondition(delta < 0 ? new > old : new < old, "Wheel must move in both directions")
+            checks += 1
+        }
+        precondition(abs(scrollView.contentView.bounds.minX - initial) < 0.01, "Opposite wheel deltas must return to the original time")
+        checks += 1
+        let frozenGutter = NSClipView(frame: NSRect(x: 0, y: 0, width: 47, height: 100))
+        frozenGutter.documentView = NSView(frame: NSRect(x: 0, y: 0, width: 47, height: 700))
+        host.addSubview(frozenGutter)
+        for x in [1.0, 23, 46] {
+            for y in [1.0, 99] {
+                let point = frozenGutter.convert(NSPoint(x: x, y: y), to: nil)
+                precondition(PanGestureScrollRouting.targetsScrollView(event(at: point)), "Frozen day labels must keep wheel ownership")
+                checks += 1
+            }
+        }
+        let today = Date()
+        let days = HomeCalendarGeometry.days(centeredOn: today)
+        let late = fixture(Calendar.current.date(bySettingHour: 23, minute: 30, second: 0, of: today))
+        scrollView.position(on: today, near: late, in: days)
+        let expected = HomeCalendarGeometry.viewportOffset(near: late, on: today, viewportWidth: scrollView.contentView.bounds.width, in: days)
+        precondition(abs(scrollView.contentView.bounds.minX - expected) < 0.01, "After-hours Today must clamp the existing viewport inside today")
+        precondition(Calendar.current.isDate(fixture(HomeCalendarGeometry.date(at: scrollView.contentView.bounds.midX, in: days)), inSameDayAs: today), "After-hours Today must not show tomorrow")
+        checks += 2
+
+        let initialScroll = HomeCalendarNativeScrollView(frame: .zero)
+        initialScroll.borderType = .noBorder
+        initialScroll.documentView = NSView(frame: NSRect(x: 0, y: 0, width: HomeCalendarGeometry.width(of: days), height: 100))
+        initialScroll.position(on: today, near: late, in: days)
+        initialScroll.frame = NSRect(x: 0, y: 0, width: 315, height: 100)
+        initialScroll.needsLayout = true
+        initialScroll.layoutSubtreeIfNeeded()
+        let initialExpected = HomeCalendarGeometry.viewportOffset(near: late, on: today, viewportWidth: initialScroll.contentView.bounds.width, in: days)
+        precondition(abs(initialScroll.contentView.bounds.minX - initialExpected) < 0.01, "Initial reset must wait for the viewport width before clamping")
+        precondition(Calendar.current.isDate(fixture(HomeCalendarGeometry.date(at: initialScroll.contentView.bounds.midX, in: days)), inSameDayAs: today), "Initial after-hours view must remain on today")
+        checks += 2
+        initialScroll.documentView = nil
+
+        let centeredScroll = HomeCalendarNativeScrollView(frame: .zero)
+        centeredScroll.borderType = .noBorder
+        centeredScroll.documentView = NSView(frame: NSRect(x: 0, y: 0, width: HomeCalendarGeometry.width(of: days), height: 100))
+        var completed = 0
+        var reportedScrolls = 0
+        centeredScroll.didScroll = { reportedScrolls += 1 }
+        centeredScroll.position(on: today, near: late, in: days, centered: true) {
+            precondition(abs(centeredScroll.contentView.bounds.midX - fixture(HomeCalendarGeometry.currentTimeOffset(of: late, in: days))) < 0.01,
+                         "Position completion must run after the hidden-time marker is centered")
+            completed += 1
+        }
+        precondition(completed == 0, "A zero-width initial layout must defer the Today highlight callback")
+        centeredScroll.frame = NSRect(x: 0, y: 0, width: 315, height: 100)
+        centeredScroll.layoutSubtreeIfNeeded()
+        precondition(completed == 1, "Position completion fires once after native layout resolves the viewport")
+        centeredScroll.position(on: today, near: late, in: days, centered: true) { completed += 1 }
+        precondition(completed == 2, "Today completion retriggers even when already centered at the same time")
+        centeredScroll.needsLayout = true
+        centeredScroll.layoutSubtreeIfNeeded()
+        precondition(completed == 2, "Ordinary native relayout must not retrigger the highlight")
+        precondition(reportedScrolls == 0, "Programmatic Today centering must preserve the selected day rather than report the adjacent gap date")
+        checks += 6
+        centeredScroll.documentView = nil
+        print("PASS \(checks) native calendar wheel-routing checks")
+    }
+}
+
+private func fixture<T>(_ value: T?) -> T {
+    guard let value else { fatalError("Missing native calendar test fixture") }
+    return value
+}


### PR DESCRIPTION
Adds a dedicated Calendar pane with horizontal day timelines stacked vertically. Roughly two complete days fit in the expanded pane. Vertical trackpad/wheel input moves through days; horizontal input moves through hours inside the day lanes. The right scroll indicator, date gutter and separated day boundaries keep orientation visible.

Event blocks preserve time scale and use a fixed 11pt medium title in every overlap lane, with up to three leading-aligned lines in full-height, non-overlapping cards. Overlapping cards retain one title line, with tail ellipses instead of shrinking. Locations flow below the actual title with a 6pt gap in full-height cards where vertical space permits, and current-time/hour labels are larger and readable in 12-hour or 24-hour format; selecting an event exposes its details. Empty night hours are cropped to 07:00–19:00 unless timed events extend the range. If now falls in hidden hours, a red line and exact-time badge appear in the inter-day gap. Today/T focuses the marker and starts its highlight only after native positioning completes; Reduce Motion uses a static highlight.

The shared calendar settings list all available EventKit calendars by account with explicit checkboxes, selection counts, Select All/Deselect All, and Refresh Calendars. This pane follows the same selection as Home. Empty selections remain empty and stale asynchronous responses cannot replace a newer selection.

Relates to #1521. This is a **stacked draft** on the [Home calendar PR](https://github.com/TheBoredTeam/boring.notch/pull/1524), which supplies shared timeline/month geometry, Today focus handling, and account-based calendar selection. Once Home lands in `dev`, this PR can be rebased to show only the pane changes. The target remains `dev` as required by the contribution guidelines.

Unlike #958, this is a time-scaled stack of day lanes rather than a vertical arrangement of the existing list. Notification priority, compact mode and Home sizing remain intact.

Validation: final Debug build passed; 2,400 day recenter steps and 47 native day/hour/reset checks passed, plus the shared Home checks. Actual component/bridge renders verify overnight, early-morning and post-focus highlight states. No translations changed.

Calendar-selection validation: Debug builds and the isolated selection regression suite passed on both feature branches; SwiftLint passed. Tests cover empty selections, separate calendar/reminder bulk actions, saved selection, new calendar discovery, obsolete IDs, and out-of-order responses. Live checkbox checks confirmed that a calendar’s events appear and disappear in both timeline views.

Native component renders with a synthetic event and fixed clocks:

![Overlapping and full-height cards with overnight current time](https://raw.githubusercontent.com/JohnnyC0rp/boring.notch/044c2cdf167de965030e9b56938a63fc2b10858a/review-previews/calendar-overnight.png)
![Stacked days and overnight current time](https://raw.githubusercontent.com/JohnnyC0rp/boring.notch/044c2cdf167de965030e9b56938a63fc2b10858a/review-previews/calendar-overnight-highlight.png)
![Early-morning hidden time](https://raw.githubusercontent.com/JohnnyC0rp/boring.notch/044c2cdf167de965030e9b56938a63fc2b10858a/review-previews/calendar-early-morning.png)
![Daytime current-time feedback](https://raw.githubusercontent.com/JohnnyC0rp/boring.notch/044c2cdf167de965030e9b56938a63fc2b10858a/review-previews/calendar-daytime-highlight.png)

Native Calendar Settings component rendered with synthetic accounts, calendars, and reminder lists:

![Calendar selection grouped by account](https://raw.githubusercontent.com/JohnnyC0rp/boring.notch/7d8451cd98573a935c051c2d38cd7125dd560871/review-previews/calendar-settings.png)

The pane has its own Fit Day–250% scale, independent of Home, controlled by a [Calendar Layout slider](https://raw.githubusercontent.com/JohnnyC0rp/boring.notch/b9797f2832550fe9b426c311949281a007541d18/review-previews/calendar-layout-independent-scales.png) or its stationary drag wheel, preserving the vertical day position. Fit Day fits the cropped or night-extended day across the viewport; narrow blocks omit titles, and measured hour labels remain separated. Clicking the wheel resets only its timeline to 100%.

![Native Calendar pane zoom, scrolling, Today focus, and click reset with synthetic events](https://raw.githubusercontent.com/JohnnyC0rp/boring.notch/8fa628e11fc3975c162393abe55e3e63d62d0e92/review-previews/calendar-pane-demo.gif)
